### PR TITLE
Fix desktop build from clean checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ desktop:
 desktop-fast:
 	$(PNPM) --filter @nerve/desktop start
 
-desktop-build:
+desktop-build: dev-deps
 	$(PNPM) --filter @nerve/web build
 	$(PNPM) --filter @nerve/orchestrator build
 	$(PNPM) --filter @nerve/desktop build

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,9 +12,10 @@
     "build": "pnpm run icons && tsc -b && node scripts/copy-preload.mjs",
     "check": "tsc -b --pretty false",
     "start": "node scripts/start-electron.mjs",
-    "dev": "pnpm --filter @nerve/web build && pnpm --filter @nerve/orchestrator build && pnpm --filter @nerve/desktop build && node scripts/start-electron.mjs",
-    "build:package": "pnpm --filter @nerve/web build && pnpm --filter @nerve/orchestrator build && pnpm --filter @nerve/desktop build && electron-builder",
-    "package:linux": "pnpm --filter @nerve/web build && pnpm --filter @nerve/orchestrator build && pnpm --filter @nerve/desktop build && electron-builder --linux AppImage deb"
+    "build:deps": "pnpm --filter @nerve/shared --filter @nerve/agent --filter @nerve/tools build",
+    "dev": "pnpm run build:deps && pnpm --filter @nerve/web build && pnpm --filter @nerve/orchestrator build && pnpm --filter @nerve/desktop build && node scripts/start-electron.mjs",
+    "build:package": "pnpm run build:deps && pnpm --filter @nerve/web build && pnpm --filter @nerve/orchestrator build && pnpm --filter @nerve/desktop build && electron-builder",
+    "package:linux": "pnpm run build:deps && pnpm --filter @nerve/web build && pnpm --filter @nerve/orchestrator build && pnpm --filter @nerve/desktop build && electron-builder --linux AppImage deb"
   },
   "dependencies": {
     "@nerve/orchestrator": "workspace:*",

--- a/packages/orchestrator/tsconfig.json
+++ b/packages/orchestrator/tsconfig.json
@@ -6,6 +6,10 @@
     "outDir": "dist",
     "types": ["node"]
   },
-  "references": [{ "path": "../shared" }, { "path": "../agent" }],
+  "references": [
+    { "path": "../shared" },
+    { "path": "../agent" },
+    { "path": "../tools" }
+  ],
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Build generated workspace packages before desktop dev/package flows
- Add missing @nerve/tools TypeScript project reference to orchestrator
- Make make desktop-build run dev-deps first

Fixes #1

## Verification
- rm -rf packages/shared/dist packages/agent/dist packages/tools/dist packages/orchestrator/dist packages/desktop/dist packages/web/dist packages/*/tsconfig.tsbuildinfo && make desktop-build
- pnpm lint
- pnpm check