### PR TITLE
Fix conversation navigator capacity and New Chat state

### DIFF
--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
@@ -2,6 +2,7 @@
 import { type QueuedPromptRecord } from "$lib/api";
 import { protocolRequest } from "@nervekit/protocol";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import { workspaceSelectors } from "$lib/features/workspace/state/workspace-selectors.svelte";
 import { composerDraft } from "$lib/features/workspace/state/selection.svelte";
 import { selectCenterTab } from "$lib/features/workspace/state/center-tabs.svelte";
 import type { CenterTabIdentity } from "$lib/features/workspace";
@@ -110,9 +111,9 @@ const activeAgent = $derived(
 const activeProject = $derived.by(() => {
   const projectId =
     activePendingConversation?.projectId ?? activeConversation?.projectId;
-  return projectId
-    ? workspaceState.projects.find((project) => project.id === projectId)
-    : undefined;
+  if (projectId)
+    return workspaceState.projects.find((project) => project.id === projectId);
+  return paneTab ? undefined : workspaceSelectors.activeProject;
 });
 const pendingConversationActive = $derived(Boolean(activePendingConversation));
 const pendingUserQuestions = $derived.by(() => {

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
@@ -79,9 +79,9 @@ function updateVisibleLimit(rowCount = rows.length) {
     viewportRef.clientHeight - inset * 2,
   );
   const capacity = Math.max(1, Math.floor(availableHeight / rowHeight));
-  // Reserve one compact row for the overflow action plus rounding/inset slack
-  // so the navigator viewport never becomes scrollable by a few pixels.
-  visibleLimit = rowCount > capacity ? Math.max(1, capacity - 2) : capacity;
+  // Reserve one row slot for the compact overflow action so the navigator
+  // viewport remains non-scrollable while using the available height.
+  visibleLimit = rowCount > capacity ? Math.max(1, capacity - 1) : capacity;
 }
 
 $effect(() => {


### PR DESCRIPTION
## Summary
- use the selected workspace project for the empty conversation pane so New Chat is enabled correctly
- remove the redundant navigator row reservation to display more conversations without introducing scrolling
- preserve conversation-specific project resolution for open and pending panes

## Validation
- `pnpm fix && pnpm check && pnpm test`
- verified navigator sizing at multiple viewport heights with Agent Browser