### PR TITLE
Optimize tag release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,35 @@ on:
       # Pre-releases: v1.2.3-rc.1, v1.2.3-beta.2, etc.
       - "v[0-9]+.[0-9]+.[0-9]+-*"
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate release tag and packages
+  verify-tag:
+    name: Verify release tag
     runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Verify release tag
+        run: node scripts/verify-release-tag.mjs "${{ github.ref_name }}"
+
+  quality-and-package:
+    name: Check, test, build, and package (Ubuntu)
+    runs-on: ubuntu-latest
+    needs: verify-tag
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository
@@ -34,26 +56,47 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify release tag
-        run: pnpm release:verify-tag -- "${{ github.ref_name }}"
-
       - name: Check formatting, lint, and packages
         run: pnpm check
 
-      - name: Run tests
+      - name: Run complete test suite
         run: pnpm test
 
       - name: Build all packages
         run: pnpm build
 
-  npm-smoke:
+      - name: Smoke built workbench HTTP and WebSocket parity
+        run: pnpm release:smoke:workbench
+
+      - name: Smoke desktop resolution and CLI
+        run: pnpm release:smoke:desktop
+
+      - name: Package unpacked desktop bundle
+        run: pnpm --filter @nervekit/desktop-shell package:dir
+
+      - name: Smoke packaged desktop identity and assets
+        run: pnpm release:smoke:desktop-package
+
+      - name: Pack and verify npm tarball
+        run: node scripts/pack-npm.mjs
+
+      - name: Upload verified npm tarball
+        uses: actions/upload-artifact@v6
+        with:
+          name: npm-package
+          path: release/npm/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  native-package-smoke:
     name: npm package smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: verify-tag
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+        os: [windows-latest, macos-latest]
 
     steps:
       - name: Check out repository
@@ -85,48 +128,16 @@ jobs:
       - name: Smoke packaged desktop identity and assets
         run: pnpm release:smoke:desktop-package
 
-      - name: Pack npm tarballs
+      - name: Pack and verify npm tarball
         run: node scripts/pack-npm.mjs
 
       - name: Verify built desktop runtime
         run: pnpm release:smoke:desktop
 
-  built-artifact-smoke:
-    name: Built workbench protocol smoke
-    runs-on: ubuntu-latest
-    needs: validate
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build all packages
-        run: pnpm build
-
-      - name: Smoke built workbench HTTP and WebSocket parity
-        run: pnpm release:smoke:workbench
-
-      - name: Smoke desktop resolution and CLI
-        run: pnpm release:smoke:desktop
-
   image-smoke:
     name: Sandbox ${{ matrix.image }} image build and smoke
     runs-on: ubuntu-latest
-    needs: validate
+    needs: verify-tag
     strategy:
       fail-fast: false
       matrix:
@@ -164,29 +175,19 @@ jobs:
     name: Publish to npmjs.com
     runs-on: ubuntu-latest
     needs:
-      - validate
-      - npm-smoke
-      - built-artifact-smoke
+      - quality-and-package
+      - native-package-smoke
       - image-smoke
     permissions:
       contents: read
       id-token: write
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: pnpm
 
       - name: Verify Node 24 and npm >= 11.5.1
         shell: bash
@@ -206,21 +207,20 @@ jobs:
             echo "npm: $(npm --version)"
           fi
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Download verified npm tarball
+        uses: actions/download-artifact@v7
+        with:
+          name: npm-package
+          path: release/npm
 
-      - name: Build all packages
-        run: pnpm build
-
-      - name: Pack npm tarballs
-        run: node scripts/pack-npm.mjs
-
-      - name: Publish desktop tarball (skip already-published version)
+      - name: Publish npm tarball
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           name="@nervekit/desktop"
-          version="$(node -e "console.log(require('./package.json').version)")"
+          version="${RELEASE_TAG#v}"
           tgz="release/npm/nervekit-desktop-${version}.tgz"
           if [ ! -f "${tgz}" ]; then
             echo "No verified tarball found at ${tgz}" >&2
@@ -230,5 +230,49 @@ jobs:
             echo "Skipping ${name}@${version} (already published)"
             exit 0
           fi
-          echo "Publishing ${tgz} as ${name}@${version}"
-          npm publish "${tgz}" --provenance --access public
+          dist_tag="latest"
+          if [[ "${version}" == *-* ]]; then
+            dist_tag="next"
+          fi
+          echo "Publishing ${tgz} as ${name}@${version} with dist-tag ${dist_tag}"
+          npm publish "${tgz}" --provenance --access public --tag "${dist_tag}"
+
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: publish-npm
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download verified npm tarball
+        uses: actions/download-artifact@v7
+        with:
+          name: npm-package
+          path: release/npm
+
+      - name: Create release and attach npm tarball
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          tgz="release/npm/nervekit-desktop-${version}.tgz"
+          if [ ! -f "${tgz}" ]; then
+            echo "No verified tarball found at ${tgz}" >&2
+            exit 1
+          fi
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists; refreshing its npm tarball"
+            gh release upload "${RELEASE_TAG}" "${tgz}" --clobber
+            exit 0
+          fi
+
+          release_args=(--verify-tag --generate-notes)
+          if [[ "${version}" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${RELEASE_TAG}" "${tgz}" "${release_args[@]}"

--- a/packages/workbench-server/src/domains/runs/run-transition.repository.ts
+++ b/packages/workbench-server/src/domains/runs/run-transition.repository.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
   RunEventDeliveryRecord,
@@ -23,6 +22,7 @@ import {
   appendJsonLine,
   atomicWriteJson,
   listChildDirs,
+  readTextFileConsistent,
 } from "../../infrastructure/storage/index.js";
 
 export class WorkbenchRunUnitOfWork implements RunUnitOfWorkPort {
@@ -236,7 +236,7 @@ async function strictJsonLines<T>(
 ): Promise<T[]> {
   let raw: string;
   try {
-    raw = await readFile(path, "utf8");
+    raw = await readTextFileConsistent(path);
   } catch (error) {
     if (isNotFound(error)) return [];
     throw error;

--- a/packages/workbench-server/src/infrastructure/storage/json.ts
+++ b/packages/workbench-server/src/infrastructure/storage/json.ts
@@ -31,6 +31,15 @@ export async function readJsonFile<T>(path: string): Promise<T> {
   return JSON.parse(raw) as T;
 }
 
+/**
+ * Read a complete text snapshot after queued in-process file mutations finish.
+ */
+export function readTextFileConsistent(path: string): Promise<string> {
+  return withFileMutation(path, (resolvedPath) =>
+    readFile(resolvedPath, "utf8"),
+  );
+}
+
 export async function readJsonLines<T>(path: string): Promise<T[]> {
   if (!(await pathExists(path))) return [];
   const raw = await readFile(path, "utf8");

--- a/packages/workbench-server/test/storage-json.test.ts
+++ b/packages/workbench-server/test/storage-json.test.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
-import { readJsonLinesTail } from "../src/infrastructure/storage/index.js";
+import {
+  readJsonLinesTail,
+  readTextFileConsistent,
+  withFileMutation,
+} from "../src/infrastructure/storage/index.js";
 
 const roots: string[] = [];
 
@@ -18,6 +22,39 @@ async function tempPath(): Promise<string> {
   roots.push(root);
   return join(root, "records.jsonl");
 }
+
+describe("readTextFileConsistent", () => {
+  it("waits for an in-process append before reading", async () => {
+    const path = await tempPath();
+    let releaseAppend!: () => void;
+    const appendReleased = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    let partialWritten!: () => void;
+    const partialReady = new Promise<void>((resolve) => {
+      partialWritten = resolve;
+    });
+
+    const append = withFileMutation(path, async (resolvedPath) => {
+      await writeFile(resolvedPath, '{"value":');
+      partialWritten();
+      await appendReleased;
+      await appendFile(resolvedPath, "1}\n");
+    });
+    await partialReady;
+
+    let readSettled = false;
+    const read = readTextFileConsistent(path).finally(() => {
+      readSettled = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(readSettled, false);
+
+    releaseAppend();
+    assert.equal(await read, '{"value":1}\n');
+    await append;
+  });
+});
 
 describe("readJsonLinesTail", () => {
   it("reads a bounded tail in file order across chunk and UTF-8 boundaries", async () => {


### PR DESCRIPTION
## Summary
- gate release work behind lightweight tag validation and run platform/image checks in parallel
- build and verify one canonical npm tarball, then publish that artifact after all checks pass
- publish prereleases under the npm `next` tag and create a matching GitHub prerelease with the tarball attached
- add per-tag concurrency and retry-safe GitHub release handling

## Validation
- `pnpm fix && pnpm check && pnpm test`
- release workflow YAML/job validation
- `node scripts/verify-release-tag.mjs v0.12.0`