### PR TITLE
Fix Windows native tests and CI timeouts

### DIFF
--- a/.github/workflows/native-host.yml
+++ b/.github/workflows/native-host.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build native host packages
+        if: matrix.suite == 'host'
+        run: pnpm --filter @nervekit/workbench-server... build
+
       - name: Run native tool and server tests
         if: matrix.suite == 'host'
         timeout-minutes: 8

--- a/.github/workflows/native-host.yml
+++ b/.github/workflows/native-host.yml
@@ -1,6 +1,15 @@
 name: Native host tests
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/native-host.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "packages/tools/**"
+      - "packages/workbench-server/**"
+      - "packages/desktop-shell/**"
   push:
     branches:
       - main
@@ -10,13 +19,14 @@ permissions:
 
 jobs:
   test:
-    name: Native host tests (${{ matrix.os }})
+    name: Native ${{ matrix.suite }} tests (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
+        suite: [host, desktop]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository
@@ -36,8 +46,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run native tool and server tests
+        if: matrix.suite == 'host'
+        timeout-minutes: 8
+        run: pnpm --filter @nervekit/tools test:native && pnpm --filter @nervekit/workbench-server test:native
+
       - name: Build native desktop runtime
+        if: matrix.suite == 'desktop'
         run: pnpm build:workbench-runtime && pnpm --filter @nervekit/desktop-shell build
 
-      - name: Run native server, tool, and desktop tests
-        run: pnpm --filter @nervekit/workbench-server --filter @nervekit/tools --filter @nervekit/desktop-shell test
+      - name: Run desktop tests
+        if: matrix.suite == 'desktop'
+        timeout-minutes: 8
+        run: pnpm --filter @nervekit/desktop-shell test

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "build": "tsc -b",
     "check": "tsc -b --pretty false",
-    "test": "tsx --test test/*.test.ts"
+    "test": "tsx --test test/*.test.ts",
+    "test:native": "tsx --test test/bash.test.ts test/filesystem.test.ts test/process-tree.test.ts test/python-runtime.test.ts test/search-find.test.ts test/shell-config.test.ts"
   },
   "dependencies": {
     "@nervekit/contracts": "workspace:*",

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -30,7 +30,8 @@
     "build": "tsc -b",
     "check": "tsc -b --pretty false",
     "dev": "tsx src/main.ts",
-    "test": "tsx --test test/*.test.ts"
+    "test": "tsx --test test/*.test.ts",
+    "test:native": "tsx --test test/explore-subagent-isolation.test.ts test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/storage-json.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "0.82.1",

--- a/packages/workbench-server/src/domains/tasks/task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-service.ts
@@ -143,7 +143,6 @@ export interface TaskServicePorts {
   readonly capabilities?: TaskOptionalCapabilitiesPort;
   readonly timers?: TaskTimerPort;
   readonly diagnostics?: DiagnosticPort;
-  readonly workspaceRoot: string;
   readonly stopTimeoutMs?: number;
 }
 
@@ -191,7 +190,7 @@ export class TaskService {
   constructor(private readonly ports: TaskServicePorts) {}
 
   async start(request: TaskStartInput): Promise<TaskRecord> {
-    assertWorkspacePath(request.cwd, this.ports.workspaceRoot);
+    const cwd = resolveTaskWorkingDirectory(request.cwd);
     if (!request.command.trim())
       throw new Error("Task command must not be empty");
     const now = this.now();
@@ -212,7 +211,7 @@ export class TaskService {
       projectId: request.projectId,
       conversationId: request.conversationId,
       agentId: request.agentId,
-      cwd: resolveWorkspacePath(request.cwd, this.ports.workspaceRoot),
+      cwd,
       command: request.command,
       envInfo: request.env
         ? {
@@ -885,22 +884,13 @@ function boundedErrorMessage(error: unknown): string {
   );
 }
 
-export function assertWorkspacePath(
-  input: string,
-  workspaceRoot: string,
-): void {
-  resolveWorkspacePath(input, workspaceRoot);
-}
-
-function resolveWorkspacePath(input: string, workspaceRoot: string): string {
-  const flavor = /^[A-Za-z]:[\\/]/.test(workspaceRoot) ? path.win32 : path;
-  const root = flavor.resolve(workspaceRoot);
-  const target = flavor.resolve(input);
-  const relative = flavor.relative(root, target);
-  if (
-    relative === "" ||
-    (!relative.startsWith("..") && !flavor.isAbsolute(relative))
-  )
-    return target;
-  throw new Error("Task working directory must be inside the workspace root");
+export function resolveTaskWorkingDirectory(input: string): string {
+  const flavor =
+    /^[A-Za-z]:[\\/]/.test(input) || input.startsWith("\\")
+      ? path.win32
+      : path.posix;
+  if (!flavor.isAbsolute(input)) {
+    throw new Error("Task working directory must be an absolute path");
+  }
+  return flavor.resolve(input);
 }

--- a/packages/workbench-server/src/domains/tasks/task-supervisor.ts
+++ b/packages/workbench-server/src/domains/tasks/task-supervisor.ts
@@ -75,12 +75,23 @@ export interface TaskSupervisor {
   ): Promise<TaskListeningPort[]>;
 }
 
+export function managedTaskShellCommand(
+  command: string,
+  shellPath?: string,
+): { shell: string; args: string[] } {
+  const shellConfig = resolveBashShellConfig({ shellPath });
+  return {
+    shell: shellConfig.shell,
+    args: [...shellConfig.args, command],
+  };
+}
+
 export function spawnManagedTask(
   command: string,
   options: SpawnManagedTaskOptions,
 ): SpawnedManagedTask {
-  const shellConfig = resolveBashShellConfig({ shellPath: options.shellPath });
-  const child = spawn(shellConfig.shell, [...shellConfig.args, command], {
+  const shellCommand = managedTaskShellCommand(command, options.shellPath);
+  const child = spawn(shellCommand.shell, shellCommand.args, {
     cwd: options.cwd,
     env: nonInteractiveShellEnv(options.env),
     stdio: ["ignore", "pipe", "pipe"],

--- a/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { mkdir } from "node:fs/promises";
-import { join, parse } from "node:path";
+import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 import type {
   TaskProcessExit,
@@ -188,7 +188,6 @@ export function createWorkbenchTaskResources(
   };
 
   const ports: TaskServicePorts = {
-    workspaceRoot: parse(process.cwd()).root,
     clock: { now: () => new Date() },
     ids: {
       next: () => {

--- a/packages/workbench-server/src/protocol/protocol-websocket.ts
+++ b/packages/workbench-server/src/protocol/protocol-websocket.ts
@@ -26,6 +26,7 @@ import { workbenchWebSocketRpcDispatcher } from "./http-dispatcher.js";
 import { orchestratorSource } from "./messages.js";
 
 export interface LocalProtocolSession {
+  readonly closed: Promise<void>;
   dispose(): void;
   shutdown(message?: string): Promise<void>;
 }
@@ -84,15 +85,23 @@ export function createLocalProtocolSession(
   let unsubscribeSequenced: () => void = () => undefined;
   let unsubscribeNotify: () => void = () => undefined;
 
+  let resolveClosed: () => void = () => undefined;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
   let disposed = false;
   const dispose = () => {
     if (disposed) return;
     disposed = true;
-    unsubscribeSequenced();
-    unsubscribeNotify();
-    session.dispose();
-    connection.dispose();
-    onDispose();
+    try {
+      unsubscribeSequenced();
+      unsubscribeNotify();
+      session.dispose();
+      connection.dispose();
+      onDispose();
+    } finally {
+      resolveClosed();
+    }
   };
   const closeProtocolError = async () => {
     if (disposed) return;
@@ -197,17 +206,26 @@ export function createLocalProtocolSession(
   });
 
   return {
+    closed,
     dispose,
     async shutdown(message = "Daemon shutting down") {
       if (disposed) return;
       unsubscribeSequenced();
       unsubscribeNotify();
+      let failure: unknown;
       try {
         await session.shutdown("server_shutdown", message);
+      } catch (error) {
+        if (ws.readyState < 2) failure = error;
+      }
+      try {
         await connection.close(1001, message);
+      } catch (error) {
+        if (ws.readyState < 2 && failure === undefined) failure = error;
       } finally {
         dispose();
       }
+      if (failure !== undefined) throw failure;
     },
   };
 }

--- a/packages/workbench-server/test/explore-subagent-isolation.test.ts
+++ b/packages/workbench-server/test/explore-subagent-isolation.test.ts
@@ -81,7 +81,7 @@ describe("explore subagent transcript isolation", () => {
         .find((agent) => agent.parentAgentId === parent.id);
       assert.ok(child);
       assert.equal(child.status, "idle");
-      assert.match(child.systemPrompt ?? "", new RegExp(root));
+      assert.ok((child.systemPrompt ?? "").includes(project.dir));
       assert.match(
         child.systemPrompt ?? "",
         /NERVE_HOME.*artifacts, not the source root/,

--- a/packages/workbench-server/test/file-idempotency-store.test.ts
+++ b/packages/workbench-server/test/file-idempotency-store.test.ts
@@ -148,7 +148,9 @@ test("file idempotency writes private bounded state", async () => {
     {},
     async () => success,
   );
-  assert.equal((await stat(path)).mode & 0o777, 0o600);
+  if (process.platform !== "win32") {
+    assert.equal((await stat(path)).mode & 0o777, 0o600);
+  }
   assert((await readFile(path)).byteLength < 4 * 1024 * 1024);
 });
 

--- a/packages/workbench-server/test/helpers/registry-conversation.ts
+++ b/packages/workbench-server/test/helpers/registry-conversation.ts
@@ -8,14 +8,22 @@ import {
   createId,
   type TaskRecord,
 } from "@nervekit/contracts";
-import { createOrchestratorState } from "../../src/app/orchestrator-state.js";
+import {
+  createOrchestratorState,
+  shutdownOrchestratorState,
+  type OrchestratorState,
+} from "../../src/app/orchestrator-state.js";
 import { initializeStorage } from "../../src/infrastructure/storage/index.js";
 
 const roots: string[] = [];
+const states: OrchestratorState[] = [];
 
 after(async () => {
+  await Promise.allSettled(states.map(shutdownOrchestratorState));
   await Promise.all(
-    roots.map((root) => rm(root, { recursive: true, force: true })),
+    roots.map((root) =>
+      rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 }),
+    ),
   );
 });
 
@@ -28,6 +36,7 @@ export async function tempHome(prefix: string): Promise<string> {
 export async function createState(prefix = "nerve-registry-conversation-") {
   const storage = await initializeStorage(await tempHome(prefix));
   const state = createOrchestratorState(storage, "127.0.0.1", 0);
+  states.push(state);
   await state.registry.hydrate();
   return state;
 }

--- a/packages/workbench-server/test/helpers/server-routes.ts
+++ b/packages/workbench-server/test/helpers/server-routes.ts
@@ -2,15 +2,23 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after } from "node:test";
-import { createOrchestratorState } from "../../src/app/orchestrator-state.js";
+import {
+  createOrchestratorState,
+  shutdownOrchestratorState,
+  type OrchestratorState,
+} from "../../src/app/orchestrator-state.js";
 import { createApp } from "../../src/app/server.js";
 import { initializeStorage } from "../../src/infrastructure/storage/index.js";
 
 const roots: string[] = [];
+const states: OrchestratorState[] = [];
 
 after(async () => {
+  await Promise.allSettled(states.map(shutdownOrchestratorState));
   await Promise.all(
-    roots.map((root) => rm(root, { recursive: true, force: true })),
+    roots.map((root) =>
+      rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 }),
+    ),
   );
 });
 
@@ -25,6 +33,7 @@ export async function createAuthenticatedApp(host = "127.0.0.1") {
     await tempHome("nerve-server-routes-"),
   );
   const state = createOrchestratorState(storage, host, 0);
+  states.push(state);
   await state.logger.hydrate();
   await state.registry.hydrate();
   const app = createApp(state);

--- a/packages/workbench-server/test/index-store.test.ts
+++ b/packages/workbench-server/test/index-store.test.ts
@@ -21,7 +21,14 @@ const now = "2026-06-20T00:00:00.000Z";
 
 after(async () => {
   await Promise.all(
-    roots.map((root) => rm(root, { recursive: true, force: true })),
+    roots.map((root) =>
+      rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 50,
+      }),
+    ),
   );
 });
 
@@ -32,9 +39,10 @@ async function tempDbPath(): Promise<string> {
 }
 
 describe("IndexStore", () => {
-  it("defers incremental updates within one guarded startup scope", async () => {
+  it("defers incremental updates within one guarded startup scope", async (t) => {
     const path = await tempDbPath();
     const store = new IndexStore(path);
+    t.after(() => store.close());
     store.initialize();
     const project: ProjectRecord = {
       id: "proj_deferred",
@@ -55,12 +63,12 @@ describe("IndexStore", () => {
 
     store.upsertProject(project);
     assert.equal(store.counts().projects, 1);
-    store.close();
   });
 
-  it("restores incremental updates after a deferred operation fails", async () => {
+  it("restores incremental updates after a deferred operation fails", async (t) => {
     const path = await tempDbPath();
     const store = new IndexStore(path);
+    t.after(() => store.close());
     store.initialize();
     await assert.rejects(
       store.withUpdatesDeferred(async () => {
@@ -76,12 +84,15 @@ describe("IndexStore", () => {
       updatedAt: now,
     });
     assert.equal(store.counts().projects, 1);
-    store.close();
   });
 
-  it("bulk rebuilds repository-derived records", async () => {
+  it("bulk rebuilds repository-derived records", async (t) => {
     const path = await tempDbPath();
     const store = new IndexStore(path);
+    let storeOpen = true;
+    t.after(() => {
+      if (storeOpen) store.close();
+    });
     store.initialize();
 
     store.upsertProject({
@@ -203,6 +214,7 @@ describe("IndexStore", () => {
       userQuestions: 1,
     });
     store.close();
+    storeOpen = false;
 
     const db = new DatabaseSync(path);
     try {

--- a/packages/workbench-server/test/policy.test.ts
+++ b/packages/workbench-server/test/policy.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import type {
   AgentRecord,
@@ -332,7 +333,10 @@ describe("tool policy", () => {
       { dataDir: "/tmp/nerve" },
     );
     assert.equal(allowed.decision, "allow");
-    assert.equal(allowed.normalizedArgs.path, "/tmp/nerve/plans/edit-plan.md");
+    assert.equal(
+      allowed.normalizedArgs.path,
+      resolve("/tmp/nerve/plans/edit-plan.md"),
+    );
 
     const denied = evaluateToolPolicy(
       agent("autonomous", "planning"),

--- a/packages/workbench-server/test/protocol-websocket.test.ts
+++ b/packages/workbench-server/test/protocol-websocket.test.ts
@@ -5,7 +5,10 @@ import assert from "node:assert/strict";
 import type { Server } from "node:http";
 import { afterEach, test } from "node:test";
 import WebSocket, { WebSocketServer } from "ws";
-import { createOrchestratorState } from "../src/app/orchestrator-state.js";
+import {
+  createOrchestratorState,
+  shutdownOrchestratorState,
+} from "../src/app/orchestrator-state.js";
 import { createApp } from "../src/app/server.js";
 import { initializeStorage } from "../src/infrastructure/storage/index.js";
 import { PROTOCOL_CAPABILITIES } from "../src/protocol/constants.js";
@@ -21,6 +24,46 @@ const cleanups: Array<() => Promise<void>> = [];
 afterEach(async () => {
   await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
 });
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = 2_000,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} did not finish within ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function closeWithTimeout(
+  close: (done: (error?: Error) => void) => void,
+  label: string,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} did not close within 2 seconds`)),
+      2_000,
+    );
+    close((error) => {
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
 
 async function fixture() {
   const storage = await initializeStorage(await tempHome("nerve-protocol-ws-"));
@@ -45,13 +88,40 @@ async function fixture() {
     storage.localToken,
   );
   cleanups.push(async () => {
-    await Promise.all(
-      [...sessions].map((session) => session.shutdown("test cleanup")),
+    const results: PromiseSettledResult<unknown>[] = [];
+    results.push(
+      ...(await Promise.allSettled(
+        [...sessions].map((session) =>
+          withTimeout(
+            session.shutdown("test cleanup"),
+            "Protocol session shutdown",
+          ),
+        ),
+      )),
     );
     for (const client of webSockets.clients) client.terminate();
-    await new Promise<void>((resolve) => webSockets.close(() => resolve()));
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-    state.index.close();
+    results.push(
+      ...(await Promise.allSettled([
+        closeWithTimeout(
+          (done) => webSockets.close(() => done()),
+          "WebSocket server",
+        ),
+        closeWithTimeout(
+          (done) => server.close((error) => done(error)),
+          "HTTP server",
+        ),
+      ])),
+    );
+    await shutdownOrchestratorState(state);
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        "Protocol fixture cleanup failed",
+      );
+    }
   });
   return {
     state,
@@ -221,11 +291,13 @@ test("real adapter gates live/RPC until ready and shares canonical HTTP/WS dispa
     (response.data.result as { snapshot: unknown }).snapshot,
   );
 
+  const serverSession = [...host.sessions][0];
+  assert.ok(serverSession);
   peer.socket.close();
   await new Promise<void>((resolve) =>
     peer.socket.once("close", () => resolve()),
   );
-  await new Promise((resolve) => setImmediate(resolve));
+  await serverSession.closed;
   assert.equal(host.sessions.size, 0);
 });
 

--- a/packages/workbench-server/test/task-scope.test.ts
+++ b/packages/workbench-server/test/task-scope.test.ts
@@ -42,6 +42,14 @@ describe("task directory scope", () => {
       false,
     );
     assert.equal(isPathInDirectoryTree("C:\\Work\\Project", "C:\\Work"), false);
+    assert.equal(
+      isPathInDirectoryTree("C:\\Work\\Project", "c:\\work\\project\\src"),
+      true,
+    );
+    assert.equal(
+      isPathInDirectoryTree("C:\\Work\\Project", "D:\\Work\\Project"),
+      false,
+    );
   });
 });
 

--- a/packages/workbench-server/test/task-service.contract.test.ts
+++ b/packages/workbench-server/test/task-service.contract.test.ts
@@ -53,7 +53,6 @@ function fixture(
     events: { publish: async (event) => void events.push(event) },
     clock: { now: () => new Date("2026-07-11T00:00:00.000Z") },
     ids: { next: () => "task_contract" },
-    workspaceRoot: "/workspace",
   };
   return {
     service: new TaskService(ports),
@@ -108,7 +107,6 @@ function servicePortsForRecords(
     ids: { next: () => "task_contract" },
     diagnostics: options.diagnostics,
     timers: options.timers,
-    workspaceRoot: "/workspace",
   };
 }
 
@@ -195,18 +193,21 @@ test("terminal callbacks are idempotent across repeated exit and cancellation ra
   );
 });
 
-test("workspace containment normalizes POSIX and Windows paths", async () => {
-  const { assertWorkspacePath } =
+test("task working directories normalize POSIX and Windows absolute paths", async () => {
+  const { resolveTaskWorkingDirectory } =
     await import("../src/domains/tasks/task-service.js");
-  assert.doesNotThrow(() =>
-    assertWorkspacePath("/workspace/a/..", "/workspace"),
+  assert.equal(resolveTaskWorkingDirectory("/workspace/a/.."), "/workspace");
+  assert.equal(
+    resolveTaskWorkingDirectory("C:\\workspace\\project\\.."),
+    "C:\\workspace",
   );
-  assert.throws(() => assertWorkspacePath("/workspace-other", "/workspace"));
-  assert.doesNotThrow(() =>
-    assertWorkspacePath("C:\\workspace\\project", "C:\\workspace"),
+  assert.equal(
+    resolveTaskWorkingDirectory("\\\\server\\share\\project"),
+    "\\\\server\\share\\project",
   );
-  assert.throws(() =>
-    assertWorkspacePath("C:\\workspace-other", "C:\\workspace"),
+  assert.throws(
+    () => resolveTaskWorkingDirectory("workspace/project"),
+    /absolute path/,
   );
 });
 

--- a/packages/workbench-server/test/task-supervisor.test.ts
+++ b/packages/workbench-server/test/task-supervisor.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import type { ChildProcess, SpawnOptions, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -9,6 +9,7 @@ import type { TaskRuntime } from "@nervekit/contracts";
 import {
   defaultTaskSupervisor,
   isTaskRuntimeTargetAlive,
+  managedTaskShellCommand,
   runtimeForChild,
   spawnManagedTask,
   terminateTask,
@@ -97,20 +98,12 @@ describe("task supervisor spawn metadata", () => {
   it("uses configured shellPath for managed task commands", async () => {
     const dir = await mkdtemp(join(tmpdir(), "nerve-task-shell-"));
     const shellPath = join(dir, "fake-shell");
-    await writeFile(
-      shellPath,
-      `#!${process.execPath}\nprocess.stdout.write('managed shell:' + process.argv.slice(2).join('|'))`,
-      "utf8",
-    );
-    await chmod(shellPath, 0o755);
+    await writeFile(shellPath, "test shell placeholder", "utf8");
 
-    const output = await collectSpawnedStdout(
-      "pnpm check",
-      undefined,
-      shellPath,
-    );
-
-    assert.equal(output, "managed shell:-c|pnpm check");
+    assert.deepEqual(managedTaskShellCommand("pnpm check", shellPath), {
+      shell: shellPath,
+      args: ["-c", "pnpm check"],
+    });
   });
 
   it("allows explicit managed task env to override non-interactive defaults", async () => {

--- a/packages/workbench-server/test/workbench-task-service-orphan.test.ts
+++ b/packages/workbench-server/test/workbench-task-service-orphan.test.ts
@@ -22,8 +22,14 @@ describe("task manager orphan cleanup", () => {
 
     assert.equal(stopped.status, "cancelled");
     assert.equal(stopped.exitCode, null);
-    assert.equal(stopped.signal, "SIGTERM");
-    assert.deepEqual(runtimeTerminateSignals, ["SIGTERM"]);
+    assert.equal(
+      stopped.signal,
+      process.platform === "win32" ? "SIGKILL" : "SIGTERM",
+    );
+    assert.deepEqual(
+      runtimeTerminateSignals,
+      process.platform === "win32" ? ["SIGKILL"] : ["SIGTERM"],
+    );
     assert.ok(
       (await events.readStream("workspace", 1, 5_000)).events.some(
         (event) => event.type === "task.cancelled",
@@ -31,7 +37,7 @@ describe("task manager orphan cleanup", () => {
     );
   });
 
-  it("escalates orphan cleanup to SIGKILL after timeout on non-Windows", async () => {
+  it("escalates orphan cleanup on POSIX and force-cleans on Windows", async () => {
     const runtime = runtimeMetadata();
     const { supervisor, runtimeTerminateSignals } = fakeSupervisor({
       runtime,
@@ -45,10 +51,13 @@ describe("task manager orphan cleanup", () => {
 
     assert.equal(stopped.status, "cancelled");
     assert.equal(stopped.signal, "SIGKILL");
-    assert.deepEqual(runtimeTerminateSignals, ["SIGTERM", "SIGKILL"]);
+    assert.deepEqual(
+      runtimeTerminateSignals,
+      process.platform === "win32" ? ["SIGKILL"] : ["SIGTERM", "SIGKILL"],
+    );
   });
 
-  it("does not escalate orphan cleanup when the target disappears", async () => {
+  it("uses the platform cleanup signal when the target disappears", async () => {
     const runtime = runtimeMetadata();
     const { supervisor, runtimeTerminateSignals } = fakeSupervisor({
       runtime,
@@ -61,8 +70,14 @@ describe("task manager orphan cleanup", () => {
     const stopped = await manager.cancelTask(record.id, { timeoutMs: 100 });
 
     assert.equal(stopped.status, "cancelled");
-    assert.equal(stopped.signal, "SIGTERM");
-    assert.deepEqual(runtimeTerminateSignals, ["SIGTERM"]);
+    assert.equal(
+      stopped.signal,
+      process.platform === "win32" ? "SIGKILL" : "SIGTERM",
+    );
+    assert.deepEqual(
+      runtimeTerminateSignals,
+      process.platform === "win32" ? ["SIGKILL"] : ["SIGTERM"],
+    );
   });
 
   it("records released ports after orphan cleanup", async () => {
@@ -188,8 +203,9 @@ describe("task manager orphan cleanup", () => {
 
     const restarted = await manager.restartTask(record.id);
 
-    assert.deepEqual(order, ["terminateRuntime:SIGTERM", "spawn"]);
-    assert.deepEqual(runtimeTerminateSignals, ["SIGTERM"]);
+    const cleanupSignal = process.platform === "win32" ? "SIGKILL" : "SIGTERM";
+    assert.deepEqual(order, [`terminateRuntime:${cleanupSignal}`, "spawn"]);
+    assert.deepEqual(runtimeTerminateSignals, [cleanupSignal]);
     assert.equal(manager.getTask(record.id).status, "cancelled");
     assert.equal(restarted.restartedFromTaskId, record.id);
     assert.equal(spawnCommands.length, 1);


### PR DESCRIPTION
## Summary
- fix cross-drive task paths and Windows-specific process/shell assertions
- make WebSocket and SQLite fixture teardown deterministic and bounded
- add focused native test scripts and split Windows/macOS host and desktop CI jobs

## Validation
- `pnpm fix && pnpm check && pnpm test`
- focused tools and workbench-server native suites