### PR TITLE
Reorder tool settings sections

### DIFF
--- a/packages/workbench-app/src/lib/features/settings/components/settings/sections/ToolsSettingsSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/settings/sections/ToolsSettingsSection.svelte
@@ -401,13 +401,6 @@ async function removeTavilyKey() {
   {/if}
 </SettingsSectionCard>
 
-<JiraToolsSettingsCard {settingsDraft} {authProviders} {onSettingsChange} />
-<ConfluenceToolsSettingsCard
-  {settingsDraft}
-  {authProviders}
-  {onSettingsChange}
-/>
-
 <SettingsSectionCard
   section="tools-tasks"
   title="Task management"
@@ -505,6 +498,13 @@ async function removeTavilyKey() {
     security sandbox.
   </p>
 </SettingsSectionCard>
+
+<JiraToolsSettingsCard {settingsDraft} {authProviders} {onSettingsChange} />
+<ConfluenceToolsSettingsCard
+  {settingsDraft}
+  {authProviders}
+  {onSettingsChange}
+/>
 
 <Dialog.Root bind:open={tavilyDialogOpen}>
   <Dialog.Content class="settings-runtime-dialog">


### PR DESCRIPTION
## Summary
- move Jira and Confluence configuration below the task management section
- keep the remaining tool settings behavior unchanged

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `git diff --check`