### PR TITLE
Retry transient OpenAI model request failures

### DIFF
--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -57,6 +57,7 @@ export * from "./harness/result.js";
 export { registerManagedProvider } from "./models/provider-registry.js";
 export * from "./transport/proxy.js";
 export * from "./models/prompt-stream.js";
+export * from "./models/provider-error-classification.js";
 export * from "./models/resolution.js";
 export { registerAgentScriptedProvider } from "./models/scripted-provider.js";
 export * from "./models/types.js";

--- a/packages/harness/src/models/provider-error-classification.ts
+++ b/packages/harness/src/models/provider-error-classification.ts
@@ -1,0 +1,11 @@
+const PERMANENT_PROVIDER_ERROR =
+  /NON_RETRYABLE|GoUsageLimitError|FreeUsageLimitError|Monthly usage limit reached|usage limit|available balance|insufficient_quota|out of budget|quota exceeded|billing|context.?length|context.?window|maximum context|too many tokens/i;
+
+const TRANSIENT_PROVIDER_ERROR =
+  /RETRYABLE|overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|error occurred while processing your request|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+
+/** Classifies known provider failures that are safe to retry automatically. */
+export function isRetryableProviderError(message?: string): boolean {
+  if (!message || PERMANENT_PROVIDER_ERROR.test(message)) return false;
+  return TRANSIENT_PROVIDER_ERROR.test(message);
+}

--- a/packages/harness/test/models/provider-error-classification.test.ts
+++ b/packages/harness/test/models/provider-error-classification.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isRetryableProviderError } from "../../src/models/provider-error-classification.js";
+
+describe("provider error classification", () => {
+  it("retries OpenAI's generic server-side processing failure", () => {
+    assert.equal(
+      isRetryableProviderError(
+        "Codex error: An error occurred while processing your request. You can retry your request, or contact us through our help center if the error persists.",
+      ),
+      true,
+    );
+  });
+
+  it("retries known transient provider failures", () => {
+    const messages = [
+      "provider returned error 500",
+      "too many requests (429)",
+      "service unavailable 503",
+      "network error: fetch failed",
+      "connection lost while reading response",
+      "websocket closed unexpectedly",
+      "stream ended before message_stop",
+      "request timed out",
+      "provider overloaded",
+    ];
+
+    for (const message of messages) {
+      assert.equal(isRetryableProviderError(message), true, message);
+    }
+  });
+
+  it("does not retry permanent failures even with transient wording", () => {
+    const messages = [
+      "500 insufficient_quota for org",
+      "service unavailable because billing must be updated",
+      "rate limit: Monthly usage limit reached",
+      "internal error: maximum context length exceeded",
+      "network error: too many tokens",
+    ];
+
+    for (const message of messages) {
+      assert.equal(isRetryableProviderError(message), false, message);
+    }
+  });
+
+  it("does not retry absent or unknown failures", () => {
+    assert.equal(isRetryableProviderError(undefined), false);
+    assert.equal(isRetryableProviderError("x"), false);
+  });
+});

--- a/packages/sandbox-agent/src/run/run-execution-errors.ts
+++ b/packages/sandbox-agent/src/run/run-execution-errors.ts
@@ -1,5 +1,8 @@
 import { RUN_FAILURE_MESSAGE_MAX_LENGTH } from "@nervekit/contracts";
-import type { AgentMessage } from "@nervekit/host-runtime/harness";
+import {
+  isRetryableProviderError,
+  type AgentMessage,
+} from "@nervekit/host-runtime/harness";
 
 export interface SandboxExecutionFailure {
   code: string;
@@ -42,18 +45,10 @@ export function previewResult(result: unknown): unknown {
 /** Classifies a provider error message as retryable or permanent. */
 export function assistantFailure(message?: string): SandboxExecutionFailure {
   const error = message ?? "Provider request failed";
-  const permanent =
-    /NON_RETRYABLE|usage limit|insufficient_quota|out of budget|billing|context.?length|context.?window|maximum context|too many tokens/i.test(
-      error,
-    );
-  const transient =
-    /RETRYABLE|overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|network.?error|connection.?error|fetch failed|socket hang up|timed? out|timeout/i.test(
-      error,
-    );
   return {
     code: "MODEL_REQUEST_FAILED",
     message: error.slice(0, RUN_FAILURE_MESSAGE_MAX_LENGTH),
-    retryable: !permanent && transient,
+    retryable: isRetryableProviderError(message),
   };
 }
 

--- a/packages/sandbox-agent/test/run-execution-collaborators.test.ts
+++ b/packages/sandbox-agent/test/run-execution-collaborators.test.ts
@@ -400,6 +400,12 @@ describe("failure classification", () => {
     assert.equal(assistantFailure("rate limit exceeded 429").retryable, true);
     assert.equal(assistantFailure("service unavailable 503").retryable, true);
     assert.equal(
+      assistantFailure(
+        "Codex error: An error occurred while processing your request. You can retry your request.",
+      ).retryable,
+      true,
+    );
+    assert.equal(
       assistantFailure("insufficient_quota for org").retryable,
       false,
     );

--- a/packages/workbench-server/src/domains/agents/run/harness-execution-shared.ts
+++ b/packages/workbench-server/src/domains/agents/run/harness-execution-shared.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { isRetryableProviderError } from "@nervekit/host-runtime/harness";
 
 export function recordFromUnknown(value: unknown): Record<string, unknown> {
   return value && typeof value === "object"
@@ -25,17 +26,9 @@ export function errorTextFromToolResult(
 }
 
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
-  if (message.stopReason !== "error" || !message.errorMessage) return false;
-  const error = message.errorMessage;
-  if (
-    /GoUsageLimitError|FreeUsageLimitError|Monthly usage limit reached|available balance|insufficient_quota|out of budget|quota exceeded|billing|context.?length|context.?window|maximum context|too many tokens/i.test(
-      error,
-    )
-  ) {
-    return false;
-  }
-  return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(
-    error,
+  return (
+    message.stopReason === "error" &&
+    isRetryableProviderError(message.errorMessage)
   );
 }
 

--- a/packages/workbench-server/test/workbench-run-retry.test.ts
+++ b/packages/workbench-server/test/workbench-run-retry.test.ts
@@ -9,7 +9,10 @@ import {
   shutdownOrchestratorState,
 } from "../src/app/orchestrator-state.js";
 import { WorkbenchRunUnitOfWork } from "../src/domains/runs/run-transition.repository.js";
-import { initializeStorage } from "../src/infrastructure/storage/index.js";
+import {
+  initializeStorage,
+  writeSettings,
+} from "../src/infrastructure/storage/index.js";
 
 describe("workbench coordinator-owned provider retry", () => {
   it("retries a valid checkpoint and projects completion back to idle", async () => {
@@ -66,6 +69,74 @@ describe("workbench coordinator-owned provider retry", () => {
         1,
       );
       assert.equal(orchestrator.registry.agents.get(agent.id)?.status, "idle");
+    } finally {
+      registration.unregister();
+      await shutdownOrchestratorState(orchestrator);
+      await rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 20,
+      });
+    }
+  });
+
+  it("exhausts three retries for OpenAI processing errors and remains continuable", async () => {
+    const errorMessage =
+      "Codex error: An error occurred while processing your request. You can retry your request.";
+    const registration = registerAgentScriptedProvider({
+      steps: Array.from({ length: 4 }, () => ({
+        type: "providerError" as const,
+        message: errorMessage,
+      })),
+    });
+    const root = await mkdtemp(
+      join(tmpdir(), "nerve-workbench-retry-exhausted-"),
+    );
+    const storage = await initializeStorage(root);
+    await writeSettings(storage, {
+      retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 },
+    });
+    const orchestrator = createOrchestratorState(storage, "127.0.0.1", 0);
+    try {
+      await orchestrator.registry.hydrate();
+      const project = await orchestrator.registry.createProject({ dir: root });
+      const conversation = await orchestrator.registry.createConversation({
+        projectId: project.id,
+      });
+      const agent = await orchestrator.registry.createAgent({
+        projectId: project.id,
+        conversationId: conversation.id,
+        model: { provider: "nerve-scripted", modelId: "scripted-fast" },
+      });
+      await orchestrator.registry.promptAgent(agent.id, {
+        text: "Retry transient OpenAI failure",
+      });
+      const unitOfWork = new WorkbenchRunUnitOfWork(storage.paths.home, 0);
+      let runId: string | undefined;
+      await waitFor(async () => {
+        const states = await unitOfWork.list();
+        runId ??= states.find((state) => state.run.agentId === agent.id)?.run
+          .runId;
+        if (!runId) return false;
+        return (await unitOfWork.load(runId))?.run.status === "interrupted";
+      });
+
+      const state = await unitOfWork.load(runId!);
+      assert.equal(state?.run.attempt, 4);
+      assert.equal(state?.run.recoverability, "checkpoint");
+      assert.equal(state?.run.failure?.retryable, true);
+      assert.equal(state?.run.failure?.continuable, true);
+      assert.match(
+        state?.run.failure?.message ?? "",
+        /processing your request/i,
+      );
+      assert.equal(
+        state?.transitions.filter(
+          (transition) => transition.kind === "retrying",
+        ).length,
+        3,
+      );
     } finally {
       registration.unregister();
       await shutdownOrchestratorState(orchestrator);


### PR DESCRIPTION
## Summary
- centralize provider-error retry classification in the shared harness
- recognize OpenAI generic processing failures as transient in workbench and sandbox agents
- verify three automatic retries followed by checkpoint-backed manual continuation

## Validation
- `pnpm fix && pnpm check && pnpm test`