### PR TITLE
Fix Windows explore cancellation teardown race

### DIFF
--- a/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
@@ -92,7 +92,9 @@ export interface RunCoordinatorPorts {
 export class RunCoordinator {
   private readonly locks = new KeyedSerialLock();
   private readonly live = new LiveExecutionRegistry();
+  private readonly pendingExecutions = new Set<Promise<void>>();
   private readonly pendingCommits = new Set<Promise<void>>();
+  private executionGeneration = 0;
   private commitGeneration = 0;
   private readonly events: RunEventFactory;
   private readonly prompts: RunPromptCoordinator;
@@ -697,6 +699,24 @@ export class RunCoordinator {
     }
   }
 
+  /** Waits until detached executions and their complete commit pipelines stop. */
+  async settled(): Promise<void> {
+    for (;;) {
+      const executionGeneration = this.executionGeneration;
+      const commitGeneration = this.commitGeneration;
+      await Promise.allSettled([...this.pendingExecutions]);
+      await Promise.all([...this.pendingCommits]);
+      if (
+        this.pendingExecutions.size === 0 &&
+        this.pendingCommits.size === 0 &&
+        executionGeneration === this.executionGeneration &&
+        commitGeneration === this.commitGeneration
+      ) {
+        return;
+      }
+    }
+  }
+
   private sink(runId: string): RunExecutionSink {
     return {
       appendEntries: (entries) =>
@@ -917,6 +937,12 @@ export class RunCoordinator {
         this.live.delete(run.runId, execution);
       }
     })();
+    this.executionGeneration += 1;
+    this.pendingExecutions.add(promise);
+    void promise.then(
+      () => this.pendingExecutions.delete(promise),
+      () => this.pendingExecutions.delete(promise),
+    );
     this.live.set(run.runId, { execution, abort, promise });
   }
 

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -127,13 +127,15 @@ export class RuntimeRegistry {
   }
 
   /**
-   * Stops registry timers and waits for queued run-event deliveries and
-   * event-journal publications to settle so no writer races teardown.
+   * Stops registry timers and waits for run executions, transition
+   * projections, event deliveries, and journal publications to settle so no
+   * writer races teardown.
    */
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
     this.services.taskNotifications.stop();
     await Promise.allSettled([...this.backgroundOperations]);
+    await this.services.runRuntime.coordinator.settled();
     await this.services.runRuntime.delivery.settled();
     await this.events.settled();
   }

--- a/packages/workbench-server/test/explore-subagent-isolation.test.ts
+++ b/packages/workbench-server/test/explore-subagent-isolation.test.ts
@@ -139,7 +139,12 @@ describe("explore subagent transcript isolation", () => {
     } finally {
       registration.unregister();
       await shutdownOrchestratorState(orchestrator);
-      await rm(root, { recursive: true, force: true });
+      await rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 50,
+      });
     }
   });
 
@@ -201,7 +206,12 @@ describe("explore subagent transcript isolation", () => {
     } finally {
       await shutdownOrchestratorState(orchestrator);
       if (restarted) await shutdownOrchestratorState(restarted);
-      await rm(root, { recursive: true, force: true });
+      await rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 50,
+      });
     }
   });
 
@@ -283,7 +293,12 @@ describe("explore subagent transcript isolation", () => {
     } finally {
       registration.unregister();
       await shutdownOrchestratorState(orchestrator);
-      await rm(root, { recursive: true, force: true });
+      await rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 3,
+        retryDelay: 50,
+      });
     }
   });
 });

--- a/packages/workbench-server/test/run-coordinator.contract.test.ts
+++ b/packages/workbench-server/test/run-coordinator.contract.test.ts
@@ -1031,6 +1031,43 @@ test("settled reads hide terminal state until its complete commit pipeline settl
   );
 });
 
+test("settled waits for cancelled detached executions to unwind", async () => {
+  let releaseExecution!: () => void;
+  const executionGate = new Promise<void>((resolve) => {
+    releaseExecution = resolve;
+  });
+  const harness = fixture({
+    execute: async (_attempt, input) => {
+      if (!input.signal.aborted) {
+        await new Promise<void>((resolve) =>
+          input.signal.addEventListener("abort", () => resolve(), {
+            once: true,
+          }),
+        );
+      }
+      await executionGate;
+      return { status: "interrupted", message: "cancelled" };
+    },
+  });
+  const run = await start(harness.coordinator);
+  await harness.coordinator.cancel(run.runId);
+
+  let settled = false;
+  const settling = harness.coordinator.settled().then(() => {
+    settled = true;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false);
+
+  releaseExecution();
+  await settling;
+  assert.equal(settled, true);
+  assert.equal(
+    (await harness.coordinator.get(run.runId))?.run.status,
+    "cancelled",
+  );
+});
+
 test("resolves an interaction once and rejects conflicting resolution", async () => {
   const harness = fixture();
   const run = await start(harness.coordinator);


### PR DESCRIPTION
## Summary
- track detached run executions and expose a coordinator quiescence boundary
- await execution and transition persistence during registry shutdown
- add regression coverage and bounded Windows cleanup retries

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `pnpm --filter @nervekit/tools test:native && pnpm --filter @nervekit/workbench-server test:native`