### PR TITLE
Fix Windows skill loader paths

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -14,7 +14,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { ExecutionError, FileError } from "../errors.js";
 import { err, ok, type Result, toError } from "../result.js";
@@ -49,7 +49,7 @@ function fileInfoFromStats(
   if (!kind)
     return err(new FileError("invalid", "Unsupported file type", path));
   return ok({
-    name: path.replace(/\/+$/, "").split("/").pop() ?? path,
+    name: basename(path),
     path,
     kind,
     size: stats.size,

--- a/packages/agent/src/harness/prompt-templates.ts
+++ b/packages/agent/src/harness/prompt-templates.ts
@@ -2,6 +2,7 @@ import { parse } from "yaml";
 import type { ExecutionEnv, FileInfo } from "./env/types.js";
 import type { PromptTemplate } from "./options.js";
 import { type Result, toError } from "./result.js";
+import { basenameEnvPath } from "./utils/env-path.js";
 
 export type PromptTemplateDiagnosticCode =
   | "file_info_failed"
@@ -244,12 +245,6 @@ function parseFrontmatter<T extends Record<string, unknown>>(
   } catch (error) {
     return { ok: false, error: toError(error) };
   }
-}
-
-function basenameEnvPath(path: string): string {
-  const normalized = path.replace(/\/+$/, "");
-  const slashIndex = normalized.lastIndexOf("/");
-  return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
 }
 
 /** Parse an argument string using simple shell-style single and double quotes. */

--- a/packages/agent/src/harness/skills/format.ts
+++ b/packages/agent/src/harness/skills/format.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "../options.js";
+import { dirnameEnvPath } from "../utils/env-path.js";
 
 /** Format a skill invocation prompt, optionally appending additional user instructions. */
 export function formatSkillInvocation(
@@ -36,12 +37,6 @@ export function formatSkillsForSystemPrompt(skills: Skill[]): string {
 
   lines.push("</available_skills>");
   return lines.join("\n");
-}
-
-function dirnameEnvPath(path: string): string {
-  const normalized = path.replace(/\/+$/, "");
-  const slashIndex = normalized.lastIndexOf("/");
-  return slashIndex <= 0 ? "/" : normalized.slice(0, slashIndex);
 }
 
 function escapeXml(value: string): string {

--- a/packages/agent/src/harness/skills/loader.ts
+++ b/packages/agent/src/harness/skills/loader.ts
@@ -1,6 +1,12 @@
 import ignore from "ignore";
 import type { ExecutionEnv, FileInfo } from "../env/types.js";
 import type { Skill } from "../options.js";
+import {
+  basenameEnvPath,
+  dirnameEnvPath,
+  joinEnvPath,
+  relativeEnvPath,
+} from "../utils/env-path.js";
 import { parseFrontmatter, type SkillFrontmatter } from "./parser.js";
 import { validateDescription, validateName } from "./validation.js";
 
@@ -351,29 +357,4 @@ async function resolveKind(
   return target.value.kind === "file" || target.value.kind === "directory"
     ? target.value.kind
     : undefined;
-}
-
-function joinEnvPath(base: string, child: string): string {
-  return `${base.replace(/\/+$/, "")}/${child.replace(/^\/+/, "")}`;
-}
-
-function dirnameEnvPath(path: string): string {
-  const normalized = path.replace(/\/+$/, "");
-  const slashIndex = normalized.lastIndexOf("/");
-  return slashIndex <= 0 ? "/" : normalized.slice(0, slashIndex);
-}
-
-function basenameEnvPath(path: string): string {
-  const normalized = path.replace(/\/+$/, "");
-  const slashIndex = normalized.lastIndexOf("/");
-  return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
-}
-
-function relativeEnvPath(root: string, path: string): string {
-  const normalizedRoot = root.replace(/\/+$/, "");
-  const normalizedPath = path.replace(/\/+$/, "");
-  if (normalizedPath === normalizedRoot) return "";
-  return normalizedPath.startsWith(`${normalizedRoot}/`)
-    ? normalizedPath.slice(normalizedRoot.length + 1)
-    : normalizedPath.replace(/^\/+/, "");
 }

--- a/packages/agent/src/harness/utils/env-path.ts
+++ b/packages/agent/src/harness/utils/env-path.ts
@@ -1,0 +1,85 @@
+const WINDOWS_DRIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
+const WINDOWS_DRIVE_ROOT_RE = /^[A-Za-z]:[\\/]+$/;
+
+function preferredSeparator(path: string): "/" | "\\" {
+  return path.includes("\\") && !path.includes("/") ? "\\" : "/";
+}
+
+function stripTrailingSeparators(path: string): string {
+  if (WINDOWS_DRIVE_ROOT_RE.test(path)) return path.slice(0, 3);
+  return path.replace(/[\\/]+$/, "") || path;
+}
+
+function toPosixPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  if (/^[A-Za-z]:\/+$/u.test(normalized)) return normalized.slice(0, 3);
+  return normalized.replace(/\/+$/, "") || normalized;
+}
+
+function isWindowsDrivePath(path: string): boolean {
+  return WINDOWS_DRIVE_PATH_RE.test(path) || /^[A-Za-z]:\//u.test(path);
+}
+
+function makeRelativeIgnorePath(path: string): string {
+  return path.replace(/^[A-Za-z]:\/?/u, "").replace(/^\/+/, "");
+}
+
+/** Join environment paths while preserving Windows-style separators when the base path uses them. */
+export function joinEnvPath(base: string, child: string): string {
+  const separator = preferredSeparator(base);
+  const normalizedBase = stripTrailingSeparators(base);
+  const normalizedChild = child.replace(/^[\\/]+/, "");
+  if (!normalizedBase) return normalizedChild;
+  const separatorPrefix = /[\\/]$/.test(normalizedBase) ? "" : separator;
+  return `${normalizedBase}${separatorPrefix}${normalizedChild}`;
+}
+
+/** Return the parent directory for either POSIX or Windows-style environment paths. */
+export function dirnameEnvPath(path: string): string {
+  const normalized = stripTrailingSeparators(path);
+  const slashIndex = Math.max(
+    normalized.lastIndexOf("/"),
+    normalized.lastIndexOf("\\"),
+  );
+  if (slashIndex === -1) return ".";
+  if (slashIndex === 0) return normalized.slice(0, 1);
+  if (slashIndex === 2 && WINDOWS_DRIVE_PATH_RE.test(normalized)) {
+    return normalized.slice(0, 3);
+  }
+  return normalized.slice(0, slashIndex);
+}
+
+/** Return the final path segment for either POSIX or Windows-style environment paths. */
+export function basenameEnvPath(path: string): string {
+  const normalized = stripTrailingSeparators(path);
+  const slashIndex = Math.max(
+    normalized.lastIndexOf("/"),
+    normalized.lastIndexOf("\\"),
+  );
+  return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
+}
+
+/**
+ * Return a POSIX-style path relative to root for ignore matching.
+ *
+ * The ignore package requires relative, slash-separated paths. Execution environments may return native Windows paths,
+ * so comparisons are performed on normalized separators before the relative path is produced.
+ */
+export function relativeEnvPath(root: string, path: string): string {
+  const normalizedRoot = toPosixPath(root);
+  const normalizedPath = toPosixPath(path);
+  const windowsComparison =
+    isWindowsDrivePath(normalizedRoot) || isWindowsDrivePath(normalizedPath);
+  const compareRoot = windowsComparison
+    ? normalizedRoot.toLowerCase()
+    : normalizedRoot;
+  const comparePath = windowsComparison
+    ? normalizedPath.toLowerCase()
+    : normalizedPath;
+
+  if (comparePath === compareRoot) return "";
+  if (comparePath.startsWith(`${compareRoot}/`)) {
+    return normalizedPath.slice(normalizedRoot.length + 1);
+  }
+  return makeRelativeIgnorePath(normalizedPath);
+}

--- a/packages/agent/test/skills-loader.test.ts
+++ b/packages/agent/test/skills-loader.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type {
+  ExecutionEnv,
+  FileInfo,
+  FileKind,
+} from "../src/harness/env/types.js";
+import { FileError } from "../src/harness/errors.js";
+import { loadSkills } from "../src/harness/skills/loader.js";
+
+type MemoryEntry = { kind: "directory" } | { kind: "file"; content: string };
+
+class MemoryExecutionEnv implements ExecutionEnv {
+  cwd: string;
+  private readonly entries = new Map<string, MemoryEntry>();
+
+  constructor(root: string, files: Record<string, string>) {
+    this.cwd = normalizePath(root);
+    this.entries.set(this.cwd, { kind: "directory" });
+    for (const [path, content] of Object.entries(files)) {
+      const normalized = normalizePath(path);
+      this.addParentDirs(normalized);
+      this.entries.set(normalized, { kind: "file", content });
+    }
+  }
+
+  async absolutePath(path: string) {
+    return { ok: true as const, value: normalizePath(path) };
+  }
+
+  async joinPath(parts: string[]) {
+    const separator = parts.some((part) => part.includes("\\")) ? "\\" : "/";
+    return { ok: true as const, value: normalizePath(parts.join(separator)) };
+  }
+
+  async readTextFile(path: string) {
+    const normalized = normalizePath(path);
+    const entry = this.entries.get(normalized);
+    if (!entry) return notFound(normalized);
+    if (entry.kind !== "file") {
+      return {
+        ok: false as const,
+        error: new FileError("is_directory", "Path is a directory", normalized),
+      };
+    }
+    return { ok: true as const, value: entry.content };
+  }
+
+  async readTextLines(path: string) {
+    const content = await this.readTextFile(path);
+    if (!content.ok) return content;
+    return { ok: true as const, value: content.value.split(/\r?\n/) };
+  }
+
+  async readBinaryFile(path: string) {
+    const content = await this.readTextFile(path);
+    if (!content.ok) return content;
+    return {
+      ok: true as const,
+      value: new TextEncoder().encode(content.value),
+    };
+  }
+
+  async writeFile() {
+    return unsupported();
+  }
+
+  async appendFile() {
+    return unsupported();
+  }
+
+  async fileInfo(path: string) {
+    const normalized = normalizePath(path);
+    const entry = this.entries.get(normalized);
+    if (!entry) return notFound(normalized);
+    return { ok: true as const, value: fileInfo(normalized, entry.kind) };
+  }
+
+  async listDir(path: string) {
+    const normalized = normalizePath(path);
+    const entry = this.entries.get(normalized);
+    if (!entry) return notFound(normalized);
+    if (entry.kind !== "directory") {
+      return {
+        ok: false as const,
+        error: new FileError(
+          "not_directory",
+          "Path is not a directory",
+          normalized,
+        ),
+      };
+    }
+    const children = [...this.entries]
+      .filter(([childPath]) => parentPath(childPath) === normalized)
+      .map(([childPath, childEntry]) => fileInfo(childPath, childEntry.kind));
+    return { ok: true as const, value: children };
+  }
+
+  async canonicalPath(path: string) {
+    const normalized = normalizePath(path);
+    return this.entries.has(normalized)
+      ? { ok: true as const, value: normalized }
+      : notFound(normalized);
+  }
+
+  async exists(path: string) {
+    return { ok: true as const, value: this.entries.has(normalizePath(path)) };
+  }
+
+  async createDir() {
+    return unsupported();
+  }
+
+  async remove() {
+    return unsupported();
+  }
+
+  async createTempDir() {
+    return unsupported();
+  }
+
+  async createTempFile() {
+    return unsupported();
+  }
+
+  async exec() {
+    return {
+      ok: true as const,
+      value: { stdout: "", stderr: "", exitCode: 0 },
+    };
+  }
+
+  async cleanup() {}
+
+  private addParentDirs(path: string): void {
+    let current = parentPath(path);
+    while (current && !this.entries.has(current)) {
+      this.entries.set(current, { kind: "directory" });
+      const parent = parentPath(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+}
+
+function normalizePath(path: string): string {
+  if (/^[A-Za-z]:[\\/]+$/.test(path)) return path.slice(0, 3);
+  return path.replace(/[\\/]+$/, "") || path;
+}
+
+function parentPath(path: string): string {
+  const normalized = normalizePath(path);
+  const slashIndex = Math.max(
+    normalized.lastIndexOf("/"),
+    normalized.lastIndexOf("\\"),
+  );
+  if (slashIndex === -1) return "";
+  if (slashIndex === 0) return normalized.slice(0, 1);
+  if (slashIndex === 2 && /^[A-Za-z]:[\\/]/.test(normalized)) {
+    return normalized.slice(0, 3);
+  }
+  return normalized.slice(0, slashIndex);
+}
+
+function basename(path: string): string {
+  const normalized = normalizePath(path);
+  const slashIndex = Math.max(
+    normalized.lastIndexOf("/"),
+    normalized.lastIndexOf("\\"),
+  );
+  return slashIndex === -1 ? normalized : normalized.slice(slashIndex + 1);
+}
+
+function fileInfo(path: string, kind: FileKind): FileInfo {
+  return { name: basename(path), path, kind, size: 0, mtimeMs: 0 };
+}
+
+function notFound(path: string) {
+  return {
+    ok: false as const,
+    error: new FileError("not_found", "Path not found", path),
+  };
+}
+
+function unsupported() {
+  return {
+    ok: false as const,
+    error: new FileError("not_supported", "Not supported by test env"),
+  };
+}
+
+function skillContent(
+  description = "Useful test skill for cross platform loading.",
+): string {
+  return `---\ndescription: ${description}\n---\n\nFollow the instructions.`;
+}
+
+describe("skill loader Windows paths", () => {
+  it("loads a nested skill under a Windows absolute root", async () => {
+    const root = String.raw`C:\Users\alice\.pi\agent\skills`;
+    const env = new MemoryExecutionEnv(root, {
+      [`${root}\\category\\agent-browser\\SKILL.md`]: skillContent(),
+    });
+
+    const result = await loadSkills(env, root);
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.deepEqual(
+      result.skills.map((skill) => skill.name),
+      ["agent-browser"],
+    );
+  });
+
+  it("honors root ignore files with Windows paths", async () => {
+    const root = String.raw`C:\Users\alice\.pi\agent\skills`;
+    const env = new MemoryExecutionEnv(root, {
+      [`${root}\\.gitignore`]: "agent-browser/\n",
+      [`${root}\\agent-browser\\SKILL.md`]: skillContent(),
+    });
+
+    const result = await loadSkills(env, root);
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.deepEqual(result.skills, []);
+  });
+
+  it("prefixes nested ignore files with POSIX-style relative paths for Windows paths", async () => {
+    const root = String.raw`C:\Users\alice\.pi\agent\skills`;
+    const env = new MemoryExecutionEnv(root, {
+      [`${root}\\category\\.gitignore`]: "ignored/\n",
+      [`${root}\\category\\ignored\\SKILL.md`]: skillContent(),
+      [`${root}\\category\\kept\\SKILL.md`]: skillContent(),
+    });
+
+    const result = await loadSkills(env, root);
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.deepEqual(
+      result.skills.map((skill) => skill.name),
+      ["kept"],
+    );
+  });
+});

--- a/packages/orchestrator/src/routes/filesystem-routes.ts
+++ b/packages/orchestrator/src/routes/filesystem-routes.ts
@@ -7,7 +7,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import {
   basename,
   dirname,
@@ -142,7 +142,7 @@ async function saveClipboardImage(input: unknown) {
 }
 
 async function directoryListing(path: string | undefined, showHidden = false) {
-  const target = resolve(path?.trim() || process.env.HOME || tmpdir());
+  const target = resolve(path?.trim() || homedir() || tmpdir());
   const info = await stat(target);
   if (!info.isDirectory()) {
     throw new Error(`${target} is not a directory.`);

--- a/packages/tools/src/execution/path.ts
+++ b/packages/tools/src/execution/path.ts
@@ -8,7 +8,9 @@ export function expandToolPathInput(input: string): string {
   let path = input.trim().replace(UNICODE_SPACES, " ").normalize("NFC");
   if (path.startsWith("@")) path = path.slice(1);
   if (path === "~") return homedir();
-  if (path.startsWith("~/")) return resolve(homedir(), path.slice(2));
+  if (path.startsWith("~/") || path.startsWith("~\\")) {
+    return resolve(homedir(), path.slice(2));
+  }
   return path;
 }
 

--- a/packages/web/src/lib/components/app/UtilityPanel.svelte
+++ b/packages/web/src/lib/components/app/UtilityPanel.svelte
@@ -75,9 +75,14 @@
     onPruneProcesses,
   }: Props = $props();
 
+  const ACTIVE_PROCESS_STATUSES = new Set(["starting", "running", "ready", "stopping"]);
+  const runningProcessCount = $derived(
+    processes.filter((process) => ACTIVE_PROCESS_STATUSES.has(process.status)).length,
+  );
+
   const tabs = $derived<TabItem[]>([
     { value: "git", label: "Git", icon: GitBranch },
-    { value: "processes", label: "Processes", icon: Terminal, count: processes.length },
+    { value: "processes", label: "Processes", icon: Terminal, count: runningProcessCount },
     { value: "history", label: "History", icon: History },
     { value: "info", label: "Context", icon: Info },
   ]);

--- a/packages/web/src/lib/tool-views/lang.ts
+++ b/packages/web/src/lib/tool-views/lang.ts
@@ -23,7 +23,7 @@ const extensionLanguage: Record<string, string> = {
 /** Map a file path to a highlight language understood by `highlightCode`. */
 export function extname(path: string | undefined): string | undefined {
   if (!path) return undefined;
-  const base = path.split("/").pop() ?? path;
+  const base = path.split(/[\\/]/).pop() ?? path;
   const dot = base.lastIndexOf(".");
   if (dot <= 0) return undefined;
   const ext = base.slice(dot + 1).toLowerCase();

--- a/packages/web/src/lib/tool-views/tool-presentation.ts
+++ b/packages/web/src/lib/tool-views/tool-presentation.ts
@@ -32,7 +32,7 @@ export type ToolPresentation = {
 };
 
 function basename(path: string): string {
-  return path.split("/").pop() || path;
+  return path.split(/[\\/]/).pop() || path;
 }
 
 function formatBytes(bytes: number | undefined): string | undefined {

--- a/packages/web/src/lib/utils/path.ts
+++ b/packages/web/src/lib/utils/path.ts
@@ -10,13 +10,13 @@
 export function shortenPath(dir?: string, home?: string): string {
   if (!dir) return "";
 
-  let rest = dir.replace(/\/+$/, "");
+  let rest = normalizeDisplayPath(dir);
   let prefix = "";
 
-  const normalizedHome = home?.replace(/\/+$/, "");
+  const normalizedHome = home ? normalizeDisplayPath(home) : undefined;
   if (
     normalizedHome &&
-    (rest === normalizedHome || rest.startsWith(`${normalizedHome}/`))
+    (pathsEqual(rest, normalizedHome) || pathStartsWith(rest, normalizedHome))
   ) {
     rest = rest.slice(normalizedHome.length);
     prefix = "~";
@@ -37,8 +37,23 @@ export function shortenPath(dir?: string, home?: string): string {
   return [...head, leaf].join("/");
 }
 
-function stripTrailingSlashes(path: string): string {
-  return path.replace(/\/+$/, "") || path;
+function normalizeDisplayPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "") || path;
+}
+
+function comparablePath(path: string): string {
+  const normalized = normalizeDisplayPath(path);
+  return /^[A-Za-z]:\//.test(normalized)
+    ? normalized.toLowerCase()
+    : normalized;
+}
+
+function pathsEqual(left: string, right: string): boolean {
+  return comparablePath(left) === comparablePath(right);
+}
+
+function pathStartsWith(candidate: string, root: string): boolean {
+  return comparablePath(candidate).startsWith(`${comparablePath(root)}/`);
 }
 
 /**
@@ -47,11 +62,11 @@ function stripTrailingSlashes(path: string): string {
  */
 export function isPathInDirectory(candidate?: string, root?: string): boolean {
   if (!candidate || !root) return false;
-  const normalizedCandidate = stripTrailingSlashes(candidate);
-  const normalizedRoot = stripTrailingSlashes(root);
+  const normalizedCandidate = normalizeDisplayPath(candidate);
+  const normalizedRoot = normalizeDisplayPath(root);
   return (
-    normalizedCandidate === normalizedRoot ||
-    normalizedCandidate.startsWith(`${normalizedRoot}/`)
+    pathsEqual(normalizedCandidate, normalizedRoot) ||
+    pathStartsWith(normalizedCandidate, normalizedRoot)
   );
 }
 
@@ -64,11 +79,11 @@ export function isPathInDirectory(candidate?: string, root?: string): boolean {
 export function tildePath(dir?: string, home?: string): string {
   if (!dir) return "";
 
-  const rest = dir.replace(/\/+$/, "");
-  const normalizedHome = home?.replace(/\/+$/, "");
+  const rest = normalizeDisplayPath(dir);
+  const normalizedHome = home ? normalizeDisplayPath(home) : undefined;
 
-  if (normalizedHome && rest === normalizedHome) return "~";
-  if (normalizedHome && rest.startsWith(`${normalizedHome}/`)) {
+  if (normalizedHome && pathsEqual(rest, normalizedHome)) return "~";
+  if (normalizedHome && pathStartsWith(rest, normalizedHome)) {
     return `~${rest.slice(normalizedHome.length)}`;
   }
   return rest || dir || "/";

--- a/packages/web/src/lib/utils/project-tree.ts
+++ b/packages/web/src/lib/utils/project-tree.ts
@@ -38,9 +38,20 @@ export function projectFolderName(dir: string): string {
 }
 
 export function shortProjectLabel(dir: string, homeDir?: string): string {
-  let path = dir.replace(/[\\/]+$/, "");
-  if (homeDir && (path === homeDir || path.startsWith(`${homeDir}/`))) {
-    path = `~${path.slice(homeDir.length)}`;
+  let path = dir.replace(/\\/g, "/").replace(/\/+$/, "");
+  const homePath = homeDir?.replace(/\\/g, "/").replace(/\/+$/, "");
+  const comparablePath = /^[A-Za-z]:\//.test(path) ? path.toLowerCase() : path;
+  const comparableHome =
+    homePath && /^[A-Za-z]:\//.test(homePath)
+      ? homePath.toLowerCase()
+      : homePath;
+  if (
+    homePath &&
+    comparableHome &&
+    (comparablePath === comparableHome ||
+      comparablePath.startsWith(`${comparableHome}/`))
+  ) {
+    path = `~${path.slice(homePath.length)}`;
   }
   const segments = path.split("/");
   return segments


### PR DESCRIPTION
## Summary
- Normalize skill loader path handling so ignore matching receives relative POSIX-style paths on Windows
- Use shared cross-platform env path helpers for skill and prompt formatting
- Fix additional Windows path display/default-home edge cases in tools, web, and filesystem routes
- Add regression tests for Windows skill loading and ignore files

Fixes #3

## Validation
- pnpm check
- pnpm lint
- pnpm --filter @nerve/agent test
- pnpm --filter @nerve/tools test
- pnpm --filter @nerve/web test
- pnpm --filter @nerve/orchestrator test