### PR TITLE
Fix prompt suggestion creation dialog

### DIFF
--- a/packages/workbench-app/src/lib/features/prompt-suggestions/components/CreatePromptSuggestionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/prompt-suggestions/components/CreatePromptSuggestionDialog.svelte
@@ -30,7 +30,7 @@ let description = $state("");
 let prompt = $state("");
 let saving = $state(false);
 let error = $state<string | undefined>(undefined);
-let nameInput = $state<HTMLInputElement | undefined>();
+let nameInput = $state<HTMLInputElement | null>(null);
 
 const scopeItems = $derived([
   { value: "user", label: "User", detail: "Available in every project" },


### PR DESCRIPTION
## Summary
- align the prompt name input ref with the shared Input component’s null binding contract
- prevent the Svelte runtime error that stopped the creation dialog from opening

## Validation
- `pnpm fix && pnpm check && pnpm test`
- manually verified the dialog opens, resets, and creates project-scoped suggestions