### PR TITLE
Add project-aware workspace tab sessions

### DIFF
--- a/packages/ui-kit/src/styles/components/workbench-layout.css
+++ b/packages/ui-kit/src/styles/components/workbench-layout.css
@@ -132,6 +132,10 @@
   gap: 0.625rem;
 }
 
+.title-left {
+  flex: 1;
+}
+
 .title-actions {
   flex: none;
   gap: 0.375rem;

--- a/packages/ui-kit/src/styles/components/workbench-tabs.css
+++ b/packages/ui-kit/src/styles/components/workbench-tabs.css
@@ -1,8 +1,7 @@
 .center-tab-strip {
-  display: grid;
+  display: flex;
   min-width: 0;
   min-height: 2rem;
-  grid-template-columns: minmax(0, 1fr) auto;
   border-bottom: 1px solid var(--border);
   background: var(--card);
 }
@@ -10,20 +9,36 @@
 .tab-scroller {
   display: flex;
   min-width: 0;
+  flex: 1;
   overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-width: thin;
+  scrollbar-width: none;
+}
+
+.tab-scroller::-webkit-scrollbar {
+  display: none;
 }
 
 .center-tab-menu-trigger {
-  flex: 0 1 12.5rem;
-  min-width: 7.5rem;
-  max-width: 15rem;
+  flex: 0 0 12.5rem;
+  width: 12.5rem;
+  min-width: 0;
   height: 2rem;
 }
 
 .center-tab-menu-trigger.wide-tab {
   flex-basis: 13.5rem;
+  width: 13.5rem;
+}
+
+.tab-overflow-control {
+  border-radius: 0;
+  border-right: 1px solid color-mix(in oklab, var(--border) 62%, transparent);
+}
+
+.tab-scroller + .tab-overflow-control {
+  border-right: 0;
+  border-left: 1px solid color-mix(in oklab, var(--border) 62%, transparent);
 }
 
 .center-tab {
@@ -43,6 +58,19 @@
   inset: 0 0 auto;
   height: 1px;
   background: transparent;
+}
+
+.center-tab.dragging {
+  opacity: 0.55;
+}
+
+.center-tab.drop-target::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 2px;
+  background: var(--primary);
+  z-index: 2;
 }
 
 .center-tab:hover {

--- a/packages/workbench-app/src/lib/app/layout/AppLayout.svelte
+++ b/packages/workbench-app/src/lib/app/layout/AppLayout.svelte
@@ -45,7 +45,7 @@ $effect(() => {
     navDrawerOpen: layout.navDrawerOpen,
     utilityDrawerOpen: layout.utilityDrawerOpen,
     autoSaveId: "nerve.workspace.v3",
-    leftLabel: "Project navigator",
+    leftLabel: "Conversations",
     rightLabel: "Utility panel",
   }}
   actions={{

--- a/packages/workbench-app/src/lib/app/layout/CenterTabStrip.svelte
+++ b/packages/workbench-app/src/lib/app/layout/CenterTabStrip.svelte
@@ -6,6 +6,8 @@ import FileText from "@lucide/svelte/icons/file-text";
 import GitPullRequest from "@lucide/svelte/icons/git-pull-request";
 import CloudCog from "@lucide/svelte/icons/cloud-cog";
 import Logs from "@lucide/svelte/icons/logs";
+import MoveLeft from "@lucide/svelte/icons/move-left";
+import MoveRight from "@lucide/svelte/icons/move-right";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import Settings from "@lucide/svelte/icons/settings";
 import Terminal from "@lucide/svelte/icons/terminal";
@@ -48,6 +50,7 @@ type Props = {
   onToggleFileDisplayMode?: (id: string) => void;
   onToggleFileLineWrap?: (id: string) => void;
   onNewConversation?: () => void;
+  onReorder?: (tab: CenterTabIdentity, targetIndex: number) => void;
 };
 
 let {
@@ -62,6 +65,7 @@ let {
   onToggleFileDisplayMode,
   onToggleFileLineWrap,
   onNewConversation,
+  onReorder,
 }: Props = $props();
 
 const newConversationShortcut = getShortcutLabel("conversation.new");
@@ -180,6 +184,24 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
     onSelect: () => onRefresh?.(identity),
   });
 
+  if (onReorder) {
+    items.push(
+      { type: "separator" },
+      {
+        label: "Move Left",
+        icon: MoveLeft,
+        disabled: !hasLeft,
+        onSelect: () => onReorder(identity, index - 1),
+      },
+      {
+        label: "Move Right",
+        icon: MoveRight,
+        disabled: !hasRight,
+        onSelect: () => onReorder(identity, index + 1),
+      },
+    );
+  }
+
   items.push(
     { type: "separator" },
     {
@@ -229,4 +251,5 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
   onCloseRight={(tab) => onCloseRight?.(castIdentity(tab))}
   onCloseLeft={(tab) => onCloseLeft?.(castIdentity(tab))}
   onNew={onNewConversation}
+  onReorder={(tab, targetIndex) => onReorder?.(castIdentity(tab), targetIndex)}
 />

--- a/packages/workbench-app/src/lib/app/layout/CenterWorkspace.svelte
+++ b/packages/workbench-app/src/lib/app/layout/CenterWorkspace.svelte
@@ -16,6 +16,7 @@ import {
   closeCenterTab,
   closeCenterTabs,
   newConversation,
+  reorderCenterTab,
   selectCenterTab,
   workspaceSelectors,
   workspaceState,
@@ -108,6 +109,7 @@ function closeCenterTabsLeft(tab: CenterTabIdentity) {
       onToggleFileDisplayMode={toggleFileDisplayMode}
       onToggleFileLineWrap={toggleFileLineWrap}
       onNewConversation={newConversation}
+      onReorder={reorderCenterTab}
     />
   {/snippet}
   {#snippet content()}

--- a/packages/workbench-app/src/lib/app/layout/ProjectDialogs.svelte
+++ b/packages/workbench-app/src/lib/app/layout/ProjectDialogs.svelte
@@ -12,6 +12,8 @@ import ProjectDirectoryPicker from "$lib/features/projects/components/ProjectDir
 import {
   createConversationForDirectory,
   deleteProjectAndRefresh,
+  openProjectDirectory,
+  selectProject,
   workspaceSelectors,
   workspaceState,
 } from "$lib/features/workspace";
@@ -46,7 +48,9 @@ async function editConversationEntry(entry: {
   {projects}
   {conversations}
   homeDir={status?.storage.home}
-  onSelect={(path) => void createConversationForDirectory(path)}
+  onSelectProject={(projectId) => void selectProject(projectId)}
+  onOpenDirectory={(path) => void openProjectDirectory(path)}
+  onNewChat={(path) => void createConversationForDirectory(path)}
   onForget={(id) => void deleteProjectAndRefresh(id)}
 />
 

--- a/packages/workbench-app/src/lib/app/layout/Titlebar.svelte
+++ b/packages/workbench-app/src/lib/app/layout/Titlebar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import Copy from "@lucide/svelte/icons/copy";
-import Folder from "@lucide/svelte/icons/folder";
 import CloudCog from "@lucide/svelte/icons/cloud-cog";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import Logs from "@lucide/svelte/icons/logs";
@@ -11,11 +10,15 @@ import X from "@lucide/svelte/icons/x";
 import { Toolbar } from "bits-ui";
 import { NerveMark } from "@nervekit/workbench-ui";
 import { WorkbenchTitlebar } from "@nervekit/workbench-ui/components/workbench";
-import type { ProjectRecord } from "$lib/api";
+import {
+  ProjectSwitcher,
+  type ProjectSwitcherItem,
+} from "$lib/features/projects";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 
 type Props = {
-  activeProject?: ProjectRecord;
+  projects?: ProjectSwitcherItem[];
+  activeProjectKey?: string;
   desktop?: boolean;
   maximized?: boolean;
   closeToTray?: boolean;
@@ -24,6 +27,7 @@ type Props = {
   authActive?: boolean;
   logsActive?: boolean;
   onOpenProject?: () => void;
+  onSelectProject?: (projectId: string) => void;
   onOpenLogs?: () => void;
   onOpenAuth?: () => void;
   onOpenSettings?: () => void;
@@ -33,7 +37,8 @@ type Props = {
 };
 
 let {
-  activeProject,
+  projects = [],
+  activeProjectKey,
   desktop = false,
   maximized = false,
   closeToTray = true,
@@ -42,6 +47,7 @@ let {
   authActive = false,
   logsActive = false,
   onOpenProject,
+  onSelectProject,
   onOpenLogs,
   onOpenAuth,
   onOpenSettings,
@@ -57,17 +63,12 @@ let {
       <span class="brand-mark"><NerveMark compact /></span>
     </span>
     <span class="divider" aria-hidden="true"></span>
-    <Button
-      variant="ghost"
-      size="sm"
-      class="project-button"
-      ariaLabel="Open project"
-      title={activeProject?.dir ?? "Open a project"}
-      onclick={() => onOpenProject?.()}
-    >
-      <Folder size={14} strokeWidth={2.1} aria-hidden="true" />
-      <span class="project-button-label">Open Project</span>
-    </Button>
+    <ProjectSwitcher
+      items={projects}
+      activeKey={activeProjectKey}
+      onSelect={onSelectProject}
+      onOpenPicker={onOpenProject}
+    />
   {/snippet}
 
   {#snippet actions()}

--- a/packages/workbench-app/src/lib/app/layout/Titlebar.svelte
+++ b/packages/workbench-app/src/lib/app/layout/Titlebar.svelte
@@ -15,6 +15,7 @@ import {
   type ProjectSwitcherItem,
 } from "$lib/features/projects";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
 
 type Props = {
   projects?: ProjectSwitcherItem[];
@@ -26,6 +27,7 @@ type Props = {
   settingsActive?: boolean;
   authActive?: boolean;
   logsActive?: boolean;
+  buildProjectMenuItems?: (item: ProjectSwitcherItem) => ContextMenuItem[];
   onOpenProject?: () => void;
   onSelectProject?: (projectId: string) => void;
   onOpenLogs?: () => void;
@@ -46,6 +48,7 @@ let {
   settingsActive = false,
   authActive = false,
   logsActive = false,
+  buildProjectMenuItems,
   onOpenProject,
   onSelectProject,
   onOpenLogs,
@@ -66,6 +69,7 @@ let {
     <ProjectSwitcher
       items={projects}
       activeKey={activeProjectKey}
+      buildMenuItems={buildProjectMenuItems}
       onSelect={onSelectProject}
       onOpenPicker={onOpenProject}
     />

--- a/packages/workbench-app/src/lib/app/layout/TitlebarContainer.svelte
+++ b/packages/workbench-app/src/lib/app/layout/TitlebarContainer.svelte
@@ -1,5 +1,21 @@
 <script lang="ts">
 import Titlebar from "$lib/app/layout/Titlebar.svelte";
+import AlertDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
+import { getShortcutLabel } from "$lib/core/shortcuts/registry";
+import { shortProjectLabel } from "$lib/core/utils/project-tree";
+import PruneConversationsDialog from "$lib/features/projects/components/PruneConversationsDialog.svelte";
+import type {
+  DeleteTarget,
+  PruneTarget,
+} from "$lib/features/projects/components/project-agent-tree-props";
+import {
+  buildProjectMenu,
+  countAgeEligible,
+  countKeepEligible,
+  countProjectConversations,
+  type ProjectTreeMenuContext,
+} from "$lib/features/projects/components/project-tree-menus";
+import type { ProjectSwitcherItem } from "$lib/features/projects";
 import {
   closeDesktopWindow,
   desktopRuntime,
@@ -11,6 +27,10 @@ import { openAuthPane } from "$lib/features/auth";
 import { openLogsPane } from "$lib/features/logs";
 import { openSettingsPane, settingsSelectors } from "$lib/features/settings";
 import {
+  deleteProjectAndRefresh,
+  newConversationInProject,
+  openProjectInEditorAndNotify,
+  pruneProjectConversationsAndRefresh,
   selectProject,
   workspaceSelectors,
   workspaceState,
@@ -19,6 +39,12 @@ import { quickProjectItems } from "$lib/features/projects";
 import { responsive } from "$lib/app/layout/responsive.svelte";
 
 const projectItems = $derived(workspaceSelectors.projectSwitcherItems);
+const status = $derived(workspaceSelectors.status);
+const conversations = $derived(workspaceSelectors.conversations);
+const newConversationShortcut = getShortcutLabel("conversation.new");
+
+let pendingDelete = $state<DeleteTarget | undefined>();
+let pendingPrune = $state<PruneTarget | undefined>();
 const quickLimit = $derived(
   responsive.isPhone ? 1 : responsive.isCompact ? 2 : 5,
 );
@@ -34,6 +60,41 @@ const settingsDraft = $derived(settingsSelectors.settingsDraft);
 const desktopQuitting = $derived(
   desktopRuntime.quitting || desktopShutdownState.quitRequested,
 );
+const menuContext = $derived<ProjectTreeMenuContext>({
+  homeDir: status?.storage.home,
+  newConversationShortcut,
+  editorAvailability: status?.runtime.editors,
+  conversationCount: (projectId) =>
+    countProjectConversations(conversations, projectId),
+  onNewConversationInProject: newConversationInProject,
+  onOpenProjectInEditor: (projectId, editor) =>
+    void openProjectInEditorAndNotify(projectId, editor),
+  requestPrune: (project) => {
+    pendingPrune = {
+      id: project.id,
+      label: shortProjectLabel(project.dir, status?.storage.home),
+    };
+  },
+  requestDelete: (target) => (pendingDelete = target),
+});
+
+function projectMenuItems(item: ProjectSwitcherItem) {
+  return buildProjectMenu(item.project, menuContext);
+}
+
+function confirmDelete() {
+  if (pendingDelete?.kind === "project") {
+    void deleteProjectAndRefresh(pendingDelete.id);
+  }
+}
+
+function confirmPrune(
+  request: Parameters<typeof pruneProjectConversationsAndRefresh>[1],
+) {
+  if (pendingPrune) {
+    void pruneProjectConversationsAndRefresh(pendingPrune.id, request);
+  }
+}
 
 function openProjectPicker() {
   workspaceState.projectPickerOpen = true;
@@ -68,6 +129,7 @@ async function handleDesktopClose() {
   settingsActive={activeCenterTab?.kind === "settings"}
   authActive={activeCenterTab?.kind === "auth"}
   logsActive={activeCenterTab?.kind === "logs"}
+  buildProjectMenuItems={projectMenuItems}
   onOpenProject={openProjectPicker}
   onSelectProject={(projectId) => void selectProject(projectId)}
   onOpenLogs={() => openLogsPane()}
@@ -76,4 +138,34 @@ async function handleDesktopClose() {
   onMinimize={() => void minimizeDesktopWindow()}
   onToggleMaximize={() => void toggleMaximizeDesktopWindow()}
   onClose={() => void handleDesktopClose()}
+/>
+
+<AlertDialog
+  open={pendingDelete?.kind === "project"}
+  title="Remove project?"
+  description={pendingDelete
+    ? `This removes “${pendingDelete.label}” from Nerve and deletes its Nerve conversations. Files on disk are not deleted.`
+    : ""}
+  confirmLabel="Remove"
+  destructive
+  onConfirm={confirmDelete}
+  onOpenChange={(open) => {
+    if (!open) pendingDelete = undefined;
+  }}
+/>
+
+<PruneConversationsDialog
+  open={!!pendingPrune}
+  projectLabel={pendingPrune?.label ?? ""}
+  totalCount={pendingPrune
+    ? countProjectConversations(conversations, pendingPrune.id)
+    : 0}
+  ageEligible={(days) =>
+    pendingPrune ? countAgeEligible(conversations, pendingPrune.id, days) : 0}
+  keepEligible={(keep) =>
+    pendingPrune ? countKeepEligible(conversations, pendingPrune.id, keep) : 0}
+  onConfirm={confirmPrune}
+  onOpenChange={(open) => {
+    if (!open) pendingPrune = undefined;
+  }}
 />

--- a/packages/workbench-app/src/lib/app/layout/TitlebarContainer.svelte
+++ b/packages/workbench-app/src/lib/app/layout/TitlebarContainer.svelte
@@ -10,9 +10,25 @@ import {
 import { openAuthPane } from "$lib/features/auth";
 import { openLogsPane } from "$lib/features/logs";
 import { openSettingsPane, settingsSelectors } from "$lib/features/settings";
-import { workspaceSelectors, workspaceState } from "$lib/features/workspace";
+import {
+  selectProject,
+  workspaceSelectors,
+  workspaceState,
+} from "$lib/features/workspace";
+import { quickProjectItems } from "$lib/features/projects";
+import { responsive } from "$lib/app/layout/responsive.svelte";
 
-const activeProject = $derived(workspaceSelectors.activeProject);
+const projectItems = $derived(workspaceSelectors.projectSwitcherItems);
+const quickLimit = $derived(
+  responsive.isPhone ? 1 : responsive.isCompact ? 2 : 5,
+);
+const quickProjects = $derived(
+  quickProjectItems(
+    projectItems,
+    workspaceState.selectedProjectKey,
+    quickLimit,
+  ),
+);
 const activeCenterTab = $derived(workspaceSelectors.activeCenterTab);
 const settingsDraft = $derived(settingsSelectors.settingsDraft);
 const desktopQuitting = $derived(
@@ -43,7 +59,8 @@ async function handleDesktopClose() {
 </script>
 
 <Titlebar
-  {activeProject}
+  projects={quickProjects}
+  activeProjectKey={workspaceState.selectedProjectKey}
   desktop={desktopRuntime.isDesktop}
   maximized={desktopRuntime.windowState.maximized}
   closeToTray={settingsDraft?.desktop.closeToTray ?? true}
@@ -52,6 +69,7 @@ async function handleDesktopClose() {
   authActive={activeCenterTab?.kind === "auth"}
   logsActive={activeCenterTab?.kind === "logs"}
   onOpenProject={openProjectPicker}
+  onSelectProject={(projectId) => void selectProject(projectId)}
   onOpenLogs={() => openLogsPane()}
   onOpenAuth={() => openAuthPane()}
   onOpenSettings={() => void openSettingsPane()}

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
@@ -299,10 +299,6 @@ async function editConversationEntry(entry: {
   focusComposer();
 }
 
-function openProjectPicker() {
-  workspaceState.projectPickerOpen = true;
-}
-
 function openToolFile(path: string, line?: number) {
   if (!activeProject) return;
   void openFilePane({ projectId: activeProject.id, path, line });
@@ -426,7 +422,6 @@ function moveQueuedPromptToComposer(prompt: QueuedPromptRecord) {
         : abortActiveRun,
     );
   }}
-  onOpenProject={openProjectPicker}
   onNewConversationInProject={newConversationInProject}
   onOpenFile={openToolFile}
   onModelChange={(value) => {

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationWelcome.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationWelcome.svelte
@@ -5,17 +5,25 @@ import { Button } from "@nervekit/ui-kit/components/ui/button";
 import { Kbd } from "@nervekit/ui-kit/components/ui/kbd";
 import { getShortcutLabel } from "$lib/core/shortcuts/registry";
 
-let { onNewChat }: { onNewChat: () => void } = $props();
+let {
+  onNewChat,
+  projectSelected = false,
+}: {
+  onNewChat: () => void;
+  projectSelected?: boolean;
+} = $props();
 
 const newChatShortcut = getShortcutLabel("conversation.new");
 </script>
 
 <ConversationSignal
   title="Where should we start?"
-  message="Open a project and begin a conversation to explore, plan, and build."
+  message={projectSelected
+    ? "Begin a conversation in the selected project to explore, plan, and build."
+    : "Select a project from the top header to begin a conversation."}
 >
   {#snippet footer()}
-    <Button onclick={onNewChat}>
+    <Button onclick={onNewChat} disabled={!projectSelected}>
       <Plus aria-hidden="true" />
       New chat
     </Button>

--- a/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
@@ -70,7 +70,7 @@ let {
   onAnswerUserQuestion,
   onDismissUserQuestion,
   onAbort,
-  onOpenProject,
+  onNewConversationInProject,
   onOpenFile,
   onModelChange,
   onThinkingLevelChange,
@@ -317,6 +317,11 @@ function menuForTranscript(
   {/snippet}
 
   {#snippet emptyExtension()}
-    <ConversationWelcome onNewChat={() => onOpenProject?.()} />
+    <ConversationWelcome
+      projectSelected={Boolean(activeProject && onNewConversationInProject)}
+      onNewChat={() => {
+        if (activeProject) onNewConversationInProject?.(activeProject.dir);
+      }}
+    />
   {/snippet}
 </ConversationPane>

--- a/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
@@ -74,7 +74,6 @@ export type WorkbenchConversationAdapterProps = {
   ) => void | Promise<void>;
   onDismissUserQuestion?: (questionId: string) => void | Promise<void>;
   onAbort?: () => void;
-  onOpenProject?: () => void;
   onNewConversationInProject?: (projectDir: string) => void;
   onOpenFile?: (path: string, line?: number) => void;
   onModelChange?: (value: string) => void;

--- a/packages/workbench-app/src/lib/features/conversations/state/selection.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/selection.ts
@@ -14,7 +14,10 @@ import { conversationState } from "$lib/features/conversations/state/conversatio
 import { stoppingAfterConversationSnapshot } from "$lib/features/conversations/state/conversation-terminal-state";
 import { fileState } from "$lib/features/filesystem/state/file-state.svelte";
 import { getPendingUserQuestions } from "$lib/features/tools/api/tools.api";
-import { replaceOpenCenterTabs } from "$lib/features/workspace/state/center-tabs.svelte";
+import {
+  replaceOpenCenterTabs,
+  setActiveCenterTab,
+} from "$lib/features/workspace/state/center-tabs.svelte";
 import {
   composerDraft,
   selection,
@@ -129,7 +132,7 @@ export function clearConversationState() {
   void voiceInputSession.cancel();
   replaceOpenCenterTabs([]);
   conversationState.activeConversationTabId = undefined;
-  workspaceState.activeCenterTab = undefined;
+  setActiveCenterTab(undefined);
   conversationState.conversationViews = {};
   conversationState.pendingConversations = {};
   fileState.fileViews = {};

--- a/packages/workbench-app/src/lib/features/conversations/state/state.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/state.ts
@@ -7,7 +7,7 @@ import type {
   PendingConversationState,
 } from "$lib/core/types/state-types";
 import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
-import { saveConversationTabs } from "$lib/features/conversations/state/conversation-tabs";
+import { saveVisibleProjectSession } from "$lib/features/workspace/state/workspace-tab-sessions";
 import { addCenterTab } from "$lib/features/workspace/state/center-tabs.svelte";
 import {
   composerDraft,
@@ -38,10 +38,7 @@ export function ensureConversationView(
 }
 
 export function persistConversationTabs() {
-  saveConversationTabs(
-    conversationState.openConversationTabIds,
-    conversationState.activeConversationTabId,
-  );
+  saveVisibleProjectSession();
 }
 
 export function addConversationTab(conversationId: string) {

--- a/packages/workbench-app/src/lib/features/conversations/state/tabs.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/tabs.ts
@@ -8,10 +8,6 @@ import {
 } from "$lib/core/state/state-keys";
 import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
 import {
-  filterStoredTabsAgainstConversations,
-  loadStoredConversationTabs,
-} from "$lib/features/conversations/state/conversation-tabs";
-import {
   nextCenterTabAfterClose,
   removeCenterTab,
   replaceOpenCenterTabs,
@@ -38,6 +34,11 @@ export async function openConversation(conversationId: string) {
     ) ??
     (await protocolRequest("conversation.get", { conversationId })).result
       .conversation;
+  if (conversation.projectId !== workspaceState.selectedProjectId) {
+    const { selectProject } =
+      await import("$lib/features/workspace/state/workspace-actions.svelte");
+    await selectProject(conversation.projectId);
+  }
   addConversationTab(conversation.id);
   conversationState.activeConversationTabId = conversation.id;
   setActiveCenterTab({ kind: "conversation", id: conversation.id });
@@ -49,20 +50,17 @@ export async function openConversation(conversationId: string) {
 }
 
 export async function restoreConversationTabs() {
-  const stored = loadStoredConversationTabs();
-  const tabIds = filterStoredTabsAgainstConversations(
-    stored.tabIds,
-    workspaceState.conversations,
-  );
-  replaceOpenCenterTabs(tabIds.map((id) => ({ kind: "conversation", id })));
+  const tabIds = workspaceState.openCenterTabs
+    .filter(
+      (tab): tab is Extract<typeof tab, { kind: "conversation" }> =>
+        tab.kind === "conversation",
+    )
+    .map((tab) => tab.id);
   for (const conversationId of tabIds) ensureConversationView(conversationId);
-  const activeId =
-    stored.activeId && tabIds.includes(stored.activeId)
-      ? stored.activeId
-      : tabIds[0];
-  conversationState.activeConversationTabId = activeId;
-  persistConversationTabs();
-  if (activeId) await openConversation(activeId);
+  const active = workspaceState.activeCenterTab;
+  conversationState.activeConversationTabId =
+    active?.kind === "conversation" ? active.id : tabIds[0];
+  if (active) await selectCenterTab(active);
 }
 
 export async function closeConversationTab(conversationId: string) {

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-tabs.svelte.ts
@@ -45,6 +45,11 @@ export async function openFilePane(input: {
   path: string;
   line?: number;
 }) {
+  if (input.projectId !== workspaceState.selectedProjectId) {
+    const { selectProject } =
+      await import("$lib/features/workspace/state/workspace-actions.svelte");
+    await selectProject(input.projectId);
+  }
   const id = encodeFileTabId(input.projectId, input.path);
   const key = fileViewKey(id);
   addFileTab(id);

--- a/packages/workbench-app/src/lib/features/git/state/pr-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/pr-tabs.svelte.ts
@@ -44,6 +44,11 @@ export async function openPrPane(input: {
   repo: string;
   number: number;
 }) {
+  if (input.projectId !== workspaceState.selectedProjectId) {
+    const { selectProject } =
+      await import("$lib/features/workspace/state/workspace-actions.svelte");
+    await selectProject(input.projectId);
+  }
   const id = encodePrTabId(input.projectId, input.repo, input.number);
   const key = prViewKey(id);
   addPrTab(id);

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+import Plus from "@lucide/svelte/icons/plus";
+import type { ProjectRecord } from "$lib/api";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import AlertDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
+import { NavigatorPanel } from "@nervekit/workbench-ui/components/navigator";
+import { buildConversationRows } from "$lib/core/utils/project-tree";
+import ProjectAgentTreeNode from "./ProjectAgentTreeNode.svelte";
+import ProjectConversationsDialog from "./ProjectConversationsDialog.svelte";
+import {
+  getShortcutAriaLabel,
+  getShortcutLabel,
+} from "$lib/core/shortcuts/registry";
+import {
+  buildConversationMenu,
+  type ProjectTreeMenuContext,
+} from "./project-tree-menus";
+import type {
+  DeleteTarget,
+  ProjectAgentTreeProps,
+} from "./project-agent-tree-props";
+
+let {
+  projects = [],
+  conversations = [],
+  agents = [],
+  selectedProjectId,
+  selectedConversationId,
+  openConversationTabIds,
+  conversationActivityById = {},
+  searchFocusToken = 0,
+  editorAvailability,
+  homeDir,
+  onOpenConversation,
+  onNewConversationInProject,
+  onOpenProjectInEditor,
+  onDeleteConversation,
+  onPruneProjectConversations,
+}: ProjectAgentTreeProps = $props();
+
+let filter = $state("");
+let searchInputEl = $state<HTMLInputElement | null>(null);
+let pendingDelete = $state<DeleteTarget | undefined>();
+let allConversationsOpen = $state(false);
+let viewportRef = $state<HTMLElement | null>(null);
+let listRef = $state<HTMLDivElement | null>(null);
+let visibleLimit = $state(8);
+
+const activeProject = $derived(
+  projects.find((project) => project.id === selectedProjectId) ?? projects[0],
+);
+const projectIds = $derived(projects.map((project) => project.id));
+const rows = $derived(
+  buildConversationRows({ conversations, agents, projectIds, filter }),
+);
+const visibleRows = $derived(rows.slice(0, visibleLimit));
+const searchShortcut = getShortcutLabel("projectSearch.focus");
+const searchShortcutAria = getShortcutAriaLabel("projectSearch.focus");
+const newConversationShortcut = getShortcutLabel("conversation.new");
+const switchProjectShortcut = getShortcutLabel("conversation.newFromProject");
+const emptyStateHint = switchProjectShortcut
+  ? `Use the folder button in the header (${switchProjectShortcut}) to get started.`
+  : "Use the folder button in the header to get started.";
+
+function updateVisibleLimit(rowCount = rows.length) {
+  if (rowCount === 0) {
+    visibleLimit = 1;
+    return;
+  }
+  if (!viewportRef || !listRef) return;
+  const row = listRef.querySelector<HTMLElement>("[data-conversation-row]");
+  const rowHeight = row?.getBoundingClientRect().height;
+  if (!rowHeight) return;
+  const viewportRect = viewportRef.getBoundingClientRect();
+  const listRect = listRef.getBoundingClientRect();
+  const inset = Math.max(0, listRect.top - viewportRect.top);
+  const availableHeight = Math.max(
+    rowHeight,
+    viewportRef.clientHeight - inset * 2,
+  );
+  const capacity = Math.max(1, Math.floor(availableHeight / rowHeight));
+  // Reserve one compact row for the overflow action plus rounding/inset slack
+  // so the navigator viewport never becomes scrollable by a few pixels.
+  visibleLimit = rowCount > capacity ? Math.max(1, capacity - 2) : capacity;
+}
+
+$effect(() => {
+  if (!viewportRef) return;
+  const rowCount = rows.length;
+  const observer = new ResizeObserver(() =>
+    requestAnimationFrame(() => updateVisibleLimit(rowCount)),
+  );
+  observer.observe(viewportRef);
+  requestAnimationFrame(() => updateVisibleLimit(rowCount));
+  return () => observer.disconnect();
+});
+
+const menuContext = $derived<ProjectTreeMenuContext>({
+  homeDir,
+  newConversationShortcut,
+  editorAvailability,
+  conversationCount: (projectId) =>
+    conversations.filter((conversation) => conversation.projectId === projectId)
+      .length,
+  onOpenConversation,
+  onNewConversationInProject,
+  onOpenProjectInEditor,
+  requestPrune: (project: ProjectRecord) =>
+    onPruneProjectConversations?.(project.id, {
+      strategy: "keepLatest",
+      keepLatest: 20,
+    }),
+  requestDelete: (target) => (pendingDelete = target),
+});
+</script>
+
+<NavigatorPanel
+  bind:searchValue={filter}
+  bind:searchRef={searchInputEl}
+  bind:viewportRef
+  placeholder="Search conversations"
+  searchAriaLabel="Search conversations"
+  {searchFocusToken}
+  {searchShortcut}
+  {searchShortcutAria}
+>
+  {#snippet searchActions()}
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      ariaLabel={activeProject
+        ? `New chat in ${activeProject.name}`
+        : "New chat"}
+      title="New chat"
+      disabled={!activeProject}
+      onclick={() => {
+        if (activeProject) onNewConversationInProject?.(activeProject.dir);
+      }}
+    >
+      <Plus class="size-4" aria-hidden="true" />
+    </Button>
+  {/snippet}
+  {#if activeProject}
+    <div class="flex flex-col" bind:this={listRef}>
+      {#if rows.length === 0}
+        <div
+          class="flex flex-col items-center gap-2 px-4 py-8 text-center text-xs text-muted-foreground"
+        >
+          <p>
+            {filter
+              ? "No conversations match your search."
+              : "No conversations in this project yet."}
+          </p>
+          {#if !filter}
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={() => onNewConversationInProject?.(activeProject.dir)}
+              >New chat</Button
+            >
+          {/if}
+        </div>
+      {/if}
+      {#each visibleRows as row (row.conversation.id)}
+        {@const rowProject =
+          projects.find(
+            (project) => project.id === row.conversation.projectId,
+          ) ?? activeProject}
+        <div data-conversation-row>
+          <ProjectAgentTreeNode
+            {row}
+            isOpen={openConversationTabIds?.has(row.conversation.id) ?? false}
+            isActive={row.conversation.id === selectedConversationId}
+            activity={conversationActivityById[row.conversation.id]}
+            menuItems={buildConversationMenu(
+              rowProject,
+              row.conversation,
+              menuContext,
+            )}
+            {onOpenConversation}
+          />
+        </div>
+      {/each}
+      {#if rows.length > visibleRows.length}
+        <Button
+          variant="ghost"
+          size="xs"
+          class="mx-auto mt-0.5 h-6 w-fit px-2 py-0 text-xs text-muted-foreground"
+          onclick={() => (allConversationsOpen = true)}
+          >Show {rows.length - visibleRows.length} more</Button
+        >
+      {/if}
+    </div>
+  {:else}
+    <div
+      class="flex flex-col items-center gap-2 px-4 py-8 text-center text-xs text-muted-foreground"
+    >
+      <p>No project selected.</p>
+      <span>{emptyStateHint}</span>
+    </div>
+  {/if}
+</NavigatorPanel>
+
+<AlertDialog
+  open={pendingDelete?.kind === "conversation"}
+  title="Delete conversation?"
+  description={pendingDelete
+    ? `This permanently removes “${pendingDelete.label}”.`
+    : ""}
+  confirmLabel="Delete"
+  destructive
+  onConfirm={() => {
+    if (pendingDelete?.kind === "conversation")
+      onDeleteConversation?.(pendingDelete.id);
+  }}
+  onOpenChange={(open) => {
+    if (!open) pendingDelete = undefined;
+  }}
+/>
+
+{#if activeProject}
+  <ProjectConversationsDialog
+    open={allConversationsOpen}
+    projectLabel={activeProject.name}
+    project={activeProject}
+    {projectIds}
+    {conversations}
+    {agents}
+    {selectedConversationId}
+    {openConversationTabIds}
+    {conversationActivityById}
+    {onOpenConversation}
+    buildMenu={(conversation) =>
+      buildConversationMenu(
+        projects.find((project) => project.id === conversation.projectId) ??
+          activeProject,
+        conversation,
+        menuContext,
+      )}
+    onOpenChange={(open) => (allConversationsOpen = open)}
+  />
+{/if}

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
@@ -28,7 +28,9 @@ type Props = {
   conversations?: ConversationRecord[];
   homeDir?: string;
   onClose?: () => void;
-  onSelect?: (path: string) => void | Promise<void>;
+  onSelectProject?: (projectId: string) => void | Promise<void>;
+  onOpenDirectory?: (path: string) => void | Promise<void>;
+  onNewChat?: (path: string) => void | Promise<void>;
   onForget?: (projectId: string) => void;
 };
 let {
@@ -37,7 +39,9 @@ let {
   conversations = [],
   homeDir,
   onClose,
-  onSelect,
+  onSelectProject,
+  onOpenDirectory,
+  onNewChat,
   onForget,
 }: Props = $props();
 type Mode = "recent" | "browse";
@@ -175,6 +179,11 @@ function handleOpenChange(next: boolean) {
   open = next;
   if (!next) onClose?.();
 }
+async function chooseProject(projectId: string) {
+  await onSelectProject?.(projectId);
+  handleOpenChange(false);
+}
+
 function handleSubmit(event: Event) {
   event.preventDefault();
   const q = query.trim();
@@ -186,7 +195,7 @@ function handleSubmit(event: Event) {
   if (mode === "recent") {
     const target =
       filteredRecents[recentSelectedIndex >= 0 ? recentSelectedIndex : 0];
-    if (target) void onSelect?.(target.dir);
+    if (target) void chooseProject(target.id);
     return;
   }
   const first = navItems[0];
@@ -195,7 +204,8 @@ function handleSubmit(event: Event) {
 async function openTarget() {
   const path = openTargetPath;
   if (!path) return;
-  await onSelect?.(path);
+  await onOpenDirectory?.(path);
+  handleOpenChange(false);
 }
 function handleFolderRowKeydown(
   event: KeyboardEvent,
@@ -218,7 +228,7 @@ function handleRecentRowKeydown(
     event.preventDefault();
     event.stopPropagation();
     recentSelectedIndex = index;
-    void onSelect?.(project.dir);
+    void chooseProject(project.id);
   }
 }
 async function copyPath(path: string) {
@@ -262,7 +272,7 @@ function handleRecentKeydown(event: KeyboardEvent) {
       {
         const target2 =
           filteredRecents[recentSelectedIndex >= 0 ? recentSelectedIndex : 0];
-        if (target2) void onSelect?.(target2.dir);
+        if (target2) void chooseProject(target2.id);
       }
       break;
   }
@@ -337,7 +347,7 @@ $effect(() => {
 </script>
 <Dialog
   bind:open
-  title="Open Project"
+  title="Switch project"
   class="project-picker-dialog"
   onOpenChange={handleOpenChange}
 >
@@ -359,8 +369,8 @@ $effect(() => {
         {homeDir}
         {loading}
         {conversationCountFor}
-        onOpen={(path) => void onSelect?.(path)}
-        onNewChat={(path) => void onSelect?.(path)}
+        onOpen={(project) => void chooseProject(project.id)}
+        onNewChat={(path) => void onNewChat?.(path)}
         onCopyPath={(path) => void copyPath(path)}
         {onForget}
         onBrowsePath={() => enterBrowse(expandHome(query, homeDir))}

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectNavigatorShell.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectNavigatorShell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import ProjectAgentTree from "$lib/features/projects/components/ProjectAgentTree.svelte";
+import ProjectConversationNavigator from "$lib/features/projects/components/ProjectConversationNavigator.svelte";
 import { projectNavigatorSignals } from "$lib/features/projects/state/project-navigator-signals.svelte";
 import { conversationSelectors } from "$lib/features/conversations/state/conversation-selectors.svelte";
 import { selection } from "$lib/features/workspace/state/selection.svelte";
@@ -14,8 +14,11 @@ import {
 } from "$lib/features/workspace/state/workspace-actions.svelte";
 
 const status = $derived(workspaceSelectors.status);
-const projects = $derived(workspaceSelectors.projects);
-const conversations = $derived(workspaceSelectors.conversations);
+const projectIds = $derived(new Set(workspaceSelectors.selectedProjectIds));
+const projects = $derived(
+  workspaceSelectors.projects.filter((project) => projectIds.has(project.id)),
+);
+const conversations = $derived(workspaceSelectors.selectedProjectConversations);
 const agents = $derived(workspaceSelectors.agents);
 const openConversationTabIds = $derived(
   workspaceSelectors.openConversationTabIds,
@@ -25,7 +28,7 @@ const conversationActivityById = $derived(
 );
 </script>
 
-<ProjectAgentTree
+<ProjectConversationNavigator
   {projects}
   {conversations}
   {agents}

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+import FolderSearch from "@lucide/svelte/icons/folder-search";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import { StatusDot } from "@nervekit/ui-kit/components/ui/status-dot";
+import {
+  getShortcutAriaLabel,
+  getShortcutLabel,
+} from "$lib/core/shortcuts/registry";
+import {
+  projectActivityIndicator,
+  type ProjectSwitcherItem,
+} from "$lib/features/projects/state/project-switcher";
+
+type Props = {
+  items?: ProjectSwitcherItem[];
+  activeKey?: string;
+  onSelect?: (projectId: string) => void;
+  onOpenPicker?: () => void;
+};
+
+let { items = [], activeKey, onSelect, onOpenPicker }: Props = $props();
+
+const switchShortcut = getShortcutLabel("conversation.newFromProject");
+const switchTitle = switchShortcut
+  ? `Switch project (${switchShortcut})`
+  : "Switch project";
+const switchAria = getShortcutAriaLabel("conversation.newFromProject");
+
+function tabLabel(item: ProjectSwitcherItem): string {
+  const indicator = projectActivityIndicator(item.activity);
+  return indicator ? `${item.label}: ${indicator.summary}` : item.label;
+}
+</script>
+
+<nav
+  class="project-switcher flex min-w-0 items-center gap-1"
+  aria-label="Projects"
+>
+  <Button
+    variant="ghost"
+    size="icon-sm"
+    class="shrink-0"
+    ariaLabel="Switch project"
+    title={switchTitle}
+    aria-keyshortcuts={switchAria}
+    onclick={() => onOpenPicker?.()}
+  >
+    <FolderSearch class="size-4" aria-hidden="true" />
+  </Button>
+  {#if items.length}
+    <span class="divider" aria-hidden="true"></span>
+  {/if}
+  <div class="flex min-w-0 items-center gap-0.5">
+    {#each items as item (item.key)}
+      {@const indicator = projectActivityIndicator(item.activity)}
+      {@const active = item.key === activeKey}
+      <Button
+        variant="ghost"
+        size="sm"
+        class={`min-w-0 max-w-56 gap-1.5 px-2 ${active ? "" : "text-muted-foreground"}`}
+        {active}
+        pressed={active}
+        aria-current={active ? "page" : undefined}
+        ariaLabel={tabLabel(item)}
+        title={`${item.project.dir}${indicator ? ` — ${indicator.summary}` : ""}`}
+        onclick={() => onSelect?.(item.project.id)}
+      >
+        {#if indicator}
+          <StatusDot tone={indicator.tone} size="xs" pulse={indicator.pulse} />
+        {/if}
+        <span class="truncate">{item.label}</span>
+      </Button>
+    {/each}
+  </div>
+</nav>
+
+<style>
+.project-switcher {
+  -webkit-app-region: no-drag;
+}
+</style>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 import FolderSearch from "@lucide/svelte/icons/folder-search";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
+import ContextMenu, {
+  type ContextMenuItem,
+} from "@nervekit/ui-kit/components/ui/context-menu-list";
 import { StatusDot } from "@nervekit/ui-kit/components/ui/status-dot";
 import {
   getShortcutAriaLabel,
@@ -14,11 +17,18 @@ import {
 type Props = {
   items?: ProjectSwitcherItem[];
   activeKey?: string;
+  buildMenuItems?: (item: ProjectSwitcherItem) => ContextMenuItem[];
   onSelect?: (projectId: string) => void;
   onOpenPicker?: () => void;
 };
 
-let { items = [], activeKey, onSelect, onOpenPicker }: Props = $props();
+let {
+  items = [],
+  activeKey,
+  buildMenuItems,
+  onSelect,
+  onOpenPicker,
+}: Props = $props();
 
 const switchShortcut = getShortcutLabel("conversation.newFromProject");
 const switchTitle = switchShortcut
@@ -54,22 +64,32 @@ function tabLabel(item: ProjectSwitcherItem): string {
     {#each items as item (item.key)}
       {@const indicator = projectActivityIndicator(item.activity)}
       {@const active = item.key === activeKey}
-      <Button
-        variant="ghost"
-        size="sm"
-        class={`min-w-0 max-w-56 gap-1.5 px-2 ${active ? "" : "text-muted-foreground"}`}
-        {active}
-        pressed={active}
-        aria-current={active ? "page" : undefined}
-        ariaLabel={tabLabel(item)}
-        title={`${item.project.dir}${indicator ? ` — ${indicator.summary}` : ""}`}
-        onclick={() => onSelect?.(item.project.id)}
+      <ContextMenu
+        items={buildMenuItems?.(item) ?? []}
+        disabled={!buildMenuItems}
+        triggerClass="block min-w-0 max-w-56"
       >
-        {#if indicator}
-          <StatusDot tone={indicator.tone} size="xs" pulse={indicator.pulse} />
-        {/if}
-        <span class="truncate">{item.label}</span>
-      </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          class={`w-full min-w-0 gap-1.5 px-2 ${active ? "" : "text-muted-foreground"}`}
+          {active}
+          pressed={active}
+          aria-current={active ? "page" : undefined}
+          ariaLabel={tabLabel(item)}
+          title={`${item.project.dir}${indicator ? ` — ${indicator.summary}` : ""}`}
+          onclick={() => onSelect?.(item.project.id)}
+        >
+          {#if indicator}
+            <StatusDot
+              tone={indicator.tone}
+              size="xs"
+              pulse={indicator.pulse}
+            />
+          {/if}
+          <span class="truncate">{item.label}</span>
+        </Button>
+      </ContextMenu>
     {/each}
   </div>
 </nav>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -57,9 +57,6 @@ function tabLabel(item: ProjectSwitcherItem): string {
   >
     <FolderSearch class="size-4" aria-hidden="true" />
   </Button>
-  {#if items.length}
-    <span class="divider" aria-hidden="true"></span>
-  {/if}
   <div class="flex min-w-0 items-center gap-0.5">
     {#each items as item (item.key)}
       {@const indicator = projectActivityIndicator(item.activity)}

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -25,7 +25,7 @@ type Props = {
   homeDir?: string;
   loading: boolean;
   conversationCountFor: (project: ProjectRecord) => number;
-  onOpen: (path: string) => void;
+  onOpen: (project: ProjectRecord) => void;
   onForget?: (projectId: string) => void;
   onCopyPath: (path: string) => void;
   onNewChat: (path: string) => void;
@@ -129,7 +129,7 @@ function cardMenu(project: ProjectRecord): ContextMenuItem[] {
               aria-selected={selectedIndex === i}
               tabindex="-1"
               title={`${project.dir}\n${dateTimeLabel(project.updatedAt)}`}
-              onclick={() => onOpen(project.dir)}
+              onclick={() => onOpen(project)}
               onmouseenter={() => onSelectedIndexChange?.(i)}
               onkeydown={(e) => onRowKeydown(e, i, project)}
             >

--- a/packages/workbench-app/src/lib/features/projects/index.ts
+++ b/packages/workbench-app/src/lib/features/projects/index.ts
@@ -1,5 +1,17 @@
 export * from "./api/projects.api";
 export { default as ProjectNavigatorShell } from "./components/ProjectNavigatorShell.svelte";
+export { default as ProjectSwitcher } from "./components/ProjectSwitcher.svelte";
+export {
+  buildProjectSwitcherItems,
+  projectActivityIndicator,
+  quickProjectItems,
+  summarizeProjectActivity,
+} from "./state/project-switcher";
+export type {
+  ProjectActivityIndicator,
+  ProjectActivitySummary,
+  ProjectSwitcherItem,
+} from "./state/project-switcher";
 export {
   focusProjectSearch,
   projectNavigatorSignals,

--- a/packages/workbench-app/src/lib/features/projects/state/project-switcher.test.ts
+++ b/packages/workbench-app/src/lib/features/projects/state/project-switcher.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ConversationRecord, ProjectRecord } from "$lib/api";
+import type { ConversationActivityState } from "$lib/features/conversations/state/conversation-activity";
+import {
+  buildProjectSwitcherItems,
+  projectActivityIndicator,
+  quickProjectItems,
+  summarizeProjectActivity,
+} from "./project-switcher";
+
+function project(
+  id: string,
+  name: string,
+  dir: string,
+  updatedAt: string,
+): ProjectRecord {
+  return { id, name, dir, updatedAt, createdAt: updatedAt } as ProjectRecord;
+}
+
+function conversation(
+  id: string,
+  projectId: string,
+  updatedAt: string,
+): ConversationRecord {
+  return {
+    id,
+    projectId,
+    title: id,
+    updatedAt,
+    createdAt: updatedAt,
+    lastUserMessageAt: updatedAt,
+  } as ConversationRecord;
+}
+
+function activity(
+  input: Partial<ConversationActivityState>,
+): ConversationActivityState {
+  return {
+    tone: "neutral",
+    pulse: false,
+    busy: false,
+    needsUser: false,
+    source: "none",
+    ...input,
+  };
+}
+
+test("summarizes each project activity state separately", () => {
+  const conversations = [
+    conversation("error", "p", "2026-01-01"),
+    conversation("waiting", "p", "2026-01-02"),
+    conversation("running", "p", "2026-01-03"),
+  ];
+  assert.deepEqual(
+    summarizeProjectActivity(conversations, {
+      error: activity({ tone: "danger", busy: true }),
+      waiting: activity({ tone: "warn", needsUser: true }),
+      running: activity({ tone: "running", busy: true }),
+    }),
+    { errors: 1, needsUser: 1, running: 1 },
+  );
+});
+
+test("collapses project activity into one indicator by severity", () => {
+  assert.equal(
+    projectActivityIndicator({ errors: 0, needsUser: 0, running: 0 }),
+    undefined,
+  );
+  assert.deepEqual(
+    projectActivityIndicator({ errors: 2, needsUser: 1, running: 3 }),
+    {
+      tone: "danger",
+      pulse: false,
+      summary: "2 with errors, 1 waiting for you, 3 running",
+    },
+  );
+  assert.deepEqual(
+    projectActivityIndicator({ errors: 0, needsUser: 1, running: 2 }),
+    { tone: "warn", pulse: false, summary: "1 waiting for you, 2 running" },
+  );
+  assert.deepEqual(
+    projectActivityIndicator({ errors: 0, needsUser: 0, running: 1 }),
+    { tone: "running", pulse: true, summary: "1 running" },
+  );
+});
+
+test("groups directory aliases and disambiguates duplicate folder names", () => {
+  const projects = [
+    project("p1", "app", "/work/one/app", "2026-01-01"),
+    project("p2", "app alias", "/work/one/app/", "2026-01-02"),
+    project("p3", "app", "/work/two/app", "2026-01-03"),
+  ];
+  const items = buildProjectSwitcherItems({
+    projects,
+    conversations: [conversation("c1", "p1", "2026-01-04")],
+    activityById: {},
+  });
+  assert.equal(items.length, 2);
+  assert.deepEqual(
+    items.find((item) => item.key === "/work/one/app")?.projectIds,
+    ["p1", "p2"],
+  );
+  assert.ok(items.every((item) => item.label !== "app"));
+});
+
+test("sorts the chosen recent projects alphabetically", () => {
+  const items = buildProjectSwitcherItems({
+    projects: [
+      project("z", "Zulu", "/zulu", "2026-01-03"),
+      project("a", "Alpha", "/alpha", "2026-01-02"),
+      project("m", "Mike", "/mike", "2026-01-01"),
+    ],
+    conversations: [],
+    activityById: {},
+  });
+  assert.deepEqual(
+    quickProjectItems(items, undefined, 2).map((item) => item.label),
+    ["alpha", "zulu"],
+  );
+});
+
+test("quick projects always retain the active project", () => {
+  const items = buildProjectSwitcherItems({
+    projects: [
+      project("a", "a", "/a", "2026-01-01"),
+      project("b", "b", "/b", "2026-01-02"),
+      project("c", "c", "/c", "2026-01-03"),
+    ],
+    conversations: [],
+    activityById: {},
+  });
+  assert.deepEqual(
+    quickProjectItems(items, "/a", 1).map((item) => item.key),
+    ["/a"],
+  );
+  assert.deepEqual(
+    quickProjectItems(items, "/a", 2).map((item) => item.key),
+    ["/a", "/c"],
+  );
+});

--- a/packages/workbench-app/src/lib/features/projects/state/project-switcher.ts
+++ b/packages/workbench-app/src/lib/features/projects/state/project-switcher.ts
@@ -1,0 +1,140 @@
+import type { StatusTone } from "@nervekit/ui-kit/core/utils/status";
+import type { ConversationRecord, ProjectRecord } from "$lib/api";
+import {
+  conversationLastUserSortAt,
+  projectFolderName,
+  projectKey,
+  shortProjectLabel,
+} from "$lib/core/utils/project-tree";
+import type { ConversationActivityState } from "$lib/features/conversations/state/conversation-activity";
+
+export type ProjectActivitySummary = {
+  errors: number;
+  needsUser: number;
+  running: number;
+};
+
+export type ProjectSwitcherItem = {
+  key: string;
+  project: ProjectRecord;
+  projectIds: string[];
+  label: string;
+  sortAt: string;
+  activity: ProjectActivitySummary;
+};
+
+export function summarizeProjectActivity(
+  conversations: ConversationRecord[],
+  activityById: Record<string, ConversationActivityState>,
+): ProjectActivitySummary {
+  const summary: ProjectActivitySummary = {
+    errors: 0,
+    needsUser: 0,
+    running: 0,
+  };
+  for (const conversation of conversations) {
+    const activity = activityById[conversation.id];
+    if (!activity) continue;
+    if (activity.tone === "danger") summary.errors += 1;
+    else if (activity.needsUser) summary.needsUser += 1;
+    else if (activity.busy) summary.running += 1;
+  }
+  return summary;
+}
+
+export type ProjectActivityIndicator = {
+  tone: StatusTone;
+  pulse: boolean;
+  /** Human-readable breakdown, e.g. "2 with errors, 1 running". */
+  summary: string;
+};
+
+export function projectActivityIndicator(
+  activity: ProjectActivitySummary,
+): ProjectActivityIndicator | undefined {
+  const parts = [
+    activity.errors ? `${activity.errors} with errors` : "",
+    activity.needsUser ? `${activity.needsUser} waiting for you` : "",
+    activity.running ? `${activity.running} running` : "",
+  ].filter(Boolean);
+  if (!parts.length) return undefined;
+  const tone: StatusTone = activity.errors
+    ? "danger"
+    : activity.needsUser
+      ? "warn"
+      : "running";
+  return { tone, pulse: tone === "running", summary: parts.join(", ") };
+}
+
+export function buildProjectSwitcherItems(input: {
+  projects: ProjectRecord[];
+  conversations: ConversationRecord[];
+  activityById: Record<string, ConversationActivityState>;
+  homeDir?: string;
+  recency?: Record<string, number>;
+}): ProjectSwitcherItem[] {
+  const byKey = new Map<string, ProjectRecord[]>();
+  for (const project of input.projects) {
+    const key = projectKey(project);
+    byKey.set(key, [...(byKey.get(key) ?? []), project]);
+  }
+
+  const folderCounts = new Map<string, number>();
+  for (const projects of byKey.values()) {
+    const folder = projectFolderName(projects[0].dir);
+    folderCounts.set(folder, (folderCounts.get(folder) ?? 0) + 1);
+  }
+
+  const items = [...byKey.entries()].map(([key, projects]) => {
+    const project = [...projects].sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt),
+    )[0];
+    const projectIds = projects.map((candidate) => candidate.id);
+    const idSet = new Set(projectIds);
+    const conversations = input.conversations.filter((conversation) =>
+      idSet.has(conversation.projectId),
+    );
+    const latestConversation = conversations
+      .map(conversationLastUserSortAt)
+      .sort((a, b) => b.localeCompare(a))[0];
+    const folder = projectFolderName(project.dir);
+    return {
+      key,
+      project,
+      projectIds,
+      label:
+        (folderCounts.get(folder) ?? 0) > 1
+          ? shortProjectLabel(project.dir, input.homeDir)
+          : folder,
+      sortAt:
+        latestConversation && latestConversation > project.updatedAt
+          ? latestConversation
+          : project.updatedAt,
+      activity: summarizeProjectActivity(conversations, input.activityById),
+    };
+  });
+
+  return items.sort((a, b) => {
+    const recent =
+      (input.recency?.[b.key] ?? 0) - (input.recency?.[a.key] ?? 0);
+    if (recent !== 0) return recent;
+    const updated = b.sortAt.localeCompare(a.sortAt);
+    return updated || a.label.localeCompare(b.label);
+  });
+}
+
+export function quickProjectItems(
+  items: ProjectSwitcherItem[],
+  activeKey: string | undefined,
+  limit: number,
+): ProjectSwitcherItem[] {
+  if (limit <= 0) return [];
+  const recent = items.slice(0, limit);
+  const active = items.find((item) => item.key === activeKey);
+  if (active && !recent.some((item) => item.key === active.key)) {
+    recent.splice(Math.max(0, recent.length - 1), 1, active);
+  }
+  return recent.sort((a, b) =>
+    a.label.localeCompare(b.label, undefined, { sensitivity: "base" }),
+  );
+}

--- a/packages/workbench-app/src/lib/features/tasks/state/task-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/task-tabs.svelte.ts
@@ -31,6 +31,17 @@ export function setTaskEntryRun(entryId: string, taskId: string): void {
 }
 
 export async function openTaskTab(taskId: string) {
+  const owningTask = taskState.tasks.find(
+    (candidate) => candidate.id === taskId,
+  );
+  if (
+    owningTask?.projectId &&
+    owningTask.projectId !== workspaceState.selectedProjectId
+  ) {
+    const { selectProject } =
+      await import("$lib/features/workspace/state/workspace-actions.svelte");
+    await selectProject(owningTask.projectId);
+  }
   const entryId = taskEntryKey(taskId);
   setTaskEntryRun(entryId, taskId);
   addCenterTab({ kind: "task", id: entryId });

--- a/packages/workbench-app/src/lib/features/workspace/index.ts
+++ b/packages/workbench-app/src/lib/features/workspace/index.ts
@@ -22,7 +22,10 @@ export {
   deleteProjectAndRefresh,
   exportUrl,
   newConversation,
+  newConversationInProject,
   openProjectDirectory,
+  openProjectInEditorAndNotify,
+  pruneProjectConversationsAndRefresh,
   selectProject,
   systemPromptUrl,
 } from "./state/workspace-actions.svelte";

--- a/packages/workbench-app/src/lib/features/workspace/index.ts
+++ b/packages/workbench-app/src/lib/features/workspace/index.ts
@@ -7,7 +7,11 @@ export {
   centerTabsToRightOf,
   closeCenterTabs,
 } from "./state/center-tab-actions.svelte";
-export { closeCenterTab, selectCenterTab } from "./state/center-tabs.svelte";
+export {
+  closeCenterTab,
+  reorderCenterTab,
+  selectCenterTab,
+} from "./state/center-tabs.svelte";
 export {
   composerDraft,
   eventBuffer,
@@ -18,6 +22,8 @@ export {
   deleteProjectAndRefresh,
   exportUrl,
   newConversation,
+  openProjectDirectory,
+  selectProject,
   systemPromptUrl,
 } from "./state/workspace-actions.svelte";
 export type { CenterTabModel } from "./state/workspace-selectors.svelte";

--- a/packages/workbench-app/src/lib/features/workspace/state/center-tab-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/center-tab-actions.svelte.ts
@@ -9,7 +9,6 @@ import {
 } from "$lib/core/state/state-keys";
 import type { CenterTabIdentity } from "$lib/core/types/state-types";
 import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
-import { saveConversationTabs } from "$lib/features/conversations/state/conversation-tabs";
 import { fileState } from "$lib/features/filesystem/state/file-state.svelte";
 import { taskState } from "$lib/features/tasks/state/task-state.svelte";
 import {
@@ -23,7 +22,13 @@ import {
   centerTabsEqual,
   replaceOpenCenterTabs,
   selectCenterTab,
+  setActiveCenterTab,
 } from "./center-tabs.svelte";
+import {
+  isGlobalCenterTab,
+  mostRecentRemainingTab,
+  removeGlobalTabFromSessions,
+} from "./workspace-tab-sessions";
 
 function tabIndex(tab: CenterTabIdentity): number {
   return workspaceState.openCenterTabs.findIndex((candidate) =>
@@ -48,34 +53,6 @@ function resetConversationSelection() {
   resetSelection();
   workspaceState.error = undefined;
   composerDraft.text = "";
-}
-
-function persistOpenConversationTabs() {
-  saveConversationTabs(
-    conversationState.openConversationTabIds,
-    conversationState.activeConversationTabId,
-  );
-}
-
-function nearestRemainingTab(
-  originalTabs: CenterTabIdentity[],
-  remainingTabs: CenterTabIdentity[],
-  closingIndices: number[],
-): CenterTabIdentity | undefined {
-  if (!remainingTabs.length) return undefined;
-  const firstClosingIndex = Math.min(...closingIndices);
-  const atOrAfter = originalTabs
-    .slice(firstClosingIndex)
-    .find((tab) =>
-      remainingTabs.some((candidate) => centerTabsEqual(candidate, tab)),
-    );
-  if (atOrAfter) return atOrAfter;
-  return originalTabs
-    .slice(0, firstClosingIndex)
-    .reverse()
-    .find((tab) =>
-      remainingTabs.some((candidate) => centerTabsEqual(candidate, tab)),
-    );
 }
 
 export function centerTabsToLeftOf(
@@ -138,7 +115,7 @@ export async function closeCenterTabs(
   );
   const fallback = tabIsInList(fallbackPreferred, remainingTabs)
     ? fallbackPreferred
-    : nearestRemainingTab(originalTabs, remainingTabs, closingIndices);
+    : mostRecentRemainingTab(tabs);
 
   const voiceTargets: VoiceInputTarget[] = [];
   for (const tab of originalTabs) {
@@ -150,6 +127,9 @@ export async function closeCenterTabs(
   }
   await voiceInputSession.cancelIfTargets(voiceTargets);
 
+  for (const tab of tabs) {
+    if (isGlobalCenterTab(tab)) removeGlobalTabFromSessions(tab);
+  }
   replaceOpenCenterTabs(remainingTabs);
 
   for (const tab of originalTabs) {
@@ -200,9 +180,7 @@ export async function closeCenterTabs(
     resetConversationSelection();
   }
 
-  persistOpenConversationTabs();
-
   if (!activeWasClosed) return;
-  workspaceState.activeCenterTab = undefined;
+  setActiveCenterTab(undefined);
   if (fallback) await selectCenterTab(fallback);
 }

--- a/packages/workbench-app/src/lib/features/workspace/state/center-tab-mirrors.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/center-tab-mirrors.svelte.ts
@@ -1,0 +1,33 @@
+import { authState } from "$lib/features/auth/state/auth-state.svelte";
+import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
+import { fileState } from "$lib/features/filesystem/state/file-state.svelte";
+import { gitState } from "$lib/features/git/state/git-state.svelte";
+import { logsState } from "$lib/features/logs/state/log-state.svelte";
+import { settingsState } from "$lib/features/settings/state/settings-state.svelte";
+import { taskState } from "$lib/features/tasks/state/task-state.svelte";
+import { workspaceState } from "./workspace-state.svelte";
+
+/** Keep feature-specific tab fields aligned with the canonical center-tab list. */
+export function syncCenterTabMirrors(): void {
+  conversationState.openConversationTabIds = workspaceState.openCenterTabs
+    .filter((tab) => tab.kind === "conversation")
+    .map((tab) => tab.id);
+  taskState.openTaskTabIds = workspaceState.openCenterTabs
+    .filter((tab) => tab.kind === "task")
+    .map((tab) => tab.id);
+  fileState.openFileTabIds = workspaceState.openCenterTabs
+    .filter((tab) => tab.kind === "file")
+    .map((tab) => tab.id);
+  gitState.openPrTabIds = workspaceState.openCenterTabs
+    .filter((tab) => tab.kind === "pr")
+    .map((tab) => tab.id);
+  settingsState.settingsTabOpen = workspaceState.openCenterTabs.some(
+    (tab) => tab.kind === "settings",
+  );
+  authState.authTabOpen = workspaceState.openCenterTabs.some(
+    (tab) => tab.kind === "auth",
+  );
+  logsState.logsTabOpen = workspaceState.openCenterTabs.some(
+    (tab) => tab.kind === "logs",
+  );
+}

--- a/packages/workbench-app/src/lib/features/workspace/state/center-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/center-tabs.svelte.ts
@@ -1,14 +1,8 @@
 import { SvelteSet } from "svelte/reactivity";
 import type { CenterTabIdentity } from "$lib/core/types/state-types";
-import { authState } from "$lib/features/auth/state/auth-state.svelte";
-import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
-import { fileState } from "$lib/features/filesystem/state/file-state.svelte";
-import { gitState } from "$lib/features/git/state/git-state.svelte";
-import { logsState } from "$lib/features/logs/state/log-state.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
-import { settingsState } from "$lib/features/settings/state/settings-state.svelte";
-import { taskState } from "$lib/features/tasks/state/task-state.svelte";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import { syncCenterTabMirrors } from "./center-tab-mirrors.svelte";
 import {
   isGlobalCenterTab,
   mostRecentRemainingTab,
@@ -71,30 +65,6 @@ function handleCenterTabError(action: "switch" | "close", caught: unknown) {
   notify.error(`Could not ${action} pane`, { description: message });
 }
 
-function syncLegacyTabFields() {
-  conversationState.openConversationTabIds = workspaceState.openCenterTabs
-    .filter((tab) => tab.kind === "conversation")
-    .map((tab) => tab.id);
-  taskState.openTaskTabIds = workspaceState.openCenterTabs
-    .filter((tab) => tab.kind === "task")
-    .map((tab) => tab.id);
-  fileState.openFileTabIds = workspaceState.openCenterTabs
-    .filter((tab) => tab.kind === "file")
-    .map((tab) => tab.id);
-  gitState.openPrTabIds = workspaceState.openCenterTabs
-    .filter((tab) => tab.kind === "pr")
-    .map((tab) => tab.id);
-  settingsState.settingsTabOpen = workspaceState.openCenterTabs.some(
-    (tab) => tab.kind === "settings",
-  );
-  authState.authTabOpen = workspaceState.openCenterTabs.some(
-    (tab) => tab.kind === "auth",
-  );
-  logsState.logsTabOpen = workspaceState.openCenterTabs.some(
-    (tab) => tab.kind === "logs",
-  );
-}
-
 export function replaceOpenCenterTabs(tabs: CenterTabIdentity[]) {
   const seen = new SvelteSet<string>();
   workspaceState.openCenterTabs = tabs.filter((tab) => {
@@ -103,7 +73,7 @@ export function replaceOpenCenterTabs(tabs: CenterTabIdentity[]) {
     seen.add(key);
     return true;
   });
-  syncLegacyTabFields();
+  syncCenterTabMirrors();
   recordTabsChanged();
 }
 
@@ -114,7 +84,7 @@ export function addCenterTab(tab: CenterTabIdentity) {
     )
   ) {
     workspaceState.openCenterTabs = [...workspaceState.openCenterTabs, tab];
-    syncLegacyTabFields();
+    syncCenterTabMirrors();
   }
 }
 
@@ -149,7 +119,7 @@ export function removeCenterTab(tab: CenterTabIdentity) {
 
 export function reorderCenterTab(tab: CenterTabIdentity, targetIndex: number) {
   reorderVisibleTab(tab, targetIndex);
-  syncLegacyTabFields();
+  syncCenterTabMirrors();
 }
 
 export function setActiveCenterTab(tab: CenterTabIdentity | undefined) {

--- a/packages/workbench-app/src/lib/features/workspace/state/center-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/center-tabs.svelte.ts
@@ -9,6 +9,14 @@ import { notify } from "$lib/features/notifications/notify.svelte";
 import { settingsState } from "$lib/features/settings/state/settings-state.svelte";
 import { taskState } from "$lib/features/tasks/state/task-state.svelte";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import {
+  isGlobalCenterTab,
+  mostRecentRemainingTab,
+  recordTabActivation,
+  recordTabsChanged,
+  removeGlobalTabFromSessions,
+  reorderVisibleTab,
+} from "./workspace-tab-sessions";
 export function centerTabKey(tab: CenterTabIdentity): string {
   return `${tab.kind}:${tab.id}`;
 }
@@ -96,6 +104,7 @@ export function replaceOpenCenterTabs(tabs: CenterTabIdentity[]) {
     return true;
   });
   syncLegacyTabFields();
+  recordTabsChanged();
 }
 
 export function addCenterTab(tab: CenterTabIdentity) {
@@ -119,25 +128,18 @@ export function replaceCenterTab(
     ),
   );
   if (centerTabsEqual(workspaceState.activeCenterTab, previous)) {
-    workspaceState.activeCenterTab = next;
+    setActiveCenterTab(next);
   }
 }
 
 export function nextCenterTabAfterClose(
   tab: CenterTabIdentity,
 ): CenterTabIdentity | undefined {
-  const tabs = workspaceState.openCenterTabs;
-  const closingIndex = tabs.findIndex((candidate) =>
-    centerTabsEqual(candidate, tab),
-  );
-  if (closingIndex === -1) return fallbackCenterTab(tab);
-  const remaining = tabs.filter(
-    (candidate) => !centerTabsEqual(candidate, tab),
-  );
-  return remaining[closingIndex] ?? remaining[closingIndex - 1] ?? remaining[0];
+  return mostRecentRemainingTab(tab);
 }
 
 export function removeCenterTab(tab: CenterTabIdentity) {
+  if (isGlobalCenterTab(tab)) removeGlobalTabFromSessions(tab);
   replaceOpenCenterTabs(
     workspaceState.openCenterTabs.filter(
       (candidate) => !centerTabsEqual(candidate, tab),
@@ -145,9 +147,16 @@ export function removeCenterTab(tab: CenterTabIdentity) {
   );
 }
 
+export function reorderCenterTab(tab: CenterTabIdentity, targetIndex: number) {
+  reorderVisibleTab(tab, targetIndex);
+  syncLegacyTabFields();
+}
+
 export function setActiveCenterTab(tab: CenterTabIdentity | undefined) {
   if (tab) addCenterTab(tab);
   workspaceState.activeCenterTab = tab;
+  if (tab) recordTabActivation(tab);
+  else recordTabsChanged();
 }
 
 export function fallbackCenterTab(

--- a/packages/workbench-app/src/lib/features/workspace/state/tab-session-helpers.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/tab-session-helpers.ts
@@ -1,0 +1,38 @@
+import type { CenterTabIdentity } from "./workspace-state.svelte";
+
+export function tabIdentityKey(tab: CenterTabIdentity): string {
+  return `${tab.kind}:${tab.id}`;
+}
+
+export function reorderTabs(
+  tabs: CenterTabIdentity[],
+  tab: CenterTabIdentity,
+  targetIndex: number,
+): CenterTabIdentity[] {
+  const key = tabIdentityKey(tab);
+  const sourceIndex = tabs.findIndex(
+    (candidate) => tabIdentityKey(candidate) === key,
+  );
+  if (sourceIndex < 0) return tabs;
+  const reordered = [...tabs];
+  const [moved] = reordered.splice(sourceIndex, 1);
+  const bounded = Math.max(0, Math.min(targetIndex, reordered.length));
+  reordered.splice(bounded, 0, moved);
+  return reordered;
+}
+
+export function mostRecentTab(
+  tabs: CenterTabIdentity[],
+  mru: string[],
+  excluding: CenterTabIdentity[],
+): CenterTabIdentity | undefined {
+  const excluded = new Set(excluding.map(tabIdentityKey));
+  const remaining = tabs.filter((tab) => !excluded.has(tabIdentityKey(tab)));
+  for (const key of mru) {
+    const tab = remaining.find(
+      (candidate) => tabIdentityKey(candidate) === key,
+    );
+    if (tab) return tab;
+  }
+  return remaining[0];
+}

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
@@ -208,7 +208,9 @@ export async function selectProject(projectId: string) {
     persistWorkspaceTabSessions();
     return;
   }
-  saveVisibleProjectSession();
+  // During startup the persisted key is hydrated before a concrete project ID.
+  // There is no outgoing visible session to save in that state.
+  if (workspaceState.selectedProjectId) saveVisibleProjectSession();
   workspaceState.selectedProjectId = project.id;
   workspaceState.selectedProjectKey = key;
   workspaceState.projectRecency[key] = Date.now();

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
@@ -1,4 +1,5 @@
 import { SvelteSet } from "svelte/reactivity";
+import { projectKey } from "$lib/core/utils/project-tree";
 import { modelKey } from "@nervekit/workbench-ui/core/utils/model";
 import {
   type AgentRecord,
@@ -32,6 +33,14 @@ import { selection } from "$lib/features/workspace/state/selection.svelte";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
 import { mergeAgentsByUpdatedAt } from "./agent-freshness";
 import { closeCenterTabs } from "./center-tab-actions.svelte";
+import { selectCenterTab, setActiveCenterTab } from "./center-tabs.svelte";
+import {
+  applyVisibleSession,
+  hydrateWorkspaceTabSessions,
+  persistWorkspaceTabSessions,
+  removeTabsFromAllSessions,
+  saveVisibleProjectSession,
+} from "./workspace-tab-sessions";
 export async function loadWorkspaceState() {
   const snapshot = await queryClient.fetchQuery({
     queryKey: queryKeys.workspace,
@@ -60,6 +69,11 @@ async function applyWorkspaceSnapshot(
   workspaceState.conversations = snapshot.snapshot.conversations;
   workspaceState.agents = agents;
   taskState.tasks = snapshot.snapshot.tasks;
+  hydrateWorkspaceTabSessions({
+    projects: snapshot.snapshot.projects,
+    conversations: snapshot.snapshot.conversations,
+    tasks: snapshot.snapshot.tasks,
+  });
   const taskEntryIds = new SvelteSet(
     taskState.tasks.map(
       (task) => task.definitionId ?? task.restartRootTaskId ?? task.id,
@@ -93,6 +107,23 @@ async function applyWorkspaceSnapshot(
   );
   if (staleOpenTabIds.length) await removeConversationTabs(staleOpenTabIds);
   if (selectedTaskId) await loadTaskLogWindow(selectedTaskId);
+  const selectedStillExists = workspaceState.projects.some(
+    (project) => projectKey(project) === workspaceState.selectedProjectKey,
+  );
+  if (!selectedStillExists) {
+    const fallback = [...workspaceState.projects].sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt),
+    )[0];
+    if (fallback) await selectProject(fallback.id);
+  } else if (
+    workspaceState.selectedProjectKey &&
+    !workspaceState.selectedProjectId
+  ) {
+    const selected = workspaceState.projects.find(
+      (project) => projectKey(project) === workspaceState.selectedProjectKey,
+    );
+    if (selected) await selectProject(selected.id);
+  }
   return snapshot.cursor;
 }
 
@@ -161,9 +192,61 @@ export async function completeFiles(query: string): Promise<CompletionItem[]> {
   });
 }
 
+export async function selectProject(projectId: string) {
+  const project = workspaceState.projects.find(
+    (candidate) => candidate.id === projectId,
+  );
+  if (!project) return;
+  const key = projectKey(project);
+  if (
+    workspaceState.selectedProjectKey === key &&
+    workspaceState.selectedProjectId
+  ) {
+    workspaceState.selectedProjectId = project.id;
+    selection.projectId = project.id;
+    workspaceState.projectRecency[key] = Date.now();
+    persistWorkspaceTabSessions();
+    return;
+  }
+  saveVisibleProjectSession();
+  workspaceState.selectedProjectId = project.id;
+  workspaceState.selectedProjectKey = key;
+  workspaceState.projectRecency[key] = Date.now();
+  const session = applyVisibleSession(key);
+  selection.projectId = project.id;
+  selection.conversationId = undefined;
+  selection.agentId = undefined;
+  selection.entryId = undefined;
+  persistWorkspaceTabSessions();
+  if (session.active) await selectCenterTab(session.active);
+  else setActiveCenterTab(undefined);
+}
+
+export async function openProjectDirectory(dir: string) {
+  try {
+    const project = await createProject(dir);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.workspace });
+    await loadWorkspaceState();
+    const current =
+      workspaceState.projects.find(
+        (candidate) => projectKey(candidate) === projectKey(project),
+      ) ?? project;
+    if (
+      !workspaceState.projects.some((candidate) => candidate.id === current.id)
+    ) {
+      workspaceState.projects = [...workspaceState.projects, current];
+    }
+    await selectProject(current.id);
+  } catch (caught) {
+    const message = caught instanceof Error ? caught.message : String(caught);
+    workspaceState.error = message;
+    notify.error("Could not open project", { description: message });
+  }
+}
+
 export function newConversation() {
   const activeProject = workspaceState.projects.find(
-    (project) => project.id === selection.projectId,
+    (project) => project.id === workspaceState.selectedProjectId,
   );
   if (!activeProject) {
     workspaceState.projectPickerOpen = true;
@@ -178,10 +261,22 @@ export function newConversationInProject(projectDir: string) {
 
 export async function deleteProjectAndRefresh(projectId: string) {
   try {
+    const deletingProject = workspaceState.projects.find(
+      (project) => project.id === projectId,
+    );
+    const deletingKey = deletingProject
+      ? projectKey(deletingProject)
+      : undefined;
+    const aliasedIds = new SvelteSet(
+      workspaceState.projects
+        .filter((project) => deletingKey && projectKey(project) === deletingKey)
+        .map((project) => project.id),
+    );
     const conversationIds = workspaceState.conversations
-      .filter((conversation) => conversation.projectId === projectId)
+      .filter((conversation) => aliasedIds.has(conversation.projectId))
       .map((conversation) => conversation.id);
     await deleteProject(projectId);
+    if (deletingKey) delete workspaceState.projectTabSessions[deletingKey];
     await removeConversationTabs(conversationIds);
     await queryClient.invalidateQueries({ queryKey: queryKeys.workspace });
     await loadWorkspaceState();
@@ -196,6 +291,9 @@ export async function deleteProjectAndRefresh(projectId: string) {
 export async function deleteConversationAndRefresh(conversationId: string) {
   try {
     await deleteConversation(conversationId);
+    removeTabsFromAllSessions(
+      (tab) => tab.kind === "conversation" && tab.id === conversationId,
+    );
     await removeConversationTabs([conversationId]);
     await queryClient.invalidateQueries({ queryKey: queryKeys.workspace });
     await loadWorkspaceState();
@@ -270,6 +368,7 @@ export async function createConversationForDirectory(dir: string) {
       ),
     ];
     workspaceState.projectPickerOpen = false;
+    await selectProject(project.id);
     openPendingConversation(project);
   } catch (caught) {
     const message = caught instanceof Error ? caught.message : String(caught);

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-selectors.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-selectors.svelte.ts
@@ -1,4 +1,6 @@
 import { SvelteSet } from "svelte/reactivity";
+import { projectKey } from "$lib/core/utils/project-tree";
+import { buildProjectSwitcherItems } from "$lib/features/projects/state/project-switcher";
 import { agentRunningTone } from "@nervekit/ui-kit/core/utils/status";
 import {
   conversationViewKey,
@@ -111,9 +113,35 @@ export const workspaceSelectors = {
     return workspaceState.planReviews;
   },
   get activeProject() {
-    const pending = activePendingConversation();
-    const projectId = pending?.projectId ?? selection.projectId;
-    return workspaceState.projects.find((project) => project.id === projectId);
+    return (
+      workspaceState.projects.find(
+        (project) => project.id === workspaceState.selectedProjectId,
+      ) ??
+      workspaceState.projects.find(
+        (project) => projectKey(project) === workspaceState.selectedProjectKey,
+      )
+    );
+  },
+  get selectedProjectIds() {
+    const key = workspaceState.selectedProjectKey;
+    return workspaceState.projects
+      .filter((project) => key && projectKey(project) === key)
+      .map((project) => project.id);
+  },
+  get selectedProjectConversations() {
+    const ids = new SvelteSet(this.selectedProjectIds);
+    return workspaceState.conversations.filter((conversation) =>
+      ids.has(conversation.projectId),
+    );
+  },
+  get projectSwitcherItems() {
+    return buildProjectSwitcherItems({
+      projects: workspaceState.projects,
+      conversations: workspaceState.conversations,
+      activityById: this.conversationActivityById,
+      homeDir: workspaceState.status?.storage.home,
+      recency: workspaceState.projectRecency,
+    });
   },
   get activeConversation() {
     return workspaceState.conversations.find(

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-state.svelte.ts
@@ -20,6 +20,12 @@ export type CenterTabIdentity =
   | { kind: "auth"; id: "auth" }
   | { kind: "logs"; id: "logs" };
 
+export type ProjectTabSession = {
+  tabs: CenterTabIdentity[];
+  active?: CenterTabIdentity;
+  mru: string[];
+};
+
 export const workspaceState = $state({
   status: undefined as StatusResponse | undefined,
   config: undefined as ClientConfig | undefined,
@@ -33,7 +39,13 @@ export const workspaceState = $state({
   approvals: [] as ApprovalWithToolCall[],
   userQuestions: [] as UserQuestionRecord[],
   planReviews: [] as PlanReviewRecord[],
+  selectedProjectId: undefined as string | undefined,
+  selectedProjectKey: undefined as string | undefined,
+  projectRecency: {} as Record<string, number>,
+  projectTabSessions: {} as Record<string, ProjectTabSession>,
+  globalCenterTabs: [] as CenterTabIdentity[],
   openCenterTabs: [] as CenterTabIdentity[],
   activeCenterTab: undefined as CenterTabIdentity | undefined,
+  centerTabMru: [] as string[],
   projectPickerOpen: false,
 });

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.test.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { CenterTabIdentity } from "./workspace-state.svelte";
+import {
+  mostRecentTab,
+  reorderTabs,
+  tabIdentityKey,
+} from "./tab-session-helpers";
+
+const a = { kind: "conversation", id: "a" } as const;
+const b = { kind: "conversation", id: "b" } as const;
+const c = { kind: "conversation", id: "c" } as const;
+const d = { kind: "conversation", id: "d" } as const;
+
+test("reorders visual tabs without changing an independent MRU list", () => {
+  const mru = [tabIdentityKey(b), tabIdentityKey(a), tabIdentityKey(c)];
+  assert.deepEqual(reorderTabs([a, b, c], a, 2), [b, c, a]);
+  assert.deepEqual(mru, ["conversation:b", "conversation:a", "conversation:c"]);
+});
+
+test("closing the active tab falls back to the previously active tab", () => {
+  const mru = [
+    tabIdentityKey(d),
+    tabIdentityKey(a),
+    tabIdentityKey(c),
+    tabIdentityKey(b),
+  ];
+  assert.deepEqual(mostRecentTab([a, b, c, d], mru, [d]), a);
+});
+
+test("falls back deterministically when MRU data is absent", () => {
+  assert.deepEqual(mostRecentTab([a, b, c], [], [a]), b);
+});
+
+test("supports global singleton identities in the same ordering model", () => {
+  const settings: CenterTabIdentity = { kind: "settings", id: "settings" };
+  assert.deepEqual(reorderTabs([a, settings, b], settings, 2), [
+    a,
+    b,
+    settings,
+  ]);
+});

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
@@ -1,0 +1,426 @@
+import type { ConversationRecord, ProjectRecord, TaskRecord } from "$lib/api";
+import { projectKey } from "$lib/core/utils/project-tree";
+import { fileViewKey, prViewKey } from "$lib/core/state/state-keys";
+import { fileState } from "$lib/features/filesystem/state/file-state.svelte";
+import { gitState } from "$lib/features/git/state/git-state.svelte";
+import type {
+  CenterTabIdentity,
+  ProjectTabSession,
+} from "./workspace-state.svelte";
+import { workspaceState } from "./workspace-state.svelte";
+import {
+  mostRecentTab,
+  reorderTabs,
+  tabIdentityKey,
+} from "./tab-session-helpers";
+
+const storageKey = "nerve.workspaceTabs.v2";
+const legacyStorageKey = "nerve.conversationTabs.v1";
+const maxSessions = 24;
+const maxTabs = 30;
+const globalKinds = new Set<CenterTabIdentity["kind"]>([
+  "settings",
+  "auth",
+  "logs",
+]);
+let hydrated = false;
+
+export const tabKey = tabIdentityKey;
+
+export function tabsEqual(
+  a: CenterTabIdentity | undefined,
+  b: CenterTabIdentity | undefined,
+): boolean {
+  return Boolean(a && b && a.kind === b.kind && a.id === b.id);
+}
+
+export function isGlobalCenterTab(tab: CenterTabIdentity): boolean {
+  return globalKinds.has(tab.kind);
+}
+
+function uniqueTabs(tabs: CenterTabIdentity[]): CenterTabIdentity[] {
+  const seen = new Set<string>();
+  return tabs
+    .filter((tab) => {
+      const key = tabKey(tab);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, maxTabs);
+}
+
+function normalizeSession(session: ProjectTabSession): ProjectTabSession {
+  const tabs = uniqueTabs(session.tabs);
+  const keys = new Set(tabs.map(tabKey));
+  const mru = [...new Set(session.mru)].filter((key) => keys.has(key));
+  for (const tab of tabs) if (!mru.includes(tabKey(tab))) mru.push(tabKey(tab));
+  return {
+    tabs,
+    active:
+      session.active && keys.has(tabKey(session.active))
+        ? session.active
+        : tabs[0],
+    mru,
+  };
+}
+
+export function saveVisibleProjectSession(): void {
+  const key = workspaceState.selectedProjectKey;
+  if (!key) return;
+  workspaceState.projectTabSessions[key] = normalizeSession({
+    tabs: [...workspaceState.openCenterTabs],
+    active: workspaceState.activeCenterTab,
+    mru: [...workspaceState.centerTabMru],
+  });
+  persistWorkspaceTabSessions();
+}
+
+export function visibleSessionFor(key: string): ProjectTabSession {
+  const session = normalizeSession(
+    workspaceState.projectTabSessions[key] ?? { tabs: [], mru: [] },
+  );
+  const present = new Set(session.tabs.map(tabKey));
+  for (const globalTab of workspaceState.globalCenterTabs) {
+    if (!present.has(tabKey(globalTab))) session.tabs.push(globalTab);
+  }
+  return normalizeSession(session);
+}
+
+export function applyVisibleSession(key: string): ProjectTabSession {
+  const session = visibleSessionFor(key);
+  workspaceState.selectedProjectKey = key;
+  workspaceState.openCenterTabs = [...session.tabs];
+  workspaceState.activeCenterTab = session.active;
+  workspaceState.centerTabMru = [...session.mru];
+  workspaceState.projectTabSessions[key] = session;
+  return session;
+}
+
+export function recordTabActivation(tab: CenterTabIdentity): void {
+  const key = tabKey(tab);
+  workspaceState.centerTabMru = [
+    key,
+    ...workspaceState.centerTabMru.filter((item) => item !== key),
+  ];
+  if (
+    isGlobalCenterTab(tab) &&
+    !workspaceState.globalCenterTabs.some((candidate) =>
+      tabsEqual(candidate, tab),
+    )
+  ) {
+    workspaceState.globalCenterTabs = [...workspaceState.globalCenterTabs, tab];
+  }
+  if (workspaceState.selectedProjectKey) saveVisibleProjectSession();
+  else persistWorkspaceTabSessions();
+}
+
+export function recordTabsChanged(): void {
+  const open = new Set(workspaceState.openCenterTabs.map(tabKey));
+  workspaceState.centerTabMru = workspaceState.centerTabMru.filter((key) =>
+    open.has(key),
+  );
+  saveVisibleProjectSession();
+}
+
+export function removeGlobalTabFromSessions(tab: CenterTabIdentity): void {
+  workspaceState.globalCenterTabs = workspaceState.globalCenterTabs.filter(
+    (candidate) => !tabsEqual(candidate, tab),
+  );
+  for (const [key, session] of Object.entries(
+    workspaceState.projectTabSessions,
+  )) {
+    workspaceState.projectTabSessions[key] = normalizeSession({
+      tabs: session.tabs.filter((candidate) => !tabsEqual(candidate, tab)),
+      active: tabsEqual(session.active, tab) ? undefined : session.active,
+      mru: session.mru.filter((candidate) => candidate !== tabKey(tab)),
+    });
+  }
+  persistWorkspaceTabSessions();
+}
+
+export function mostRecentRemainingTab(
+  excluding: CenterTabIdentity | CenterTabIdentity[],
+): CenterTabIdentity | undefined {
+  return mostRecentTab(
+    workspaceState.openCenterTabs,
+    workspaceState.centerTabMru,
+    Array.isArray(excluding) ? excluding : [excluding],
+  );
+}
+
+export function reorderVisibleTab(
+  tab: CenterTabIdentity,
+  targetIndex: number,
+): void {
+  workspaceState.openCenterTabs = reorderTabs(
+    workspaceState.openCenterTabs,
+    tab,
+    targetIndex,
+  );
+  saveVisibleProjectSession();
+}
+
+export function removeTabsFromAllSessions(
+  predicate: (tab: CenterTabIdentity) => boolean,
+): void {
+  for (const [key, session] of Object.entries(
+    workspaceState.projectTabSessions,
+  )) {
+    const tabs = session.tabs.filter((tab) => !predicate(tab));
+    const keys = new Set(tabs.map(tabKey));
+    workspaceState.projectTabSessions[key] = normalizeSession({
+      tabs,
+      active:
+        session.active && keys.has(tabKey(session.active))
+          ? session.active
+          : undefined,
+      mru: session.mru.filter((item) => keys.has(item)),
+    });
+  }
+  workspaceState.openCenterTabs = workspaceState.openCenterTabs.filter(
+    (tab) => !predicate(tab),
+  );
+  recordTabsChanged();
+}
+
+type StoredTab = CenterTabIdentity & {
+  projectId?: string;
+  path?: string;
+  line?: number;
+  displayMode?: "raw" | "rendered";
+  wrapLines?: boolean;
+  repo?: string;
+  number?: number;
+};
+
+type StoredSession = {
+  tabs: StoredTab[];
+  active?: CenterTabIdentity;
+  mru: string[];
+};
+
+type StoredPayload = {
+  selectedProjectKey?: string;
+  projectRecency?: Record<string, number>;
+  sessions?: Record<string, StoredSession>;
+  globals?: CenterTabIdentity[];
+};
+
+function isIdentity(value: unknown): value is CenterTabIdentity {
+  if (!value || typeof value !== "object") return false;
+  const tab = value as { kind?: unknown; id?: unknown };
+  return (
+    typeof tab.kind === "string" &&
+    typeof tab.id === "string" &&
+    [
+      "conversation",
+      "pending-conversation",
+      "task",
+      "file",
+      "pr",
+      "settings",
+      "auth",
+      "logs",
+    ].includes(tab.kind)
+  );
+}
+
+function parseSession(value: unknown): ProjectTabSession | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as { tabs?: unknown; active?: unknown; mru?: unknown };
+  const storedTabs = Array.isArray(raw.tabs)
+    ? (raw.tabs.filter(isIdentity) as StoredTab[])
+    : [];
+  const tabs: CenterTabIdentity[] = [];
+  for (const stored of storedTabs) {
+    if (stored.kind === "file") {
+      if (!stored.projectId || !stored.path) continue;
+      fileState.fileViews[fileViewKey(stored.id)] = {
+        id: stored.id,
+        projectId: stored.projectId,
+        path: stored.path,
+        line: stored.line,
+        displayMode: stored.displayMode,
+        wrapLines: stored.wrapLines,
+        loading: false,
+      };
+    } else if (stored.kind === "pr") {
+      if (
+        !stored.projectId ||
+        !stored.repo ||
+        typeof stored.number !== "number"
+      )
+        continue;
+      gitState.prViews[prViewKey(stored.id)] = {
+        id: stored.id,
+        projectId: stored.projectId,
+        repo: stored.repo,
+        number: stored.number,
+        loading: false,
+      };
+    }
+    tabs.push({ kind: stored.kind, id: stored.id } as CenterTabIdentity);
+  }
+  const active = isIdentity(raw.active) ? raw.active : undefined;
+  const mru = Array.isArray(raw.mru)
+    ? raw.mru.filter((item): item is string => typeof item === "string")
+    : [];
+  return normalizeSession({ tabs, active, mru });
+}
+
+function readPayload(): StoredPayload | undefined {
+  if (typeof localStorage === "undefined") return undefined;
+  try {
+    return JSON.parse(localStorage.getItem(storageKey) ?? "null") as
+      | StoredPayload
+      | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function legacySessions(
+  projects: ProjectRecord[],
+  conversations: ConversationRecord[],
+): Record<string, ProjectTabSession> {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = JSON.parse(
+      localStorage.getItem(legacyStorageKey) ?? "null",
+    ) as { tabIds?: unknown; activeId?: unknown } | null;
+    const ids = Array.isArray(raw?.tabIds)
+      ? raw.tabIds.filter((id): id is string => typeof id === "string")
+      : [];
+    const sessions: Record<string, ProjectTabSession> = {};
+    for (const id of ids) {
+      const conversation = conversations.find(
+        (candidate) => candidate.id === id,
+      );
+      const project =
+        conversation &&
+        projects.find((candidate) => candidate.id === conversation.projectId);
+      if (!project) continue;
+      const key = projectKey(project);
+      sessions[key] ??= { tabs: [], mru: [] };
+      const tab = { kind: "conversation" as const, id };
+      sessions[key].tabs.push(tab);
+      sessions[key].mru.push(tabKey(tab));
+      if (raw?.activeId === id) sessions[key].active = tab;
+    }
+    return sessions;
+  } catch {
+    return {};
+  }
+}
+
+export function hydrateWorkspaceTabSessions(input: {
+  projects: ProjectRecord[];
+  conversations: ConversationRecord[];
+  tasks: TaskRecord[];
+}): void {
+  if (hydrated) return;
+  hydrated = true;
+  const projectKeys = new Set(input.projects.map(projectKey));
+  const conversationIds = new Set(input.conversations.map((item) => item.id));
+  const taskIds = new Set(
+    input.tasks.map(
+      (task) => task.definitionId ?? task.restartRootTaskId ?? task.id,
+    ),
+  );
+  const stored = readPayload();
+  const rawSessions =
+    stored?.sessions ?? legacySessions(input.projects, input.conversations);
+  const sessions: Record<string, ProjectTabSession> = {};
+  for (const [key, raw] of Object.entries(rawSessions).slice(0, maxSessions)) {
+    if (!projectKeys.has(key)) continue;
+    const parsed = parseSession(raw);
+    if (!parsed) continue;
+    parsed.tabs = parsed.tabs.filter((tab) => {
+      if (tab.kind === "pending-conversation") return false;
+      if (tab.kind === "file")
+        return Boolean(fileState.fileViews[fileViewKey(tab.id)]);
+      if (tab.kind === "pr")
+        return Boolean(gitState.prViews[prViewKey(tab.id)]);
+      if (tab.kind === "conversation") return conversationIds.has(tab.id);
+      if (tab.kind === "task") return taskIds.has(tab.id);
+      return true;
+    });
+    sessions[key] = normalizeSession(parsed);
+  }
+  workspaceState.projectTabSessions = sessions;
+  workspaceState.globalCenterTabs = (stored?.globals ?? [])
+    .filter(isIdentity)
+    .filter(isGlobalCenterTab);
+  if (!stored?.selectedProjectKey) {
+    workspaceState.openCenterTabs = [...workspaceState.globalCenterTabs];
+    workspaceState.activeCenterTab = workspaceState.globalCenterTabs[0];
+    workspaceState.centerTabMru = workspaceState.globalCenterTabs.map(tabKey);
+  }
+  workspaceState.projectRecency = stored?.projectRecency ?? {};
+  workspaceState.selectedProjectKey =
+    stored?.selectedProjectKey && projectKeys.has(stored.selectedProjectKey)
+      ? stored.selectedProjectKey
+      : undefined;
+  if (typeof localStorage !== "undefined" && !stored)
+    localStorage.removeItem(legacyStorageKey);
+}
+
+export function persistWorkspaceTabSessions(): void {
+  if (typeof localStorage === "undefined") return;
+  const sessions = Object.fromEntries(
+    Object.entries(workspaceState.projectTabSessions)
+      .slice(0, maxSessions)
+      .map(([key, session]) => {
+        const tabs = session.tabs.flatMap((tab): StoredTab[] => {
+          if (tab.kind === "pending-conversation") return [];
+          if (tab.kind === "file") {
+            const view = fileState.fileViews[fileViewKey(tab.id)];
+            return view
+              ? [
+                  {
+                    ...tab,
+                    projectId: view.projectId,
+                    path: view.path,
+                    line: view.line,
+                    displayMode: view.displayMode,
+                    wrapLines: view.wrapLines,
+                  },
+                ]
+              : [];
+          }
+          if (tab.kind === "pr") {
+            const view = gitState.prViews[prViewKey(tab.id)];
+            return view
+              ? [
+                  {
+                    ...tab,
+                    projectId: view.projectId,
+                    repo: view.repo,
+                    number: view.number,
+                  },
+                ]
+              : [];
+          }
+          return [tab];
+        });
+        const keys = new Set(tabs.map(tabKey));
+        const stored: StoredSession = {
+          tabs,
+          active:
+            session.active && keys.has(tabKey(session.active))
+              ? session.active
+              : undefined,
+          mru: session.mru.filter((item) => keys.has(item)),
+        };
+        return [key, stored];
+      }),
+  );
+  const payload: StoredPayload = {
+    selectedProjectKey: workspaceState.selectedProjectKey,
+    projectRecency: workspaceState.projectRecency,
+    sessions,
+    globals: workspaceState.globalCenterTabs,
+  };
+  localStorage.setItem(storageKey, JSON.stringify(payload));
+}

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
@@ -3,6 +3,7 @@ import { projectKey } from "$lib/core/utils/project-tree";
 import { fileViewKey, prViewKey } from "$lib/core/state/state-keys";
 import { fileState } from "$lib/features/filesystem/state/file-state.svelte";
 import { gitState } from "$lib/features/git/state/git-state.svelte";
+import { syncCenterTabMirrors } from "./center-tab-mirrors.svelte";
 import type {
   CenterTabIdentity,
   ProjectTabSession,
@@ -94,6 +95,7 @@ export function applyVisibleSession(key: string): ProjectTabSession {
   workspaceState.activeCenterTab = session.active;
   workspaceState.centerTabMru = [...session.mru];
   workspaceState.projectTabSessions[key] = session;
+  syncCenterTabMirrors();
   return session;
 }
 
@@ -356,6 +358,7 @@ export function hydrateWorkspaceTabSessions(input: {
     workspaceState.openCenterTabs = [...workspaceState.globalCenterTabs];
     workspaceState.activeCenterTab = workspaceState.globalCenterTabs[0];
     workspaceState.centerTabMru = workspaceState.globalCenterTabs.map(tabKey);
+    syncCenterTabMirrors();
   }
   workspaceState.projectRecency = stored?.projectRecency ?? {};
   workspaceState.selectedProjectKey =

--- a/packages/workbench-ui/src/lib/components/navigator/navigator-panel.svelte
+++ b/packages/workbench-ui/src/lib/components/navigator/navigator-panel.svelte
@@ -13,6 +13,8 @@ let {
   searchShortcut,
   searchShortcutAria,
   searchRef = $bindable(null),
+  viewportRef = $bindable(null),
+  searchActions,
   children,
 }: {
   /** Two-way bound search query. */
@@ -26,6 +28,8 @@ let {
   /** aria-keyshortcuts value for the search input. */
   searchShortcutAria?: string;
   searchRef?: HTMLInputElement | null;
+  viewportRef?: HTMLElement | null;
+  searchActions?: Snippet;
   children: Snippet;
 } = $props();
 
@@ -46,21 +50,27 @@ $effect(() => {
 <Tooltip.Provider delayDuration={300} disableHoverableContent>
   <aside class="navigator-panel">
     <div class="search-box">
-      <Search size={13} strokeWidth={2.25} aria-hidden="true" />
-      <Input
-        bind:ref={searchRef}
-        bind:value={searchValue}
-        size="xs"
-        {placeholder}
-        ariaLabel={searchAriaLabel ?? placeholder}
-        aria-keyshortcuts={searchShortcutAria}
-        {title}
-      />
+      <div class="search-field">
+        <Search size={13} strokeWidth={2.25} aria-hidden="true" />
+        <Input
+          bind:ref={searchRef}
+          bind:value={searchValue}
+          size="xs"
+          {placeholder}
+          ariaLabel={searchAriaLabel ?? placeholder}
+          aria-keyshortcuts={searchShortcutAria}
+          {title}
+        />
+      </div>
+      {#if searchActions}
+        <div class="search-actions">{@render searchActions()}</div>
+      {/if}
     </div>
 
     <ScrollArea
       class="navigator-scroll"
       viewportClass="navigator-viewport"
+      bind:viewportRef
       type="auto"
     >
       <div class="navigator-list">
@@ -84,26 +94,40 @@ $effect(() => {
 }
 
 .search-box {
-  position: relative;
-  display: grid;
+  display: flex;
   width: 100%;
   min-width: 0;
   align-items: center;
+  gap: 0.35rem;
   padding: 0.45rem;
   border-bottom: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
   background: transparent;
 }
 
-.search-box :global(svg) {
+.search-field {
+  position: relative;
+  min-width: 0;
+  flex: 1;
+}
+
+.search-field :global(svg) {
   position: absolute;
+  top: 50%;
   left: 0.85rem;
   z-index: 1;
+  transform: translateY(-50%);
   color: var(--muted-foreground);
   pointer-events: none;
 }
 
-.search-box :global([data-slot="input"]) {
+.search-field :global([data-slot="input"]) {
   padding-left: 1.75rem;
+}
+
+.search-actions {
+  display: flex;
+  flex: none;
+  align-items: center;
 }
 
 :global(.navigator-scroll) {

--- a/packages/workbench-ui/src/lib/components/workbench/types.ts
+++ b/packages/workbench-ui/src/lib/components/workbench/types.ts
@@ -42,6 +42,11 @@ export type WorkbenchTabModel = WorkbenchTabIdentity & {
   draft?: boolean;
 };
 
+export type WorkbenchTabReorderHandler = (
+  tab: WorkbenchTabIdentity,
+  targetIndex: number,
+) => void;
+
 export type WorkbenchTabMenuBuilder = (input: {
   tab: WorkbenchTabModel;
   tabs: WorkbenchTabModel[];

--- a/packages/workbench-ui/src/lib/components/workbench/workbench-tab-strip.svelte
+++ b/packages/workbench-ui/src/lib/components/workbench/workbench-tab-strip.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+import ChevronRight from "@lucide/svelte/icons/chevron-right";
+import MoveLeft from "@lucide/svelte/icons/move-left";
+import MoveRight from "@lucide/svelte/icons/move-right";
 import Plus from "@lucide/svelte/icons/plus";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import X from "@lucide/svelte/icons/x";
@@ -29,6 +33,7 @@ let {
   onCloseRight,
   onCloseLeft,
   onNew,
+  onReorder,
 }: {
   tabs?: WorkbenchTabModel[];
   refreshShortcut?: string;
@@ -45,7 +50,69 @@ let {
   onCloseRight?: (tab: WorkbenchTabIdentity) => void;
   onCloseLeft?: (tab: WorkbenchTabIdentity) => void;
   onNew?: () => void;
+  onReorder?: (tab: WorkbenchTabIdentity, targetIndex: number) => void;
 } = $props();
+
+let scroller = $state<HTMLDivElement | null>(null);
+let canScrollLeft = $state(false);
+let canScrollRight = $state(false);
+let draggedKey = $state<string | undefined>();
+let dropIndex = $state<number | undefined>();
+let announcement = $state("");
+
+function updateOverflow() {
+  if (!scroller) return;
+  canScrollLeft = scroller.scrollLeft > 1;
+  canScrollRight =
+    scroller.scrollLeft + scroller.clientWidth < scroller.scrollWidth - 1;
+}
+
+function scrollTabs(direction: -1 | 1) {
+  scroller?.scrollBy({
+    left: direction * Math.max(160, scroller.clientWidth * 0.75),
+    behavior: "smooth",
+  });
+}
+
+function startDrag(event: DragEvent, tab: WorkbenchTabModel) {
+  if (!onReorder) return;
+  draggedKey = tabKey(tab);
+  event.dataTransfer?.setData("text/plain", draggedKey);
+  if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+}
+
+function dropTab(event: DragEvent, index: number) {
+  event.preventDefault();
+  const key = draggedKey ?? event.dataTransfer?.getData("text/plain");
+  const tab = tabs.find((candidate) => tabKey(candidate) === key);
+  if (tab) {
+    onReorder?.(identity(tab), index);
+    announcement = `${tab.label} moved to position ${index + 1}`;
+  }
+  draggedKey = undefined;
+  dropIndex = undefined;
+}
+
+$effect(() => {
+  if (!scroller) return;
+  const observer = new ResizeObserver(updateOverflow);
+  observer.observe(scroller);
+  updateOverflow();
+  return () => observer.disconnect();
+});
+
+$effect(() => {
+  const active = tabs.find((tab) => tab.active);
+  requestAnimationFrame(() => {
+    updateOverflow();
+    if (active && scroller) {
+      const element = [
+        ...scroller.querySelectorAll<HTMLElement>("[data-tab-key]"),
+      ].find((candidate) => candidate.dataset.tabKey === tabKey(active));
+      element?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  });
+});
 
 function identity(tab: WorkbenchTabModel): WorkbenchTabIdentity {
   return { kind: tab.kind, id: tab.id };
@@ -59,7 +126,7 @@ function defaultMenu(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
   const id = identity(tab);
   const hasLeft = index > 0;
   const hasRight = index >= 0 && index < tabs.length - 1;
-  return [
+  const items: ContextMenuItem[] = [
     {
       label: "Refresh",
       icon: RefreshCw,
@@ -67,6 +134,25 @@ function defaultMenu(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
       disabled: !onRefresh,
       onSelect: () => onRefresh?.(id),
     },
+  ];
+  if (onReorder) {
+    items.push(
+      { type: "separator" },
+      {
+        label: "Move Left",
+        icon: MoveLeft,
+        disabled: !hasLeft,
+        onSelect: () => onReorder(id, index - 1),
+      },
+      {
+        label: "Move Right",
+        icon: MoveRight,
+        disabled: !hasRight,
+        onSelect: () => onReorder(id, index + 1),
+      },
+    );
+  }
+  items.push(
     { type: "separator" },
     {
       label: "Close Pane",
@@ -94,7 +180,8 @@ function defaultMenu(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
       disabled: !hasLeft || !onCloseLeft,
       onSelect: () => onCloseLeft?.(id),
     },
-  ];
+  );
+  return items;
 }
 
 function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
@@ -103,7 +190,19 @@ function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
 </script>
 
 <nav class="center-tab-strip" aria-label="Open center tabs">
-  <div class="tab-scroller" role="tablist" aria-label="Open center panes">
+  {#if canScrollLeft || canScrollRight}
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="tab-overflow-control"
+      ariaLabel="Scroll tabs left"
+      disabled={!canScrollLeft}
+      onclick={() => scrollTabs(-1)}
+    >
+      <ChevronLeft size={14} strokeWidth={2.2} />
+    </Button>
+  {/if}
+  <div class="tab-scroller" bind:this={scroller} onscroll={updateOverflow}>
     {#each tabs as tab, index (tabKey(tab))}
       {@const Icon = tab.icon}
       {@const SelectIcon = tab.selectIcon}
@@ -117,6 +216,22 @@ function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
           class:active={tab.active}
           class:running={tab.running}
           class:errored={Boolean(tab.error)}
+          class:dragging={draggedKey === tabKey(tab)}
+          class:drop-target={dropIndex === index && draggedKey !== tabKey(tab)}
+          data-tab-key={tabKey(tab)}
+          role="presentation"
+          draggable={Boolean(onReorder)}
+          ondragstart={(event) => startDrag(event, tab)}
+          ondragover={(event) => {
+            if (!onReorder) return;
+            event.preventDefault();
+            dropIndex = index;
+          }}
+          ondrop={(event) => dropTab(event, index)}
+          ondragend={() => {
+            draggedKey = undefined;
+            dropIndex = undefined;
+          }}
         >
           <div class="tab-leading">
             {#if tab.toggle && ToggleIcon}
@@ -184,6 +299,18 @@ function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
       </ContextMenu>
     {/each}
   </div>
+  {#if canScrollLeft || canScrollRight}
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="tab-overflow-control"
+      ariaLabel="Scroll tabs right"
+      disabled={!canScrollRight}
+      onclick={() => scrollTabs(1)}
+    >
+      <ChevronRight size={14} strokeWidth={2.2} />
+    </Button>
+  {/if}
 
   {#if onNew}
     <div class="tab-actions">
@@ -199,4 +326,5 @@ function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
       </Button>
     </div>
   {/if}
+  <span class="sr-only" aria-live="polite">{announcement}</span>
 </nav>


### PR DESCRIPTION
## Summary
- add a titlebar project switcher with activity indicators and a project-scoped conversation navigator
- persist and restore per-project workspace tab sessions, including MRU selection and cross-project tab routing
- add drag, overflow, and context-menu controls for reordering center tabs

## Validation
- pnpm fix
- pnpm check
- pnpm test