### PR TITLE
Add new conversation action to editor tabs

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/EditorSurface.svelte
+++ b/packages/workbench-app/src/lib/app/shell/EditorSurface.svelte
@@ -15,6 +15,7 @@ import {
   centerTabsToRightOf,
   closeCenterTab,
   closeCenterTabs,
+  newConversation,
   reorderCenterTab,
   selectCenterTab,
   workspaceSelectors,
@@ -107,6 +108,7 @@ function closeCenterTabsLeft(tab: CenterTabIdentity) {
       onCloseLeft={closeCenterTabsLeft}
       onToggleFileDisplayMode={toggleFileDisplayMode}
       onToggleFileLineWrap={toggleFileLineWrap}
+      onNew={newConversation}
       onReorder={reorderCenterTab}
     />
   {/snippet}

--- a/packages/workbench-app/src/lib/app/shell/EditorTabStripContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/EditorTabStripContainer.svelte
@@ -24,7 +24,10 @@ import type {
   CenterTabModel,
 } from "$lib/features/workspace";
 import { notify } from "$lib/features/notifications/notify.svelte";
-import { getShortcutLabel } from "$lib/core/shortcuts/registry";
+import {
+  getShortcutAriaLabel,
+  getShortcutLabel,
+} from "$lib/core/shortcuts/registry";
 import {
   fileToggleLabel,
   fileWrapLabel,
@@ -46,6 +49,7 @@ type Props = {
   onCloseLeft?: (tab: CenterTabIdentity) => void;
   onToggleFileDisplayMode?: (id: string) => void;
   onToggleFileLineWrap?: (id: string) => void;
+  onNew?: () => void;
   onReorder?: (tab: CenterTabIdentity, targetIndex: number) => void;
 };
 
@@ -60,12 +64,15 @@ let {
   onCloseLeft,
   onToggleFileDisplayMode,
   onToggleFileLineWrap,
+  onNew,
   onReorder,
 }: Props = $props();
 
 const refreshShortcut = getShortcutLabel("pane.refresh");
 const closeShortcut = getShortcutLabel("pane.close");
 const closeOthersShortcut = getShortcutLabel("pane.closeOthers");
+const newShortcut = getShortcutLabel("conversation.new");
+const newShortcutAria = getShortcutAriaLabel("conversation.new");
 
 const workbenchTabs = $derived(tabs.map(toWorkbenchTab));
 
@@ -233,6 +240,9 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
   {refreshShortcut}
   {closeShortcut}
   {closeOthersShortcut}
+  newLabel="New chat"
+  {newShortcut}
+  {newShortcutAria}
   buildMenuItems={({ tab }) => tabMenu(tab)}
   onSelect={(tab) => onSelect?.(castIdentity(tab))}
   onClose={(tab) => onClose?.(castIdentity(tab))}
@@ -240,5 +250,6 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
   onCloseOther={(tab) => onCloseOther?.(castIdentity(tab))}
   onCloseRight={(tab) => onCloseRight?.(castIdentity(tab))}
   onCloseLeft={(tab) => onCloseLeft?.(castIdentity(tab))}
+  {onNew}
   onReorder={(tab, targetIndex) => onReorder?.(castIdentity(tab), targetIndex)}
 />


### PR DESCRIPTION
## Summary
- add a fixed plus action at the right edge of the editor tab strip
- create a new conversation in the currently selected project
- expose the configured shortcut in tooltip and accessibility metadata

## Validation
- `pnpm fix && pnpm check && pnpm test`
- visually verified in light and dark themes