### PR TITLE
Fix recovered task termination and shutdown cleanup

### DIFF
--- a/packages/website/src/content/docs/guides/background-tasks.md
+++ b/packages/website/src/content/docs/guides/background-tasks.md
@@ -28,6 +28,10 @@ Nerve has no persistent sidecar supervisor. On restart it verifies process ident
 
 Linux uses `/proc` start identity and process groups; macOS uses process-start fingerprints and groups; Windows uses creation time and process-tree termination. Port discovery is best effort.
 
+A normal **Stop** requests graceful process-tree termination and escalates after a bounded wait. Verified recovered or stuck-stopping runs also offer a confirmed **Force kill**. After the run is terminal, remove its history or choose **Run saved task again** to launch the definition's current configuration. Nerve does not force-kill `recovery_unknown` records because their PID identity is unverified.
+
+Quitting the desktop app immediately terminates active local task process trees before its owned daemon exits. Closing to the tray leaves tasks running.
+
 ## Agent notifications
 
 Task terminal changes can become deduplicated `task_event` system entries in the conversation and can wake an agent waiting for completion. This is separate from desktop/browser toast notifications.

--- a/packages/website/src/content/docs/troubleshooting/tasks-and-recovery.md
+++ b/packages/website/src/content/docs/troubleshooting/tasks-and-recovery.md
@@ -23,7 +23,13 @@ Check the readiness URL/pattern and task logs. A server listening on a different
 
 ## Stop does not complete
 
-Nerve attempts graceful process-tree termination then bounded escalation. Platform security software or child detachment can interfere. Confirm identity before manual OS termination.
+Nerve attempts graceful process-tree termination then bounded escalation. For a verified `recovered` run or one stuck in `stopping`, use **Force kill** and confirm immediate process-tree termination. Force kill can lose buffered output and process cleanup, but the terminal run record can then be removed or its current saved task definition can be run again.
+
+Platform security software or child detachment can still interfere. Nerve never offers force kill for `recovery_unknown`; confirm identity before manual OS termination.
+
+## Quitting Nerve
+
+Quitting the desktop application immediately terminates active local task process trees before the owned daemon shuts down. Closing a window to the system tray does not quit Nerve or stop tasks.
 
 ## Agent run recovery is separate
 

--- a/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
@@ -102,7 +102,7 @@ function focusTasks() {
       focusTasks();
       void openTaskTab(id);
     }}
-    onCancelTask={(id) => void cancelSelectedTask(id)}
+    onCancelTask={(id, request) => void cancelSelectedTask(id, request)}
     onRestartTask={(id) => void restartSelectedTask(id)}
     onRemoveTask={(id) => void removeTask(id)}
     onPruneTasks={() => void pruneFinishedTasks()}

--- a/packages/workbench-app/src/lib/features/tasks/api/tasks.api.ts
+++ b/packages/workbench-app/src/lib/features/tasks/api/tasks.api.ts
@@ -1,4 +1,5 @@
 import type {
+  CancelTaskRequest,
   StartTaskRequest,
   TaskLogQuery,
   TaskLogQueryResponse,
@@ -31,8 +32,12 @@ export async function launchTaskDefinition(
     .result;
 }
 
-export async function cancelTask(taskId: string): Promise<TaskRecord> {
-  return (await protocolRequest("task.cancel", { taskId })).result.task;
+export async function cancelTask(
+  taskId: string,
+  request: CancelTaskRequest = {},
+): Promise<TaskRecord> {
+  return (await protocolRequest("task.cancel", { taskId, ...request })).result
+    .task;
 }
 
 export async function restartTask(

--- a/packages/workbench-app/src/lib/features/tasks/components/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/tasks/components/TasksPanelView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ProjectRecord, TaskRecord } from "$lib/api";
+import type { CancelTaskRequest } from "@nervekit/contracts";
 import { createWorkbenchTaskPanelAdapter } from "$lib/features/tasks/state/workbench-task-panel-adapter.svelte";
 import { TasksPanelView } from "$lib/presentation";
 
@@ -9,7 +10,7 @@ type Props = {
   selectedTask?: TaskRecord;
   homeDir?: string;
   onOpenTaskOutput?: (id: string) => void;
-  onCancelTask?: (id: string) => void;
+  onCancelTask?: (id: string, request?: CancelTaskRequest) => void;
   onRestartTask?: (id: string) => void;
   onRemoveTask?: (id: string) => void;
   onPruneTasks?: () => void;
@@ -39,7 +40,7 @@ const adapter = createWorkbenchTaskPanelAdapter(
   () => selectedTask,
   {
     openTaskOutput: (id) => onOpenTaskOutput?.(id),
-    cancelTask: (id) => onCancelTask?.(id),
+    cancelTask: (id, request) => onCancelTask?.(id, request),
     restartTask: (id) => onRestartTask?.(id),
     removeTask: (id) => onRemoveTask?.(id),
     pruneTasks: () => onPruneTasks?.(),

--- a/packages/workbench-app/src/lib/features/tasks/state/tasks.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/tasks.svelte.ts
@@ -1,3 +1,4 @@
+import type { CancelTaskRequest } from "@nervekit/contracts";
 import {
   cancelTask,
   deleteTask,
@@ -26,16 +27,23 @@ export async function selectTask(taskId: string) {
   await loadTaskLogWindow(taskId);
 }
 
-export async function cancelSelectedTask(taskId: string) {
+export async function cancelSelectedTask(
+  taskId: string,
+  request: CancelTaskRequest = {},
+) {
   const wasOrphaned =
     taskState.tasks.find((task) => task.id === taskId)?.status === "orphaned";
-  await cancelTask(taskId);
+  await cancelTask(taskId, request);
   await loadWorkspaceState();
   if (taskState.selectedTaskId) {
     await loadTaskLogWindow(taskState.selectedTaskId);
   }
   notify.success(
-    wasOrphaned ? "Orphaned task cleanup completed" : "Task cancelled",
+    request.signal === "SIGKILL"
+      ? "Task force killed"
+      : wasOrphaned
+        ? "Orphaned task cleanup completed"
+        : "Task cancelled",
   );
 }
 

--- a/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
@@ -5,6 +5,7 @@ import type {
   TaskRecord,
 } from "$lib/api";
 import type {
+  CancelTaskRequest,
   CreateTaskDefinitionRequest,
   UpdateTaskDefinitionRequest,
 } from "@nervekit/contracts";
@@ -40,7 +41,7 @@ import {
 
 export type WorkbenchTaskPanelHostActions = {
   readonly openTaskOutput?: (id: string) => void;
-  readonly cancelTask?: (id: string) => void;
+  readonly cancelTask?: (id: string, request?: CancelTaskRequest) => void;
   readonly restartTask?: (id: string) => void;
   readonly removeTask?: (id: string) => void;
   readonly pruneTasks?: () => void;
@@ -158,7 +159,12 @@ export function createWorkbenchTaskPanelAdapter(
         runningDefinitionId = undefined;
       }
     },
-    cancelTask: (id) => hostActions.cancelTask?.(id),
+    cancelTask: (id, request) => hostActions.cancelTask?.(id, request),
+    forceKillTask: (id) =>
+      hostActions.cancelTask?.(id, {
+        signal: "SIGKILL",
+        reason: "force_kill",
+      }),
     restartTask: (id) => hostActions.restartTask?.(id),
     removeTask: (id) => hostActions.removeTask?.(id),
     pruneTasks: () => hostActions.pruneTasks?.(),

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
@@ -5,6 +5,7 @@ import History from "@lucide/svelte/icons/history";
 import Pencil from "@lucide/svelte/icons/pencil";
 import Play from "@lucide/svelte/icons/play";
 import RotateCw from "@lucide/svelte/icons/rotate-cw";
+import Skull from "@lucide/svelte/icons/skull";
 import Square from "@lucide/svelte/icons/square";
 import Terminal from "@lucide/svelte/icons/terminal";
 import Trash2 from "@lucide/svelte/icons/trash-2";
@@ -26,6 +27,7 @@ let {
   onOpen,
   onRun,
   onCancel,
+  onForceKill,
   onRestart,
   onEdit,
   onDelete,
@@ -39,6 +41,7 @@ let {
   onOpen?: (taskId: string) => void;
   onRun?: () => void;
   onCancel?: (taskId: string) => void;
+  onForceKill?: (taskId: string) => void;
   onRestart?: (taskId: string) => void;
   onEdit?: () => void;
   onDelete?: () => void;
@@ -97,12 +100,21 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
       disabled: !capabilities.restart,
       onSelect: () => onRestart?.(active.id),
     });
-    items.push({
-      label: "Stop",
-      icon: Square,
-      disabled: !capabilities.cancel,
-      onSelect: () => onCancel?.(active.id),
-    });
+    if (active.status !== "stopping")
+      items.push({
+        label: "Stop",
+        icon: Square,
+        disabled: !capabilities.cancel,
+        onSelect: () => onCancel?.(active.id),
+      });
+    if (active.status === "recovered" || active.status === "stopping")
+      items.push({
+        label: "Force kill",
+        icon: Skull,
+        destructive: true,
+        disabled: !capabilities.cancel,
+        onSelect: () => onForceKill?.(active.id),
+      });
   }
 
   if (items.length > 0) items.push({ type: "separator" });
@@ -173,7 +185,14 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
     >
   {/snippet}
   {#snippet actions()}
-    {#if active}
+    {#if active?.status === "stopping"}
+      <PanelToolbarButton
+        icon={Skull}
+        label="Force kill task"
+        disabled={!capabilities.cancel}
+        onclick={() => onForceKill?.(active.id)}
+      />
+    {:else if active}
       <PanelToolbarButton
         icon={Square}
         label="Stop task"

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
@@ -3,6 +3,7 @@ import BookmarkPlus from "@lucide/svelte/icons/bookmark-plus";
 import Copy from "@lucide/svelte/icons/copy";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
 import RotateCw from "@lucide/svelte/icons/rotate-cw";
+import Skull from "@lucide/svelte/icons/skull";
 import Square from "@lucide/svelte/icons/square";
 import Terminal from "@lucide/svelte/icons/terminal";
 import X from "@lucide/svelte/icons/x";
@@ -20,7 +21,9 @@ let {
   capabilities,
   onOpen,
   onCancel,
+  onForceKill,
   onRestart,
+  onRerunDefinition,
   onRemove,
   onCopy,
   onSaveAsDefinition,
@@ -31,7 +34,9 @@ let {
   capabilities: TaskEntryCapabilities;
   onOpen?: (taskId: string) => void;
   onCancel?: (taskId: string) => void;
+  onForceKill?: (taskId: string) => void;
   onRestart?: (taskId: string) => void;
+  onRerunDefinition?: () => void;
   onRemove?: (taskId: string) => void;
   onCopy?: (text: string) => void;
   onSaveAsDefinition?: (task: TaskRecord) => void;
@@ -66,12 +71,27 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
       onSelect: () => onRestart?.(run.id),
     },
   ];
-  if (entry.isActive)
+  if (entry.definition && entry.isRemovable)
+    items.push({
+      label: "Run saved task again",
+      icon: RotateCw,
+      disabled: !capabilities.start,
+      onSelect: () => onRerunDefinition?.(),
+    });
+  if (entry.isActive && run.status !== "stopping")
     items.push({
       label: "Stop",
       icon: Square,
       disabled: !capabilities.cancel,
       onSelect: () => onCancel?.(run.id),
+    });
+  if (entry.canForceKill)
+    items.push({
+      label: "Force kill",
+      icon: Skull,
+      destructive: true,
+      disabled: !capabilities.cancel,
+      onSelect: () => onForceKill?.(run.id),
     });
 
   if (!entry.definition)
@@ -99,7 +119,7 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
       onSelect: () => onCopy?.(run.cwd),
     },
   ];
-  if (!entry.isActive)
+  if (entry.isRemovable)
     trailing.push({
       label: "Remove run",
       icon: X,
@@ -129,7 +149,14 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
     <Badge tone={taskTone(run.status)} size="xs">{run.status}</Badge>
   {/snippet}
   {#snippet actions()}
-    {#if entry.isActive}
+    {#if run.status === "stopping"}
+      <PanelToolbarButton
+        icon={Skull}
+        label={`Force kill ${label.text}`}
+        disabled={!capabilities.cancel}
+        onclick={() => onForceKill?.(run.id)}
+      />
+    {:else if entry.isActive}
       <PanelToolbarButton
         icon={Square}
         label={`Stop ${label.text}`}

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunsDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunsDialog.svelte
@@ -18,7 +18,9 @@ let {
   capabilities,
   onOpen,
   onCancel,
+  onForceKill,
   onRestart,
+  onRerunDefinition,
   onRemove,
   onCopy,
   onSaveAsDefinition,
@@ -29,7 +31,9 @@ let {
   capabilities: TaskEntryCapabilities;
   onOpen: (taskId: string) => void;
   onCancel: (taskId: string) => void;
+  onForceKill: (taskId: string) => void;
   onRestart: (taskId: string) => void;
+  onRerunDefinition: (entry: TaskRunEntry) => void;
   onRemove: (taskId: string) => void;
   onCopy: (text: string) => void;
   onSaveAsDefinition: (task: TaskRecord) => void;
@@ -99,7 +103,9 @@ function openRun(taskId: string): void {
                   {capabilities}
                   onOpen={openRun}
                   {onCancel}
+                  {onForceKill}
                   {onRestart}
+                  onRerunDefinition={() => onRerunDefinition(entry)}
                   {onRemove}
                   {onCopy}
                   {onSaveAsDefinition}

--- a/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
@@ -51,6 +51,7 @@ const projected = $derived(projectTaskPanel(model.definitions, model.tasks));
 let addOpen = $state(false);
 let saving = $state(false);
 let confirmPruneOpen = $state(false);
+let forceKillTask = $state<TaskRecord | undefined>();
 let editDefinition = $state<TaskPanelDefinition | undefined>();
 let deleteDefinition = $state<TaskPanelDefinition | undefined>();
 let saveSourceTask = $state<TaskRecord | undefined>();
@@ -69,7 +70,7 @@ const SPLIT_MIN_WIDTH = 720;
 const splitLayout = $derived(panelWidth >= SPLIT_MIN_WIDTH);
 const selectedRuns = $derived(taskLineageRuns(model.tasks, model.selectedTask));
 const prunableRuns = $derived(
-  projected.runs.filter((entry) => !entry.isActive).length,
+  projected.runs.filter((entry) => entry.isRemovable).length,
 );
 const runsFit = createPanelRowFit({
   region: () => runsRegion,
@@ -119,6 +120,17 @@ async function removeDefinition(): Promise<void> {
   await panelActions.deleteDefinition(deleteDefinition);
   deleteDefinition = undefined;
 }
+
+async function confirmForceKill(): Promise<void> {
+  if (!forceKillTask) return;
+  const taskId = forceKillTask.id;
+  forceKillTask = undefined;
+  await panelActions.forceKillTask(taskId);
+}
+
+function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
+  if (entry.definition) void panelActions.runDefinition(entry.definition);
+}
 </script>
 
 {#snippet taskList()}
@@ -145,6 +157,8 @@ async function removeDefinition(): Promise<void> {
                 onOpen={(id) => void panelActions.openTaskOutput(id)}
                 onRun={() => void panelActions.runDefinition(entry.definition)}
                 onCancel={(id) => void panelActions.cancelTask(id)}
+                onForceKill={(id) =>
+                  (forceKillTask = model.tasks.find((task) => task.id === id))}
                 onRestart={(id) => void panelActions.restartTask(id)}
                 onEdit={() => (editDefinition = entry.definition)}
                 onDelete={() => (deleteDefinition = entry.definition)}
@@ -161,7 +175,12 @@ async function removeDefinition(): Promise<void> {
                       {capabilities}
                       onOpen={(id) => void panelActions.openTaskOutput(id)}
                       onCancel={(id) => void panelActions.cancelTask(id)}
+                      onForceKill={(id) =>
+                        (forceKillTask = model.tasks.find(
+                          (task) => task.id === id,
+                        ))}
                       onRestart={(id) => void panelActions.restartTask(id)}
+                      onRerunDefinition={() => rerunDefinition(runEntry)}
                       onRemove={(id) => void panelActions.removeTask(id)}
                       onCopy={(text) => void panelActions.copyText(text)}
                     />
@@ -198,6 +217,8 @@ async function removeDefinition(): Promise<void> {
                 {capabilities}
                 onOpen={(id) => void panelActions.openTaskOutput(id)}
                 onCancel={(id) => void panelActions.cancelTask(id)}
+                onForceKill={(id) =>
+                  (forceKillTask = model.tasks.find((task) => task.id === id))}
                 onRestart={(id) => void panelActions.restartTask(id)}
                 onRemove={(id) => void panelActions.removeTask(id)}
                 onCopy={(text) => void panelActions.copyText(text)}
@@ -279,7 +300,10 @@ async function removeDefinition(): Promise<void> {
   {capabilities}
   onOpen={(id) => void panelActions.openTaskOutput(id)}
   onCancel={(id) => void panelActions.cancelTask(id)}
+  onForceKill={(id) =>
+    (forceKillTask = model.tasks.find((task) => task.id === id))}
   onRestart={(id) => void panelActions.restartTask(id)}
+  onRerunDefinition={rerunDefinition}
   onRemove={(id) => void panelActions.removeTask(id)}
   onCopy={(text) => void panelActions.copyText(text)}
   onSaveAsDefinition={(task) => (saveSourceTask = task)}
@@ -322,6 +346,18 @@ async function removeDefinition(): Promise<void> {
     void createDefinition({ ...input, sourceTaskId: saveSourceTask.id })}
   onOpenChange={(open) => {
     if (!open) saveSourceTask = undefined;
+  }}
+/>
+<ConfirmDialog
+  open={Boolean(forceKillTask)}
+  destructive
+  title="Force kill task?"
+  description={`Immediately terminates ${forceKillTask?.displayName ?? forceKillTask?.name ?? forceKillTask?.command ?? "this task"}. Buffered output and process cleanup may be lost.`}
+  confirmLabel="Force kill"
+  onConfirm={() => void confirmForceKill()}
+  onCancel={() => (forceKillTask = undefined)}
+  onOpenChange={(open) => {
+    if (!open) forceKillTask = undefined;
   }}
 />
 <ConfirmDialog

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
@@ -110,6 +110,25 @@ test("sorts runs with recovery concerns first, then newest first", () => {
   assert.equal(projected.runs[0]?.needsRecovery, true);
 });
 
+test("projects force-kill and removal safety from explicit statuses", () => {
+  const projected = projectTaskPanel(
+    [],
+    [
+      run("task_recovered", { status: "recovered" }),
+      run("task_stopping", { status: "stopping" }),
+      run("task_unknown", { status: "recovery_unknown" }),
+      run("task_done", { status: "cancelled" }),
+    ],
+  );
+  const entries = new Map(projected.runs.map((entry) => [entry.key, entry]));
+
+  assert.equal(entries.get("task_recovered")?.canForceKill, true);
+  assert.equal(entries.get("task_stopping")?.canForceKill, true);
+  assert.equal(entries.get("task_unknown")?.canForceKill, false);
+  assert.equal(entries.get("task_unknown")?.isRemovable, false);
+  assert.equal(entries.get("task_done")?.isRemovable, true);
+});
+
 test("labels definitions by their label and runs by display name, then command", () => {
   const projected = projectTaskPanel(
     [definition()],

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
@@ -30,6 +30,15 @@ const RECOVERY_STATUSES = new Set([
   "orphaned",
 ]);
 
+const REMOVABLE_STATUSES = new Set([
+  "completed",
+  "failed",
+  "timed_out",
+  "cancelled",
+  "orphaned",
+  "interrupted",
+]);
+
 export type TaskGroups = {
   running: TaskRecord[];
   orphaned: TaskRecord[];
@@ -177,6 +186,8 @@ function toRunEntry(
     run,
     definition,
     isActive: RUNNING_LIKE_STATUSES.has(run.status),
+    canForceKill: run.status === "recovered" || run.status === "stopping",
+    isRemovable: REMOVABLE_STATUSES.has(run.status),
     needsRecovery: RECOVERY_STATUSES.has(run.status),
   };
 }
@@ -219,8 +230,15 @@ export function createTaskPanelActions(
     runDefinition: (definition) => {
       if (enabled("start")) return host.runDefinition(definition);
     },
-    cancelTask: (taskId) => {
-      if (enabled("cancel")) return host.cancelTask(taskId);
+    cancelTask: (taskId, request) => {
+      if (enabled("cancel")) return host.cancelTask(taskId, request);
+    },
+    forceKillTask: (taskId) => {
+      if (enabled("cancel"))
+        return host.cancelTask(taskId, {
+          signal: "SIGKILL",
+          reason: "force_kill",
+        });
     },
     restartTask: (taskId) => {
       if (enabled("restart")) return host.restartTask(taskId);

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-types.ts
@@ -1,4 +1,5 @@
 import type {
+  CancelTaskRequest,
   CreateTaskDefinitionRequest,
   StartTaskRequest,
   TaskLogQuery,
@@ -24,6 +25,8 @@ export interface TaskRunEntry {
   readonly run: TaskRecord;
   readonly definition?: TaskPanelDefinition;
   readonly isActive: boolean;
+  readonly canForceKill: boolean;
+  readonly isRemovable: boolean;
   readonly needsRecovery: boolean;
 }
 
@@ -84,7 +87,11 @@ export interface TaskPanelActions {
   readonly runDefinition: (
     definition: TaskPanelDefinition,
   ) => void | Promise<void>;
-  readonly cancelTask: (taskId: string) => void | Promise<void>;
+  readonly cancelTask: (
+    taskId: string,
+    request?: CancelTaskRequest,
+  ) => void | Promise<void>;
+  readonly forceKillTask: (taskId: string) => void | Promise<void>;
   readonly restartTask: (taskId: string) => void | Promise<void>;
   readonly removeTask: (taskId: string) => void | Promise<void>;
   readonly pruneTasks: () => void | Promise<void>;

--- a/packages/workbench-server/src/domains/tasks/workbench-task-service-orphan.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-service-orphan.ts
@@ -69,7 +69,7 @@ export async function cleanupOrphanedTask(
   request: CancelTaskRequest,
 ): Promise<TaskRecord> {
   const record = this.getTask(taskId);
-  if (record.status !== "orphaned") return record;
+  if (!isPersistedRuntimeCleanupStatus(record.status)) return record;
 
   const validationError = this.orphanCleanupValidationError(record.runtime);
   if (validationError) {
@@ -81,7 +81,10 @@ export async function cleanupOrphanedTask(
     record,
     runtime,
   );
-  const timeoutMs = request.timeoutMs ?? 5000;
+  const timeoutMs =
+    initialSignal === "SIGKILL"
+      ? Math.min(request.timeoutMs ?? 250, 250)
+      : (request.timeoutMs ?? 5000);
 
   await this.events.publish("task.stop_requested", {
     task: record,
@@ -371,7 +374,7 @@ export async function finalizeOrphanCleanup(
   context: Record<string, unknown> = {},
 ): Promise<TaskRecord> {
   const record = this.getTask(taskId);
-  if (record.status !== "orphaned") return record;
+  if (!isPersistedRuntimeCleanupStatus(record.status)) return record;
   const managed = this.managed.get(taskId);
   this.clearReadinessWatch(managed);
   if (managed?.runtimeTimer) clearTimeout(managed.runtimeTimer);
@@ -435,6 +438,14 @@ export async function failOrphanCleanup(
     }),
   });
   throw new Error(message);
+}
+
+function isPersistedRuntimeCleanupStatus(
+  status: TaskRecord["status"],
+): boolean {
+  return (
+    status === "orphaned" || status === "recovered" || status === "stopping"
+  );
 }
 
 function taskListeningPortsFromContext(value: unknown): TaskListeningPort[] {

--- a/packages/workbench-server/src/domains/tasks/workbench-task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-service.ts
@@ -199,7 +199,7 @@ export class WorkbenchTaskService extends TaskService {
     request: CancelTaskRequest = {},
   ): Promise<TaskRecord> {
     const record = this.getTask(taskId);
-    if (record.status === "orphaned")
+    if (this.needsPersistedRuntimeCleanup(record))
       return this.cleanupOrphanedTask(record.id, request);
     if (this.managed.get(taskId)?.stopping && request.signal !== "SIGKILL") {
       return record;
@@ -212,11 +212,51 @@ export class WorkbenchTaskService extends TaskService {
     options: { confirmUnverifiedReplacement?: boolean } = {},
   ): Promise<TaskRecord> {
     const record = this.getTask(taskId);
-    if (record.status === "orphaned") {
+    if (this.needsPersistedRuntimeCleanup(record)) {
       await this.envForRestart(record);
       await this.cleanupOrphanedTask(record.id, { timeoutMs: 5000 });
     }
     return this.restart(taskId, options);
+  }
+
+  async shutdown(): Promise<void> {
+    const active = this.listTasks({ includeForeground: true }).filter((task) =>
+      isActiveTaskStatus(task.status),
+    );
+    const outcomes = await Promise.allSettled(
+      active.map((task) =>
+        this.cancelTask(task.id, {
+          signal: "SIGKILL",
+          timeoutMs: 100,
+          reason: "daemon_shutdown",
+        }),
+      ),
+    );
+    await Promise.all(
+      outcomes.map(async (outcome, index) => {
+        if (outcome.status === "fulfilled") return;
+        const task = active[index];
+        await this.logger?.warn(
+          "Task force termination failed during shutdown",
+          {
+            taskId: task?.id,
+            projectId: task?.projectId,
+            conversationId: task?.conversationId,
+            agentId: task?.agentId,
+            error: outcome.reason,
+          },
+        );
+      }),
+    );
+  }
+
+  private needsPersistedRuntimeCleanup(record: TaskRecord): boolean {
+    if (record.status === "orphaned" || record.status === "recovered") {
+      return true;
+    }
+    if (record.status !== "stopping" || !record.runtime) return false;
+    const managed = this.managed.get(record.id);
+    return !managed?.child && !managed?.exitPromise;
   }
 
   async associateDefinition(

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -133,6 +133,7 @@ export class RuntimeRegistry {
    */
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
+    await this.services.tasks.shutdown();
     this.services.taskNotifications.stop();
     await Promise.allSettled([...this.backgroundOperations]);
     await this.services.runRuntime.coordinator.settled();

--- a/packages/workbench-server/test/workbench-task-service-orphan.test.ts
+++ b/packages/workbench-server/test/workbench-task-service-orphan.test.ts
@@ -37,6 +37,83 @@ describe("task manager orphan cleanup", () => {
     );
   });
 
+  it("cleans a recovered runtime instead of leaving it stopping", async () => {
+    const runtime = runtimeMetadata();
+    let alive = true;
+    const { supervisor, runtimeTerminateSignals } = fakeSupervisor({
+      runtime,
+      isRuntimeTargetAlive: () => alive,
+      onTerminateRuntime() {
+        alive = false;
+      },
+    });
+    const { manager, storage } = await createManager(supervisor);
+    const record = await seedTaskRecord(storage, {
+      runtime,
+      status: "recovered",
+      finishedAt: undefined,
+    });
+    await manager.hydrate();
+
+    const stopped = await manager.cancelTask(record.id);
+
+    assert.equal(stopped.status, "cancelled");
+    assert.deepEqual(
+      runtimeTerminateSignals,
+      process.platform === "win32" ? ["SIGKILL"] : ["SIGTERM"],
+    );
+  });
+
+  it("force-kills a recovered runtime immediately", async () => {
+    const runtime = runtimeMetadata();
+    let alive = true;
+    const { supervisor, runtimeTerminateSignals } = fakeSupervisor({
+      runtime,
+      isRuntimeTargetAlive: () => alive,
+      onTerminateRuntime() {
+        alive = false;
+      },
+    });
+    const { manager, storage } = await createManager(supervisor);
+    const record = await seedTaskRecord(storage, {
+      runtime,
+      status: "recovered",
+      finishedAt: undefined,
+    });
+    await manager.hydrate();
+
+    const stopped = await manager.cancelTask(record.id, { signal: "SIGKILL" });
+
+    assert.equal(stopped.status, "cancelled");
+    assert.equal(stopped.signal, "SIGKILL");
+    assert.deepEqual(runtimeTerminateSignals, ["SIGKILL"]);
+  });
+
+  it("force-cleans a legacy unmanaged stopping record", async () => {
+    const runtime = runtimeMetadata();
+    let alive = true;
+    const { supervisor, runtimeTerminateSignals } = fakeSupervisor({
+      runtime,
+      isRuntimeTargetAlive: () => alive,
+      onTerminateRuntime() {
+        alive = false;
+      },
+    });
+    const { manager, storage } = await createManager(supervisor);
+    const record = await seedTaskRecord(storage, {
+      runtime,
+      status: "recovered",
+      finishedAt: undefined,
+    });
+    await manager.hydrate();
+    await manager.updateTask(record.id, { status: "stopping" });
+
+    const stopped = await manager.cancelTask(record.id, { signal: "SIGKILL" });
+
+    assert.equal(stopped.status, "cancelled");
+    assert.deepEqual(runtimeTerminateSignals, ["SIGKILL"]);
+  });
+
   it("escalates orphan cleanup on POSIX and force-cleans on Windows", async () => {
     const runtime = runtimeMetadata();
     const { supervisor, runtimeTerminateSignals } = fakeSupervisor({
@@ -209,6 +286,44 @@ describe("task manager orphan cleanup", () => {
     assert.equal(manager.getTask(record.id).status, "cancelled");
     assert.equal(restarted.restartedFromTaskId, record.id);
     assert.equal(spawnCommands.length, 1);
+  });
+
+  it("force-kills every verified active runtime during shutdown despite failures", async () => {
+    const firstRuntime = runtimeMetadata({
+      childPid: 1234,
+      processGroupId: 1234,
+    });
+    const secondRuntime = runtimeMetadata({
+      childPid: 5678,
+      processGroupId: 5678,
+    });
+    const alive = new Set([1234, 5678]);
+    const { supervisor, runtimeTerminateSignals } = fakeSupervisor({
+      isRuntimeTargetAlive: (runtime) => alive.has(runtime.childPid ?? -1),
+      onTerminateRuntime(runtime) {
+        if (runtime.childPid === 1234)
+          throw new Error("injected shutdown failure");
+        alive.delete(runtime.childPid ?? -1);
+      },
+    });
+    const { manager, storage } = await createManager(supervisor);
+    const first = await seedTaskRecord(storage, {
+      runtime: firstRuntime,
+      status: "recovered",
+      finishedAt: undefined,
+    });
+    const second = await seedTaskRecord(storage, {
+      runtime: secondRuntime,
+      status: "recovered",
+      finishedAt: undefined,
+    });
+    await manager.hydrate();
+
+    await manager.shutdown();
+
+    assert.equal(runtimeTerminateSignals.length, 2);
+    assert.equal(manager.getTask(first.id).status, "recovered");
+    assert.equal(manager.getTask(second.id).status, "cancelled");
   });
 
   it("does not start a duplicate task when orphan cleanup fails", async () => {


### PR DESCRIPTION
## Summary
- clean up recovered and unmanaged stopping task runtimes, with confirmed force-kill support
- allow safe run removal and rerun saved task definitions from task history
- immediately terminate active task process trees during owned daemon shutdown
- document recovery behavior and add lifecycle, shutdown, and UI projection tests

## Validation
- `pnpm fix && pnpm check && pnpm test`