### PR TITLE
chore: stop publishing internal npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           set -euo pipefail
           # Publish in dependency-friendly order.
-          order=(shared tools agent web orchestrator cli desktop)
+          order=(shared tools agent orchestrator desktop)
           for pkg in "${order[@]}"; do
             tgz="$(ls release/npm/nervekit-${pkg}-*.tgz 2>/dev/null | head -n1 || true)"
             if [ -z "${tgz}" ]; then

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-image:sandbox-manager": "node scripts/build-sandbox-manager-image.mjs",
     "desktop": "pnpm --filter @nervekit/desktop dev --",
     "desktop:remote-enabled": "pnpm desktop -- --host 0.0.0.0 --allow-remote --mobile-https",
-    "release:build": "pnpm --filter @nervekit/shared build && pnpm --filter @nervekit/agent build && pnpm --filter @nervekit/tools build && pnpm --filter @nervekit/shared-ui build && pnpm --filter @nervekit/sandbox-manager-ui build && pnpm --filter @nervekit/sandbox-manager build && node scripts/copy-sandbox-manager-ui-dist-to-manager.mjs && pnpm --filter @nervekit/web build && pnpm --filter @nervekit/orchestrator build && node scripts/copy-web-dist-to-orchestrator.mjs && pnpm --filter @nervekit/cli build && pnpm --filter @nervekit/desktop build",
+    "release:build": "pnpm --filter @nervekit/shared build && pnpm --filter @nervekit/agent build && pnpm --filter @nervekit/tools build && pnpm --filter @nervekit/shared-ui build && pnpm --filter @nervekit/sandbox-manager-ui build && pnpm --filter @nervekit/sandbox-manager build && node scripts/copy-sandbox-manager-ui-dist-to-manager.mjs && pnpm --filter @nervekit/web build && pnpm --filter @nervekit/orchestrator build && node scripts/copy-web-dist-to-orchestrator.mjs && pnpm --filter @nervekit/desktop build",
     "release:verify-tag": "node scripts/verify-release-tag.mjs"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,13 +1,10 @@
 {
   "name": "@nervekit/cli",
   "version": "0.6.0",
+  "private": true,
   "author": "ThilinaTLM",
   "license": "Apache-2.0",
   "type": "module",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ThilinaTLM/nerve.git",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,13 +1,10 @@
 {
   "name": "@nervekit/web",
   "version": "0.6.0",
+  "private": true,
   "author": "ThilinaTLM",
   "license": "Apache-2.0",
   "type": "module",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ThilinaTLM/nerve.git",

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -101,6 +101,7 @@ export default defineConfig(({ mode }) => {
         },
         workbox: {
           globPatterns: ["**/*.{js,css,html,svg,png,webp,woff2,json}"],
+          maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
           cleanupOutdatedCaches: true,
           // Serve the cached app shell for in-app navigations (fast + offline),
           // but never hijack the token->cookie auth redirect, the CA download,

--- a/scripts/pack-npm.mjs
+++ b/scripts/pack-npm.mjs
@@ -10,9 +10,7 @@ const publishPackages = [
   ["@nervekit/shared", join("packages", "shared")],
   ["@nervekit/tools", join("packages", "tools")],
   ["@nervekit/agent", join("packages", "agent")],
-  ["@nervekit/web", join("packages", "web")],
   ["@nervekit/orchestrator", join("packages", "orchestrator")],
-  ["@nervekit/cli", join("packages", "cli")],
   ["@nervekit/desktop", join("packages", "desktop")],
 ];
 


### PR DESCRIPTION
## Summary
- mark the internal Web and CLI packages private
- publish only the Desktop runtime dependency graph
- retain the Web build for orchestrator assets and raise the PWA cache limit for the production bundle

## Validation
- pnpm check
- pnpm test
- pnpm release:build
- node scripts/pack-npm.mjs
- node packages/desktop/dist/bin.js --version