### PR TITLE
chore(deps): update pi-ai to 0.82.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check:boundaries": "node scripts/check-package-boundaries.mjs"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.0"
+    "@earendil-works/pi-ai": "0.82.1"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -37,7 +37,7 @@
     "test": "tsx --test \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.0",
+    "@earendil-works/pi-ai": "0.82.1",
     "@nervekit/contracts": "workspace:*",
     "ignore": "7.0.5",
     "sharp": "^0.34.5",

--- a/packages/sandbox-manager/package.json
+++ b/packages/sandbox-manager/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.1081.0",
     "@aws-sdk/client-ecs": "^3.1081.0",
-    "@earendil-works/pi-ai": "0.82.0",
+    "@earendil-works/pi-ai": "0.82.1",
     "@nervekit/contracts": "workspace:*",
     "@nervekit/protocol": "workspace:*",
     "node-pg-migrate": "8.0.4",

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -33,7 +33,7 @@
     "test": "tsx --test test/*.test.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.0",
+    "@earendil-works/pi-ai": "0.82.1",
     "@hono/node-server": "1.19.14",
     "@nervekit/contracts": "workspace:*",
     "@peculiar/x509": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.0
-        version: 0.82.0(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.82.1
+        version: 0.82.1(ws@8.21.0)(zod@4.1.12)
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -84,8 +84,8 @@ importers:
   packages/harness:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.0
-        version: 0.82.0(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.82.1
+        version: 0.82.1(ws@8.21.0)(zod@4.1.12)
       '@nervekit/contracts':
         specifier: workspace:*
         version: link:../contracts
@@ -190,8 +190,8 @@ importers:
         specifier: ^3.1081.0
         version: 3.1081.0
       '@earendil-works/pi-ai':
-        specifier: 0.82.0
-        version: 0.82.0(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.82.1
+        version: 0.82.1(ws@8.21.0)(zod@4.1.12)
       '@nervekit/contracts':
         specifier: workspace:*
         version: link:../contracts
@@ -474,8 +474,8 @@ importers:
   packages/workbench-server:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.0
-        version: 0.82.0(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.82.1
+        version: 0.82.1(ws@8.21.0)(zod@4.1.12)
       '@hono/node-server':
         specifier: 1.19.14
         version: 1.19.14(hono@4.12.25)
@@ -1225,8 +1225,8 @@ packages:
   '@dagrejs/graphlib@4.0.1':
     resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
-  '@earendil-works/pi-ai@0.82.0':
-    resolution: {integrity: sha512-8MvW9+zno13sXDuT2kFMnWeTNUufUhPeZDRVO+igGoBRCDWgn7Xh2FkRQI1mRuet6QhF4ENQuLYdIAOyG6BhNw==}
+  '@earendil-works/pi-ai@0.82.1':
+    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -6596,7 +6596,7 @@ snapshots:
 
   '@dagrejs/graphlib@4.0.1': {}
 
-  '@earendil-works/pi-ai@0.82.0(ws@8.21.0)(zod@4.1.12)':
+  '@earendil-works/pi-ai@0.82.1(ws@8.21.0)(zod@4.1.12)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.1.12)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,4 @@ allowBuilds:
   protobufjs: true
   sharp: true
 minimumReleaseAgeExclude:
-  - "@earendil-works/pi-ai@0.82.0"
+  - "@earendil-works/pi-ai@0.82.1"


### PR DESCRIPTION
## Summary
- update all `@earendil-works/pi-ai` pins from 0.82.0 to 0.82.1
- update the pnpm release-age exclusion and lockfile

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `pnpm install --frozen-lockfile`