### PR TITLE
Fix oversized summary lifecycle events

### DIFF
--- a/packages/contracts/src/domains/conversations/conversation.events.schema.ts
+++ b/packages/contracts/src/domains/conversations/conversation.events.schema.ts
@@ -1,10 +1,7 @@
 import { z } from "zod";
 import { definePublicEvent } from "../events/event-definition.schema.js";
 import { projectRecordSchema } from "../projects/project.schema.js";
-import {
-  conversationEntrySchema,
-  conversationRecordSchema,
-} from "./tree.schema.js";
+import { conversationRecordSchema } from "./tree.schema.js";
 
 const workbenchRoles = ["workbench_server"] as const;
 const conversationIdSchema = z.string().startsWith("conv_");
@@ -39,7 +36,6 @@ export const conversationLifecycleEventDefinitions = [
       conversationId: conversationIdSchema,
       activeEntryId: entryIdSchema.optional(),
       targetEntryId: entryIdSchema.optional(),
-      summaryEntry: conversationEntrySchema.optional(),
     }),
     { allowedSourceRoles: workbenchRoles, scope: ["conversationId"] },
   ),
@@ -49,7 +45,7 @@ export const conversationLifecycleEventDefinitions = [
       conversationId: conversationIdSchema,
       fromEntryId: entryIdSchema.optional(),
       targetEntryId: entryIdSchema.optional(),
-      entry: conversationEntrySchema,
+      entryId: entryIdSchema,
     }),
     { allowedSourceRoles: workbenchRoles, scope: ["conversationId"] },
   ),

--- a/packages/contracts/src/domains/conversations/conversation.schema.ts
+++ b/packages/contracts/src/domains/conversations/conversation.schema.ts
@@ -220,7 +220,7 @@ export interface ConversationCompactionCancelledData {
 
 export interface ConversationCompactedData {
   conversationId: string;
-  entry: ConversationEntry;
+  entryId: string;
   tokensBefore: number;
   firstKeptEntryId: string;
   reason?: ConversationCompactionReason;
@@ -816,7 +816,7 @@ const conversationCompactionCancelledDataSchema = z.object({
 
 const conversationCompactedDataSchema = z.object({
   conversationId: z.string().startsWith("conv_"),
-  entry: conversationEntrySchema,
+  entryId: z.string().startsWith("entry_"),
   tokensBefore: z.number().int().nonnegative(),
   firstKeptEntryId: z.string().startsWith("entry_"),
   reason: z.enum(["manual", "threshold", "overflow"]).optional(),

--- a/packages/contracts/test/protocol.schema.test.ts
+++ b/packages/contracts/test/protocol.schema.test.ts
@@ -93,6 +93,69 @@ describe("compact explore payloads", () => {
   });
 });
 
+describe("summary lifecycle event references", () => {
+  it("keeps generated summary text out of public completion events", () => {
+    const compacted = validatePublicEvent(
+      "conversation.compacted",
+      {
+        conversationId: "conv_test",
+        entryId: "entry_compaction",
+        tokensBefore: 20_000,
+        firstKeptEntryId: "entry_recent",
+      },
+      "workbench_server",
+    ) as Record<string, unknown>;
+    assert.equal(compacted.entryId, "entry_compaction");
+    assert.equal(compacted.entry, undefined);
+
+    assert.doesNotThrow(() =>
+      validatePublicEvent(
+        "conversation.branch_summarized",
+        {
+          conversationId: "conv_test",
+          fromEntryId: "entry_old",
+          targetEntryId: "entry_target",
+          entryId: "entry_summary",
+        },
+        "workbench_server",
+      ),
+    );
+    assert.doesNotThrow(() =>
+      validatePublicEvent(
+        "conversation.navigated",
+        {
+          conversationId: "conv_test",
+          activeEntryId: "entry_summary",
+          targetEntryId: "entry_target",
+        },
+        "workbench_server",
+      ),
+    );
+
+    const oversizedEntry = {
+      id: "entry_summary",
+      conversationId: "conv_test",
+      role: "system",
+      kind: "branch_summary",
+      text: "x".repeat(20_000),
+      summary: "x".repeat(20_000),
+      createdAt: ts,
+    };
+    assert.throws(() =>
+      validatePublicEvent(
+        "conversation.compacted",
+        {
+          conversationId: "conv_test",
+          entry: oversizedEntry,
+          tokensBefore: 20_000,
+          firstKeptEntryId: "entry_recent",
+        },
+        "workbench_server",
+      ),
+    );
+  });
+});
+
 describe("Protocol v1 shared schemas", () => {
   it("validates exact-set subscriptions with per-stream modes", () => {
     const set = message("stream.subscription.set", {

--- a/packages/workbench-app/src/lib/features/conversations/state/conversation-reducers.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/conversation-reducers.ts
@@ -98,8 +98,7 @@ export function handleConversationEvent(
   // Validate branch membership before materializing an appended entry; on
   // divergence the snapshot refresh rebuilds coherent state.
   const entry =
-    event.type === "conversation.entry.appended" ||
-    event.type === "conversation.compacted"
+    event.type === "conversation.entry.appended"
       ? (event.data?.entry as ConversationEntry | undefined)
       : undefined;
   if (
@@ -186,12 +185,6 @@ function applyAppEffects(
       scheduleContextUsageRefresh(conversationId);
       break;
     }
-    case "conversation.compacted":
-      if (entry) {
-        view.activeEntryId = entry.id;
-        updateTreeNodesForEntry(view, entry);
-      }
-      break;
     case "conversation.context.updated":
       clearContextUsageRefresh(conversationId);
       break;

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-events.test.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-events.test.ts
@@ -34,6 +34,9 @@ describe("workspace run lifecycle events", () => {
     for (const type of [
       "conversation.created",
       "conversation.deleted",
+      "conversation.compacted",
+      "conversation.branch_summarized",
+      "conversation.navigated",
       "agent.created",
       "agent.subagent_started",
       "toolCall.updated",

--- a/packages/workbench-server/src/domains/conversations/operations/compaction-service.ts
+++ b/packages/workbench-server/src/domains/conversations/operations/compaction-service.ts
@@ -329,7 +329,7 @@ export class CompactionService {
         await this.rebuildConversations();
         await this.events.publish("conversation.compacted", {
           conversationId,
-          entry,
+          entryId: entry.id,
           tokensBefore: preparation.tokensBefore,
           firstKeptEntryId,
           reason,

--- a/packages/workbench-server/src/domains/conversations/operations/navigation-service.ts
+++ b/packages/workbench-server/src/domains/conversations/operations/navigation-service.ts
@@ -64,7 +64,6 @@ export class NavigationService {
       conversationId: conversation.id,
       activeEntryId: nextActiveEntryId,
       targetEntryId: activeEntryId,
-      summaryEntry,
     });
     return updated;
   }
@@ -129,7 +128,7 @@ export class NavigationService {
       conversationId: conversation.id,
       fromEntryId: oldLeafId,
       targetEntryId,
-      entry,
+      entryId: entry.id,
     });
     return entry;
   }

--- a/packages/workbench-server/test/compaction-service.test.ts
+++ b/packages/workbench-server/test/compaction-service.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { validatePublicEvent } from "@nervekit/contracts";
 import { CompactionService } from "../src/domains/conversations/operations/compaction-service.js";
 
 const timestamp = "2026-07-19T00:00:00.000Z";
@@ -89,6 +90,7 @@ describe("CompactionService", () => {
       async () => undefined,
       {
         publish: async (type: string, data: unknown) => {
+          validatePublicEvent(type, data, "workbench_server");
           events.push({ type, data });
         },
       } as never,
@@ -141,7 +143,95 @@ describe("CompactionService", () => {
     assert.ok(
       events.some((event) => event.type === "conversation.compaction.started"),
     );
-    assert.ok(events.some((event) => event.type === "conversation.compacted"));
+    const compacted = events.find(
+      (event) => event.type === "conversation.compacted",
+    );
+    assert.ok(compacted);
+    assert.equal(
+      (compacted.data as { entryId?: string }).entryId,
+      "entry_compaction",
+    );
+    assert.equal((compacted.data as { entry?: unknown }).entry, undefined);
+  });
+
+  it("publishes a reference event for summaries larger than the public text limit", async () => {
+    const events: Array<{ type: string; data: unknown }> = [];
+    const branch = [
+      {
+        type: "message",
+        id: "entry_old",
+        parentId: null,
+        timestamp,
+        message: {
+          role: "user",
+          content: "source ".repeat(20_000),
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "entry_recent",
+        parentId: "entry_old",
+        timestamp,
+        message: {
+          role: "user",
+          content: "continue",
+          timestamp: Date.parse(timestamp),
+        },
+      },
+    ];
+    let activeLeafId = "entry_recent";
+    const storage = {
+      getLeafId: async () => activeLeafId,
+      getPathToRoot: async () => branch,
+      appendEntry: async (entry: { id: string }) => {
+        activeLeafId = entry.id;
+      },
+    };
+    const largeSummary = `${structuredSummary()}\n${"detail ".repeat(3_000)}`;
+    const service = new CompactionService(
+      () => ({ id: "conv_test", projectId: "proj_test" }) as never,
+      () => ({ id: "proj_test", dir: "/tmp/project" }) as never,
+      async (input) =>
+        ({
+          ...input,
+          id: "entry_compaction",
+          parentEntryId: input.parentEntryId ?? null,
+          kind: input.kind ?? "message",
+          createdAt: input.createdAt ?? timestamp,
+        }) as never,
+      { openStorage: async () => storage } as never,
+      async () => undefined,
+      {
+        publish: async (type: string, data: unknown) => {
+          validatePublicEvent(type, data, "workbench_server");
+          events.push({ type, data });
+        },
+      } as never,
+      async () => ({ text: largeSummary, generatedBy: "model" }),
+    );
+
+    const result = await service.compactConversation(
+      "conv_test",
+      {},
+      {
+        reason: "manual",
+        activeConversation: { getStorage: () => storage } as never,
+      },
+    );
+
+    assert.ok(result.entry.text.length > 16_384);
+    const compacted = events.find(
+      (event) => event.type === "conversation.compacted",
+    );
+    assert.equal(
+      (compacted?.data as { entryId?: string } | undefined)?.entryId,
+      "entry_compaction",
+    );
+    assert.equal(
+      events.some((event) => event.type === "conversation.compaction.failed"),
+      false,
+    );
   });
 
   it("publishes coalesced summary tail snapshots while summarizing", async () => {

--- a/packages/workbench-server/test/navigation-service.test.ts
+++ b/packages/workbench-server/test/navigation-service.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { validatePublicEvent } from "@nervekit/contracts";
+import { NavigationService } from "../src/domains/conversations/operations/navigation-service.js";
+
+const timestamp = "2026-07-26T00:00:00.000Z";
+
+describe("NavigationService", () => {
+  it("publishes references for a branch summary larger than the public text limit", async () => {
+    let conversation = {
+      id: "conv_test",
+      projectId: "proj_test",
+      title: "Test",
+      mode: "coding",
+      permissionLevel: "standard",
+      approvalPolicy: {},
+      activeEntryId: "entry_old",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    } as never;
+    const targetEntry = {
+      id: "entry_target",
+      conversationId: "conv_test",
+      role: "user",
+      kind: "message",
+      text: "target",
+      createdAt: timestamp,
+    } as never;
+    const events: Array<{ type: string; data: Record<string, unknown> }> = [];
+    let persistedSummary = "";
+    let leafId: string | null = "entry_old";
+    const targetHarnessEntry = {
+      type: "message",
+      id: "entry_target",
+      parentId: null,
+      timestamp,
+      message: {
+        role: "user",
+        content: "target",
+        timestamp: Date.parse(timestamp),
+      },
+    };
+    const oldHarnessEntry = {
+      type: "message",
+      id: "entry_old",
+      parentId: "entry_target",
+      timestamp,
+      message: {
+        role: "assistant",
+        content: "old branch work",
+        timestamp: Date.parse(timestamp),
+      },
+    };
+    const storage = {
+      getLeafId: async () => leafId,
+      getPathToRoot: async (entryId: string) =>
+        entryId === "entry_target"
+          ? [targetHarnessEntry]
+          : [targetHarnessEntry, oldHarnessEntry],
+      setLeafId: async (entryId: string | null) => {
+        leafId = entryId;
+      },
+      appendEntry: async (entry: { id: string; summary: string }) => {
+        persistedSummary = entry.summary;
+        leafId = entry.id;
+      },
+    };
+    const service = new NavigationService(
+      () => conversation,
+      () => ({ id: "proj_test", dir: "/tmp/project" }) as never,
+      new Map([["conv_test", [targetEntry]]]),
+      async (updated) => {
+        conversation = updated as never;
+      },
+      async (input) =>
+        ({
+          ...input,
+          id: "entry_summary",
+          parentEntryId: input.parentEntryId ?? undefined,
+          kind: input.kind ?? "message",
+          createdAt: timestamp,
+        }) as never,
+      {
+        openStorage: async () => storage,
+        setLeaf: async (
+          _conversation: unknown,
+          entryId: string | undefined,
+        ) => {
+          leafId = entryId ?? null;
+        },
+      } as never,
+      async () => undefined,
+      {
+        publish: async (type: string, data: Record<string, unknown>) => {
+          validatePublicEvent(type, data, "workbench_server");
+          events.push({ type, data });
+        },
+      } as never,
+    );
+
+    const updated = await service.navigateConversation("conv_test", {
+      activeEntryId: "entry_target",
+      summarize: true,
+      summaryInstructions: "instruction ".repeat(2_000),
+    });
+
+    assert.ok(persistedSummary.length > 16_384);
+    assert.equal(updated.activeEntryId, "entry_summary");
+    const summarized = events.find(
+      (event) => event.type === "conversation.branch_summarized",
+    );
+    assert.equal(summarized?.data.entryId, "entry_summary");
+    assert.equal(summarized?.data.entry, undefined);
+    const navigated = events.find(
+      (event) => event.type === "conversation.navigated",
+    );
+    assert.equal(navigated?.data.activeEntryId, "entry_summary");
+    assert.equal(navigated?.data.targetEntryId, "entry_target");
+    assert.equal(navigated?.data.summaryEntry, undefined);
+  });
+});

--- a/packages/workbench-server/test/registry-conversation-lifecycle.test.ts
+++ b/packages/workbench-server/test/registry-conversation-lifecycle.test.ts
@@ -200,6 +200,11 @@ describe("RuntimeRegistry conversation lifecycle", () => {
       assert.equal((started.data as { reason?: string }).reason, "manual");
       assert.ok(compacted);
       assert.equal((compacted.data as { reason?: string }).reason, "manual");
+      assert.equal(
+        (compacted.data as { entryId?: string }).entryId,
+        result.entry.id,
+      );
+      assert.equal((compacted.data as { entry?: unknown }).entry, undefined);
       assert.equal(result.entry.kind, "compaction");
       assert.equal(
         (result.entry.details as { reason?: string }).reason,

--- a/packages/workbench-ui/src/lib/state/adapters.ts
+++ b/packages/workbench-ui/src/lib/state/adapters.ts
@@ -3,7 +3,6 @@ import {
   assertTransition,
   conversationEventTypes,
   type ConversationActiveRunSnapshot,
-  ConversationCompactedData,
   ConversationCompactionCancelledData,
   ConversationCompactionFailedData,
   ConversationCompactionProgressData,
@@ -196,7 +195,7 @@ export function applyConversationEvent(
       );
       break;
     case "conversation.compacted":
-      applyCompacted(next, event.data as ConversationCompactedData);
+      applyCompacted(next);
       break;
     case "conversation.live.turn.started":
       applyLiveTurnStarted(
@@ -680,12 +679,7 @@ function applyCompactionCancelled(
   };
 }
 
-function applyCompacted(
-  state: ConversationRenderState,
-  data: ConversationCompactedData,
-): void {
-  state.entries = upsert(state.entries, data.entry.id, data.entry);
-  state.activeEntryIds = nextActiveEntryIds(state.activeEntryIds, data.entry);
+function applyCompacted(state: ConversationRenderState): void {
   clearTransientCompaction(state);
 }
 

--- a/packages/workbench-ui/src/lib/state/conversation-events.test.ts
+++ b/packages/workbench-ui/src/lib/state/conversation-events.test.ts
@@ -529,6 +529,33 @@ describe("conversation event reducer", () => {
     assert.equal(state.transient?.compaction?.summaryPreview, undefined);
   });
 
+  it("consumes reference-only compaction completion before snapshot refresh", () => {
+    let state = emptyConversationRenderState("conv_test");
+    state = applyConversationEvent(
+      state,
+      evt(1, "conversation.compaction.started", {
+        conversationId: "conv_test",
+        runId: "run_test",
+        reason: "manual",
+        startedAt: ts,
+      }),
+    );
+    state = applyConversationEvent(
+      state,
+      evt(2, "conversation.compacted", {
+        conversationId: "conv_test",
+        entryId: "entry_compaction",
+        tokensBefore: 20_000,
+        firstKeptEntryId: "entry_recent",
+        reason: "manual",
+      }),
+    );
+
+    assert.equal(state.transient?.compaction, undefined);
+    assert.equal(state.entries.length, 0);
+    assert.equal(state.cursorSeq, 2);
+  });
+
   it("starts a running compaction notice from a progress snapshot alone", () => {
     let state = emptyConversationRenderState("conv_test");
     state = applyConversationEvent(


### PR DESCRIPTION
## Summary
- replace embedded compaction and branch-summary entries with durable entry ID references
- keep public event payload limits unchanged and refresh authoritative snapshots client-side
- add regressions for summaries larger than the public text limit

## Validation
- `pnpm fix && pnpm check && pnpm test`