### PR TITLE
feat(compaction): stream summary preview into the compaction card

### DIFF
--- a/packages/contracts/src/domains/conversations/conversation-runtime.events.schema.ts
+++ b/packages/contracts/src/domains/conversations/conversation-runtime.events.schema.ts
@@ -14,7 +14,9 @@ export const conversationRuntimeEventDefinitions = Object.entries(
 function isBufferedConversationEvent(name: string): boolean {
   return (
     name.startsWith("conversation.live.") ||
-    name === "conversation.context.updated"
+    name === "conversation.context.updated" ||
+    // Progress snapshots are idempotent tails; they never need a per-event fsync.
+    name === "conversation.compaction.progress"
   );
 }
 

--- a/packages/contracts/src/domains/conversations/conversation.schema.ts
+++ b/packages/contracts/src/domains/conversations/conversation.schema.ts
@@ -163,6 +163,11 @@ export interface ConversationEntryAppendedData {
 
 export type ConversationCompactionReason = "manual" | "threshold" | "overflow";
 
+/** Logical lines of generated summary text carried in a compaction progress snapshot. */
+export const COMPACTION_PROGRESS_PREVIEW_LINES = 6;
+/** Hard cap on the preview payload; the trailing characters are kept when longer. */
+export const COMPACTION_PROGRESS_PREVIEW_MAX_CHARS = 1_200;
+
 export interface ConversationCompactionStartedData {
   conversationId: string;
   agentId?: string;
@@ -175,6 +180,23 @@ export interface ConversationCompactionStartedData {
   triggerReserveTokens?: number;
   keepRecentTokens?: number;
   failedEntryId?: string;
+}
+
+export interface ConversationCompactionProgressData {
+  conversationId: string;
+  agentId?: string;
+  runId?: string;
+  reason: ConversationCompactionReason;
+  /** Monotonic per-compaction snapshot counter; stale snapshots are dropped. */
+  sequence: number;
+  /** 1 = first summarization request, 2 = structural-repair retry. */
+  attempt: number;
+  /** Trailing lines of the summary generated so far. */
+  preview: string;
+  /** Logical line count of everything generated so far. */
+  generatedLines: number;
+  /** Character count of everything generated so far. */
+  generatedChars: number;
 }
 
 export interface ConversationCompactionFailedData {
@@ -396,6 +418,7 @@ export type ConversationEventData =
   | ConversationPromptCancelledData
   | ConversationEntryAppendedData
   | ConversationCompactionStartedData
+  | ConversationCompactionProgressData
   | ConversationCompactionFailedData
   | ConversationCompactionCancelledData
   | ConversationCompactedData
@@ -760,6 +783,18 @@ const conversationCompactionStartedDataSchema = z.object({
   failedEntryId: z.string().startsWith("entry_").optional(),
 });
 
+const conversationCompactionProgressDataSchema = z.object({
+  conversationId: z.string().startsWith("conv_"),
+  agentId: z.string().startsWith("agent_").optional(),
+  runId: runIdSchema.optional(),
+  reason: z.enum(["manual", "threshold", "overflow"]),
+  sequence: z.number().int().positive(),
+  attempt: z.number().int().positive(),
+  preview: z.string().max(COMPACTION_PROGRESS_PREVIEW_MAX_CHARS),
+  generatedLines: z.number().int().nonnegative(),
+  generatedChars: z.number().int().nonnegative(),
+});
+
 const conversationCompactionFailedDataSchema = z.object({
   conversationId: z.string().startsWith("conv_"),
   agentId: z.string().startsWith("agent_").optional(),
@@ -918,6 +953,7 @@ export const conversationEventPayloadSchemas = {
   "conversation.prompt.cancelled": conversationPromptQueuedDataSchema,
   "conversation.entry.appended": conversationEntryAppendedDataSchema,
   "conversation.compaction.started": conversationCompactionStartedDataSchema,
+  "conversation.compaction.progress": conversationCompactionProgressDataSchema,
   "conversation.compaction.failed": conversationCompactionFailedDataSchema,
   "conversation.compaction.cancelled":
     conversationCompactionCancelledDataSchema,
@@ -961,6 +997,7 @@ export const conversationEventTypes = [
   "conversation.prompt.cancelled",
   "conversation.entry.appended",
   "conversation.compaction.started",
+  "conversation.compaction.progress",
   "conversation.compaction.failed",
   "conversation.compaction.cancelled",
   "conversation.compacted",

--- a/packages/contracts/test/protocol.schema.test.ts
+++ b/packages/contracts/test/protocol.schema.test.ts
@@ -288,6 +288,11 @@ describe("Protocol v1 shared schemas", () => {
       (definition) => definition.name === "conversation.compaction.started",
     );
     assert.equal(canonicalLifecycle?.supersedable, false);
+    const compactionProgress = definitions.find(
+      (definition) => definition.name === "conversation.compaction.progress",
+    );
+    assert.equal(compactionProgress?.delivery, "sequenced");
+    assert.equal(compactionProgress?.supersedable, true);
     const delta = definitions.find(
       (definition) => definition.name === "conversation.live.content.delta",
     );

--- a/packages/harness/src/harness/compaction/compaction.ts
+++ b/packages/harness/src/harness/compaction/compaction.ts
@@ -1,5 +1,12 @@
-import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
-import { completeSimpleWithModel } from "../../models/provider-registry.js";
+import type {
+  AssistantMessage,
+  ImageContent,
+  TextContent,
+} from "@earendil-works/pi-ai";
+import {
+  completeSimpleWithModel,
+  streamSimpleWithModel,
+} from "../../models/provider-registry.js";
 import type {
   AgentMessage,
   AnyModel,
@@ -237,19 +244,43 @@ export function isStructuredCompactionSummary(summary: string): boolean {
   );
 }
 
+/** Incremental summarization progress for user-facing feedback. */
+export type SummaryStreamProgress = {
+  /** 1 = first summarization request, 2 = structural-repair retry. */
+  attempt: number;
+  /** Accumulated text of the current attempt. */
+  text: string;
+};
+
+export type GenerateSummaryInput = {
+  messages: AgentMessage[];
+  model: AnyModel;
+  reserveTokens: number;
+  apiKey: string;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+  customInstructions?: string;
+  previousSummary?: string;
+  thinkingLevel?: ThinkingLevel;
+  env?: Record<string, string>;
+  /** Called with the accumulated text as the summary streams in. */
+  onProgress?: (progress: SummaryStreamProgress) => void;
+};
+
 /** Generate or update a conversation summary for compaction. */
-export async function generateSummary(
-  currentMessages: AgentMessage[],
-  model: AnyModel,
-  reserveTokens: number,
-  apiKey: string,
-  headers?: Record<string, string>,
-  signal?: AbortSignal,
-  customInstructions?: string,
-  previousSummary?: string,
-  thinkingLevel?: ThinkingLevel,
-  env?: Record<string, string>,
-): Promise<Result<string, CompactionError>> {
+export async function generateSummary({
+  messages: currentMessages,
+  model,
+  reserveTokens,
+  apiKey,
+  headers,
+  signal,
+  customInstructions,
+  previousSummary,
+  thinkingLevel,
+  env,
+  onProgress,
+}: GenerateSummaryInput): Promise<Result<string, CompactionError>> {
   const maxTokens = Math.min(
     Math.floor(0.8 * reserveTokens),
     model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
@@ -273,8 +304,11 @@ export async function generateSummary(
       ? { maxTokens, signal, apiKey, headers, env, reasoning: thinkingLevel }
       : { maxTokens, signal, apiKey, headers, env };
 
-  const requestSummary = (text: string) =>
-    completeSimpleWithModel(
+  const requestSummary = async (
+    text: string,
+    attempt: number,
+  ): Promise<AssistantMessage> => {
+    const stream = streamSimpleWithModel(
       model,
       {
         systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
@@ -288,14 +322,26 @@ export async function generateSummary(
       },
       completionOptions,
     );
-  const readText = (response: Awaited<ReturnType<typeof requestSummary>>) =>
+    let accumulated = "";
+    for await (const event of stream) {
+      if (event.type !== "text_delta") continue;
+      accumulated += event.delta;
+      try {
+        onProgress?.({ attempt, text: accumulated });
+      } catch {
+        // Progress reporting is best effort and must never fail summarization.
+      }
+    }
+    return await stream.result();
+  };
+  const readText = (response: AssistantMessage) =>
     response.content
       .filter((c): c is { type: "text"; text: string } => c.type === "text")
       .map((c) => c.text)
       .join("\n")
       .trim();
   const responseError = (
-    response: Awaited<ReturnType<typeof requestSummary>>,
+    response: AssistantMessage,
   ): CompactionError | undefined => {
     if (response.stopReason === "aborted") {
       return new CompactionError(
@@ -312,7 +358,7 @@ export async function generateSummary(
     return undefined;
   };
 
-  let response = await requestSummary(promptText);
+  let response = await requestSummary(promptText, 1);
   let failure = responseError(response);
   if (failure) return err(failure);
   let textContent = readText(response);
@@ -320,6 +366,7 @@ export async function generateSummary(
   if (missingHeadings.length > 0) {
     response = await requestSummary(
       `${promptText}\n\n<draft-summary>\n${textContent}\n</draft-summary>\n\nThe draft is structurally incomplete. Rewrite the entire checkpoint using the exact required format and include these missing sections: ${missingHeadings.join(", ")}.`,
+      2,
     );
     failure = responseError(response);
     if (failure) return err(failure);
@@ -486,13 +533,15 @@ export async function compact(
 
   let summary: string;
 
+  // Summary progress is not streamed from here: the split-turn branch runs two
+  // summarizations concurrently, so their deltas cannot form one ordered draft.
   if (isSplitTurn && turnPrefixMessages.length > 0) {
     const [historyResult, turnPrefixResult] = await Promise.all([
       messagesToSummarize.length > 0
-        ? generateSummary(
-            messagesToSummarize,
+        ? generateSummary({
+            messages: messagesToSummarize,
             model,
-            settings.reserveTokens,
+            reserveTokens: settings.reserveTokens,
             apiKey,
             headers,
             signal,
@@ -500,7 +549,7 @@ export async function compact(
             previousSummary,
             thinkingLevel,
             env,
-          )
+          })
         : Promise.resolve(ok<string, CompactionError>("No prior history.")),
       generateTurnPrefixSummary(
         turnPrefixMessages,
@@ -517,10 +566,10 @@ export async function compact(
     if (!turnPrefixResult.ok) return err(turnPrefixResult.error);
     summary = `${historyResult.value}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.value}`;
   } else {
-    const summaryResult = await generateSummary(
-      messagesToSummarize,
+    const summaryResult = await generateSummary({
+      messages: messagesToSummarize,
       model,
-      settings.reserveTokens,
+      reserveTokens: settings.reserveTokens,
       apiKey,
       headers,
       signal,
@@ -528,7 +577,7 @@ export async function compact(
       previousSummary,
       thinkingLevel,
       env,
-    );
+    });
     if (!summaryResult.ok) return err(summaryResult.error);
     summary = summaryResult.value;
   }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -26,6 +26,7 @@ export {
   findCutPoint,
   findTurnStartIndex,
   generateSummary,
+  type GenerateSummaryInput,
   getCompactionDecisionTokens,
   getLastAssistantUsage,
   getLatestCompactionEntry,
@@ -35,6 +36,7 @@ export {
   serializeConversation,
   shouldAutoCompact,
   shouldCompact,
+  type SummaryStreamProgress,
 } from "./harness/compaction/compaction.js";
 export * from "./harness/conversation/conversation.js";
 export * from "./harness/conversation/jsonl-repo.js";

--- a/packages/workbench-server/src/domains/agents/run/auto-compaction-runner.ts
+++ b/packages/workbench-server/src/domains/agents/run/auto-compaction-runner.ts
@@ -15,7 +15,7 @@ import type { WorkbenchAgentMechanicsDeps } from "./workbench-agent-mechanics.js
 const MAX_AUTO_CONTINUATIONS_PER_RUN = 3;
 
 export const AUTO_COMPACTION_CONTINUE_MESSAGE =
-  "Context was compacted into the checkpoint above. Continue this task in the same run: read Work Remaining, Current Working State, and Continuation Plan first; do not repeat Work Completed. Execute the remaining steps, validate the result, and stop when the task is complete.";
+  "Context was compacted into the checkpoint above. Continue from it: follow Work Remaining and the Continuation Plan, skip work already completed, then validate and stop when the task is done.";
 
 export class AutoCompactionRunner {
   private readonly continuationCounts = new Map<string, number>();

--- a/packages/workbench-server/src/domains/conversations/operations/compaction-progress-publisher.ts
+++ b/packages/workbench-server/src/domains/conversations/operations/compaction-progress-publisher.ts
@@ -1,0 +1,121 @@
+import {
+  COMPACTION_PROGRESS_PREVIEW_LINES,
+  COMPACTION_PROGRESS_PREVIEW_MAX_CHARS,
+  type ConversationCompactionReason,
+} from "@nervekit/contracts";
+import type { StreamLogRegistry } from "../../../infrastructure/events/index.js";
+
+export interface CompactionProgressContext {
+  conversationId: string;
+  agentId?: string;
+  runId?: string;
+  reason: ConversationCompactionReason;
+}
+
+export interface CompactionProgressPublisherOptions {
+  /** Minimum delay between published snapshots. */
+  intervalMs?: number;
+  now?: () => number;
+}
+
+export interface CompactionProgressReport {
+  /** 1 = first summarization request, 2 = structural-repair retry. */
+  attempt: number;
+  /** Accumulated summary text of the current attempt. */
+  text: string;
+}
+
+const DEFAULT_INTERVAL_MS = 200;
+
+/**
+ * Publishes coalesced tail snapshots of the summary while compaction runs.
+ * Snapshots are self-contained, so throttling and dropped intermediates stay
+ * safe: the newest snapshot always fully describes what the UI must render.
+ */
+export class CompactionProgressPublisher {
+  #sequence = 0;
+  #lastPublishedAt = 0;
+  #lastAttempt = 0;
+  #lastPreview: string | undefined;
+  #pending: CompactionProgressReport | undefined;
+  #tail: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly events: StreamLogRegistry,
+    private readonly context: CompactionProgressContext,
+    private readonly options: CompactionProgressPublisherOptions = {},
+  ) {}
+
+  /** Records progress and publishes at most one snapshot per interval. */
+  report(report: CompactionProgressReport): void {
+    this.#pending = report;
+    const intervalMs = this.options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    const now = (this.options.now ?? Date.now)();
+    const attemptChanged =
+      this.#lastAttempt !== 0 && report.attempt !== this.#lastAttempt;
+    if (!attemptChanged && now - this.#lastPublishedAt < intervalMs) return;
+    this.#publishPending(now);
+  }
+
+  /** Publishes the last pending snapshot and awaits outstanding publishes. */
+  async flush(): Promise<void> {
+    this.#publishPending((this.options.now ?? Date.now)());
+    await this.#tail;
+  }
+
+  #publishPending(now: number): void {
+    const pending = this.#pending;
+    this.#pending = undefined;
+    if (!pending) return;
+    const text = pending.text;
+    const preview = previewTail(text);
+    if (!preview || preview === this.#lastPreview) return;
+    this.#lastPreview = preview;
+    this.#lastAttempt = pending.attempt;
+    this.#lastPublishedAt = now;
+    this.#sequence += 1;
+    const data = {
+      conversationId: this.context.conversationId,
+      agentId: this.context.agentId,
+      runId: this.context.runId,
+      reason: this.context.reason,
+      sequence: this.#sequence,
+      attempt: pending.attempt,
+      preview,
+      generatedLines: countLogicalLines(text),
+      generatedChars: text.length,
+    };
+    this.#tail = this.#tail
+      .catch(() => undefined)
+      .then(() =>
+        this.events
+          .publish("conversation.compaction.progress", data)
+          .then(() => undefined)
+          // Progress is best effort: it must never fail the compaction.
+          .catch(() => undefined),
+      );
+  }
+}
+
+/**
+ * Splits text into logical lines, treating one final LF as a terminator rather
+ * than an additional empty line (same semantics as collapsed tool output).
+ */
+function splitLogicalLines(text: string): string[] {
+  if (text.length === 0) return [];
+  const content = text.endsWith("\n") ? text.slice(0, -1) : text;
+  return content.split("\n");
+}
+
+function countLogicalLines(text: string): number {
+  return splitLogicalLines(text).length;
+}
+
+/** Trailing preview lines, truncated from the front when still too long. */
+function previewTail(text: string): string {
+  const lines = splitLogicalLines(text.trimEnd());
+  const tail = lines.slice(-COMPACTION_PROGRESS_PREVIEW_LINES).join("\n");
+  return tail.length > COMPACTION_PROGRESS_PREVIEW_MAX_CHARS
+    ? tail.slice(tail.length - COMPACTION_PROGRESS_PREVIEW_MAX_CHARS)
+    : tail;
+}

--- a/packages/workbench-server/src/domains/conversations/operations/compaction-service.ts
+++ b/packages/workbench-server/src/domains/conversations/operations/compaction-service.ts
@@ -18,6 +18,11 @@ import type {
 import { HttpError } from "../../../http/errors.js";
 import type { StreamLogRegistry } from "../../../infrastructure/events/index.js";
 import type { ConversationHarnessStorage } from "../conversation-harness-storage.js";
+import {
+  CompactionProgressPublisher,
+  type CompactionProgressPublisherOptions,
+  type CompactionProgressReport,
+} from "./compaction-progress-publisher.js";
 import { buildExtractiveSummary } from "./summary.js";
 
 export interface AppendConversationEntryInput {
@@ -55,6 +60,8 @@ export type CompactionSummarizer = (input: {
   instructions?: string;
   summaryReserveTokens: number;
   signal?: AbortSignal;
+  /** Receives the summary text as it streams in, for live UI feedback. */
+  onProgress?: (progress: CompactionProgressReport) => void;
 }) => Promise<{ text: string; generatedBy: "model" } | undefined>;
 
 export interface CompactConversationOptions {
@@ -107,6 +114,7 @@ export class CompactionService {
     private readonly rebuildConversations: () => Promise<void>,
     private readonly events: StreamLogRegistry,
     private readonly summarize?: CompactionSummarizer,
+    private readonly progressOptions: CompactionProgressPublisherOptions = {},
   ) {}
 
   async compactConversation(
@@ -198,6 +206,17 @@ export class CompactionService {
 
       const startedAt = new Date().toISOString();
       let started = false;
+      const progress = new CompactionProgressPublisher(
+        this.events,
+        {
+          conversationId,
+          agentId: options.agentId,
+          runId: options.runId,
+          reason,
+        },
+        this.progressOptions,
+      );
+      const flushProgress = () => progress.flush().catch(() => undefined);
       try {
         await this.events.publish("conversation.compaction.started", {
           conversationId,
@@ -222,7 +241,8 @@ export class CompactionService {
           request.instructions,
           summaryReserveTokens,
           operation.controller.signal,
-        );
+          (report) => progress.report(report),
+        ).finally(flushProgress);
         throwIfCompactionAborted(operation.controller.signal);
         const generatedBy =
           modelSummary?.generatedBy ?? "orchestrator-extractive";
@@ -323,6 +343,7 @@ export class CompactionService {
         });
         return { conversation: this.getConversation(conversationId), entry };
       } catch (error) {
+        await flushProgress();
         if (started) {
           const cancelled =
             operation.controller.signal.aborted && !operation.committing;
@@ -379,6 +400,7 @@ export class CompactionService {
     instructions: string | undefined,
     summaryReserveTokens: number,
     signal: AbortSignal,
+    onProgress?: (progress: CompactionProgressReport) => void,
   ): Promise<{ text: string; generatedBy: "model" } | undefined> {
     if (!this.summarize) return undefined;
     try {
@@ -390,6 +412,7 @@ export class CompactionService {
         instructions,
         summaryReserveTokens,
         signal,
+        onProgress,
       });
       throwIfCompactionAborted(signal);
       return summary?.text.trim()

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -212,6 +212,7 @@ export function composeRuntime(
     instructions,
     summaryReserveTokens,
     signal,
+    onProgress,
   }) => {
     const conversation = getConversation(conversationId);
     const resolvedAgentId = agentId ?? conversation.activeAgentId;
@@ -226,18 +227,19 @@ export function composeRuntime(
     const requestModel = requestAuth.baseUrl
       ? { ...model, baseUrl: requestAuth.baseUrl }
       : model;
-    const result = await generateSummary(
+    const result = await generateSummary({
       messages,
-      requestModel,
-      summaryReserveTokens,
-      requestAuth.apiKey ?? "",
-      requestAuth.headers,
+      model: requestModel,
+      reserveTokens: summaryReserveTokens,
+      apiKey: requestAuth.apiKey ?? "",
+      headers: requestAuth.headers,
       signal,
-      instructions,
+      customInstructions: instructions,
       previousSummary,
-      agent.thinkingLevel,
-      requestAuth.env,
-    );
+      thinkingLevel: agent.thinkingLevel,
+      env: requestAuth.env,
+      onProgress,
+    });
     return result.ok
       ? { text: result.value, generatedBy: "model" as const }
       : undefined;

--- a/packages/workbench-server/test/compaction-service.test.ts
+++ b/packages/workbench-server/test/compaction-service.test.ts
@@ -144,6 +144,118 @@ describe("CompactionService", () => {
     assert.ok(events.some((event) => event.type === "conversation.compacted"));
   });
 
+  it("publishes coalesced summary tail snapshots while summarizing", async () => {
+    const events: Array<{ type: string; data: unknown }> = [];
+    const branch = [
+      {
+        type: "message",
+        id: "entry_old",
+        parentId: null,
+        timestamp,
+        message: {
+          role: "user",
+          content: "x".repeat(20_000),
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "entry_recent",
+        parentId: "entry_old",
+        timestamp,
+        message: {
+          role: "user",
+          content: "continue",
+          timestamp: Date.parse(timestamp),
+        },
+      },
+    ];
+    let activeLeafId = "entry_recent";
+    const storage = {
+      getLeafId: async () => activeLeafId,
+      getPathToRoot: async () => branch,
+      appendEntry: async (entry: { id: string }) => {
+        activeLeafId = entry.id;
+      },
+    };
+    const summary = structuredSummary();
+    const service = new CompactionService(
+      () => ({ id: "conv_test", projectId: "proj_test" }) as never,
+      () => ({ id: "proj_test", dir: "/tmp/project" }) as never,
+      async (input) =>
+        ({
+          ...input,
+          id: "entry_compaction",
+          parentEntryId: input.parentEntryId ?? null,
+          kind: input.kind ?? "message",
+          createdAt: input.createdAt ?? timestamp,
+        }) as never,
+      { openStorage: async () => storage } as never,
+      async () => undefined,
+      {
+        publish: async (type: string, data: unknown) => {
+          events.push({ type, data });
+        },
+      } as never,
+      async ({ onProgress }) => {
+        // First attempt streams a draft, then the structural repair restarts it.
+        onProgress?.({ attempt: 1, text: "## Goal\ndraft" });
+        onProgress?.({ attempt: 1, text: "## Goal\ndraft\nmore draft" });
+        onProgress?.({ attempt: 2, text: summary.slice(0, 40) });
+        onProgress?.({ attempt: 2, text: summary });
+        return { text: summary, generatedBy: "model" };
+      },
+    );
+
+    await service.compactConversation(
+      "conv_test",
+      {},
+      {
+        reason: "threshold",
+        agentId: "agent_test",
+        runId: "run_test",
+        activeConversation: { getStorage: () => storage } as never,
+      },
+    );
+
+    const progress = events
+      .filter((event) => event.type === "conversation.compaction.progress")
+      .map(
+        (event) =>
+          event.data as {
+            sequence: number;
+            attempt: number;
+            preview: string;
+            generatedLines: number;
+            generatedChars: number;
+            runId?: string;
+          },
+      );
+    assert.ok(progress.length >= 3);
+    assert.deepEqual(
+      progress.map((snapshot) => snapshot.sequence),
+      progress.map((_snapshot, index) => index + 1),
+    );
+    assert.deepEqual([progress[0].attempt, progress.at(-1)?.attempt], [1, 2]);
+    assert.equal(progress[0].preview, "## Goal\ndraft");
+    assert.equal(progress[0].runId, "run_test");
+    for (const snapshot of progress) {
+      assert.ok(snapshot.preview.split("\n").length <= 6);
+    }
+    const last = progress.at(-1);
+    assert.equal(last?.generatedChars, summary.length);
+    assert.equal(last?.generatedLines, summary.split("\n").length);
+    assert.equal(last?.preview, summary.split("\n").slice(-6).join("\n"));
+
+    const progressIndexes = events.flatMap((event, index) =>
+      event.type === "conversation.compaction.progress" ? [index] : [],
+    );
+    const compactedIndex = events.findIndex(
+      (event) => event.type === "conversation.compacted",
+    );
+    assert.ok(compactedIndex > (progressIndexes.at(-1) ?? -1));
+  });
+
   it("aborts model summarization without creating a checkpoint", async () => {
     const events: Array<{ type: string; data: unknown }> = [];
     let appendCalls = 0;

--- a/packages/workbench-ui/src/lib/components/transcript/CompactionCard.svelte
+++ b/packages/workbench-ui/src/lib/components/transcript/CompactionCard.svelte
@@ -3,7 +3,12 @@ import { type StatusTone } from "@nervekit/ui-kit/components/ui/status-dot";
 import type { CompactionNotice } from "../../state/transcript-types";
 import { formatTokens } from "@nervekit/ui-kit/core/utils/usage";
 import CardShell from "../../tools/components/tool-call/CardShell.svelte";
+import ResultCodeBlock from "../../tools/components/tool-call/ResultCodeBlock.svelte";
 import type { MetaItem } from "../../tools/views/tool-presentation";
+import {
+  COLLAPSED_LINES,
+  splitLogicalLines,
+} from "../../tools/views/tool-view-helpers";
 
 type Props = {
   notice: CompactionNotice;
@@ -43,56 +48,17 @@ const contextPercent = $derived.by(() => {
   return Math.round((used / notice.contextWindow) * 100);
 });
 
-/** First meaningful lines of the summary, stripped of markdown scaffolding. */
-const summaryLead = $derived.by(() => {
-  const text = (notice.summary ?? notice.text ?? "").trim();
-  if (!text) return "";
-  const meaningful: string[] = [];
-  for (const raw of text.split("\n")) {
-    const line = raw.trim();
-    if (!line || line.startsWith("#") || line.startsWith("---")) continue;
-    if (/^generated locally/i.test(line)) continue;
-    if (/^treat this as a context checkpoint/i.test(line)) continue;
-    const cleaned = line
-      .replace(/^[-*]\s+/, "")
-      .replace(/^\d+\.\s+/, "")
-      .replace(/^\[[ xX]\]\s+/, "")
-      .replace(/\*\*/g, "")
-      .trim();
-    if (!cleaned) continue;
-    meaningful.push(cleaned);
-    if (meaningful.length >= 2) break;
-  }
-  const lead = meaningful.join(" ");
-  return lead.length > 180 ? `${lead.slice(0, 180).trim()}…` : lead;
+/**
+ * Trailing lines of the checkpoint: the live draft while summarizing, and the
+ * committed summary once done, so the body never jumps at completion.
+ */
+const previewText = $derived.by(() => {
+  if (notice.state === "running") return notice.summaryPreview?.trimEnd() ?? "";
+  if (notice.state !== "completed") return "";
+  const summary = (notice.summary ?? notice.text ?? "").trimEnd();
+  if (!summary) return "";
+  return splitLogicalLines(summary).slice(-COLLAPSED_LINES).join("\n");
 });
-
-const chips = $derived.by<MetaItem[]>(() => {
-  const items: MetaItem[] = [];
-  if (typeof notice.tokensBefore === "number") {
-    items.push({ text: `${formatTokens(notice.tokensBefore)} before` });
-  }
-  if (typeof notice.tokensAfter === "number") {
-    items.push({ text: `≈${formatTokens(notice.tokensAfter)} after` });
-  }
-  if (typeof notice.freedTokens === "number" && notice.freedTokens > 0) {
-    items.push({
-      text: `${formatTokens(notice.freedTokens)} freed`,
-      tone: "success",
-    });
-  }
-  if (typeof compactedMessages === "number") {
-    items.push({ text: `${compactedMessages} messages` });
-  }
-  if (typeof contextPercent === "number") {
-    items.push({ text: `${contextPercent}% context` });
-  }
-  return items;
-});
-
-const errorMessage = $derived(
-  notice.errorMessage?.trim() || "Could not compact this conversation.",
-);
 
 let now = $state(Date.now());
 $effect(() => {
@@ -119,20 +85,72 @@ const elapsedLabel = $derived(
 const showElapsed = $derived(
   elapsedSeconds !== undefined && elapsedSeconds >= 1,
 );
+
+const completedChips = $derived.by<MetaItem[]>(() => {
+  const items: MetaItem[] = [];
+  if (typeof notice.tokensBefore === "number") {
+    items.push({ text: `${formatTokens(notice.tokensBefore)} before` });
+  }
+  if (typeof notice.tokensAfter === "number") {
+    items.push({ text: `≈${formatTokens(notice.tokensAfter)} after` });
+  }
+  if (typeof notice.freedTokens === "number" && notice.freedTokens > 0) {
+    items.push({
+      text: `${formatTokens(notice.freedTokens)} freed`,
+      tone: "success",
+    });
+  }
+  if (typeof compactedMessages === "number") {
+    items.push({ text: `${compactedMessages} messages` });
+  }
+  if (typeof contextPercent === "number") {
+    items.push({ text: `${contextPercent}% context` });
+  }
+  return items;
+});
+
+const runningChips = $derived.by<MetaItem[]>(() => {
+  const items: MetaItem[] = [];
+  const before = notice.contextTokens ?? notice.tokensBefore;
+  if (typeof before === "number") {
+    items.push({ text: `${formatTokens(before)} before` });
+  }
+  if (typeof contextPercent === "number") {
+    items.push({ text: `${contextPercent}% context` });
+  }
+  if (typeof notice.generatedLines === "number" && notice.generatedLines > 0) {
+    items.push({ text: `${notice.generatedLines} lines` });
+  }
+  if (showElapsed && elapsedLabel) {
+    items.push({ text: elapsedLabel });
+  }
+  return items;
+});
+
+const chips = $derived(
+  notice.state === "completed"
+    ? completedChips
+    : notice.state === "running"
+      ? runningChips
+      : [],
+);
+
+const errorMessage = $derived(
+  notice.errorMessage?.trim() || "Could not compact this conversation.",
+);
+
 const bodyVisible = $derived(
   notice.state === "running" ||
     notice.state === "cancelled" ||
-    (notice.state === "completed" && Boolean(summaryLead)),
+    (notice.state === "completed" && previewText.length > 0),
 );
 const layoutRevision = $derived(
   [
     notice.state,
     bodyVisible ? "body" : "no-body",
     notice.state === "failed" ? "error" : "no-error",
-    notice.state === "completed" && chips.length > 0
-      ? `footer:${chips.length}`
-      : "no-footer",
-    showElapsed ? "elapsed" : "no-elapsed",
+    chips.length > 0 ? `footer:${chips.length}` : "no-footer",
+    `preview:${previewText.length}`,
   ].join("|"),
 );
 </script>
@@ -145,30 +163,27 @@ const layoutRevision = $derived(
     badge="compact"
     arg={{ text: reasonLabel }}
     error={notice.state === "failed" ? errorMessage : undefined}
-    meta={notice.state === "completed" ? chips : []}
+    meta={chips}
     {bodyVisible}
     {layoutRevision}
   >
-    {#if notice.state === "running"}
-      <div class="flex min-w-0 items-baseline gap-2">
-        <span class="m-0 min-w-0 text-sm leading-6 text-muted-foreground"
-          >Summarizing recent work…</span
-        >
-        {#if showElapsed}
-          <span class="ml-auto text-xs text-muted-foreground/80 tabular-nums"
-            >{elapsedLabel}</span
-          >
-        {/if}
-      </div>
+    {#if previewText}
+      <ResultCodeBlock
+        code={previewText}
+        language="markdown"
+        trim={false}
+        wrap
+        overflow="hidden"
+        tail
+        fixedRows={COLLAPSED_LINES}
+      />
+    {:else if notice.state === "running"}
+      <p class="m-0 text-sm leading-6 text-muted-foreground">
+        Summarizing recent work…
+      </p>
     {:else if notice.state === "cancelled"}
       <p class="m-0 text-sm leading-6 text-muted-foreground">
         Compaction stopped.
-      </p>
-    {:else if notice.state === "completed" && summaryLead}
-      <p
-        class="m-0 line-clamp-2 overflow-hidden text-sm leading-6 text-muted-foreground"
-      >
-        {summaryLead}
       </p>
     {/if}
   </CardShell>

--- a/packages/workbench-ui/src/lib/components/transcript/TranscriptList.svelte
+++ b/packages/workbench-ui/src/lib/components/transcript/TranscriptList.svelte
@@ -279,6 +279,16 @@ function measurementVersionForRow(row: TranscriptRowItem): string {
       plan ? `${plan.id}:${plan.status}` : "no-plan",
     ].join(":");
   }
+  if (node.kind === "compaction") {
+    const notice = node.notice;
+    return [
+      "compaction",
+      notice.state,
+      notice.summaryPreview?.length ?? 0,
+      notice.summary?.length ?? 0,
+      notice.errorMessage?.length ?? 0,
+    ].join(":");
+  }
   return node.key;
 }
 

--- a/packages/workbench-ui/src/lib/state/adapters.ts
+++ b/packages/workbench-ui/src/lib/state/adapters.ts
@@ -6,6 +6,7 @@ import {
   ConversationCompactedData,
   ConversationCompactionCancelledData,
   ConversationCompactionFailedData,
+  ConversationCompactionProgressData,
   ConversationCompactionStartedData,
   ConversationEntry,
   ConversationEntryAppendedData,
@@ -196,6 +197,13 @@ export function applyConversationEvent(
       applyCompactionStarted(
         next,
         event.data as ConversationCompactionStartedData,
+        event.ts,
+      );
+      break;
+    case "conversation.compaction.progress":
+      applyCompactionProgress(
+        next,
+        event.data as ConversationCompactionProgressData,
         event.ts,
       );
       break;
@@ -622,6 +630,40 @@ function applyCompactionStarted(
     transient.compaction,
   );
   state.error = undefined;
+}
+
+function applyCompactionProgress(
+  state: ConversationRenderState,
+  data: ConversationCompactionProgressData,
+  ts: string,
+): void {
+  const current = state.transient?.compaction;
+  // Terminal states win; a late snapshot must not revive a finished notice.
+  if (current && current.state !== "running") return;
+  if (
+    current?.previewSequence !== undefined &&
+    data.sequence <= current.previewSequence
+  ) {
+    return;
+  }
+  const transient = ensureTransient(state);
+  // A snapshot can arrive first after a resync that started mid-compaction.
+  const base: CompactionNotice = current ?? {
+    id: liveCompactionId(data.conversationId, data.runId, data.reason),
+    state: "running",
+    reason: data.reason,
+    conversationId: data.conversationId,
+    agentId: data.agentId,
+    runId: data.runId,
+    createdAt: ts,
+  };
+  transient.compaction = {
+    ...base,
+    summaryPreview: data.preview,
+    previewSequence: data.sequence,
+    generatedLines: data.generatedLines,
+    generatedChars: data.generatedChars,
+  };
 }
 
 function applyCompactionFailed(

--- a/packages/workbench-ui/src/lib/state/conversation-events.test.ts
+++ b/packages/workbench-ui/src/lib/state/conversation-events.test.ts
@@ -453,6 +453,107 @@ describe("conversation event reducer", () => {
     );
   });
 
+  it("tracks streaming compaction previews and drops stale snapshots", () => {
+    const compactionEvent = (
+      seq: number,
+      type: string,
+      data: Record<string, unknown>,
+    ) =>
+      evt(seq, type, {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        runId: "run_test",
+        reason: "threshold",
+        ...data,
+      });
+
+    let state = emptyConversationRenderState("conv_test");
+    state = applyConversationEvent(state, startRun());
+    state = applyConversationEvent(
+      state,
+      compactionEvent(2, "conversation.compaction.started", { startedAt: ts }),
+    );
+    state = applyConversationEvent(
+      state,
+      compactionEvent(3, "conversation.compaction.progress", {
+        sequence: 2,
+        attempt: 1,
+        preview: "## Goal\nFinish",
+        generatedLines: 2,
+        generatedChars: 14,
+      }),
+    );
+
+    assert.equal(state.transient?.compaction?.state, "running");
+    assert.equal(
+      state.transient?.compaction?.summaryPreview,
+      "## Goal\nFinish",
+    );
+    assert.equal(state.transient?.compaction?.generatedLines, 2);
+
+    state = applyConversationEvent(
+      state,
+      compactionEvent(4, "conversation.compaction.progress", {
+        sequence: 1,
+        attempt: 1,
+        preview: "stale",
+        generatedLines: 1,
+        generatedChars: 5,
+      }),
+    );
+    assert.equal(
+      state.transient?.compaction?.summaryPreview,
+      "## Goal\nFinish",
+    );
+
+    state = applyConversationEvent(
+      state,
+      compactionEvent(5, "conversation.compaction.cancelled", {
+        cancelledAt: ts,
+      }),
+    );
+    assert.equal(state.transient?.compaction?.state, "cancelled");
+    assert.equal(state.transient?.compaction?.summaryPreview, undefined);
+
+    state = applyConversationEvent(
+      state,
+      compactionEvent(6, "conversation.compaction.progress", {
+        sequence: 9,
+        attempt: 2,
+        preview: "late",
+        generatedLines: 1,
+        generatedChars: 4,
+      }),
+    );
+    assert.equal(state.transient?.compaction?.state, "cancelled");
+    assert.equal(state.transient?.compaction?.summaryPreview, undefined);
+  });
+
+  it("starts a running compaction notice from a progress snapshot alone", () => {
+    let state = emptyConversationRenderState("conv_test");
+    state = applyConversationEvent(
+      state,
+      evt(1, "conversation.compaction.progress", {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        runId: "run_test",
+        reason: "threshold",
+        sequence: 7,
+        attempt: 1,
+        preview: "## Goal",
+        generatedLines: 1,
+        generatedChars: 7,
+      }),
+    );
+
+    assert.equal(state.transient?.compaction?.state, "running");
+    assert.equal(state.transient?.compaction?.previewSequence, 7);
+    assert.equal(
+      state.transient?.compaction?.id,
+      "live:compaction:run_test:threshold",
+    );
+  });
+
   it("calls the snapshot recovery hook on offset gaps", () => {
     let state = emptyConversationRenderState("conv_test");
     state = applyConversationEvent(state, startRun());

--- a/packages/workbench-ui/src/lib/state/transcript-types.ts
+++ b/packages/workbench-ui/src/lib/state/transcript-types.ts
@@ -30,6 +30,12 @@ export type CompactionNotice = {
   failedEntryId?: string;
   errorMessage?: string;
   details?: unknown;
+  /** Tail of the summary text while it streams (running state only). */
+  summaryPreview?: string;
+  /** Last applied progress snapshot counter; guards out-of-order snapshots. */
+  previewSequence?: number;
+  generatedLines?: number;
+  generatedChars?: number;
   createdAt?: string;
   completedAt?: string;
 };


### PR DESCRIPTION
## Summary

Polishes the auto-compaction presentation in the transcript. The compaction card keeps its pseudo-tool-call look, but now behaves like a real tool card: it streams the summary being generated, and keeps the same body once the checkpoint is committed.

## Changes

**Live streaming**
- `generateSummary` takes an options object (`GenerateSummaryInput`) and streams through `streamSimpleWithModel`, reporting accumulated text via `onProgress({ attempt, text })`. `attempt: 2` marks the structural-repair retry so the draft resets instead of appending. Split-turn summarization in `compact()` stays non-streaming (two concurrent summaries cannot form one ordered draft).

**Transport**
- New `conversation.compaction.progress` event (sequenced, `supersedable`) carrying an idempotent tail snapshot: `preview`, `sequence`, `attempt`, `generatedLines`, `generatedChars`.
- New `CompactionProgressPublisher`: 200 ms throttle, serialized publishes, dedupes identical previews, forces a publish on attempt change, and swallows every failure so progress can never break compaction. Progress is flushed before any terminal compaction event, so `conversation.compacted` is always last.

**UI**
- `CompactionNotice` gains `summaryPreview` / `previewSequence` / `generatedLines` / `generatedChars`; the reducer ignores stale sequences and terminal states, and synthesizes a running notice when a snapshot arrives first after a resync.
- `CompactionCard` renders the body with `ResultCodeBlock` (`tail`, `fixedRows = COLLAPSED_LINES`, markdown) both while streaming and after completion, so there is no layout jump; running state gains meta chips (context, generated lines, elapsed) and the old two-line lead is gone. `TranscriptList` remeasures compaction rows as the preview grows.

**Continuation prompt**
- `AUTO_COMPACTION_CONTINUE_MESSAGE` shortened to a concise directive. It remains a plain user message with the existing trigger rule (only when the turn would otherwise end, max 3 per run).

## Validation

`pnpm fix && pnpm check && pnpm test` all pass. New coverage: progress publication/ordering (`compaction-service.test.ts`), reducer behavior for streaming previews and stale/late snapshots (`conversation-events.test.ts`), and the event delivery/supersedable assertion (`protocol.schema.test.ts`).

## Known limitations

- Providers without text deltas and the extractive fallback path show the previous "Summarizing recent work…" line (no preview).
- Progress snapshots persist in the conversation stream log, bounded by the throttle, the 1200-char preview cap, and preview dedupe.