### PR TITLE
Fix compaction preview jitter while streaming

### DIFF
--- a/packages/workbench-ui/src/lib/components/transcript/CompactionCard.svelte
+++ b/packages/workbench-ui/src/lib/components/transcript/CompactionCard.svelte
@@ -9,6 +9,10 @@ import {
   COLLAPSED_LINES,
   splitLogicalLines,
 } from "../../tools/views/tool-view-helpers";
+import {
+  compactionCardBodyKind,
+  compactionCardLayoutRevision,
+} from "./compaction-card-layout";
 
 type Props = {
   notice: CompactionNotice;
@@ -145,13 +149,15 @@ const bodyVisible = $derived(
     (notice.state === "completed" && previewText.length > 0),
 );
 const layoutRevision = $derived(
-  [
-    notice.state,
-    bodyVisible ? "body" : "no-body",
-    notice.state === "failed" ? "error" : "no-error",
-    chips.length > 0 ? `footer:${chips.length}` : "no-footer",
-    `preview:${previewText.length}`,
-  ].join("|"),
+  compactionCardLayoutRevision({
+    state: notice.state,
+    bodyKind: compactionCardBodyKind({
+      bodyVisible,
+      previewVisible: previewText.length > 0,
+    }),
+    errorVisible: notice.state === "failed",
+    footerItemCount: chips.length,
+  }),
 );
 </script>
 

--- a/packages/workbench-ui/src/lib/components/transcript/compaction-card-layout.test.ts
+++ b/packages/workbench-ui/src/lib/components/transcript/compaction-card-layout.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  compactionCardBodyKind,
+  compactionCardLayoutRevision,
+} from "./compaction-card-layout";
+
+function runningRevision(previewText: string, footerItemCount = 2): string {
+  return compactionCardLayoutRevision({
+    state: "running",
+    bodyKind: compactionCardBodyKind({
+      bodyVisible: true,
+      previewVisible: previewText.length > 0,
+    }),
+    errorVisible: false,
+    footerItemCount,
+  });
+}
+
+describe("compaction card layout revision", () => {
+  it("changes once when the running placeholder becomes a preview", () => {
+    assert.notEqual(runningRevision(""), runningRevision("First token"));
+  });
+
+  it("stays stable while preview text streams into the same structure", () => {
+    assert.equal(
+      runningRevision("First token"),
+      runningRevision("First token and many later streamed tokens"),
+    );
+  });
+
+  it("changes for actual structural milestones", () => {
+    const running = runningRevision("Preview");
+    assert.notEqual(running, runningRevision("Preview", 3));
+    assert.notEqual(
+      running,
+      compactionCardLayoutRevision({
+        state: "completed",
+        bodyKind: "preview",
+        errorVisible: false,
+        footerItemCount: 2,
+      }),
+    );
+    assert.notEqual(
+      running,
+      compactionCardLayoutRevision({
+        state: "running",
+        bodyKind: "preview",
+        errorVisible: true,
+        footerItemCount: 2,
+      }),
+    );
+    assert.notEqual(
+      running,
+      compactionCardLayoutRevision({
+        state: "running",
+        bodyKind: "none",
+        errorVisible: false,
+        footerItemCount: 2,
+      }),
+    );
+  });
+});

--- a/packages/workbench-ui/src/lib/components/transcript/compaction-card-layout.ts
+++ b/packages/workbench-ui/src/lib/components/transcript/compaction-card-layout.ts
@@ -1,0 +1,29 @@
+import type { CompactionNoticeState } from "../../state/transcript-types";
+
+export type CompactionCardBodyKind = "none" | "status" | "preview";
+
+export function compactionCardBodyKind(input: {
+  bodyVisible: boolean;
+  previewVisible: boolean;
+}): CompactionCardBodyKind {
+  if (!input.bodyVisible) return "none";
+  return input.previewVisible ? "preview" : "status";
+}
+
+/**
+ * Full-card structural milestone. Preview text is intentionally excluded so
+ * streamed deltas do not restart geometry and content motion for every token.
+ */
+export function compactionCardLayoutRevision(input: {
+  state: CompactionNoticeState;
+  bodyKind: CompactionCardBodyKind;
+  errorVisible: boolean;
+  footerItemCount: number;
+}): string {
+  return [
+    input.state,
+    `body:${input.bodyKind}`,
+    input.errorVisible ? "error" : "no-error",
+    input.footerItemCount > 0 ? `footer:${input.footerItemCount}` : "no-footer",
+  ].join("|");
+}


### PR DESCRIPTION
## Summary
- make compaction card lifecycle revisions depend only on structural UI changes
- prevent streamed preview tokens from repeatedly restarting the full-card motion
- add regression coverage for stable streaming revisions and real lifecycle milestones

## Validation
- `pnpm --filter @nervekit/workbench-ui test`
- `pnpm --filter @nervekit/workbench-ui check`
- `pnpm fix && pnpm check && pnpm test`