### PR TITLE
Improve tasks panel create and restart flows

### DIFF
--- a/packages/orchestrator/src/domains/tasks/task-manager-restart.ts
+++ b/packages/orchestrator/src/domains/tasks/task-manager-restart.ts
@@ -1,0 +1,108 @@
+import type { TaskRecord } from "@nervekit/shared";
+import type { TaskManager } from "./task-manager.js";
+import { spawnManagedTaskRun } from "./task-manager-start.js";
+
+export async function restartActiveTaskInPlace(
+  this: TaskManager,
+  record: TaskRecord,
+  env: Record<string, string> | undefined,
+): Promise<TaskRecord> {
+  const managed = this.managed.get(record.id);
+  if (!managed?.child) return record;
+
+  managed.stopping = true;
+  managed.finalized = true;
+  this.clearReadinessWatch(managed);
+  if (managed.runtimeTimer) clearTimeout(managed.runtimeTimer);
+  await this.flushTaskOutputBuffers(record.id);
+
+  const signal: NodeJS.Signals = "SIGTERM";
+  const stopping = await this.updateTask(record.id, { status: "stopping" });
+  await this.events.publish("task.stop_requested", {
+    taskId: record.id,
+    signal,
+    reason: "restart requested",
+  });
+  await this.logger?.info("Task restart stop requested", {
+    taskId: record.id,
+    projectId: record.projectId,
+    conversationId: record.conversationId,
+    agentId: record.agentId,
+    context: { signal, restart: true },
+  });
+
+  void this.requestTermination(
+    stopping,
+    managed.child,
+    signal,
+    "restart requested",
+  );
+
+  const timeoutMs = 5000;
+  const timeoutResult = Symbol("task-restart-stop-timeout");
+  let timeout: NodeJS.Timeout | undefined;
+  const closed = await Promise.race<
+    | { exitCode: number | null; signal: NodeJS.Signals | null }
+    | typeof timeoutResult
+  >([
+    managed.closePromise ?? Promise.resolve(timeoutResult),
+    new Promise<typeof timeoutResult>((resolveTimeout) => {
+      timeout = setTimeout(() => resolveTimeout(timeoutResult), timeoutMs);
+    }),
+  ]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+
+  if (closed === timeoutResult) {
+    void this.requestTermination(
+      this.tasks.get(record.id) ?? stopping,
+      managed.child,
+      "SIGKILL",
+      `restart stop timed out after ${timeoutMs}ms`,
+    );
+  }
+
+  this.resolveManagedTerminal(record.id, undefined);
+  if (this.managed.get(record.id) === managed) {
+    this.managed.delete(record.id);
+  }
+
+  const previous = this.tasks.get(record.id) ?? record;
+  const now = new Date().toISOString();
+  const reset: TaskRecord = {
+    ...previous,
+    status: "starting",
+    readiness: this.taskReadiness.buildReadiness({
+      cwd: previous.cwd,
+      command: previous.command,
+      readyUrl: previous.readiness.readyUrl,
+      readyOnUrl: previous.readiness.readyOnUrl,
+      readyPattern: previous.readiness.readyPattern,
+      readyTimeoutMs: previous.readiness.timeoutMs,
+    }),
+    startedAt: now,
+    updatedAt: now,
+    finishedAt: undefined,
+    exitCode: undefined,
+    signal: undefined,
+    error: undefined,
+    runtime: undefined,
+    restartedFromTaskId: previous.restartedFromTaskId,
+    restartRootTaskId: previous.restartRootTaskId ?? previous.id,
+    restartGeneration: (previous.restartGeneration ?? 0) + 1,
+    completion: previous.completion
+      ? { ...previous.completion, entryId: undefined, injectedAt: undefined }
+      : undefined,
+    notifications: previous.notifications
+      ? {
+          ...previous.notifications,
+          readyEntryId: undefined,
+          terminalEntryId: undefined,
+          readyDeliveredAt: undefined,
+          terminalDeliveredAt: undefined,
+        }
+      : undefined,
+  };
+  await this.upsertTask(reset);
+  return await spawnManagedTaskRun.call(this, reset, { env });
+}

--- a/packages/orchestrator/src/domains/tasks/task-manager-start.ts
+++ b/packages/orchestrator/src/domains/tasks/task-manager-start.ts
@@ -20,6 +20,11 @@ import {
 } from "./task-port-inspector.js";
 import { isActiveTaskStatus } from "./task-status.js";
 
+export type SpawnManagedTaskRunOptions = {
+  env?: Record<string, string>;
+  onOutput?: (update: ToolExecutionOutputUpdate) => void;
+};
+
 export async function startTask(
   this: TaskManager,
   request: StartTaskRequest & {
@@ -105,10 +110,6 @@ export async function startTask(
     visibility: request.visibility ?? "background",
   };
 
-  const readinessPattern = this.taskReadiness.compilePattern(
-    request.readyPattern,
-  );
-
   await this.upsertTask(record);
   await this.events.publish("task.created", { task: record });
   await this.logger?.info("Task created", {
@@ -124,9 +125,23 @@ export async function startTask(
     },
   });
 
-  const spawned = this.supervisor.spawn(request.command, {
-    cwd: record.cwd,
+  return await spawnManagedTaskRun.call(this, record, {
     env: request.env,
+    onOutput: request.onOutput,
+  });
+}
+
+export async function spawnManagedTaskRun(
+  this: TaskManager,
+  record: TaskRecord,
+  options: SpawnManagedTaskRunOptions = {},
+): Promise<TaskRecord> {
+  const readinessPattern = this.taskReadiness.compilePattern(
+    record.readiness.readyPattern,
+  );
+  const spawned = this.supervisor.spawn(record.command, {
+    cwd: record.cwd,
+    env: options.env,
     shellPath: this.storage.settings.runtime.shellPath,
   });
   const { child, runtime } = spawned;
@@ -153,12 +168,13 @@ export async function startTask(
     terminalPromise,
     resolveTerminal,
     readinessPattern,
-    onOutput: request.onOutput,
+    onOutput: options.onOutput,
   };
   managed.finalizationPromise = closePromise
-    .then(({ exitCode, signal }) =>
-      this.markTaskExited(record.id, exitCode, signal),
-    )
+    .then(({ exitCode, signal }) => {
+      if (this.managed.get(record.id) !== managed) return undefined;
+      return this.markTaskExited(record.id, exitCode, signal);
+    })
     .catch(async (error: unknown) => {
       if (this.logger) {
         await this.logger
@@ -176,19 +192,22 @@ export async function startTask(
   this.managed.set(record.id, managed);
 
   child.stdout?.on("data", (chunk) => {
+    if (this.managed.get(record.id) !== managed) return;
     void this.captureOutput(record.id, "stdout", chunk);
   });
   child.stderr?.on("data", (chunk) => {
+    if (this.managed.get(record.id) !== managed) return;
     void this.captureOutput(record.id, "stderr", chunk);
   });
   child.on("error", (error) => {
+    if (this.managed.get(record.id) !== managed) return;
     void this.markTaskError(record.id, error.message);
   });
 
   await this.updateTask(record.id, { status: "running" });
   this.scheduleReadyUrlPolling(record.id);
   this.scheduleReadinessTimeout(record.id);
-  this.scheduleRuntimeTimeout(record.id, request.timeoutMs);
+  this.scheduleRuntimeTimeout(record.id, record.timeoutMs);
   await this.events.publish("task.started", {
     task: this.getTask(record.id),
     pid: runtime.childPid,

--- a/packages/orchestrator/src/domains/tasks/task-manager.ts
+++ b/packages/orchestrator/src/domains/tasks/task-manager.ts
@@ -76,6 +76,7 @@ import {
   scheduleReadyUrlPolling as scheduleReadyUrlPollingImpl,
   scheduleRuntimeTimeout as scheduleRuntimeTimeoutImpl,
 } from "./task-manager-output-readiness.js";
+import { restartActiveTaskInPlace as restartActiveTaskInPlaceImpl } from "./task-manager-restart.js";
 import { startTask as startTaskImpl } from "./task-manager-start.js";
 
 export interface TaskManagerOptions {
@@ -330,10 +331,14 @@ export class TaskManager {
   async restartTask(taskId: string): Promise<TaskRecord> {
     const record = this.getTask(taskId);
     const env = await this.envForRestart(record);
+    if (
+      isActiveTaskStatus(record.status) &&
+      this.managed.get(record.id)?.child
+    ) {
+      return await this.restartActiveTaskInPlace(record, env);
+    }
     if (record.status === "orphaned") {
       await this.cleanupOrphanedTask(record.id, { timeoutMs: 5000 });
-    } else if (isActiveTaskStatus(record.status)) {
-      await this.cancelTask(taskId);
     }
     return this.startTask({
       name: record.name,
@@ -360,6 +365,13 @@ export class TaskManager {
       visibility: record.visibility,
       restartedFromTaskId: record.id,
     });
+  }
+
+  async restartActiveTaskInPlace(
+    record: TaskRecord,
+    env: Record<string, string> | undefined,
+  ): Promise<TaskRecord> {
+    return await restartActiveTaskInPlaceImpl.call(this, record, env);
   }
 
   async removeTask(taskId: string): Promise<void> {

--- a/packages/orchestrator/test/helpers/task-manager.ts
+++ b/packages/orchestrator/test/helpers/task-manager.ts
@@ -141,8 +141,8 @@ export function runtimeMetadata(
 }
 
 export type FakeSupervisorOptions = {
-  child?: FakeChild;
-  runtime?: TaskRuntime;
+  child?: FakeChild | FakeChild[];
+  runtime?: TaskRuntime | TaskRuntime[];
   onSpawn?: (command: string, options: SpawnManagedTaskOptions) => void;
   onTerminate?: (signal: NodeJS.Signals) => void | Promise<void>;
   onTerminateRuntime?: (
@@ -168,8 +168,13 @@ export function fakeSupervisor(options: FakeSupervisorOptions): {
   spawnCommands: string[];
   spawnCalls: Array<{ command: string; options: SpawnManagedTaskOptions }>;
 } {
-  const child = options.child ?? fakeChild();
-  const runtime = options.runtime ?? runtimeMetadata({ childPid: child.pid });
+  const children = Array.isArray(options.child)
+    ? options.child
+    : [options.child ?? fakeChild()];
+  const runtimes = Array.isArray(options.runtime)
+    ? options.runtime
+    : [options.runtime];
+  let spawnIndex = 0;
   const terminateSignals: NodeJS.Signals[] = [];
   const runtimeTerminateSignals: NodeJS.Signals[] = [];
   const spawnCommands: string[] = [];
@@ -184,13 +189,20 @@ export function fakeSupervisor(options: FakeSupervisorOptions): {
     spawnCalls,
     supervisor: {
       spawn(command, spawnOptions) {
+        const index = Math.min(spawnIndex, children.length - 1);
+        spawnIndex += 1;
+        const child = children[index] ?? children[0] ?? fakeChild();
+        const runtime =
+          runtimes[index] ??
+          runtimes[0] ??
+          runtimeMetadata({ childPid: child.pid });
         spawnCommands.push(command);
         spawnCalls.push({ command, options: spawnOptions });
         options.onSpawn?.(command, spawnOptions);
         return { child, runtime };
       },
       async terminate(terminatedChild, signal) {
-        assert.equal(terminatedChild, child);
+        assert.ok(children.includes(terminatedChild as FakeChild));
         terminateSignals.push(signal);
         await options.onTerminate?.(signal);
         return { attempted: true, method: "direct-child" };

--- a/packages/orchestrator/test/task-manager-launch-env.test.ts
+++ b/packages/orchestrator/test/task-manager-launch-env.test.ts
@@ -40,6 +40,46 @@ describe("task manager launch env", () => {
     );
   });
 
+  it("restarts an active supervised task in place with stored env", async () => {
+    const env = { PORT: "4321", API_TOKEN: "secret" };
+    const firstChild = fakeChild(1234);
+    const secondChild = fakeChild(5678);
+    const replacementRuntime = runtimeMetadata({
+      childPid: 5678,
+      processGroupId: 5678,
+      spawnedAt: "2026-01-02T03:05:05.000Z",
+    });
+    const { supervisor, spawnCalls, terminateSignals } = fakeSupervisor({
+      child: [firstChild, secondChild],
+      runtime: [runtimeMetadata({ childPid: 1234 }), replacementRuntime],
+      onTerminate(signal) {
+        if (signal === "SIGTERM") firstChild.emitClose(0, signal);
+      },
+    });
+    const { manager, storage, events } = await createManager(supervisor);
+    const task = await startFakeTask(manager, storage, env, {
+      name: "web-dev",
+    });
+
+    const restarted = await manager.restartTask(task.id);
+
+    assert.equal(restarted.id, task.id);
+    assert.equal(restarted.name, "web-dev");
+    assert.equal(restarted.status, "running");
+    assert.equal(restarted.restartRootTaskId, task.id);
+    assert.equal(restarted.restartGeneration, 1);
+    assert.deepEqual(restarted.runtime, replacementRuntime);
+    assert.equal(spawnCalls.length, 2);
+    assert.deepEqual(spawnCalls[1]?.options.env, env);
+    assert.deepEqual(terminateSignals, ["SIGTERM"]);
+    assert.equal(manager.listTasks().length, 1);
+    assert.equal(manager.listTasks()[0]?.id, task.id);
+    assert.equal(
+      events.replaySince(0).some((event) => event.type === "task.cancelled"),
+      false,
+    );
+  });
+
   it("passes stored env to replacement spawn on restart", async () => {
     const env = { PORT: "4321", API_TOKEN: "secret" };
     const child = fakeChild();

--- a/packages/orchestrator/test/task-manager-lifecycle.test.ts
+++ b/packages/orchestrator/test/task-manager-lifecycle.test.ts
@@ -81,6 +81,41 @@ describe("task manager cancel lifecycle", () => {
   });
 });
 
+describe("task manager active restart lifecycle", () => {
+  it("ignores a late close from the old run after an in-place restart", async () => {
+    const firstChild = fakeChild(1234);
+    const secondChild = fakeChild(5678);
+    const replacementRuntime = runtimeMetadata({
+      childPid: 5678,
+      processGroupId: 5678,
+      spawnedAt: "2026-01-02T03:05:05.000Z",
+    });
+    const { supervisor } = fakeSupervisor({
+      child: [firstChild, secondChild],
+      runtime: [runtimeMetadata({ childPid: 1234 }), replacementRuntime],
+    });
+    const { manager, storage } = await createManager(supervisor);
+    const task = await startFakeTask(manager, storage);
+    const oldManaged = manager.managed.get(task.id);
+    assert.ok(oldManaged);
+    oldManaged.closePromise = Promise.resolve({
+      exitCode: 0,
+      signal: "SIGTERM",
+    });
+
+    const restarted = await manager.restartTask(task.id);
+    firstChild.emitClose(1, null);
+    await delay(0);
+
+    const current = manager.getTask(task.id);
+    assert.equal(restarted.id, task.id);
+    assert.equal(current.status, "running");
+    assert.deepEqual(current.runtime, replacementRuntime);
+    assert.equal(current.exitCode, undefined);
+    assert.equal(current.signal, undefined);
+  });
+});
+
 describe("task manager runtime metadata", () => {
   it("persists runtime metadata when starting a task", async () => {
     const runtime = runtimeMetadata({ childPid: 4321, processGroupId: 4321 });

--- a/packages/web/src/lib/features/tasks/components/PinnedCommandDialog.svelte
+++ b/packages/web/src/lib/features/tasks/components/PinnedCommandDialog.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import type { PinnedCommand, UpdatePinnedCommandRequest } from "$lib/api";
+  import type {
+    CreatePinnedCommandRequest,
+    PinnedCommand,
+    UpdatePinnedCommandRequest,
+  } from "$lib/api";
   import { Button } from "$lib/components/ui/button";
   import Dialog from "$lib/components/ui/dialog-shell";
   import { Input } from "$lib/components/ui/input";
@@ -11,7 +15,7 @@
     command?: PinnedCommand;
     projectCwd?: string;
     saving?: boolean;
-    onSave?: (input: UpdatePinnedCommandRequest) => void;
+    onSave?: (input: CreatePinnedCommandRequest | UpdatePinnedCommandRequest) => void;
     onOpenChange?: (open: boolean) => void;
   };
 
@@ -28,14 +32,20 @@
   let commandText = $state("");
   let cwd = $state("");
 
-  const title = $derived(command ? "Edit pinned task" : "Pinned task");
+  const title = $derived(command ? "Edit pinned task" : "Pin a command");
+  const description = $derived(
+    command
+      ? "Update the label, command, and optional working directory for this pinned task."
+      : "Create a reusable task shortcut for this project.",
+  );
+  const submitLabel = $derived(command ? "Save pinned task" : "Pin task");
   const canSave = $derived(!saving && commandText.trim().length > 0);
 
   $effect(() => {
-    if (!open || !command) return;
-    label = command.label ?? "";
-    commandText = command.command;
-    cwd = command.cwd ?? "";
+    if (!open) return;
+    label = command?.label ?? "";
+    commandText = command?.command ?? "";
+    cwd = command?.cwd ?? "";
   });
 
   function submit() {
@@ -50,7 +60,7 @@
   }
 </script>
 
-<Dialog bind:open {title} description="Update the label, command, and optional working directory for this pinned task." class="max-w-xl" {onOpenChange}>
+<Dialog bind:open {title} {description} class="max-w-xl" {onOpenChange}>
   <div class="grid gap-4 p-4">
     <div class="grid gap-1.5">
       <Label for="pinned-command-label">Label</Label>
@@ -85,6 +95,6 @@
 
   {#snippet footer()}
     <Button variant="ghost" onclick={() => (open = false)} disabled={saving}>Cancel</Button>
-    <Button onclick={submit} disabled={!canSave}>{saving ? "Saving…" : "Save pinned task"}</Button>
+    <Button onclick={submit} disabled={!canSave}>{saving ? "Saving…" : submitLabel}</Button>
   {/snippet}
 </Dialog>

--- a/packages/web/src/lib/features/tasks/components/TaskListItem.svelte
+++ b/packages/web/src/lib/features/tasks/components/TaskListItem.svelte
@@ -39,6 +39,8 @@
 
   const ACTIVE = new Set(["starting", "running", "ready", "stopping"]);
   const isActive = $derived(ACTIVE.has(task.status));
+  const taskLabel = $derived(task.name ?? task.command);
+  const showingTaskName = $derived(Boolean(task.name));
   const envCount = $derived(task.envInfo?.keys.length ?? 0);
   const envSummary = $derived(envCount === 0 ? undefined : `${envCount} redacted ${envCount === 1 ? "var" : "vars"}`);
   const envKeys = $derived(task.envInfo?.keys.join(", "));
@@ -103,7 +105,7 @@
             }}
           >
             <StatusDot tone={taskTone(task.status)} pulse={taskPulse(task.status)} />
-            <div class="min-w-0 flex-1 truncate font-mono text-xs text-foreground">{task.command}</div>
+            <div class={showingTaskName ? "min-w-0 flex-1 truncate text-xs font-medium text-foreground" : "min-w-0 flex-1 truncate font-mono text-xs text-foreground"}>{taskLabel}</div>
             {#if envCount > 0}<Badge tone="neutral" size="xs" title={envKeys}>env</Badge>{/if}
             <Badge tone={taskTone(task.status)} size="xs" class={taskTone(task.status) === "neutral" ? "border-border bg-muted text-muted-foreground" : ""}>{task.status}</Badge>
           </button>

--- a/packages/web/src/lib/features/tasks/components/TaskUtilityPanel.svelte
+++ b/packages/web/src/lib/features/tasks/components/TaskUtilityPanel.svelte
@@ -10,6 +10,7 @@
     deletePinnedCommand,
     getPinnedCommands,
     updatePinnedCommand,
+    type CreatePinnedCommandRequest,
     type PinnedCommand,
     type UpdatePinnedCommandRequest,
     type TaskRecord,
@@ -17,8 +18,7 @@
   } from "$lib/api";
   import { Button } from "$lib/components/ui/button";
   import ConfirmDialog from "$lib/components/ui/confirm-dialog";
-  import { Input } from "$lib/components/ui/input";
-  import * as Popover from "$lib/components/ui/popover";
+
   import * as Tooltip from "$lib/components/ui/tooltip";
   import PanelSection from "$lib/app/layout/utility/PanelSection.svelte";
   import { writeClipboardText } from "$lib/core/clipboard";
@@ -76,10 +76,8 @@
 
   let pinned = $state<PinnedCommand[]>([]);
   let loadingPinned = $state(false);
-  let addPopoverOpen = $state(false);
+  let addPinOpen = $state(false);
   let savingPin = $state(false);
-  let newPinCommand = $state("");
-  let newPinLabel = $state("");
   let runningPinId = $state<string | undefined>(undefined);
   let pinToDelete = $state<PinnedCommand | undefined>(undefined);
   let pinToEdit = $state<PinnedCommand | undefined>(undefined);
@@ -140,21 +138,15 @@
     }
   }
 
-  async function createPin() {
+  async function createPin(input: CreatePinnedCommandRequest) {
     if (!activeProject) return;
-    const command = newPinCommand.trim();
-    if (command.length === 0) return;
-    const label = newPinLabel.trim();
     savingPin = true;
     try {
-      const created = await createPinnedCommand(activeProject.id, {
-        command,
-        label: label.length > 0 ? label : undefined,
-      });
+      const created = await createPinnedCommand(activeProject.id, input);
       pinned = [...pinned, created];
-      newPinCommand = "";
-      newPinLabel = "";
-      addPopoverOpen = false;
+      addPinOpen = false;
+      pinnedSectionOpen = true;
+      notify.success("Command pinned");
     } catch (error) {
       notify.error(`Could not pin command: ${errorMessage(error)}`);
     } finally {
@@ -220,24 +212,9 @@
       <PanelSection title="Pinned" icon={Pin} bind:open={pinnedSectionOpen}>
         {#snippet meta()}<span class="font-mono">{pinned.length}</span>{/snippet}
         {#snippet actions()}
-          <Popover.Root bind:open={addPopoverOpen}>
-            <Popover.Trigger class="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50" title="Pin a command" aria-label="Pin a command">
-              <Plus size={13} strokeWidth={2.3} />
-            </Popover.Trigger>
-            <Popover.Content align="end" collisionPadding={8} class="w-[min(340px,calc(100vw-2rem))] gap-3 p-3">
-              <div class="text-xs font-medium text-foreground">Pin a command</div>
-              <div class="flex flex-col gap-1.5">
-                <Input bind:value={newPinCommand} placeholder="pnpm dev" class="h-8 font-mono text-xs" />
-                <Input bind:value={newPinLabel} placeholder="Label (optional)" class="h-8 text-xs" />
-                <div class="flex justify-end">
-                  <Button size="sm" disabled={savingPin || newPinCommand.trim().length === 0} onclick={() => void createPin()}>
-                    <Pin />
-                    Pin
-                  </Button>
-                </div>
-              </div>
-            </Popover.Content>
-          </Popover.Root>
+          <button class="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50" title="Pin a command" aria-label="Pin a command" type="button" onclick={() => (addPinOpen = true)}>
+            <Plus size={13} strokeWidth={2.3} />
+          </button>
         {/snippet}
         <div class="flex flex-col gap-1.5">
           {#if loadingPinned && pinned.length === 0}
@@ -301,6 +278,13 @@
     {/if}
   </div>
 </Tooltip.Provider>
+
+<PinnedCommandDialog
+  bind:open={addPinOpen}
+  projectCwd={activeProject?.dir}
+  saving={savingPin}
+  onSave={(input) => void createPin(input)}
+/>
 
 <PinnedCommandDialog
   bind:open={editPinOpen}

--- a/packages/web/src/lib/features/tasks/state/tasks.svelte.ts
+++ b/packages/web/src/lib/features/tasks/state/tasks.svelte.ts
@@ -35,15 +35,17 @@ export async function cancelSelectedTask(taskId: string) {
 
 export async function restartSelectedTask(taskId: string) {
   const restarted = await restartTask(taskId);
-  replaceCenterTab(
-    { kind: "task", id: taskId },
-    { kind: "task", id: restarted.id },
-  );
+  if (restarted.id !== taskId) {
+    replaceCenterTab(
+      { kind: "task", id: taskId },
+      { kind: "task", id: restarted.id },
+    );
+  }
   taskState.selectedTaskId = restarted.id;
   await loadWorkspaceState();
   taskState.taskLogs = await getTaskLogs(restarted.id);
   notify.success("Task restarted", {
-    description: restarted.name ?? restarted.id,
+    description: restarted.name ?? restarted.command ?? restarted.id,
   });
 }
 
@@ -88,7 +90,9 @@ export async function runTaskCommand(input: {
   const task = await startTask(input);
   await loadWorkspaceState();
   await selectTask(task.id);
-  notify.success("Command started", { description: input.command });
+  notify.success("Command started", {
+    description: input.name ?? input.command,
+  });
   return task;
 }
 


### PR DESCRIPTION
## Summary
- replace pinned task creation popover with the shared dialog flow
- show task labels in task rows while keeping command details in tooltips/copy actions
- restart active supervised tasks in place so cancelled originals do not appear in Finished

## Validation
- pnpm --filter @nervekit/orchestrator test -- test/task-manager-launch-env.test.ts test/task-manager-lifecycle.test.ts
- pnpm --filter @nervekit/orchestrator check
- pnpm --filter @nervekit/web check
- pnpm lint
- pnpm check