### PR TITLE
Compact planning context before implementation

### DIFF
--- a/packages/contracts/src/domains/plans/plan-review.schema.ts
+++ b/packages/contracts/src/domains/plans/plan-review.schema.ts
@@ -46,6 +46,7 @@ export const resolvePlanReviewRequestSchema = z.object({
   feedback: z.string().optional(),
   implementationModel: modelSelectionSchema.optional(),
   implementationThinkingLevel: thinkingLevelSchema.optional(),
+  compactBeforeImplementation: z.boolean().optional(),
 });
 export type ResolvePlanReviewRequest = z.infer<
   typeof resolvePlanReviewRequestSchema
@@ -54,4 +55,5 @@ export type ResolvePlanReviewRequest = z.infer<
 export type PlanImplementationSelection = {
   implementationModel?: ModelSelection;
   implementationThinkingLevel?: ThinkingLevel;
+  compactBeforeImplementation?: boolean;
 };

--- a/packages/contracts/test/plan-review.schema.test.ts
+++ b/packages/contracts/test/plan-review.schema.test.ts
@@ -11,6 +11,7 @@ describe("plan review resolve request schema", () => {
           modelId: "claude-sonnet-4-5",
         },
         implementationThinkingLevel: "max",
+        compactBeforeImplementation: true,
       }),
       {
         implementationModel: {
@@ -18,6 +19,7 @@ describe("plan review resolve request schema", () => {
           modelId: "claude-sonnet-4-5",
         },
         implementationThinkingLevel: "max",
+        compactBeforeImplementation: true,
       },
     );
   });
@@ -31,6 +33,11 @@ describe("plan review resolve request schema", () => {
     assert.throws(() =>
       resolvePlanReviewRequestSchema.parse({
         implementationModel: { provider: "anthropic", modelId: "" },
+      }),
+    );
+    assert.throws(() =>
+      resolvePlanReviewRequestSchema.parse({
+        compactBeforeImplementation: "yes",
       }),
     );
   });

--- a/packages/harness/src/harness/compaction/compaction.ts
+++ b/packages/harness/src/harness/compaction/compaction.ts
@@ -161,6 +161,14 @@ export const SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assi
 
 Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`;
 
+export type CompactionSummaryProfile =
+  | { kind: "default" }
+  | { kind: "plan-implementation"; planPath: string };
+
+export const PLAN_IMPLEMENTATION_SUMMARIZATION_SYSTEM_PROMPT = `You are a context summarization assistant preparing a coding agent to move from approved planning into implementation. The approved plan is stored in a separate file and is the authoritative implementation specification.
+
+Do NOT continue the conversation. Do NOT implement the plan. Do NOT answer questions from the conversation. Do NOT reproduce the plan's steps or content. ONLY output the structured implementation handoff requested by the user prompt.`;
+
 const REQUIRED_SUMMARY_HEADINGS = [
   "Goal",
   "Requirements and Constraints",
@@ -216,6 +224,41 @@ Rules:
 
 ${SUMMARY_FORMAT}`;
 
+export function summarizationPrompts(
+  profile: CompactionSummaryProfile | undefined,
+  updating: boolean,
+): { systemPrompt: string; userPrompt: string } {
+  if (!profile || profile.kind === "default") {
+    return {
+      systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
+      userPrompt: updating ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT,
+    };
+  }
+
+  const updateRule = updating
+    ? "Reconcile the new messages with <previous-summary>, retaining only information still needed for implementation."
+    : "Summarize the planning conversation as a one-time implementation handoff.";
+  return {
+    systemPrompt: PLAN_IMPLEMENTATION_SUMMARIZATION_SYSTEM_PROMPT,
+    userPrompt: `The messages above are planning history for an approved plan. The implementation agent will read this checkpoint and then the authoritative plan file at:
+
+${profile.planPath}
+
+${updateRule}
+
+Rules:
+- Treat the plan file as the source of truth. Reference its exact path, but do not restate, paraphrase, or duplicate its implementation steps.
+- Preserve only complementary context that may not be recoverable from the plan or repository: user constraints, research evidence, environment facts, unresolved risks, failures, commands, paths, and identifiers.
+- Planning and research are not implementation. Do not claim code changes, tests, or validation unless the conversation contains direct evidence they occurred outside planning.
+- In Work Remaining, direct the next agent to read the plan file, implement it, and validate the result rather than recreating the plan.
+- Make Current Working State explicit, including partial workspace changes or failures if any. Otherwise state that implementation has not started.
+- Drop planning narration, deliberation, superseded approaches, and all plan content already recoverable from the plan file.
+- Summarize only. Do not continue the task in this response.
+
+${SUMMARY_FORMAT}`,
+  };
+}
+
 export const UPDATE_SUMMARIZATION_PROMPT = `The messages above are NEW conversation messages to reconcile with the existing checkpoint in <previous-summary> tags. Another agent will read ONLY the updated checkpoint.
 
 Rules:
@@ -261,6 +304,7 @@ export type GenerateSummaryInput = {
   signal?: AbortSignal;
   customInstructions?: string;
   previousSummary?: string;
+  summaryProfile?: CompactionSummaryProfile;
   thinkingLevel?: ThinkingLevel;
   env?: Record<string, string>;
   /** Called with the accumulated text as the summary streams in. */
@@ -277,6 +321,7 @@ export async function generateSummary({
   signal,
   customInstructions,
   previousSummary,
+  summaryProfile,
   thinkingLevel,
   env,
   onProgress,
@@ -285,9 +330,11 @@ export async function generateSummary({
     Math.floor(0.8 * reserveTokens),
     model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
   );
-  let basePrompt = previousSummary
-    ? UPDATE_SUMMARIZATION_PROMPT
-    : SUMMARIZATION_PROMPT;
+  const prompts = summarizationPrompts(
+    summaryProfile,
+    Boolean(previousSummary),
+  );
+  let basePrompt = prompts.userPrompt;
   if (customInstructions) {
     basePrompt = `${basePrompt}\n\nAdditional focus: ${customInstructions}`;
   }
@@ -311,7 +358,7 @@ export async function generateSummary({
     const stream = streamSimpleWithModel(
       model,
       {
-        systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
+        systemPrompt: prompts.systemPrompt,
         messages: [
           {
             role: "user" as const,

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -16,6 +16,7 @@ export {
   type AutoCompactionPolicy,
   type AutoCompactionReason,
   calculateContextTokens,
+  type CompactionSummaryProfile,
   compact,
   computeContextUsage,
   DEFAULT_AUTO_COMPACTION_SETTINGS,

--- a/packages/harness/test/harness/compaction/summary-prompts.test.ts
+++ b/packages/harness/test/harness/compaction/summary-prompts.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  PLAN_IMPLEMENTATION_SUMMARIZATION_SYSTEM_PROMPT,
+  SUMMARIZATION_PROMPT,
+  SUMMARIZATION_SYSTEM_PROMPT,
+  summarizationPrompts,
+} from "../../../src/harness/compaction/compaction.js";
+
+const requiredHeadings = [
+  "Goal",
+  "Requirements and Constraints",
+  "Work Completed",
+  "Work Remaining",
+  "Key Decisions",
+  "Current Working State",
+  "Continuation Plan",
+  "Critical References",
+];
+
+describe("compaction summary prompts", () => {
+  it("keeps the default summarization prompts unchanged", () => {
+    assert.deepEqual(summarizationPrompts(undefined, false), {
+      systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
+      userPrompt: SUMMARIZATION_PROMPT,
+    });
+  });
+
+  it("builds a plan-aware implementation handoff without duplicating the plan", () => {
+    const planPath = "/home/test/.nerve/plans/feature.md";
+    const prompts = summarizationPrompts(
+      { kind: "plan-implementation", planPath },
+      false,
+    );
+
+    assert.equal(
+      prompts.systemPrompt,
+      PLAN_IMPLEMENTATION_SUMMARIZATION_SYSTEM_PROMPT,
+    );
+    assert.match(
+      prompts.userPrompt,
+      new RegExp(planPath.replaceAll("/", "\\/")),
+    );
+    assert.match(prompts.userPrompt, /source of truth/i);
+    assert.match(
+      prompts.userPrompt,
+      /do not restate, paraphrase, or duplicate/i,
+    );
+    for (const heading of requiredHeadings) {
+      assert.match(prompts.userPrompt, new RegExp(`^## ${heading}$`, "m"));
+    }
+  });
+});

--- a/packages/workbench-app/src/lib/features/tools/api/tools.api.ts
+++ b/packages/workbench-app/src/lib/features/tools/api/tools.api.ts
@@ -23,6 +23,7 @@ export type PlanReviewResolveOptions = {
   feedback?: string;
   implementationModel?: ModelSelection;
   implementationThinkingLevel?: AgentRecord["thinkingLevel"];
+  compactBeforeImplementation?: boolean;
 };
 
 export async function getToolCalls(): Promise<ToolCallTranscriptRecord[]> {

--- a/packages/workbench-app/src/lib/presentation/state/tool-types.ts
+++ b/packages/workbench-app/src/lib/presentation/state/tool-types.ts
@@ -32,4 +32,5 @@ export type PlanReviewResolveOptions = {
   feedback?: string;
   implementationModel?: ModelSelection;
   implementationThinkingLevel?: AgentRecord["thinkingLevel"];
+  compactBeforeImplementation?: boolean;
 };

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
@@ -18,7 +18,7 @@ import {
 import PlanImplementationModelDialog from "./PlanImplementationModelDialog.svelte";
 import ToolFooter from "./ToolFooter.svelte";
 
-type PlanAcceptTarget = "same" | "new-chat";
+type PlanAcceptTarget = "same" | "compact" | "new-chat";
 
 type Props = {
   toolCall: ToolCallDisplayRecord;
@@ -165,6 +165,30 @@ async function acceptSame(options?: PlanReviewResolveOptions) {
   }
 }
 
+async function acceptCompact(options?: PlanReviewResolveOptions) {
+  if (
+    !planReview ||
+    !pendingReview ||
+    accepting ||
+    rejecting ||
+    !onAcceptPlanReview
+  ) {
+    return;
+  }
+  accepting = "compact";
+  actionError = undefined;
+  try {
+    await onAcceptPlanReview(planReview.id, {
+      ...options,
+      compactBeforeImplementation: true,
+    });
+  } catch (error) {
+    actionError = errorMessage(error, "Could not compact and accept the plan.");
+  } finally {
+    accepting = undefined;
+  }
+}
+
 async function acceptNewChat(options?: PlanReviewResolveOptions) {
   if (
     !planReview ||
@@ -189,6 +213,11 @@ async function acceptNewChat(options?: PlanReviewResolveOptions) {
 function openSameModelDialog() {
   if (!pendingReview || accepting || rejecting) return;
   implementationDialog = "same";
+}
+
+function openCompactModelDialog() {
+  if (!pendingReview || accepting || rejecting) return;
+  implementationDialog = "compact";
 }
 
 function openNewChatModelDialog() {
@@ -251,15 +280,23 @@ async function rejectPlan() {
             />{/if}
           {accepting === "same"
             ? "Accepting…"
-            : accepting === "new-chat"
-              ? "Accepting in new chat…"
-              : "Accept & Implement"}
+            : accepting === "compact"
+              ? "Compacting…"
+              : accepting === "new-chat"
+                ? "Accepting in new chat…"
+                : "Accept & Implement"}
           {#snippet menu()}
             <DropdownMenu.Item
               disabled={actionsDisabled}
               onSelect={() => void acceptSame()}
             >
               Accept & implement
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={actionsDisabled}
+              onSelect={() => void acceptCompact()}
+            >
+              Compact & implement
             </DropdownMenu.Item>
             {#if onAcceptPlanReviewInNewChat}
               <DropdownMenu.Item
@@ -275,6 +312,12 @@ async function rejectPlan() {
               onSelect={openSameModelDialog}
             >
               Choose model & implement
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={actionsDisabled}
+              onSelect={openCompactModelDialog}
+            >
+              Choose model & compact
             </DropdownMenu.Item>
             {#if onAcceptPlanReviewInNewChat}
               <DropdownMenu.Item
@@ -315,6 +358,19 @@ async function rejectPlan() {
         implementationDialog = open ? "same" : undefined;
       }}
       onConfirm={acceptSame}
+    />
+    <PlanImplementationModelDialog
+      open={implementationDialog === "compact"}
+      title="Choose implementation model"
+      description="The selected model will compact the planning context, then implement the plan in this conversation."
+      confirmLabel="Compact and implement"
+      models={planReviewModels}
+      initialModelKey={planReviewModelKey}
+      initialThinkingLevel={planReviewThinkingLevel}
+      onOpenChange={(open) => {
+        implementationDialog = open ? "compact" : undefined;
+      }}
+      onConfirm={acceptCompact}
     />
     {#if onAcceptPlanReviewInNewChat}
       <PlanImplementationModelDialog

--- a/packages/workbench-server/src/domains/conversations/operations/compaction-service.ts
+++ b/packages/workbench-server/src/domains/conversations/operations/compaction-service.ts
@@ -1,6 +1,7 @@
 import {
   type AgentMessage,
   buildConversationContext,
+  type CompactionSummaryProfile,
   type Conversation,
   type ConversationTreeEntry,
   createCompactionSummaryMessage,
@@ -23,7 +24,10 @@ import {
   type CompactionProgressPublisherOptions,
   type CompactionProgressReport,
 } from "./compaction-progress-publisher.js";
-import { buildExtractiveSummary } from "./summary.js";
+import {
+  buildExtractiveSummary,
+  buildPlanImplementationSummary,
+} from "./summary.js";
 
 export interface AppendConversationEntryInput {
   id?: string;
@@ -58,6 +62,7 @@ export type CompactionSummarizer = (input: {
   messages: AgentMessage[];
   previousSummary?: string;
   instructions?: string;
+  summaryProfile?: CompactionSummaryProfile;
   summaryReserveTokens: number;
   signal?: AbortSignal;
   /** Receives the summary text as it streams in, for live UI feedback. */
@@ -80,6 +85,7 @@ export interface CompactConversationOptions {
   safetyHeadroomTokens?: number;
   failedEntryId?: string;
   activeConversation?: Conversation;
+  summaryProfile?: CompactionSummaryProfile;
   signal?: AbortSignal;
 }
 
@@ -239,6 +245,7 @@ export class CompactionService {
           messagesToSummarize,
           preparation.previousSummary,
           request.instructions,
+          options.summaryProfile,
           summaryReserveTokens,
           operation.controller.signal,
           (report) => progress.report(report),
@@ -248,13 +255,18 @@ export class CompactionService {
           modelSummary?.generatedBy ?? "orchestrator-extractive";
         const summary =
           modelSummary?.text ??
-          buildExtractiveSummary({
-            title: "Context checkpoint",
-            messages: messagesToSummarize,
-            previousSummary: preparation.previousSummary,
-            instructions: request.instructions,
-            maxChars: Math.max(1_000, Math.floor(summaryReserveTokens * 3.2)),
-          });
+          (options.summaryProfile?.kind === "plan-implementation"
+            ? buildPlanImplementationSummary(options.summaryProfile.planPath)
+            : buildExtractiveSummary({
+                title: "Context checkpoint",
+                messages: messagesToSummarize,
+                previousSummary: preparation.previousSummary,
+                instructions: request.instructions,
+                maxChars: Math.max(
+                  1_000,
+                  Math.floor(summaryReserveTokens * 3.2),
+                ),
+              }));
         const tokensAfter = estimatePostCompactionTokens(
           branch,
           firstKeptEntryId,
@@ -281,6 +293,7 @@ export class CompactionService {
           tokensAfter,
           freedTokens,
           reason,
+          summaryProfile: options.summaryProfile?.kind,
           policy: {
             contextWindow: options.contextWindow,
             thresholdTokens: options.thresholdTokens,
@@ -398,6 +411,7 @@ export class CompactionService {
     messages: AgentMessage[],
     previousSummary: string | undefined,
     instructions: string | undefined,
+    summaryProfile: CompactionSummaryProfile | undefined,
     summaryReserveTokens: number,
     signal: AbortSignal,
     onProgress?: (progress: CompactionProgressReport) => void,
@@ -410,6 +424,7 @@ export class CompactionService {
         messages,
         previousSummary,
         instructions,
+        summaryProfile,
         summaryReserveTokens,
         signal,
         onProgress,

--- a/packages/workbench-server/src/domains/conversations/operations/summary.ts
+++ b/packages/workbench-server/src/domains/conversations/operations/summary.ts
@@ -15,6 +15,36 @@ export interface ExtractiveSummaryInput {
   maxChars?: number;
 }
 
+export function buildPlanImplementationSummary(planPath: string): string {
+  return `## Goal
+Implement the approved plan at ${planPath}.
+
+## Requirements and Constraints
+- Treat ${planPath} as the authoritative implementation source of truth.
+- Read the plan file directly; this checkpoint intentionally does not duplicate it.
+
+## Work Completed
+- [x] Planning and user review are complete.
+- No implementation work is claimed by this checkpoint.
+
+## Work Remaining
+- [ ] Read ${planPath}, implement it, and validate the completed changes.
+
+## Key Decisions
+- **External plan**: The approved plan file is authoritative; avoid reconstructing it from planning history.
+
+## Current Working State
+- Implementation has not started from this checkpoint.
+
+## Continuation Plan
+1. Read ${planPath}.
+2. Implement the plan as written.
+3. Run the required validation and fix any failures.
+
+## Critical References
+- ${planPath}`;
+}
+
 export function buildExtractiveSummary(input: ExtractiveSummaryInput): string {
   const llmMessages = convertToLlm(input.messages);
   const serialized = serializeConversation(llmMessages).trim();

--- a/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
+++ b/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
@@ -57,6 +57,12 @@ export interface HumanInputResolutionDeps {
   ): Promise<ConversationEntry>;
   getConversationEntries(conversationId: string): ConversationEntry[];
   harnessStorage: ConversationHarnessStorage;
+  compactPlanConversation(input: {
+    conversationId: string;
+    agentId: string;
+    runId?: string;
+    planPath: string;
+  }): Promise<void>;
 }
 
 export class HumanInputResolutionService {
@@ -90,6 +96,22 @@ export class HumanInputResolutionService {
       pendingReview.agentId,
       implementation,
     );
+    if (implementation?.compactBeforeImplementation) {
+      try {
+        await this.deps.compactPlanConversation({
+          conversationId: pendingReview.conversationId,
+          agentId: pendingReview.agentId,
+          runId: source.toolCall.runId,
+          planPath: pendingReview.planPath,
+        });
+      } catch (error) {
+        if (
+          !(error instanceof HttpError && error.code === "NOTHING_TO_COMPACT")
+        ) {
+          throw error;
+        }
+      }
+    }
 
     let review: PlanReviewRecord;
     try {

--- a/packages/workbench-server/src/protocol/method-handlers/interaction-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/interaction-method-handlers.ts
@@ -93,9 +93,11 @@ export const interactionMethodHandlers = defineWorkbenchMethodHandlers({
 function implementation(request: {
   implementationModel?: ModelSelection;
   implementationThinkingLevel?: ThinkingLevel;
+  compactBeforeImplementation?: boolean;
 }) {
   return {
     implementationModel: request.implementationModel,
     implementationThinkingLevel: request.implementationThinkingLevel,
+    compactBeforeImplementation: request.compactBeforeImplementation,
   };
 }

--- a/packages/workbench-server/src/routes/tool-routes.ts
+++ b/packages/workbench-server/src/routes/tool-routes.ts
@@ -143,6 +143,7 @@ export function createToolRoutes(state: OrchestratorState): Hono {
         {
           implementationModel: body.implementationModel,
           implementationThinkingLevel: body.implementationThinkingLevel,
+          compactBeforeImplementation: body.compactBeforeImplementation,
         },
       );
       return c.json({ planReview: planReviewPreview(planReview) });

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -210,6 +210,7 @@ export function composeRuntime(
     messages,
     previousSummary,
     instructions,
+    summaryProfile,
     summaryReserveTokens,
     signal,
     onProgress,
@@ -236,6 +237,7 @@ export function composeRuntime(
       signal,
       customInstructions: instructions,
       previousSummary,
+      summaryProfile,
       thinkingLevel: agent.thinkingLevel,
       env: requestAuth.env,
       onProgress,
@@ -505,6 +507,23 @@ export function composeRuntime(
     getConversationEntries: (conversationId) =>
       state.getConversationEntries(conversationId),
     harnessStorage: services.harnessStorage,
+    compactPlanConversation: async (input) => {
+      await services.compactionService.compactConversation(
+        input.conversationId,
+        { keepRecentTokens: 1 },
+        {
+          reason: "manual",
+          agentId: input.agentId,
+          runId: input.runId,
+          keepRecentTokens: 1,
+          summaryReserveTokens: 4_000,
+          summaryProfile: {
+            kind: "plan-implementation",
+            planPath: input.planPath,
+          },
+        },
+      );
+    },
   });
   services.pruneConversations = new PruneProjectConversationsService({
     getProject,

--- a/packages/workbench-server/test/compaction-service.test.ts
+++ b/packages/workbench-server/test/compaction-service.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { validatePublicEvent } from "@nervekit/contracts";
 import { CompactionService } from "../src/domains/conversations/operations/compaction-service.js";
+import { buildPlanImplementationSummary } from "../src/domains/conversations/operations/summary.js";
 
 const timestamp = "2026-07-19T00:00:00.000Z";
 
@@ -32,9 +33,21 @@ Finish the task.
 }
 
 describe("CompactionService", () => {
+  it("builds a concise structured fallback for plan implementation", () => {
+    const planPath = "/tmp/approved-plan.md";
+    const summary = buildPlanImplementationSummary(planPath);
+
+    assert.match(summary, /## Goal/);
+    assert.match(summary, /## Work Remaining/);
+    assert.match(summary, /implementation has not started/i);
+    assert.match(summary, new RegExp(planPath.replaceAll("/", "\\/")));
+    assert.doesNotMatch(summary, /conversation excerpt/i);
+  });
+
   it("forwards the summary budget and records model provenance and policy", async () => {
     const events: Array<{ type: string; data: unknown }> = [];
     let summarizerBudget = 0;
+    let summaryProfile: unknown;
     const branch = [
       {
         type: "message",
@@ -96,6 +109,7 @@ describe("CompactionService", () => {
       } as never,
       async (input) => {
         summarizerBudget = input.summaryReserveTokens;
+        summaryProfile = input.summaryProfile;
         return { text: structuredSummary(), generatedBy: "model" };
       },
     );
@@ -117,6 +131,10 @@ describe("CompactionService", () => {
         keepRecentPercent: 15,
         safetyHeadroomTokens: 10_000,
         activeConversation: { getStorage: () => activeStorage } as never,
+        summaryProfile: {
+          kind: "plan-implementation",
+          planPath: "/tmp/approved-plan.md",
+        },
       },
     );
 
@@ -125,8 +143,14 @@ describe("CompactionService", () => {
       generatedBy?: string;
       policy?: Record<string, unknown>;
       freedTokens?: number;
+      summaryProfile?: string;
     };
     assert.equal(details.generatedBy, "model");
+    assert.equal(details.summaryProfile, "plan-implementation");
+    assert.deepEqual(summaryProfile, {
+      kind: "plan-implementation",
+      planPath: "/tmp/approved-plan.md",
+    });
     assert.equal(details.policy?.profile, "balanced");
     assert.equal(details.policy?.summaryReserveTokens, 8_000);
     assert.ok((details.freedTokens ?? 0) > 0);

--- a/packages/workbench-server/test/workbench-run-regressions.test.ts
+++ b/packages/workbench-server/test/workbench-run-regressions.test.ts
@@ -7,6 +7,7 @@ import type {
   RunRecord,
 } from "@nervekit/contracts";
 import { AutoCompactionRunner } from "../src/domains/agents/run/auto-compaction-runner.js";
+import { HttpError } from "../src/http/errors.js";
 import { RuntimeState } from "../src/runtime/runtime-state.js";
 import { HumanInputResolutionService } from "../src/domains/human-input/human-input-resolution.service.js";
 import { WorkbenchRunQuery } from "../src/domains/runs/workbench-run-query.js";
@@ -267,6 +268,72 @@ describe("workbench coordinator behavior regressions", () => {
     assert.equal(fixture.resolutions.length, 1);
     assert.equal(fixture.resolutions[0]?.continueRun, true);
     assert.equal(fixture.starts.length, 0);
+  });
+
+  it("compacts with the selected implementation model before accepting and resuming", async () => {
+    const fixture = acceptanceFixture("pending");
+
+    const accepted = await fixture.service.acceptPlanReview(
+      fixture.review.id,
+      undefined,
+      {
+        implementationModel: {
+          provider: "nerve-faux",
+          modelId: "faux-selected",
+        },
+        implementationThinkingLevel: "high",
+        compactBeforeImplementation: true,
+      },
+    );
+
+    assert.equal(accepted.status, "accepted");
+    assert.deepEqual(fixture.lifecycle, ["configure", "compact", "accept"]);
+    assert.deepEqual(fixture.compactions, [
+      {
+        conversationId: fixture.review.conversationId,
+        agentId: fixture.review.agentId,
+        runId: "run_source",
+        planPath: fixture.review.planPath,
+      },
+    ]);
+    assert.equal(fixture.resolutions[0]?.continueRun, true);
+  });
+
+  it("leaves the plan pending when pre-implementation compaction fails", async () => {
+    const fixture = acceptanceFixture("pending", "pending", {
+      compactionError: new Error("summary provider failed"),
+    });
+
+    await assert.rejects(
+      fixture.service.acceptPlanReview(fixture.review.id, undefined, {
+        compactBeforeImplementation: true,
+      }),
+      /summary provider failed/,
+    );
+
+    assert.deepEqual(fixture.lifecycle, ["compact"]);
+    assert.equal(fixture.currentToolCall.status, "waiting_for_user");
+    assert.equal(fixture.resolutions.length, 0);
+  });
+
+  it("accepts when a short planning conversation has nothing to compact", async () => {
+    const fixture = acceptanceFixture("pending", "pending", {
+      compactionError: new HttpError(
+        409,
+        "NOTHING_TO_COMPACT",
+        "Nothing to compact.",
+      ),
+    });
+
+    const accepted = await fixture.service.acceptPlanReview(
+      fixture.review.id,
+      undefined,
+      { compactBeforeImplementation: true },
+    );
+
+    assert.equal(accepted.status, "accepted");
+    assert.deepEqual(fixture.lifecycle, ["compact", "accept"]);
+    assert.equal(fixture.resolutions[0]?.continueRun, true);
   });
 
   it("accepts a plan after source cancellation without continuing the cancelled run", async () => {
@@ -590,6 +657,7 @@ function agentRecord(): AgentRecord {
 function acceptanceFixture(
   sourceState: "pending" | "terminal" | "terminal_race",
   reviewStatus: PlanReviewRecord["status"] = "pending",
+  options: { compactionError?: Error } = {},
 ) {
   const source = { ...agentRecord(), mode: "planning" as const };
   const review = { ...planReview(), status: reviewStatus };
@@ -604,6 +672,8 @@ function acceptanceFixture(
   const resumedToolCalls: unknown[] = [];
   const completedToolCalls: unknown[] = [];
   const appendedEntries: Array<Record<string, unknown>> = [];
+  const lifecycle: string[] = [];
+  const compactions: Array<Record<string, unknown>> = [];
   let currentReview = review;
   let currentToolCall = {
     id: review.toolCallId,
@@ -627,6 +697,7 @@ function acceptanceFixture(
     plans: {
       listPlanReviews: () => [currentReview],
       acceptPlanReview: async () => {
+        lifecycle.push("accept");
         currentReview = { ...currentReview, status: "accepted" };
         return currentReview;
       },
@@ -675,7 +746,10 @@ function acceptanceFixture(
     },
     getAgent: (agentId: string) =>
       agentId === createdAgent.id ? createdAgent : source,
-    configureAgent: async () => source,
+    configureAgent: async () => {
+      lifecycle.push("configure");
+      return source;
+    },
     setAgentStatus: async () => undefined,
     continueAgent: async () => undefined,
     createConversation: async () => ({
@@ -694,6 +768,11 @@ function acceptanceFixture(
         timestamp: "2026-07-13T00:00:01.000Z",
       }),
     },
+    compactPlanConversation: async (input: Record<string, unknown>) => {
+      lifecycle.push("compact");
+      compactions.push(input);
+      if (options.compactionError) throw options.compactionError;
+    },
   } as never);
   return {
     service,
@@ -707,6 +786,8 @@ function acceptanceFixture(
     resumedToolCalls,
     completedToolCalls,
     appendedEntries,
+    lifecycle,
+    compactions,
   };
 }
 


### PR DESCRIPTION
## Summary
- add same-chat **Compact & implement** and **Choose model & compact** plan acceptance actions
- generate a plan-aware implementation checkpoint that references the approved plan without duplicating it
- compact before resolving plan acceptance, preserve retry safety, and use a concise fallback when model summarization is unavailable
- extend shared contracts and add prompt, compaction, and run lifecycle coverage

## Validation
- `pnpm fix && pnpm check && pnpm test`