### PR TITLE
Use direct GitHub API for pull request workflows

### DIFF
--- a/packages/tools/src/git/git-github-api-client.ts
+++ b/packages/tools/src/git/git-github-api-client.ts
@@ -1,0 +1,254 @@
+import { GitWorkflowError } from "./git-errors.js";
+import type { GithubRepositoryRef } from "./git-github-parsers.js";
+import type { GithubRequestObservation } from "./git-observability.js";
+
+const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_TOKEN_TTL_MS = 5 * 60_000;
+
+type TokenEntry = { readonly token: string; readonly expiresAt: number };
+
+type GithubApiClientOptions = {
+  readonly tokenProvider: (hostname: string) => Promise<string>;
+  readonly fetch?: typeof fetch;
+  readonly now?: () => number;
+  readonly tokenTtlMs?: number;
+  readonly timeoutMs?: number;
+  readonly onRequestCompleted?: (observation: GithubRequestObservation) => void;
+};
+
+type RestOptions = {
+  readonly method?: "GET" | "POST" | "PUT";
+  readonly body?: unknown;
+  readonly operation: string;
+};
+
+type GraphqlEnvelope<T> = {
+  readonly data?: T;
+  readonly errors?: readonly { readonly message?: string }[];
+};
+
+export class GithubApiClient {
+  readonly #fetch: typeof fetch;
+  readonly #now: () => number;
+  readonly #tokenTtlMs: number;
+  readonly #timeoutMs: number;
+  readonly #tokens = new Map<string, TokenEntry>();
+  readonly #tokenRequests = new Map<string, Promise<string>>();
+
+  constructor(readonly options: GithubApiClientOptions) {
+    this.#fetch = options.fetch ?? fetch;
+    this.#now = options.now ?? Date.now;
+    this.#tokenTtlMs = options.tokenTtlMs ?? DEFAULT_TOKEN_TTL_MS;
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async graphql<T>(
+    repository: GithubRepositoryRef,
+    operation: string,
+    query: string,
+    variables: Readonly<Record<string, unknown>>,
+  ): Promise<T> {
+    const envelope = await this.#request<GraphqlEnvelope<T>>(
+      repository.hostname,
+      "https://api.github.com/graphql",
+      {
+        method: "POST",
+        body: { query, variables },
+        operation,
+      },
+    );
+    if (envelope.errors?.length || envelope.data === undefined) {
+      const detail = envelope.errors
+        ?.map((error) => error.message?.trim())
+        .filter(Boolean)
+        .join("; ")
+        .slice(0, 500);
+      if (
+        detail &&
+        /Could not resolve to a (PullRequest|Repository)/i.test(detail)
+      )
+        throw new GitWorkflowError(
+          404,
+          "GH_NOT_FOUND",
+          "GitHub resource not found.",
+        );
+      throw new GitWorkflowError(
+        502,
+        "GH_GRAPHQL_FAILED",
+        detail || "GitHub returned an invalid GraphQL response.",
+      );
+    }
+    return envelope.data;
+  }
+
+  rest<T>(
+    repository: GithubRepositoryRef,
+    path: string,
+    options: RestOptions,
+  ): Promise<T> {
+    return this.#request<T>(
+      repository.hostname,
+      `https://api.github.com${path}`,
+      options,
+    );
+  }
+
+  async token(hostname: string): Promise<string> {
+    const cached = this.#tokens.get(hostname);
+    if (cached && cached.expiresAt > this.#now()) return cached.token;
+    const existing = this.#tokenRequests.get(hostname);
+    if (existing) return existing;
+
+    const request = (async () => {
+      try {
+        const token = (await this.options.tokenProvider(hostname)).trim();
+        if (!token) throw new Error("GitHub CLI returned an empty token.");
+        this.#tokens.set(hostname, {
+          token,
+          expiresAt: this.#now() + this.#tokenTtlMs,
+        });
+        return token;
+      } catch (error) {
+        const text = error instanceof Error ? error.message : String(error);
+        if (/ENOENT|not found|not recognized/i.test(text)) {
+          throw new GitWorkflowError(
+            503,
+            "GH_CLI_UNAVAILABLE",
+            "GitHub CLI (gh) is not installed.",
+          );
+        }
+        throw new GitWorkflowError(
+          401,
+          "GH_AUTH_REQUIRED",
+          "Not authenticated. Run `gh auth login`.",
+        );
+      }
+    })();
+    this.#tokenRequests.set(hostname, request);
+    try {
+      return await request;
+    } finally {
+      if (this.#tokenRequests.get(hostname) === request)
+        this.#tokenRequests.delete(hostname);
+    }
+  }
+
+  async #request<T>(
+    hostname: string,
+    url: string,
+    options: RestOptions,
+  ): Promise<T> {
+    let lastStatus: number | undefined;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const startedAt = performance.now();
+      try {
+        const token = await this.token(hostname);
+        const response = await this.#fetch(url, {
+          method: options.method ?? "GET",
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body:
+            options.body === undefined
+              ? undefined
+              : JSON.stringify(options.body),
+          signal: AbortSignal.timeout(this.#timeoutMs),
+        });
+        lastStatus = response.status;
+        if (response.status === 401 && attempt === 0) {
+          this.#tokens.delete(hostname);
+          this.#observe(options.operation, startedAt, false, response.status);
+          continue;
+        }
+        if (!response.ok) throw apiError(response.status, response.headers);
+        const value = (await response.json()) as T;
+        this.#observe(options.operation, startedAt, true, response.status);
+        return value;
+      } catch (error) {
+        if (error instanceof GitWorkflowError) {
+          this.#observe(options.operation, startedAt, false, lastStatus);
+          throw error;
+        }
+        this.#observe(options.operation, startedAt, false, lastStatus);
+        throw new GitWorkflowError(
+          503,
+          "GH_API_UNAVAILABLE",
+          error instanceof Error && error.name === "TimeoutError"
+            ? "GitHub API request timed out."
+            : "Could not reach the GitHub API.",
+        );
+      }
+    }
+    throw new GitWorkflowError(
+      401,
+      "GH_AUTH_REQUIRED",
+      "GitHub authentication expired. Run `gh auth refresh` or `gh auth login`.",
+    );
+  }
+
+  #observe(
+    operation: string,
+    startedAt: number,
+    succeeded: boolean,
+    status?: number,
+  ): void {
+    try {
+      this.options.onRequestCompleted?.({
+        operation,
+        durationMs: performance.now() - startedAt,
+        succeeded,
+        status,
+      });
+    } catch {
+      // Diagnostics must never affect GitHub operations.
+    }
+  }
+}
+
+function apiError(status: number, headers: Headers): GitWorkflowError {
+  if (status === 401) {
+    return new GitWorkflowError(
+      401,
+      "GH_AUTH_REQUIRED",
+      "GitHub authentication expired. Run `gh auth refresh` or `gh auth login`.",
+    );
+  }
+  if (status === 403) {
+    const rateLimited = headers.get("x-ratelimit-remaining") === "0";
+    return new GitWorkflowError(
+      403,
+      rateLimited ? "GH_RATE_LIMITED" : "GH_FORBIDDEN",
+      rateLimited
+        ? "GitHub API rate limit exceeded. Try again later."
+        : "GitHub denied this operation. Check the token permissions.",
+    );
+  }
+  if (status === 404)
+    return new GitWorkflowError(
+      404,
+      "GH_NOT_FOUND",
+      "GitHub resource not found.",
+    );
+  if (status === 409 || status === 422)
+    return new GitWorkflowError(
+      409,
+      "GH_CONFLICT",
+      "GitHub rejected the operation because the pull request changed or cannot be merged.",
+    );
+  if (status === 429)
+    return new GitWorkflowError(
+      429,
+      "GH_RATE_LIMITED",
+      "GitHub API rate limit exceeded. Try again later.",
+    );
+  return new GitWorkflowError(
+    status >= 500 ? 503 : 400,
+    status >= 500 ? "GH_API_UNAVAILABLE" : "GH_API_FAILED",
+    status >= 500
+      ? "GitHub API is temporarily unavailable."
+      : "GitHub rejected the request.",
+  );
+}

--- a/packages/tools/src/git/git-github-parsers.ts
+++ b/packages/tools/src/git/git-github-parsers.ts
@@ -5,40 +5,72 @@ function isGithubHost(hostname: string): boolean {
   return normalized === "github.com" || normalized === "ssh.github.com";
 }
 
-export function isGithubRemoteUrl(url: string): boolean {
-  const trimmed = url.trim();
-  if (trimmed.length === 0) return false;
+export type GithubRepositoryRef = {
+  readonly hostname: "github.com";
+  readonly owner: string;
+  readonly repo: string;
+  readonly remoteUrl: string;
+};
 
+export function parseGithubRepositoryUrl(
+  remoteUrl: string,
+): GithubRepositoryRef | null {
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) return null;
+
+  let hostname: string | undefined;
+  let pathname: string | undefined;
   try {
     const parsed = new URL(trimmed);
-    if (parsed.hostname) return isGithubHost(parsed.hostname);
+    hostname = parsed.hostname;
+    pathname = parsed.pathname;
   } catch {
-    // Fall through to SCP-like git remote syntax, e.g.
-    // `git@github.com:owner/repo.git`.
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex <= 0 || separatorIndex === trimmed.length - 1)
+      return null;
+    const authority = trimmed.slice(0, separatorIndex);
+    pathname = trimmed.slice(separatorIndex + 1);
+    if (authority.includes("/") || hasWhitespace(authority)) return null;
+    const atIndex = authority.lastIndexOf("@");
+    hostname = atIndex >= 0 ? authority.slice(atIndex + 1) : authority;
   }
 
-  const scpHost = parseScpLikeRemoteHost(trimmed);
-  return scpHost ? isGithubHost(scpHost) : false;
+  if (!hostname || !isGithubHost(hostname) || !pathname) return null;
+  const parts = pathname
+    .replace(/^\/+/, "")
+    .replace(/\.git\/?$/, "")
+    .split("/");
+  if (parts.length !== 2 || parts.some((part) => !part || hasWhitespace(part)))
+    return null;
+  return {
+    hostname: "github.com",
+    owner: parts[0] as string,
+    repo: parts[1] as string,
+    remoteUrl: trimmed,
+  };
 }
 
-function parseScpLikeRemoteHost(remoteUrl: string): string | null {
-  const separatorIndex = remoteUrl.indexOf(":");
-  if (separatorIndex <= 0 || separatorIndex === remoteUrl.length - 1)
-    return null;
+export function parseGithubRepositoryRemote(
+  stdout: string,
+): GithubRepositoryRef | null {
+  const entries = stdout.split("\n").flatMap((line) => {
+    const parsed = parseGitRemoteEntry(line);
+    if (!parsed) return [];
+    const repository = parseGithubRepositoryUrl(parsed.url);
+    return repository ? [{ ...parsed, repository }] : [];
+  });
+  const selected =
+    entries.find(
+      (entry) => entry.name === "origin" && entry.kind === "fetch",
+    ) ??
+    entries.find((entry) => entry.kind === "fetch") ??
+    entries.find((entry) => entry.name === "origin") ??
+    entries[0];
+  return selected?.repository ?? null;
+}
 
-  const authority = remoteUrl.slice(0, separatorIndex);
-  const path = remoteUrl.slice(separatorIndex + 1);
-  if (
-    authority.includes("/") ||
-    hasWhitespace(authority) ||
-    hasWhitespace(path)
-  ) {
-    return null;
-  }
-
-  const atIndex = authority.lastIndexOf("@");
-  const host = atIndex >= 0 ? authority.slice(atIndex + 1) : authority;
-  return host.length > 0 && !host.includes(":") ? host : null;
+export function isGithubRemoteUrl(url: string): boolean {
+  return parseGithubRepositoryUrl(url) !== null;
 }
 
 function hasWhitespace(value: string): boolean {
@@ -57,6 +89,23 @@ export function parseGitRemoteUrls(stdout: string): string[] {
     if (url) urls.add(url);
   }
   return [...urls];
+}
+
+type GitRemoteEntry = {
+  readonly name: string;
+  readonly url: string;
+  readonly kind: "fetch" | "push";
+};
+
+function parseGitRemoteEntry(line: string): GitRemoteEntry | null {
+  const trimmed = line.trim();
+  const firstWhitespaceIndex = findFirstWhitespace(trimmed);
+  if (firstWhitespaceIndex <= 0) return null;
+  const name = trimmed.slice(0, firstWhitespaceIndex);
+  const value = trimmed.slice(firstWhitespaceIndex).trim();
+  const match = /^(.*) \((fetch|push)\)$/.exec(value);
+  if (!match?.[1] || !match[2]) return null;
+  return { name, url: match[1].trim(), kind: match[2] as "fetch" | "push" };
 }
 
 function parseGitRemoteUrlLine(line: string): string | null {

--- a/packages/tools/src/git/git-github-service.ts
+++ b/packages/tools/src/git/git-github-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- GitHub workflows share one typed mapping boundary across GraphQL and REST resources. */
 import type {
   GithubPr,
   GithubPrCheckoutResponse,
@@ -7,8 +8,8 @@ import type {
   GithubPrCore,
   GithubPrFile,
   GithubPrFilesResponse,
-  GithubPrListFilters,
   GithubPrInitial,
+  GithubPrListFilters,
   GithubPrListResponse,
   GithubPrMergeMethod,
   GithubPrMergeResponse,
@@ -17,27 +18,30 @@ import type {
   GitRepoSummary,
 } from "@nervekit/contracts";
 import { GitWorkflowError } from "./git-errors.js";
+import type { GithubApiClient } from "./git-github-api-client.js";
 import {
   noChecksSummary,
-  parseGithubChecks,
   summarizeStatusCheckRollup,
 } from "./git-github-parsers.js";
+import type { GithubRepositoryRef } from "./git-github-parsers.js";
 import { parsePorcelainV2 } from "./git-status.js";
 
 type ExecResult = { stdout: string; stderr: string };
-
 type GitCommandLikeError = Error & {
   code: number | null;
   stdout: string;
   stderr: string;
 };
+type RemoteState = {
+  hasRemote: boolean;
+  hasGithubRemote: boolean;
+  githubRepository: GithubRepositoryRef | null;
+};
 
 export type GithubServiceContext = {
   resolveRepoDir(projectId: string, relativePath: string): string;
-  repoRemoteState(repoDir: string): Promise<{
-    hasRemote: boolean;
-    hasGithubRemote: boolean;
-  }>;
+  repoRemoteState(repoDir: string): Promise<RemoteState>;
+  githubApi: GithubApiClient;
   runGh(repoDir: string, args: string[]): Promise<ExecResult>;
   runGit(repoDir: string, args: string[]): Promise<ExecResult>;
   ensureGithubRemote(repoDir: string): Promise<void>;
@@ -52,160 +56,17 @@ export type GithubServiceContext = {
   isGitCommandError(error: unknown): error is GitCommandLikeError;
 };
 
-export async function githubStatus(
-  context: GithubServiceContext,
-  projectId: string,
-  relativePath: string,
-): Promise<GithubStatusResponse> {
-  const repoDir = context.resolveRepoDir(projectId, relativePath);
-  const remoteState = await context.repoRemoteState(repoDir);
-  if (!remoteState.hasRemote) {
-    return {
-      available: false,
-      authenticated: false,
-      login: null,
-      reason: "No remote repository configured.",
-    };
-  }
-  if (!remoteState.hasGithubRemote) {
-    return {
-      available: false,
-      authenticated: false,
-      login: null,
-      reason: "Remote repository is not GitHub.",
-    };
-  }
-
-  try {
-    await context.runGh(repoDir, ["--version"]);
-  } catch {
-    return {
-      available: false,
-      authenticated: false,
-      login: null,
-      reason: "GitHub CLI (gh) is not installed.",
-    };
-  }
-  try {
-    const { stdout } = await context.runGh(repoDir, [
-      "api",
-      "user",
-      "--jq",
-      ".login",
-    ]);
-    const login = stdout.trim();
-    return {
-      available: true,
-      authenticated: login.length > 0,
-      login: login.length > 0 ? login : null,
-    };
-  } catch (error) {
-    return {
-      available: true,
-      authenticated: false,
-      login: null,
-      reason: context.isGitCommandError(error)
-        ? "Not authenticated. Run `gh auth login`."
-        : "GitHub authentication check failed.",
-    };
-  }
-}
-
-export function githubPrListArgs(filters: GithubPrListFilters): string[] {
-  const args = ["pr", "list", "--state", "open", "--limit", "10"];
-  if (filters.author === "me") args.push("--author", "@me");
-  if (filters.author === "username" && filters.username) {
-    args.push("--author", filters.username);
-  }
-  if (filters.head) args.push("--head", filters.head);
-  for (const label of filters.labels) args.push("--label", label);
-
-  const search = [`sort:${filters.sort}`];
-  if (filters.title) search.push(`in:title ${quoteSearchValue(filters.title)}`);
-  if (filters.drafts === "exclude") search.push("draft:false");
-  if (filters.drafts === "only") search.push("draft:true");
-  args.push("--search", search.join(" "));
-  args.push(
-    "--json",
-    "number,title,url,state,isDraft,headRefName,baseRefName,updatedAt,statusCheckRollup",
-  );
-  return args;
-}
-
-function quoteSearchValue(value: string): string {
-  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
-}
-
-export async function listOpenPrs(
-  context: GithubServiceContext,
-  projectId: string,
-  relativePath: string,
-  filters: GithubPrListFilters,
-): Promise<GithubPrListResponse> {
-  const repoDir = context.resolveRepoDir(projectId, relativePath);
-  await context.ensureGithubRemote(repoDir);
-  const { stdout } = await context.mapGh(() =>
-    context.runGh(repoDir, githubPrListArgs(filters)),
-  );
-  const raw = JSON.parse(stdout || "[]") as Array<{
-    number: number;
-    title: string;
-    url: string;
-    state: string;
-    isDraft: boolean;
-    headRefName: string;
-    baseRefName: string;
-    updatedAt: string;
-    statusCheckRollup?: unknown[] | null;
-  }>;
-  return {
-    prs: raw.slice(0, 10).map(
-      (pr): GithubPr => ({
-        number: pr.number,
-        title: pr.title,
-        url: pr.url,
-        state: pr.state,
-        isDraft: pr.isDraft,
-        headRefName: pr.headRefName,
-        baseRefName: pr.baseRefName,
-        updatedAt: pr.updatedAt,
-        checks: summarizeStatusCheckRollup(pr.statusCheckRollup),
-      }),
-    ),
-  };
-}
-
-async function loadPrChecks(
-  context: GithubServiceContext,
-  repoDir: string,
-  number: number,
-): Promise<ReturnType<typeof noChecksSummary>> {
-  try {
-    const { stdout } = await context.runGh(repoDir, [
-      "pr",
-      "checks",
-      String(number),
-      "--json",
-      "name,state,link",
-    ]);
-    return parseGithubChecks(stdout);
-  } catch (error) {
-    if (context.isGitCommandError(error) && error.stdout.trim().length > 0) {
-      try {
-        return parseGithubChecks(error.stdout);
-      } catch {
-        // Fall through to the no-checks fallback below.
-      }
-    }
-    return noChecksSummary();
-  }
-}
-
-type GithubAuthorRaw = {
-  login?: string;
-  avatarUrl?: string;
+type GithubAuthorRaw = { login?: string; avatarUrl?: string } | null;
+type GithubCheckRollupRaw = {
+  contexts?: { nodes?: unknown[] | null } | null;
 } | null;
-
+type GithubCommitNodeRaw = {
+  oid: string;
+  messageHeadline?: string;
+  authoredDate?: string;
+  authors?: { nodes?: Array<{ name?: string } | null> | null } | null;
+  statusCheckRollup?: GithubCheckRollupRaw;
+};
 type GithubPrDetailRaw = {
   number: number;
   title: string;
@@ -226,116 +87,281 @@ type GithubPrDetailRaw = {
   mergeable?: string | null;
   mergeStateStatus?: string | null;
   reviewDecision?: string | null;
-  comments?: Array<{
-    id?: string;
-    databaseId?: number;
-    author?: GithubAuthorRaw;
-    body?: string;
-    createdAt?: string;
-    updatedAt?: string;
-    url?: string;
-  }>;
-  reviews?: Array<{
-    id?: string;
-    databaseId?: number;
-    author?: GithubAuthorRaw;
-    state?: string;
-    body?: string;
-    submittedAt?: string;
-    url?: string;
-  }>;
-  labels?: Array<{ name?: string; color?: string }>;
-  reviewRequests?: Array<{
-    login?: string;
-    avatarUrl?: string;
-    requestedReviewer?: { login?: string; avatarUrl?: string };
-  }>;
-  commits?: Array<{
-    oid: string;
-    messageHeadline?: string;
-    authoredDate?: string;
-    authors?: Array<{ name?: string }>;
-  }>;
+  comments?: {
+    nodes?: Array<{
+      id?: string;
+      databaseId?: number;
+      author?: GithubAuthorRaw;
+      body?: string;
+      createdAt?: string;
+      updatedAt?: string;
+      url?: string;
+    } | null> | null;
+  } | null;
+  reviews?: {
+    nodes?: Array<{
+      id?: string;
+      databaseId?: number;
+      author?: GithubAuthorRaw;
+      state?: string;
+      body?: string;
+      submittedAt?: string;
+      url?: string;
+    } | null> | null;
+  } | null;
+  labels?: {
+    nodes?: Array<{ name?: string; color?: string } | null> | null;
+  } | null;
+  reviewRequests?: {
+    nodes?: Array<{
+      requestedReviewer?: {
+        login?: string;
+        slug?: string;
+        avatarUrl?: string;
+      } | null;
+    } | null> | null;
+  } | null;
+  commits?: {
+    nodes?: Array<{ commit?: GithubCommitNodeRaw } | null> | null;
+  } | null;
 };
-
-type GithubRepoMergeRaw = {
-  nameWithOwner?: string;
+type GithubRepoRaw = {
   mergeCommitAllowed?: boolean;
   squashMergeAllowed?: boolean;
   rebaseMergeAllowed?: boolean;
+  pullRequest?: GithubPrDetailRaw | null;
 };
+type RepositoryResponse = { repository?: GithubRepoRaw | null };
 
-export function allowedMergeMethods(
-  raw: GithubRepoMergeRaw,
-): GithubPrMergeMethod[] {
-  const methods: GithubPrMergeMethod[] = [];
-  if (raw.mergeCommitAllowed) methods.push("merge");
-  if (raw.squashMergeAllowed) methods.push("squash");
-  if (raw.rebaseMergeAllowed) methods.push("rebase");
-  return methods;
-}
-
-async function repoMergeSettings(
-  context: GithubServiceContext,
-  repoDir: string,
-): Promise<{ nameWithOwner: string; allowedMethods: GithubPrMergeMethod[] }> {
-  const { stdout } = await context.mapGh(() =>
-    context.runGh(repoDir, [
-      "repo",
-      "view",
-      "--json",
-      "nameWithOwner,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed",
-    ]),
-  );
-  const raw = JSON.parse(stdout || "{}") as GithubRepoMergeRaw;
-  return {
-    nameWithOwner: raw.nameWithOwner ?? "{owner}/{repo}",
-    allowedMethods: allowedMergeMethods(raw),
-  };
-}
-
-async function prBehindBy(
-  context: GithubServiceContext,
-  repoDir: string,
-  nameWithOwner: string,
-  baseOid: string,
-  headOid: string,
-): Promise<number | null> {
-  if (!baseOid || !headOid) return null;
-  try {
-    const { stdout } = await context.runGh(repoDir, [
-      "api",
-      `repos/${nameWithOwner}/compare/${baseOid}...${headOid}`,
-      "--jq",
-      ".behind_by",
-    ]);
-    const value = Number(stdout.trim());
-    return Number.isInteger(value) && value >= 0 ? value : null;
-  } catch {
-    return null;
+const CORE_FIELDS = `
+  number title url state isDraft headRefName baseRefName headRefOid baseRefOid
+  updatedAt createdAt additions deletions changedFiles
+  author { login avatarUrl }
+`;
+const CONVERSATION_FIELDS = `
+  body createdAt updatedAt
+  comments(first: 100) {
+    nodes { id databaseId body createdAt updatedAt url author { login avatarUrl } }
   }
+  reviews(first: 100) {
+    nodes { id databaseId state body submittedAt url author { login avatarUrl } }
+  }
+`;
+const OVERVIEW_FIELDS = `
+  headRefOid baseRefOid mergeable mergeStateStatus reviewDecision
+  labels(first: 100) { nodes { name color } }
+  reviewRequests(first: 100) {
+    nodes {
+      requestedReviewer {
+        ... on User { login avatarUrl }
+        ... on Team { slug avatarUrl }
+      }
+    }
+  }
+`;
+const CHECK_FIELDS = `
+  commits(last: 1) {
+    nodes {
+      commit {
+        statusCheckRollup {
+          contexts(first: 100) {
+            nodes {
+              __typename
+              ... on CheckRun { name status conclusion detailsUrl }
+              ... on StatusContext { context state targetUrl }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+const REPOSITORY_SETTINGS_FIELDS = `
+  mergeCommitAllowed squashMergeAllowed rebaseMergeAllowed
+`;
+
+function repositoryQuery(fields: string, includeSettings = false): string {
+  return `query PullRequest($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      ${includeSettings ? REPOSITORY_SETTINGS_FIELDS : ""}
+      pullRequest(number: $number) { ${fields} }
+    }
+  }`;
 }
 
-async function viewPr(
-  context: GithubServiceContext,
-  repoDir: string,
-  number: number,
-  fields: string,
-): Promise<GithubPrDetailRaw> {
-  const { stdout } = await context.mapGh(() =>
-    context.runGh(repoDir, ["pr", "view", String(number), "--json", fields]),
-  );
-  return JSON.parse(stdout || "{}") as GithubPrDetailRaw;
+function variables(repository: GithubRepositoryRef, number: number) {
+  return { owner: repository.owner, repo: repository.repo, number };
+}
+
+function requireRepository(data: RepositoryResponse): GithubRepoRaw {
+  if (!data.repository)
+    throw new GitWorkflowError(
+      404,
+      "GH_NOT_FOUND",
+      "GitHub repository not found.",
+    );
+  return data.repository;
+}
+
+function requirePr(repository: GithubRepoRaw): GithubPrDetailRaw {
+  if (!repository.pullRequest)
+    throw new GitWorkflowError(404, "GH_NOT_FOUND", "Pull request not found.");
+  return repository.pullRequest;
 }
 
 async function preparePr(
   context: GithubServiceContext,
   projectId: string,
   relativePath: string,
-): Promise<string> {
+): Promise<{ repoDir: string; repository: GithubRepositoryRef }> {
   const repoDir = context.resolveRepoDir(projectId, relativePath);
   await context.ensureGithubRemote(repoDir);
-  return repoDir;
+  const repository = (await context.repoRemoteState(repoDir)).githubRepository;
+  if (!repository)
+    throw new GitWorkflowError(
+      409,
+      "GH_NO_GITHUB_REMOTE",
+      "This repository does not have a GitHub remote configured.",
+    );
+  return { repoDir, repository };
+}
+
+export async function githubStatus(
+  context: GithubServiceContext,
+  projectId: string,
+  relativePath: string,
+): Promise<GithubStatusResponse> {
+  const repoDir = context.resolveRepoDir(projectId, relativePath);
+  const remoteState = await context.repoRemoteState(repoDir);
+  if (!remoteState.hasRemote)
+    return {
+      available: false,
+      authenticated: false,
+      login: null,
+      reason: "No remote repository configured.",
+    };
+  if (!remoteState.githubRepository)
+    return {
+      available: false,
+      authenticated: false,
+      login: null,
+      reason: "Remote repository is not GitHub.",
+    };
+  try {
+    const user = await context.githubApi.rest<{ login?: string }>(
+      remoteState.githubRepository,
+      "/user",
+      { operation: "github-status" },
+    );
+    const login = user.login?.trim() ?? "";
+    return {
+      available: true,
+      authenticated: Boolean(login),
+      login: login || null,
+    };
+  } catch (error) {
+    if (error instanceof GitWorkflowError) {
+      if (error.code === "GH_CLI_UNAVAILABLE")
+        return {
+          available: false,
+          authenticated: false,
+          login: null,
+          reason: error.message,
+        };
+      if (error.code === "GH_AUTH_REQUIRED")
+        return {
+          available: true,
+          authenticated: false,
+          login: null,
+          reason: error.message,
+        };
+    }
+    return {
+      available: true,
+      authenticated: false,
+      login: null,
+      reason: "GitHub authentication check failed.",
+    };
+  }
+}
+
+function quoteSearchValue(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+export function githubPrSearch(filters: GithubPrListFilters): string {
+  const search = ["is:pr", "is:open"];
+  if (filters.author === "me") search.push("author:@me");
+  if (filters.author === "username" && filters.username)
+    search.push(`author:${quoteSearchValue(filters.username)}`);
+  if (filters.head) search.push(`head:${quoteSearchValue(filters.head)}`);
+  for (const label of filters.labels)
+    search.push(`label:${quoteSearchValue(label)}`);
+  if (filters.title) search.push(`in:title ${quoteSearchValue(filters.title)}`);
+  if (filters.drafts === "exclude") search.push("draft:false");
+  if (filters.drafts === "only") search.push("draft:true");
+  search.push(
+    `sort:updated-${filters.sort === "updated-asc" ? "asc" : "desc"}`,
+  );
+  return search.join(" ");
+}
+
+const PR_LIST_QUERY = `query PullRequests($query: String!) {
+  search(query: $query, type: ISSUE, first: 10) {
+    nodes {
+      ... on PullRequest {
+        number title url state isDraft headRefName baseRefName updatedAt
+        ${CHECK_FIELDS}
+      }
+    }
+  }
+}`;
+
+function checkRollup(raw: GithubPrDetailRaw): readonly unknown[] | null {
+  return (
+    raw.commits?.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? null
+  );
+}
+
+export async function listOpenPrs(
+  context: GithubServiceContext,
+  projectId: string,
+  relativePath: string,
+  filters: GithubPrListFilters,
+): Promise<GithubPrListResponse> {
+  const { repository } = await preparePr(context, projectId, relativePath);
+  const data = await context.githubApi.graphql<{
+    search?: { nodes?: Array<GithubPrDetailRaw | null> | null } | null;
+  }>(repository, "list-pull-requests", PR_LIST_QUERY, {
+    query: `repo:${repository.owner}/${repository.repo} ${githubPrSearch(filters)}`,
+  });
+  return {
+    prs: (data.search?.nodes ?? []).flatMap((raw) =>
+      raw
+        ? [
+            {
+              number: raw.number,
+              title: raw.title,
+              url: raw.url,
+              state: raw.state,
+              isDraft: raw.isDraft,
+              headRefName: raw.headRefName,
+              baseRefName: raw.baseRefName,
+              updatedAt: raw.updatedAt,
+              checks: summarizeStatusCheckRollup(checkRollup(raw)),
+            } satisfies GithubPr,
+          ]
+        : [],
+    ),
+  };
+}
+
+export function allowedMergeMethods(raw: GithubRepoRaw): GithubPrMergeMethod[] {
+  const methods: GithubPrMergeMethod[] = [];
+  if (raw.mergeCommitAllowed) methods.push("merge");
+  if (raw.squashMergeAllowed) methods.push("squash");
+  if (raw.rebaseMergeAllowed) methods.push("rebase");
+  return methods;
 }
 
 function mapPrCore(raw: GithubPrDetailRaw): GithubPrCore {
@@ -358,10 +384,14 @@ function mapPrCore(raw: GithubPrDetailRaw): GithubPrCore {
   };
 }
 
+function compact<T>(values: Array<T | null> | null | undefined): T[] {
+  return (values ?? []).filter((value): value is T => value !== null);
+}
+
 function mapPrConversation(raw: GithubPrDetailRaw): GithubPrConversation {
   return {
     body: raw.body ?? "",
-    comments: (raw.comments ?? []).map((comment, index) => ({
+    comments: compact(raw.comments?.nodes).map((comment, index) => ({
       id: String(comment.id ?? comment.databaseId ?? `comment-${index}`),
       author: comment.author?.login ?? null,
       authorAvatarUrl: comment.author?.avatarUrl,
@@ -370,7 +400,7 @@ function mapPrConversation(raw: GithubPrDetailRaw): GithubPrConversation {
       updatedAt: comment.updatedAt,
       url: comment.url,
     })),
-    reviews: (raw.reviews ?? []).map((review, index) => ({
+    reviews: compact(raw.reviews?.nodes).map((review, index) => ({
       id: String(review.id ?? review.databaseId ?? `review-${index}`),
       author: review.author?.login ?? null,
       authorAvatarUrl: review.author?.avatarUrl,
@@ -384,7 +414,7 @@ function mapPrConversation(raw: GithubPrDetailRaw): GithubPrConversation {
 
 function mapPrOverview(
   raw: GithubPrDetailRaw,
-  settings: { allowedMethods: GithubPrMergeMethod[] },
+  settings: GithubRepoRaw,
   behindBy: number | null,
 ): GithubPrOverview {
   return {
@@ -392,23 +422,56 @@ function mapPrOverview(
     mergeStateStatus: raw.mergeStateStatus ?? null,
     reviewDecision: raw.reviewDecision ?? null,
     behindBy,
-    labels: (raw.labels ?? [])
-      .filter((label): label is { name: string; color?: string } =>
-        Boolean(label.name),
-      )
-      .map((label) => ({ name: label.name, color: label.color })),
-    reviewRequests: (raw.reviewRequests ?? []).flatMap((request) => {
-      const reviewer = request.requestedReviewer ?? request;
-      return reviewer.login
-        ? [{ login: reviewer.login, avatarUrl: reviewer.avatarUrl }]
-        : [];
+    labels: compact(raw.labels?.nodes).flatMap((label) =>
+      label.name ? [{ name: label.name, color: label.color }] : [],
+    ),
+    reviewRequests: compact(raw.reviewRequests?.nodes).flatMap((request) => {
+      const reviewer = request.requestedReviewer;
+      const login = reviewer?.login ?? reviewer?.slug;
+      return login ? [{ login, avatarUrl: reviewer?.avatarUrl }] : [];
     }),
-    mergeSettings: { allowedMethods: settings.allowedMethods },
+    mergeSettings: { allowedMethods: allowedMergeMethods(settings) },
   };
 }
 
-const PR_INITIAL_FIELDS =
-  "number,title,url,state,isDraft,headRefName,baseRefName,headRefOid,baseRefOid,updatedAt,createdAt,author,additions,deletions,changedFiles,body,comments,reviews,mergeable,mergeStateStatus,reviewDecision,labels,reviewRequests";
+async function behindBy(
+  context: GithubServiceContext,
+  repository: GithubRepositoryRef,
+  baseOid: string,
+  headOid: string,
+): Promise<number | null> {
+  if (!baseOid || !headOid) return null;
+  try {
+    const result = await context.githubApi.rest<{ behind_by?: number }>(
+      repository,
+      `/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/compare/${encodeURIComponent(baseOid)}...${encodeURIComponent(headOid)}`,
+      { operation: "compare-pull-request" },
+    );
+    return Number.isInteger(result.behind_by) && (result.behind_by ?? -1) >= 0
+      ? (result.behind_by ?? null)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadPr(
+  context: GithubServiceContext,
+  repository: GithubRepositoryRef,
+  number: number,
+  fields: string,
+  operation: string,
+  includeSettings = false,
+): Promise<{ raw: GithubPrDetailRaw; settings: GithubRepoRaw }> {
+  const data = await context.githubApi.graphql<RepositoryResponse>(
+    repository,
+    operation,
+    repositoryQuery(fields, includeSettings),
+    variables(repository, number),
+  );
+  const settings = requireRepository(data);
+  return { raw: requirePr(settings), settings };
+}
 
 export async function prInitial(
   context: GithubServiceContext,
@@ -416,22 +479,25 @@ export async function prInitial(
   relativePath: string,
   number: number,
 ): Promise<GithubPrInitial> {
-  const repoDir = await preparePr(context, projectId, relativePath);
-  const [raw, settings] = await Promise.all([
-    viewPr(context, repoDir, number, PR_INITIAL_FIELDS),
-    repoMergeSettings(context, repoDir),
-  ]);
-  const behindBy = await prBehindBy(
+  const { repository } = await preparePr(context, projectId, relativePath);
+  const { raw, settings } = await loadPr(
     context,
-    repoDir,
-    settings.nameWithOwner,
+    repository,
+    number,
+    `${CORE_FIELDS}${CONVERSATION_FIELDS}${OVERVIEW_FIELDS}`,
+    "pull-request-initial",
+    true,
+  );
+  const divergence = await behindBy(
+    context,
+    repository,
     raw.baseRefOid ?? "",
     raw.headRefOid ?? "",
   );
   return {
     core: mapPrCore(raw),
     conversation: mapPrConversation(raw),
-    overview: mapPrOverview(raw, settings, behindBy),
+    overview: mapPrOverview(raw, settings, divergence),
   };
 }
 
@@ -441,14 +507,18 @@ export async function prCore(
   relativePath: string,
   number: number,
 ): Promise<GithubPrCore> {
-  const repoDir = await preparePr(context, projectId, relativePath);
-  const raw = await viewPr(
-    context,
-    repoDir,
-    number,
-    "number,title,url,state,isDraft,headRefName,baseRefName,headRefOid,baseRefOid,updatedAt,createdAt,author,additions,deletions,changedFiles",
+  const { repository } = await preparePr(context, projectId, relativePath);
+  return mapPrCore(
+    (
+      await loadPr(
+        context,
+        repository,
+        number,
+        CORE_FIELDS,
+        "pull-request-core",
+      )
+    ).raw,
   );
-  return mapPrCore(raw);
 }
 
 export async function prConversation(
@@ -457,14 +527,18 @@ export async function prConversation(
   relativePath: string,
   number: number,
 ): Promise<GithubPrConversation> {
-  const repoDir = await preparePr(context, projectId, relativePath);
-  const raw = await viewPr(
-    context,
-    repoDir,
-    number,
-    "body,comments,reviews,createdAt,updatedAt",
+  const { repository } = await preparePr(context, projectId, relativePath);
+  return mapPrConversation(
+    (
+      await loadPr(
+        context,
+        repository,
+        number,
+        CONVERSATION_FIELDS,
+        "pull-request-conversation",
+      )
+    ).raw,
   );
-  return mapPrConversation(raw);
 }
 
 export async function prOverview(
@@ -473,25 +547,30 @@ export async function prOverview(
   relativePath: string,
   number: number,
 ): Promise<GithubPrOverview> {
-  const repoDir = await preparePr(context, projectId, relativePath);
-  const [raw, settings] = await Promise.all([
-    viewPr(
-      context,
-      repoDir,
-      number,
-      "headRefOid,baseRefOid,mergeable,mergeStateStatus,reviewDecision,labels,reviewRequests",
-    ),
-    repoMergeSettings(context, repoDir),
-  ]);
-  const behindBy = await prBehindBy(
+  const { repository } = await preparePr(context, projectId, relativePath);
+  const { raw, settings } = await loadPr(
     context,
-    repoDir,
-    settings.nameWithOwner,
-    raw.baseRefOid ?? "",
-    raw.headRefOid ?? "",
+    repository,
+    number,
+    OVERVIEW_FIELDS,
+    "pull-request-overview",
+    true,
   );
-  return mapPrOverview(raw, settings, behindBy);
+  return mapPrOverview(
+    raw,
+    settings,
+    await behindBy(
+      context,
+      repository,
+      raw.baseRefOid ?? "",
+      raw.headRefOid ?? "",
+    ),
+  );
 }
+
+const COMMITS_FIELDS = `commits(first: 100) {
+  nodes { commit { oid messageHeadline authoredDate authors(first: 1) { nodes { name } } } }
+}`;
 
 export async function prCommits(
   context: GithubServiceContext,
@@ -499,16 +578,31 @@ export async function prCommits(
   relativePath: string,
   number: number,
 ): Promise<GithubPrCommitsResponse> {
-  const repoDir = await preparePr(context, projectId, relativePath);
-  const raw = await viewPr(context, repoDir, number, "commits");
+  const { repository } = await preparePr(context, projectId, relativePath);
+  const raw = (
+    await loadPr(
+      context,
+      repository,
+      number,
+      COMMITS_FIELDS,
+      "pull-request-commits",
+    )
+  ).raw;
   return {
-    commits: (raw.commits ?? []).map((commit) => ({
-      oid: commit.oid,
-      abbrev: commit.oid.slice(0, 7),
-      messageHeadline: commit.messageHeadline ?? "",
-      authoredDate: commit.authoredDate,
-      authorName: commit.authors?.[0]?.name,
-    })),
+    commits: compact(raw.commits?.nodes).flatMap((node) => {
+      const commit = node.commit;
+      return commit
+        ? [
+            {
+              oid: commit.oid,
+              abbrev: commit.oid.slice(0, 7),
+              messageHeadline: commit.messageHeadline ?? "",
+              authoredDate: commit.authoredDate,
+              authorName: compact(commit.authors?.nodes)[0]?.name,
+            },
+          ]
+        : [];
+    }),
   };
 }
 
@@ -518,28 +612,26 @@ export async function prChecks(
   relativePath: string,
   number: number,
 ): Promise<GithubPrChecksResponse> {
-  const repoDir = await preparePr(context, projectId, relativePath);
-  return { checks: await loadPrChecks(context, repoDir, number) };
+  const { repository } = await preparePr(context, projectId, relativePath);
+  const raw = (
+    await loadPr(
+      context,
+      repository,
+      number,
+      CHECK_FIELDS,
+      "pull-request-checks",
+    )
+  ).raw;
+  return {
+    checks: raw.commits
+      ? summarizeStatusCheckRollup(checkRollup(raw))
+      : noChecksSummary(),
+  };
 }
 
 const MAX_PR_FILES = 300;
 const PR_FILES_PER_PAGE = 100;
 const MAX_PR_PATCH_BYTES = 2 * 1024 * 1024;
-
-function truncateUtf8(value: string, maxBytes: number): string {
-  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
-  let low = 0;
-  let high = value.length;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    if (Buffer.byteLength(value.slice(0, middle), "utf8") <= maxBytes) {
-      low = middle;
-    } else {
-      high = middle - 1;
-    }
-  }
-  return value.slice(0, low);
-}
 
 type GithubPrFileRaw = {
   filename?: string;
@@ -550,6 +642,19 @@ type GithubPrFileRaw = {
   changes?: number;
   patch?: string;
 };
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(value.slice(0, middle), "utf8") <= maxBytes)
+      low = middle;
+    else high = middle - 1;
+  }
+  return value.slice(0, low);
+}
 
 function fileStatus(value?: string): GithubPrFile["status"] {
   switch (value) {
@@ -572,49 +677,39 @@ export async function prFiles(
   relativePath: string,
   number: number,
 ): Promise<GithubPrFilesResponse> {
-  const repoDir = context.resolveRepoDir(projectId, relativePath);
-  await context.ensureGithubRemote(repoDir);
-  const countResult = await context.mapGh(() =>
-    context.runGh(repoDir, [
-      "pr",
-      "view",
-      String(number),
-      "--json",
-      "changedFiles",
-      "--jq",
-      ".changedFiles",
-    ]),
+  const { repository } = await preparePr(context, projectId, relativePath);
+  const root = `/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/pulls/${number}`;
+  const detailPromise = context.githubApi.rest<{ changed_files?: number }>(
+    repository,
+    root,
+    { operation: "pull-request-file-count" },
   );
   const rawFiles: GithubPrFileRaw[] = [];
   for (let page = 1; page <= MAX_PR_FILES / PR_FILES_PER_PAGE; page += 1) {
-    const { stdout } = await context.mapGh(() =>
-      context.runGh(repoDir, [
-        "api",
-        `repos/{owner}/{repo}/pulls/${number}/files?per_page=${PR_FILES_PER_PAGE}&page=${page}`,
-      ]),
+    const pageFiles = await context.githubApi.rest<GithubPrFileRaw[]>(
+      repository,
+      `${root}/files?per_page=${PR_FILES_PER_PAGE}&page=${page}`,
+      { operation: "pull-request-files" },
     );
-    const pageFiles = JSON.parse(stdout || "[]") as GithubPrFileRaw[];
     rawFiles.push(...pageFiles);
     if (pageFiles.length < PR_FILES_PER_PAGE) break;
   }
-  const totalValue = Number(countResult.stdout.trim());
-  const totalCount = Number.isInteger(totalValue)
-    ? totalValue
+  const detail = await detailPromise;
+  const totalCount = Number.isInteger(detail.changed_files)
+    ? (detail.changed_files ?? rawFiles.length)
     : rawFiles.length;
   let patchBytesRemaining = MAX_PR_PATCH_BYTES;
   let boundedPatches = false;
   const files = rawFiles.slice(0, MAX_PR_FILES).flatMap((file) => {
     if (!file.filename) return [];
-    const rawPatch = file.patch;
-    let patch: string | null = rawPatch ?? null;
-    let patchTruncated = false;
-    if (rawPatch) {
-      const bounded = truncateUtf8(rawPatch, patchBytesRemaining);
-      patch = bounded.length > 0 ? bounded : null;
-      patchTruncated = bounded.length < rawPatch.length;
-      boundedPatches ||= patchTruncated;
-      patchBytesRemaining -= Buffer.byteLength(bounded, "utf8");
-    }
+    const bounded = file.patch
+      ? truncateUtf8(file.patch, patchBytesRemaining)
+      : "";
+    const patchTruncated = Boolean(
+      file.patch && bounded.length < file.patch.length,
+    );
+    boundedPatches ||= patchTruncated;
+    patchBytesRemaining -= Buffer.byteLength(bounded, "utf8");
     return [
       {
         path: file.filename,
@@ -623,7 +718,7 @@ export async function prFiles(
         additions: file.additions ?? 0,
         deletions: file.deletions ?? 0,
         changes: file.changes ?? 0,
-        patch,
+        patch: bounded || null,
         patchTruncated,
       },
     ];
@@ -635,12 +730,6 @@ export async function prFiles(
   };
 }
 
-const mergeMethodFlag: Record<GithubPrMergeMethod, string> = {
-  merge: "--merge",
-  squash: "--squash",
-  rebase: "--rebase",
-};
-
 export async function mergePr(
   context: GithubServiceContext,
   projectId: string,
@@ -649,44 +738,46 @@ export async function mergePr(
   method: GithubPrMergeMethod,
   expectedHeadOid: string,
 ): Promise<GithubPrMergeResponse> {
-  const repoDir = context.resolveRepoDir(projectId, relativePath);
-  await context.ensureGithubRemote(repoDir);
-  const [settings, urlResult] = await Promise.all([
-    repoMergeSettings(context, repoDir),
-    context.mapGh(() =>
-      context.runGh(repoDir, [
-        "pr",
-        "view",
-        String(number),
-        "--json",
-        "url",
-        "--jq",
-        ".url",
-      ]),
-    ),
-  ]);
-  if (!settings.allowedMethods.includes(method)) {
+  const { repoDir, repository } = await preparePr(
+    context,
+    projectId,
+    relativePath,
+  );
+  const settingsData = await context.githubApi.graphql<RepositoryResponse>(
+    repository,
+    "pull-request-merge-settings",
+    `query MergeSettings($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) { ${REPOSITORY_SETTINGS_FIELDS} }
+    }`,
+    { owner: repository.owner, repo: repository.repo },
+  );
+  const settings = requireRepository(settingsData);
+  if (!allowedMergeMethods(settings).includes(method))
     throw new GitWorkflowError(
       409,
       "GH_PR_MERGE_METHOD_DISABLED",
       `The repository does not allow the ${method} merge method.`,
     );
-  }
-  await context.mapGh(() =>
-    context.runGh(repoDir, [
-      "pr",
-      "merge",
-      String(number),
-      mergeMethodFlag[method],
-      "--match-head-commit",
-      expectedHeadOid,
-    ]),
+  const result = await context.githubApi.rest<{ merged?: boolean }>(
+    repository,
+    `/repos/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/pulls/${number}/merge`,
+    {
+      method: "PUT",
+      operation: "merge-pull-request",
+      body: { merge_method: method, sha: expectedHeadOid },
+    },
   );
+  if (!result.merged)
+    throw new GitWorkflowError(
+      409,
+      "GH_CONFLICT",
+      "GitHub could not merge the pull request.",
+    );
   context.invalidateStableMetadata(repoDir);
   return {
     number,
     merged: true,
-    url: urlResult.stdout.trim(),
+    url: `https://github.com/${repository.owner}/${repository.repo}/pull/${number}`,
   };
 }
 
@@ -696,18 +787,16 @@ export async function checkoutPr(
   relativePath: string,
   number: number,
 ): Promise<GithubPrCheckoutResponse> {
-  const repoDir = context.resolveRepoDir(projectId, relativePath);
-  await context.ensureGithubRemote(repoDir);
+  const { repoDir } = await preparePr(context, projectId, relativePath);
   const { files } = parsePorcelainV2(
     (await context.runGit(repoDir, ["status", "--porcelain=v2"])).stdout,
   );
-  if (files.length > 0) {
+  if (files.length > 0)
     throw new GitWorkflowError(
       409,
       "GIT_DIRTY_WORKTREE",
       "Working tree has uncommitted changes. Commit or stash them before checking out a PR.",
     );
-  }
   await context.mapGh(() =>
     context.runGh(repoDir, ["pr", "checkout", String(number)]),
   );

--- a/packages/tools/src/git/git-observability.ts
+++ b/packages/tools/src/git/git-observability.ts
@@ -10,6 +10,13 @@ export interface GitCommandObservation {
   readonly succeeded: boolean;
 }
 
+export interface GithubRequestObservation {
+  readonly operation: string;
+  readonly durationMs: number;
+  readonly succeeded: boolean;
+  readonly status?: number;
+}
+
 export interface GitOverviewObservation {
   readonly durationMs: number;
   readonly succeeded: boolean;
@@ -19,5 +26,8 @@ export interface GitServiceOptions {
   readonly stableMetadataTtlMs?: number;
   readonly now?: () => number;
   readonly onCommandCompleted?: (observation: GitCommandObservation) => void;
+  readonly onGithubRequestCompleted?: (
+    observation: GithubRequestObservation,
+  ) => void;
   readonly onOverviewCompleted?: (observation: GitOverviewObservation) => void;
 }

--- a/packages/tools/src/git/git-repository-metadata.ts
+++ b/packages/tools/src/git/git-repository-metadata.ts
@@ -4,13 +4,18 @@ import {
   readRefSnapshot,
   type GitRefSnapshot,
 } from "./git-branches.js";
+import type { GithubRepositoryRef } from "./git-github-parsers.js";
 import type { GitService } from "./git-service.js";
 
 export type StableRepoMetadata = {
   readonly refSnapshot: GitRefSnapshot;
   readonly baseBranch: string;
   readonly comparisonBaseRef: string;
-  readonly remoteState: { hasRemote: boolean; hasGithubRemote: boolean };
+  readonly remoteState: {
+    hasRemote: boolean;
+    hasGithubRemote: boolean;
+    githubRepository: GithubRepositoryRef | null;
+  };
 };
 
 type CacheEntry = {

--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -36,7 +36,11 @@ import {
   runGitCommand,
 } from "./git-command.js";
 import { GitWorkflowError } from "./git-errors.js";
-import { isGithubRemoteUrl, parseGitRemoteUrls } from "./git-github-parsers.js";
+import { GithubApiClient } from "./git-github-api-client.js";
+import {
+  parseGithubRepositoryRemote,
+  parseGitRemoteUrls,
+} from "./git-github-parsers.js";
 import {
   checkoutPr as checkoutGithubPr,
   type GithubServiceContext,
@@ -73,6 +77,7 @@ const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next"]);
 
 export class GitService {
   readonly #stableMetadataCache: GitRepositoryMetadataCache;
+  readonly #githubApi: GithubApiClient;
 
   constructor(
     readonly getProject: (projectId: string) => GitWorkspaceRef,
@@ -83,6 +88,19 @@ export class GitService {
       options.stableMetadataTtlMs ?? 30_000,
       options.now ?? Date.now,
     );
+    this.#githubApi = new GithubApiClient({
+      tokenProvider: async (hostname) =>
+        (
+          await this.runGh(process.cwd(), [
+            "auth",
+            "token",
+            "--hostname",
+            hostname,
+          ])
+        ).stdout,
+      now: options.now,
+      onRequestCompleted: options.onGithubRequestCompleted,
+    });
   }
 
   static forWorkspace(rootDir: string, name = basename(rootDir)): GitService {
@@ -171,16 +189,21 @@ export class GitService {
 
   async repoRemoteState(
     repoDir: string,
-  ): Promise<{ hasRemote: boolean; hasGithubRemote: boolean }> {
+  ): Promise<StableRepoMetadata["remoteState"]> {
     try {
       const { stdout } = await this.runGit(repoDir, ["remote", "-v"]);
-      const urls = parseGitRemoteUrls(stdout);
+      const githubRepository = parseGithubRepositoryRemote(stdout);
       return {
-        hasRemote: stdout.trim().length > 0,
-        hasGithubRemote: urls.some(isGithubRemoteUrl),
+        hasRemote: parseGitRemoteUrls(stdout).length > 0,
+        hasGithubRemote: githubRepository !== null,
+        githubRepository,
       };
     } catch {
-      return { hasRemote: false, hasGithubRemote: false };
+      return {
+        hasRemote: false,
+        hasGithubRemote: false,
+        githubRepository: null,
+      };
     }
   }
 
@@ -853,6 +876,7 @@ export class GitService {
         this.resolveRepoDir(projectId, relativePath),
       repoRemoteState: async (repoDir) =>
         (await this.stableRepoMetadata(repoDir)).remoteState,
+      githubApi: this.#githubApi,
       runGh: (repoDir, args) => this.runGh(repoDir, args),
       runGit: (repoDir, args) => this.runGit(repoDir, args),
       ensureGithubRemote: (repoDir) => this.ensureGithubRemote(repoDir),
@@ -896,6 +920,8 @@ export { GitCommandError } from "./git-command.js";
 export {
   isGithubRemoteUrl,
   parseGithubChecks,
+  parseGithubRepositoryRemote,
+  parseGithubRepositoryUrl,
   parseGitRemoteUrls,
   summarizeChecks,
   summarizeStatusCheckRollup,

--- a/packages/tools/test/git-github-api-client.test.ts
+++ b/packages/tools/test/git-github-api-client.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { GithubApiClient } from "../src/git/git-github-api-client.js";
+import {
+  parseGithubRepositoryRemote,
+  parseGithubRepositoryUrl,
+} from "../src/git/git-github-parsers.js";
+
+const repository = {
+  hostname: "github.com" as const,
+  owner: "example",
+  repo: "repo",
+  remoteUrl: "git@github.com:example/repo.git",
+};
+
+describe("GitHub repository parsing", () => {
+  it("parses HTTPS, SSH, and SCP-like remotes", () => {
+    assert.deepEqual(parseGithubRepositoryUrl("https://github.com/a/b.git"), {
+      hostname: "github.com",
+      owner: "a",
+      repo: "b",
+      remoteUrl: "https://github.com/a/b.git",
+    });
+    assert.equal(
+      parseGithubRepositoryUrl("ssh://git@github.com/a/b.git")?.repo,
+      "b",
+    );
+    assert.equal(
+      parseGithubRepositoryUrl("git@github.com:a/b.git")?.owner,
+      "a",
+    );
+    assert.equal(parseGithubRepositoryUrl("https://gitlab.com/a/b.git"), null);
+  });
+
+  it("prefers the origin fetch remote", () => {
+    const result = parseGithubRepositoryRemote(
+      "upstream\tgit@github.com:other/upstream.git (fetch)\n" +
+        "origin\thttps://github.com/example/repo.git (push)\n" +
+        "origin\thttps://github.com/example/repo.git (fetch)\n",
+    );
+    assert.equal(result?.owner, "example");
+    assert.equal(result?.repo, "repo");
+  });
+});
+
+describe("GithubApiClient", () => {
+  it("deduplicates token acquisition and sends bearer authentication", async () => {
+    let tokenCalls = 0;
+    const headers: string[] = [];
+    const client = new GithubApiClient({
+      tokenProvider: async () => {
+        tokenCalls += 1;
+        return "secret-token";
+      },
+      fetch: async (_input, init) => {
+        headers.push(new Headers(init?.headers).get("authorization") ?? "");
+        return Response.json({ login: "octocat" });
+      },
+    });
+    await Promise.all([
+      client.rest(repository, "/user", { operation: "one" }),
+      client.rest(repository, "/user", { operation: "two" }),
+    ]);
+    assert.equal(tokenCalls, 1);
+    assert.deepEqual(headers, ["Bearer secret-token", "Bearer secret-token"]);
+  });
+
+  it("reacquires once after a 401", async () => {
+    let tokenCalls = 0;
+    let requests = 0;
+    const client = new GithubApiClient({
+      tokenProvider: async () => `token-${++tokenCalls}`,
+      fetch: async () => {
+        requests += 1;
+        return requests === 1
+          ? new Response(null, { status: 401 })
+          : Response.json({ login: "octocat" });
+      },
+    });
+    const result = await client.rest<{ login: string }>(repository, "/user", {
+      operation: "status",
+    });
+    assert.equal(result.login, "octocat");
+    assert.equal(tokenCalls, 2);
+  });
+
+  it("never includes a token in API errors", async () => {
+    const client = new GithubApiClient({
+      tokenProvider: async () => "highly-secret-token",
+      fetch: async () => new Response("highly-secret-token", { status: 403 }),
+    });
+    await assert.rejects(
+      client.rest(repository, "/user", { operation: "status" }),
+      (error: Error) => !error.message.includes("highly-secret-token"),
+    );
+  });
+});

--- a/packages/tools/test/git-github-service.test.ts
+++ b/packages/tools/test/git-github-service.test.ts
@@ -3,18 +3,20 @@ import { describe, it } from "node:test";
 import type { GithubPrListFilters } from "@nervekit/contracts";
 import {
   allowedMergeMethods,
-  githubPrListArgs,
+  githubPrSearch,
   listOpenPrs,
   mergePr,
-  prChecks,
-  prConversation,
-  prCore,
   prFiles,
   prInitial,
-  prOverview,
 } from "../src/git/git-github-service.js";
 import { summarizeStatusCheckRollup } from "../src/git/git-github-parsers.js";
 
+const repository = {
+  hostname: "github.com" as const,
+  owner: "example",
+  repo: "repo",
+  remoteUrl: "git@github.com:example/repo.git",
+};
 const defaults: GithubPrListFilters = {
   author: "any",
   drafts: "include",
@@ -23,210 +25,190 @@ const defaults: GithubPrListFilters = {
   sort: "updated-desc",
 };
 
+function context(api: {
+  graphql?: (operation: string, variables: Record<string, unknown>) => unknown;
+  rest?: (
+    path: string,
+    options: { body?: unknown; method?: string },
+  ) => unknown;
+}) {
+  return {
+    resolveRepoDir: () => "/repo",
+    ensureGithubRemote: async () => undefined,
+    repoRemoteState: async () => ({
+      hasRemote: true,
+      hasGithubRemote: true,
+      githubRepository: repository,
+    }),
+    githubApi: {
+      graphql: async <T>(
+        _repository: unknown,
+        operation: string,
+        _query: string,
+        variables: Record<string, unknown>,
+      ) => api.graphql?.(operation, variables) as T,
+      rest: async <T>(
+        _repository: unknown,
+        path: string,
+        options: { body?: unknown; method?: string },
+      ) => api.rest?.(path, options) as T,
+    },
+    invalidateStableMetadata: () => undefined,
+  } as unknown as Parameters<typeof listOpenPrs>[0];
+}
+
 describe("GitHub PR listing", () => {
-  it("builds exact server-side filters with a fixed limit", () => {
-    const args = githubPrListArgs({
-      author: "me",
-      drafts: "exclude",
-      title: 'fix "Windows" \\ paths',
-      head: "feature/git-panel",
-      labels: ["bug", "needs review"],
-      sort: "updated-asc",
-    });
-    assert.deepEqual(args.slice(0, 6), [
-      "pr",
-      "list",
-      "--state",
-      "open",
-      "--limit",
-      "10",
-    ]);
-    assert.ok(args.includes("@me"));
-    assert.ok(args.includes("feature/git-panel"));
-    assert.equal(args.filter((arg) => arg === "--label").length, 2);
-    const search = args[args.indexOf("--search") + 1];
+  it("builds exact server-side filters", () => {
     assert.equal(
-      search,
-      'sort:updated-asc in:title "fix \\"Windows\\" \\\\ paths" draft:false',
+      githubPrSearch({
+        author: "me",
+        drafts: "exclude",
+        title: 'fix "Windows" \\ paths',
+        head: "feature/git-panel",
+        labels: ["bug", "needs review"],
+        sort: "updated-asc",
+      }),
+      'is:pr is:open author:@me head:"feature/git-panel" label:"bug" label:"needs review" in:title "fix \\"Windows\\" \\\\ paths" draft:false sort:updated-asc',
     );
-    assert.match(args.at(-1) ?? "", /statusCheckRollup/);
   });
 
-  it("lists PRs and checks with one gh invocation", async () => {
-    const calls: string[][] = [];
-    const context = {
-      resolveRepoDir: () => "/repo",
-      ensureGithubRemote: async () => undefined,
-      mapGh: async <T>(fn: () => Promise<T>) => fn(),
-      runGh: async (_repo: string, args: string[]) => {
-        calls.push(args);
-        return {
-          stderr: "",
-          stdout: JSON.stringify([
-            {
-              number: 7,
-              title: "Fast panel",
-              url: "https://github.com/example/repo/pull/7",
-              state: "OPEN",
-              isDraft: false,
-              headRefName: "feature",
-              baseRefName: "main",
-              updatedAt: "2026-07-20T00:00:00Z",
-              statusCheckRollup: [
+  it("lists PRs and check rollups with one GraphQL request", async () => {
+    const calls: string[] = [];
+    const result = await listOpenPrs(
+      context({
+        graphql: (operation) => {
+          calls.push(operation);
+          return {
+            search: {
+              nodes: [
                 {
-                  __typename: "CheckRun",
-                  name: "test",
-                  status: "COMPLETED",
-                  conclusion: "SUCCESS",
-                  detailsUrl: "https://example.test/check",
+                  number: 7,
+                  title: "Fast panel",
+                  url: "https://github.com/example/repo/pull/7",
+                  state: "OPEN",
+                  isDraft: false,
+                  headRefName: "feature",
+                  baseRefName: "main",
+                  updatedAt: "2026-07-20T00:00:00Z",
+                  commits: {
+                    nodes: [
+                      {
+                        commit: {
+                          statusCheckRollup: {
+                            contexts: {
+                              nodes: [
+                                {
+                                  __typename: "CheckRun",
+                                  name: "test",
+                                  status: "COMPLETED",
+                                  conclusion: "SUCCESS",
+                                },
+                              ],
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
                 },
               ],
             },
-          ]),
-        };
-      },
-    };
-    const result = await listOpenPrs(
-      context as Parameters<typeof listOpenPrs>[0],
+          };
+        },
+      }),
       "proj_test",
       ".",
       defaults,
     );
-    assert.equal(calls.length, 1);
+    assert.deepEqual(calls, ["list-pull-requests"]);
     assert.equal(result.prs[0]?.checks.status, "passing");
-    assert.equal(result.prs[0]?.checks.runs[0]?.name, "test");
   });
 });
 
-describe("GitHub PR detail and mutations", () => {
-  it("loads core and detail sections independently", async () => {
-    const calls: string[][] = [];
-    const context = {
-      resolveRepoDir: () => "/repo",
-      ensureGithubRemote: async () => undefined,
-      mapGh: async <T>(fn: () => Promise<T>) => fn(),
-      runGh: async (_repo: string, args: string[]) => {
-        calls.push(args);
-        if (args[0] === "repo") {
+describe("GitHub PR details and mutations", () => {
+  it("maps one initial GraphQL response and a REST comparison", async () => {
+    const operations: string[] = [];
+    const result = await prInitial(
+      context({
+        graphql: (operation) => {
+          operations.push(operation);
           return {
-            stderr: "",
-            stdout: JSON.stringify({
-              nameWithOwner: "example/repo",
+            repository: {
               mergeCommitAllowed: false,
               squashMergeAllowed: true,
               rebaseMergeAllowed: true,
-            }),
+              pullRequest: {
+                number: 7,
+                title: "Feature rich PR",
+                url: "https://github.com/example/repo/pull/7",
+                state: "OPEN",
+                isDraft: false,
+                headRefName: "feature",
+                baseRefName: "main",
+                headRefOid: "head123",
+                baseRefOid: "base123",
+                updatedAt: "2026-07-21T00:00:00Z",
+                createdAt: "2026-07-20T00:00:00Z",
+                author: { login: "octocat" },
+                changedFiles: 1,
+                body: "Description",
+                comments: {
+                  nodes: [
+                    {
+                      id: "comment-1",
+                      author: { login: "reviewer" },
+                      body: "Looks good",
+                      createdAt: "2026-07-21T00:00:00Z",
+                    },
+                  ],
+                },
+                reviews: { nodes: [] },
+                labels: { nodes: [{ name: "enhancement", color: "00ff00" }] },
+                reviewRequests: {
+                  nodes: [{ requestedReviewer: { login: "next-reviewer" } }],
+                },
+                mergeable: "MERGEABLE",
+              },
+            },
           };
-        }
-        if (args[0] === "api") return { stderr: "", stdout: "2\n" };
-        if (args[1] === "checks") return { stderr: "", stdout: "[]" };
-        return {
-          stderr: "",
-          stdout: JSON.stringify({
-            number: 7,
-            title: "Feature rich PR",
-            url: "https://github.com/example/repo/pull/7",
-            state: "OPEN",
-            isDraft: false,
-            headRefName: "feature",
-            baseRefName: "main",
-            headRefOid: "head1234567",
-            baseRefOid: "base1234567",
-            updatedAt: "2026-07-21T00:00:00Z",
-            createdAt: "2026-07-20T00:00:00Z",
-            author: { login: "octocat" },
-            changedFiles: 1,
-            mergeable: "MERGEABLE",
-            mergeStateStatus: "BEHIND",
-            comments: [
-              {
-                id: "comment-1",
-                author: { login: "reviewer" },
-                body: "Looks good",
-                createdAt: "2026-07-21T00:00:00Z",
-              },
-            ],
-            reviews: [
-              {
-                id: "review-1",
-                author: { login: "maintainer" },
-                state: "APPROVED",
-                body: "Approved",
-                submittedAt: "2026-07-22T00:00:00Z",
-              },
-            ],
-            labels: [{ name: "enhancement", color: "00ff00" }],
-            reviewRequests: [{ login: "next-reviewer" }],
-            commits: [],
-          }),
-        };
-      },
-    };
-
-    const typed = context as Parameters<typeof prCore>[0];
-    const initial = await prInitial(typed, "proj_test", ".", 7);
-    assert.equal(initial.core.title, "Feature rich PR");
-    assert.equal(initial.conversation.comments[0]?.author, "reviewer");
-    assert.equal(initial.overview.behindBy, 2);
-    const initialPrViews = calls.filter(
-      (args) => args[0] === "pr" && args[1] === "view",
+        },
+        rest: (path) => {
+          assert.match(path, /compare\/base123\.\.\.head123/);
+          return { behind_by: 2 };
+        },
+      }) as Parameters<typeof prInitial>[0],
+      "proj_test",
+      ".",
+      7,
     );
-    assert.equal(initialPrViews.length, 1);
-    const initialFields = initialPrViews[0]?.at(-1) ?? "";
-    assert.match(initialFields, /title/);
-    assert.match(initialFields, /comments/);
-    assert.match(initialFields, /mergeStateStatus/);
-
-    calls.length = 0;
-    const core = await prCore(typed, "proj_test", ".", 7);
-    assert.equal(core.title, "Feature rich PR");
-    const coreFields = calls.at(-1)?.at(-1) ?? "";
-    assert.doesNotMatch(coreFields, /comments|commits|statusCheckRollup/);
-
-    const conversation = await prConversation(typed, "proj_test", ".", 7);
-    assert.equal(conversation.comments[0]?.author, "reviewer");
-    assert.equal(conversation.reviews[0]?.state, "APPROVED");
-
-    const overview = await prOverview(typed, "proj_test", ".", 7);
-    assert.deepEqual(overview.mergeSettings.allowedMethods, [
+    assert.deepEqual(operations, ["pull-request-initial"]);
+    assert.equal(result.core.title, "Feature rich PR");
+    assert.equal(result.conversation.comments[0]?.author, "reviewer");
+    assert.equal(result.overview.behindBy, 2);
+    assert.deepEqual(result.overview.mergeSettings.allowedMethods, [
       "squash",
       "rebase",
     ]);
-    assert.equal(overview.behindBy, 2);
-    assert.equal(overview.reviewRequests[0]?.login, "next-reviewer");
-    assert.ok(
-      calls.some((args) => args[0] === "api" && args[1]?.includes("compare")),
-    );
-
-    const checks = await prChecks(typed, "proj_test", ".", 7);
-    assert.equal(checks.checks.status, "none");
   });
 
-  it("maps paginated file patches and rename metadata", async () => {
-    const context = {
-      resolveRepoDir: () => "/repo",
-      ensureGithubRemote: async () => undefined,
-      mapGh: async <T>(fn: () => Promise<T>) => fn(),
-      runGh: async (_repo: string, args: string[]) => {
-        if (args[0] === "pr") return { stderr: "", stdout: "1\n" };
-        return {
-          stderr: "",
-          stdout: JSON.stringify([
-            {
-              filename: "src/new.ts",
-              previous_filename: "src/old.ts",
-              status: "renamed",
-              additions: 2,
-              deletions: 1,
-              changes: 3,
-              patch: "@@ -1 +1 @@\n-old\n+new",
-            },
-          ]),
-        };
-      },
-    };
+  it("maps bounded file patches and rename metadata", async () => {
     const result = await prFiles(
-      context as Parameters<typeof prFiles>[0],
+      context({
+        rest: (path) =>
+          path.endsWith("/files?per_page=100&page=1")
+            ? [
+                {
+                  filename: "src/new.ts",
+                  previous_filename: "src/old.ts",
+                  status: "renamed",
+                  additions: 2,
+                  deletions: 1,
+                  changes: 3,
+                  patch: "@@ -1 +1 @@\n-old\n+new",
+                },
+              ]
+            : { changed_files: 1 },
+      }) as Parameters<typeof prFiles>[0],
       "proj_test",
       ".",
       7,
@@ -235,10 +217,9 @@ describe("GitHub PR detail and mutations", () => {
     assert.equal(result.truncated, false);
     assert.equal(result.files[0]?.previousPath, "src/old.ts");
     assert.equal(result.files[0]?.status, "renamed");
-    assert.match(result.files[0]?.patch ?? "", /\+new/);
   });
 
-  it("uses repository-allowed noninteractive merge methods with a head guard", async () => {
+  it("uses allowed merge methods and sends the expected head SHA", async () => {
     assert.deepEqual(
       allowedMergeMethods({
         mergeCommitAllowed: true,
@@ -247,74 +228,40 @@ describe("GitHub PR detail and mutations", () => {
       }),
       ["merge", "rebase"],
     );
-    for (const [method, flag] of [
-      ["merge", "--merge"],
-      ["squash", "--squash"],
-      ["rebase", "--rebase"],
-    ] as const) {
-      const calls: string[][] = [];
-      const context = {
-        resolveRepoDir: () => "/repo",
-        ensureGithubRemote: async () => undefined,
-        invalidateStableMetadata: () => undefined,
-        mapGh: async <T>(fn: () => Promise<T>) => fn(),
-        runGh: async (_repo: string, args: string[]) => {
-          calls.push(args);
-          if (args[0] === "repo") {
-            return {
-              stderr: "",
-              stdout: JSON.stringify({
-                nameWithOwner: "example/repo",
-                mergeCommitAllowed: true,
-                squashMergeAllowed: true,
-                rebaseMergeAllowed: true,
-              }),
-            };
-          }
-          if (args[1] === "view") {
-            return {
-              stderr: "",
-              stdout: "https://github.com/example/repo/pull/7\n",
-            };
-          }
-          return { stderr: "", stdout: "" };
+    let body: unknown;
+    const result = await mergePr(
+      context({
+        graphql: () => ({
+          repository: {
+            mergeCommitAllowed: true,
+            squashMergeAllowed: true,
+            rebaseMergeAllowed: true,
+          },
+        }),
+        rest: (_path, options) => {
+          body = options.body;
+          return { merged: true };
         },
-      };
-      await mergePr(
-        context as Parameters<typeof mergePr>[0],
-        "proj_test",
-        ".",
-        7,
-        method,
-        "head1234567",
-      );
-      assert.ok(
-        calls.some((args) =>
-          args
-            .join(" ")
-            .includes(`pr merge 7 ${flag} --match-head-commit head1234567`),
-        ),
-      );
-    }
+      }) as Parameters<typeof mergePr>[0],
+      "proj_test",
+      ".",
+      7,
+      "squash",
+      "head1234567",
+    );
+    assert.deepEqual(body, {
+      merge_method: "squash",
+      sha: "head1234567",
+    });
+    assert.equal(result.url, "https://github.com/example/repo/pull/7");
   });
 });
 
 describe("status check rollups", () => {
   it("normalizes check runs and status contexts", () => {
     const summary = summarizeStatusCheckRollup([
-      {
-        __typename: "CheckRun",
-        name: "build",
-        status: "IN_PROGRESS",
-        conclusion: null,
-      },
-      {
-        __typename: "StatusContext",
-        context: "lint",
-        state: "FAILURE",
-        targetUrl: "https://example.test/lint",
-      },
-      { unexpected: true },
+      { name: "build", status: "IN_PROGRESS", conclusion: null },
+      { context: "lint", state: "FAILURE", targetUrl: "https://example.test" },
     ]);
     assert.equal(summary.status, "failing");
     assert.equal(summary.total, 2);

--- a/packages/ui-kit/src/lib/components/ui/spinner/spinner.svelte
+++ b/packages/ui-kit/src/lib/components/ui/spinner/spinner.svelte
@@ -4,29 +4,39 @@ import type { SVGAttributes } from "svelte/elements";
 
 let {
   class: className,
+  variant = "ring",
   role = "status",
   "aria-label": ariaLabel = "Loading",
   ...restProps
-}: SVGAttributes<SVGSVGElement> = $props();
+}: SVGAttributes<SVGSVGElement> & { variant?: "ring" | "refresh" } = $props();
 </script>
 
 <svg
   viewBox="0 0 24 24"
   fill="none"
+  stroke="currentColor"
   {role}
   aria-label={ariaLabel}
   class={cn("spinner-ring size-4", className)}
   {...restProps}
 >
-  <circle
-    cx="12"
-    cy="12"
-    r="9"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="butt"
-    pathLength="100"
-    stroke-dasharray="88 12"
-  />
+  {#if variant === "refresh"}
+    <path
+      d="M21 12a9 9 0 0 0-15.219-6.219L3 8m0-5v5h5m-5 4a9 9 0 0 0 15.219 6.219L21 16m0 5v-5h-5"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  {:else}
+    <circle
+      cx="12"
+      cy="12"
+      r="9"
+      fill="none"
+      stroke-width="2"
+      stroke-linecap="butt"
+      pathLength="100"
+      stroke-dasharray="88 12"
+    />
+  {/if}
 </svg>

--- a/packages/workbench-app/src/lib/features/git/components/PrShell.svelte
+++ b/packages/workbench-app/src/lib/features/git/components/PrShell.svelte
@@ -91,9 +91,11 @@ $effect(() => {
   onRefresh={() =>
     activeCenterPrView && void refreshPrPane(activeCenterPrView.id)}
   onCheckout={() => void checkoutActivePr()}
-  onOpenExternal={() =>
-    activeCenterPrView?.core.data &&
-    window.open(activeCenterPrView.core.data.url, "_blank", "noopener")}
+  onOpenExternal={() => {
+    const url =
+      activeCenterPrView?.core.data?.url ?? activeCenterPrView?.summary?.url;
+    if (url) window.open(url, "_blank", "noopener");
+  }}
   onTabChange={(tab) =>
     activeCenterPrView && selectPrTab(activeCenterPrView.id, tab)}
   onSectionRetry={retrySection}

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
@@ -1,3 +1,4 @@
+import { SvelteMap } from "svelte/reactivity";
 import type { ProjectRecord } from "$lib/api";
 import type { GithubPrListFilters } from "@nervekit/contracts";
 import {
@@ -28,6 +29,7 @@ import {
   filterMergedOpenPrs,
   type GitPanelProjectState,
   type GitPanelRefreshOptions,
+  type GitPanelRepoState,
   gitPanelState,
   mergeRepoSummary,
   patchGitOverviewState,
@@ -312,6 +314,24 @@ export async function refreshGithub(
   }
 }
 
+const prRefreshRequests = new SvelteMap<string, Promise<void>>();
+
+function currentPrFilters(state: GitPanelRepoState): GithubPrListFilters {
+  return {
+    author: state.prFilters.author,
+    ...(state.prFilters.author === "username"
+      ? { username: state.prFilters.username }
+      : {}),
+    drafts: state.prFilters.drafts,
+    title: state.prFilters.title,
+    ...(state.prFilters.currentBranchOnly && state.repoSummary?.currentBranch
+      ? { head: state.repoSummary.currentBranch }
+      : {}),
+    labels: [...state.prFilters.labels],
+    sort: state.prFilters.sort,
+  };
+}
+
 export async function refreshPrs(
   projectId: string,
   repo: string,
@@ -324,69 +344,85 @@ export async function refreshPrs(
     clearGithubState(projectId, state);
     return;
   }
-  if (state.prsRequestInFlight) {
+  const refreshKey = automaticRefreshKey(projectId, repo);
+  const existing = prRefreshRequests.get(refreshKey);
+  if (existing) {
     state.prsRefreshQueued ||= force;
-    return;
+    state.prsQueuedVisible ||= showLoading;
+    if (showLoading) {
+      state.loadingPrs = true;
+      state.prsError = undefined;
+    }
+    return existing;
   }
-  automaticRefreshScheduler.noteDirectStart(
-    automaticRefreshKey(projectId, repo),
-    { prs: true },
-  );
-  const requestSeq = state.prsRequestSeq + 1;
-  state.prsRequestSeq = requestSeq;
+
+  if (showLoading) {
+    state.loadingPrs = true;
+    state.prsError = undefined;
+  }
   state.prsRequestInFlight = true;
-  if (showLoading) state.loadingPrs = true;
-  try {
-    const filters: GithubPrListFilters = {
-      author: state.prFilters.author,
-      ...(state.prFilters.author === "username"
-        ? { username: state.prFilters.username }
-        : {}),
-      drafts: state.prFilters.drafts,
-      title: state.prFilters.title,
-      ...(state.prFilters.currentBranchOnly && state.repoSummary?.currentBranch
-        ? { head: state.repoSummary.currentBranch }
-        : {}),
-      labels: [...state.prFilters.labels],
-      sort: state.prFilters.sort,
-    };
-    const queryKey = queryKeys.git.prs(
-      projectId,
-      repo,
-      githubPrFiltersFingerprint(filters),
-    );
-    if (force) await queryClient.invalidateQueries({ queryKey });
-    const result = await queryClient.fetchQuery({
-      queryKey,
-      queryFn: () => listGithubPrs(projectId, repo, filters),
-      staleTime: hasPendingPrChecks(state.prs)
-        ? PR_PENDING_POLL_MS
-        : GIT_STALE_MS,
-    });
-    if (state.prsRequestSeq === requestSeq) {
-      const prs = filterMergedOpenPrs(projectId, repo, result.prs);
-      setPrsIfChanged(state, prs);
-      syncOpenPrViews(projectId, repo, prs);
-    }
-  } catch (error) {
-    if (state.prsRequestSeq === requestSeq && !silent) {
-      notify.error(`Could not list PRs: ${errorMessage(error)}`);
-    }
-  } finally {
-    if (state.prsRequestSeq === requestSeq) {
-      if (showLoading) state.loadingPrs = false;
-      state.prsRequestInFlight = false;
-      if (state.prsRefreshQueued) {
+  automaticRefreshScheduler.noteDirectStart(refreshKey, { prs: true });
+
+  const request = (async () => {
+    let nextSilent = silent;
+    let nextForce = force;
+    try {
+      do {
         state.prsRefreshQueued = false;
-        queueMicrotask(() => {
+        state.prsQueuedVisible = false;
+        const requestSeq = state.prsRequestSeq + 1;
+        state.prsRequestSeq = requestSeq;
+        try {
+          const filters = currentPrFilters(state);
+          const queryKey = queryKeys.git.prs(
+            projectId,
+            repo,
+            githubPrFiltersFingerprint(filters),
+          );
+          if (nextForce) await queryClient.invalidateQueries({ queryKey });
+          const result = await queryClient.fetchQuery({
+            queryKey,
+            queryFn: () => listGithubPrs(projectId, repo, filters),
+            staleTime: hasPendingPrChecks(state.prs)
+              ? PR_PENDING_POLL_MS
+              : GIT_STALE_MS,
+          });
           if (
-            typeof document === "undefined" ||
-            document.visibilityState === "visible"
-          )
-            void refreshPrs(projectId, repo, true, true);
-        });
-      }
+            state.prsRequestSeq === requestSeq &&
+            githubPrFiltersFingerprint(filters) ===
+              githubPrFiltersFingerprint(currentPrFilters(state))
+          ) {
+            const prs = filterMergedOpenPrs(projectId, repo, result.prs);
+            setPrsIfChanged(state, prs);
+            syncOpenPrViews(projectId, repo, prs);
+            state.prsError = undefined;
+          }
+        } catch (error) {
+          if (state.prsRequestSeq === requestSeq && !nextSilent) {
+            state.prsError = errorMessage(error);
+            notify.error(`Could not list PRs: ${state.prsError}`);
+          }
+        }
+        nextForce = state.prsRefreshQueued;
+        nextSilent = !state.prsQueuedVisible;
+      } while (
+        state.prsRefreshQueued &&
+        (typeof document === "undefined" ||
+          document.visibilityState === "visible")
+      );
+    } finally {
+      state.prsRequestInFlight = false;
+      state.prsRefreshQueued = false;
+      state.prsQueuedVisible = false;
+      state.loadingPrs = false;
     }
+  })();
+  prRefreshRequests.set(refreshKey, request);
+  try {
+    await request;
+  } finally {
+    if (prRefreshRequests.get(refreshKey) === request)
+      prRefreshRequests.delete(refreshKey);
   }
 }
 

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
@@ -65,9 +65,11 @@ export type GitPanelRepoState = {
   operations: GitPanelOperationsState;
   loadingOverview: boolean;
   loadingPrs: boolean;
+  prsError?: string;
   loadingBranches: boolean;
   prsRequestInFlight: boolean;
   prsRefreshQueued: boolean;
+  prsQueuedVisible: boolean;
   prsRequestSeq: number;
   overviewRequestInFlight: boolean;
   overviewRefreshQueued: boolean;
@@ -172,9 +174,11 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     operations: createOperationsState(),
     loadingOverview: false,
     loadingPrs: false,
+    prsError: undefined,
     loadingBranches: false,
     prsRequestInFlight: false,
     prsRefreshQueued: false,
+    prsQueuedVisible: false,
     prsRequestSeq: 0,
     overviewRequestInFlight: false,
     overviewRefreshQueued: false,
@@ -613,6 +617,14 @@ export function clearGithubState(
   }
   if (state.prsRefreshQueued) {
     state.prsRefreshQueued = false;
+    changed = true;
+  }
+  if (state.prsQueuedVisible) {
+    state.prsQueuedVisible = false;
+    changed = true;
+  }
+  if (state.prsError) {
+    state.prsError = undefined;
     changed = true;
   }
   if (changed) applyGitContextFromProject(projectId);

--- a/packages/workbench-app/src/lib/features/git/state/git-refresh-coordinator.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-refresh-coordinator.svelte.ts
@@ -35,6 +35,7 @@ import { GIT_STALE_MS, PR_PENDING_POLL_MS } from "./git-refresh-policy";
 export const GIT_RESOURCE_STALE_MS = GIT_STALE_MS;
 export const PR_CONVERSATION_STALE_MS = 60_000;
 const IMMUTABLE_HEAD_STALE_MS = Number.POSITIVE_INFINITY;
+const PR_DETAIL_CACHE_MS = 5 * 60_000;
 
 type LoadOptions = { force?: boolean; silent?: boolean };
 type Section = "conversation" | "overview" | "commits" | "checks" | "files";
@@ -75,18 +76,19 @@ async function fetchResource<T>(input: {
   if (!input.options?.force) {
     const queryState = queryClient.getQueryState<T>(input.key);
     const cached = queryClient.getQueryData<T>(input.key);
+    if (cached !== undefined && ownsResource(input.key, version)) {
+      if (input.resource.data !== cached) {
+        input.resource.data = cached;
+        input.apply?.(cached);
+      }
+      input.resource.error = undefined;
+    }
     if (
       cached !== undefined &&
       queryState?.dataUpdatedAt !== undefined &&
       Date.now() - queryState.dataUpdatedAt < input.staleTime
-    ) {
-      if (ownsResource(input.key, version) && input.resource.data !== cached) {
-        input.resource.data = cached;
-        input.resource.error = undefined;
-        input.apply?.(cached);
-      }
+    )
       return cached;
-    }
   }
 
   const request = (async (): Promise<T | undefined> => {
@@ -102,6 +104,7 @@ async function fetchResource<T>(input: {
         queryKey: input.key,
         queryFn: input.query,
         staleTime: input.staleTime,
+        gcTime: PR_DETAIL_CACHE_MS,
       });
       if (ownsResource(input.key, version)) {
         if (input.resource.data !== data) {
@@ -245,14 +248,13 @@ export async function loadPrInitial(
   if (!options.force) {
     const queryState = queryClient.getQueryState<GithubPrInitial>(initialKey);
     const cached = queryClient.getQueryData<GithubPrInitial>(initialKey);
+    if (cached !== undefined) applyInitial(cached);
     if (
       cached !== undefined &&
       queryState?.dataUpdatedAt !== undefined &&
       Date.now() - queryState.dataUpdatedAt < GIT_RESOURCE_STALE_MS
-    ) {
-      applyInitial(cached);
+    )
       return cached;
-    }
   }
 
   const resources = [view.core, view.conversation, view.overview] as const;
@@ -272,6 +274,7 @@ export async function loadPrInitial(
         queryFn: () =>
           getGithubPrInitial(view.projectId, view.repo, view.number),
         staleTime: GIT_RESOURCE_STALE_MS,
+        gcTime: PR_DETAIL_CACHE_MS,
       });
       applyInitial(data);
       return data;
@@ -440,14 +443,36 @@ export function demandPrTab(view: PrViewState): void {
 }
 
 export async function refreshCurrentPr(view: PrViewState): Promise<void> {
-  const sections: Section[] =
-    view.activeTab === "conversation"
-      ? ["conversation", "overview", "checks"]
-      : [view.activeTab];
-  await Promise.all([
-    loadPrCore(view, { force: true }),
-    ...sections.map((section) => loadPrSection(view, section, { force: true })),
-  ]);
+  if (view.refreshing) return;
+  view.refreshing = true;
+  view.refreshError = undefined;
+  const previousHeadOid = view.core.data?.headRefOid;
+  try {
+    await loadPrCore(view, { force: true });
+    const headChanged =
+      Boolean(previousHeadOid) &&
+      Boolean(view.core.data?.headRefOid) &&
+      previousHeadOid !== view.core.data?.headRefOid;
+    if (headChanged) {
+      view.commits.data = undefined;
+      view.commits.error = undefined;
+      view.files.data = undefined;
+      view.files.error = undefined;
+      view.selectedFilePath = undefined;
+    }
+    const sections: Section[] =
+      view.activeTab === "conversation"
+        ? ["conversation", "overview", "checks"]
+        : [view.activeTab];
+    await Promise.all(
+      sections.map((section) => loadPrSection(view, section, { force: true })),
+    );
+    view.refreshError =
+      view.core.error ??
+      sections.map((section) => view[section].error).find(Boolean);
+  } finally {
+    view.refreshing = false;
+  }
 }
 
 let activePrId: string | undefined;

--- a/packages/workbench-app/src/lib/features/git/state/git-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-state.svelte.ts
@@ -1,4 +1,5 @@
 import type {
+  GithubPr,
   GithubPrChecksResponse,
   GithubPrCommitsResponse,
   GithubPrConversation,
@@ -25,6 +26,7 @@ export type PrViewState = {
   /** Relative repo path ("." for the project root). */
   repo: string;
   number: number;
+  summary?: GithubPr;
   core: PrResourceState<GithubPrCore>;
   conversation: PrResourceState<GithubPrConversation>;
   overview: PrResourceState<GithubPrOverview>;
@@ -34,6 +36,8 @@ export type PrViewState = {
   activeTab: GithubPrTab;
   selectedFilePath?: string;
   selectedMergeMethod?: GithubPrMergeMethod;
+  refreshing: boolean;
+  refreshError?: string;
   merging: boolean;
   mergeError?: string;
 };

--- a/packages/workbench-app/src/lib/features/git/state/pr-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/pr-tabs.svelte.ts
@@ -43,6 +43,7 @@ function createPrView(input: {
   projectId: string;
   repo: string;
   number: number;
+  summary?: GithubPr;
 }): PrViewState {
   return {
     ...input,
@@ -53,6 +54,7 @@ function createPrView(input: {
     checks: emptyResource(),
     files: emptyResource(),
     activeTab: "conversation",
+    refreshing: false,
     merging: false,
   };
 }
@@ -87,6 +89,7 @@ export function syncOpenPrViews(
     if (view.projectId !== projectId || view.repo !== repo) continue;
     const summary = prs.find((pr) => pr.number === view.number);
     if (!summary) continue;
+    view.summary = summary;
     if (!prChecksEqual(view.checks.data?.checks, summary.checks)) {
       view.checks.data = { checks: summary.checks };
     }
@@ -118,9 +121,10 @@ export async function openPrPane(input: {
   const id = encodePrTabId(input.projectId, input.repo, input.number);
   const key = prViewKey(id);
   addPrTab(id);
-  gitState.prViews[key] ??= createPrView({ id, ...input });
-  const view = gitState.prViews[key];
   const summary = openPrSummary(input.projectId, input.repo, input.number);
+  gitState.prViews[key] ??= createPrView({ id, ...input, summary });
+  const view = gitState.prViews[key];
+  if (summary) view.summary = summary;
   if (summary && !view.checks.data)
     view.checks.data = { checks: summary.checks };
   setActiveCenterTab({ kind: "pr", id });

--- a/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
@@ -125,6 +125,7 @@ export function createWorkbenchGitPanelAdapter(
         loadingOverview: current?.loadingOverview ?? false,
         loadingBranches: current?.loadingBranches ?? false,
         loadingPullRequests: current?.loadingPrs ?? false,
+        pullRequestError: current?.prsError,
         operations: current?.operations ?? {
           fetching: false,
           pulling: false,

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
@@ -266,6 +266,7 @@ function parseSession(value: unknown): ProjectTabSession | undefined {
         checks: { loading: false, refreshing: false },
         files: { loading: false, refreshing: false },
         activeTab: "conversation",
+        refreshing: false,
         merging: false,
       };
     }

--- a/packages/workbench-app/src/lib/presentation/git/GitPullRequestsContent.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPullRequestsContent.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import ListFilter from "@lucide/svelte/icons/list-filter";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
 import type {
   GithubPr,
   GithubStatusResponse,
@@ -8,6 +10,7 @@ import type {
 } from "@nervekit/contracts";
 import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
 import {
+  PanelBanner,
   PanelHeader,
   PanelList,
   PanelToolbarButton,
@@ -34,6 +37,7 @@ type Props = {
   github?: GithubStatusResponse;
   selectedRepoHasGithubRemote: boolean;
   loadingPrs: boolean;
+  refreshError?: string;
   capabilities: GitPanelCapabilities;
   expandedPr?: number;
   onExpandedPrChange?: (number: number | undefined) => void;
@@ -53,6 +57,7 @@ let {
   github,
   selectedRepoHasGithubRemote,
   loadingPrs,
+  refreshError,
   capabilities,
   expandedPr = $bindable(undefined),
   onExpandedPrChange,
@@ -89,9 +94,10 @@ function toggleChecks(pr: GithubPr) {
     />
     <PanelToolbarButton
       icon={RefreshCw}
-      label="Refresh PRs"
+      label={loadingPrs ? "Refreshing pull requests" : "Refresh PRs"}
       title={`Refresh PRs · signed in as ${github.login ?? "unknown"}`}
       loading={loadingPrs}
+      loadingVariant="refresh"
       disabled={!capabilities.refresh.enabled || loadingPrs}
       onclick={onRefreshPrs}
     />
@@ -116,12 +122,29 @@ function toggleChecks(pr: GithubPr) {
     </div>
   {/if}
 
+  {#if refreshError}
+    <PanelBanner tone="destructive" icon={TriangleAlert}>
+      Could not refresh PRs: {refreshError}
+      {#snippet actions()}
+        <PanelToolbarButton
+          icon={RotateCcw}
+          label="Retry refreshing pull requests"
+          dense
+          disabled={loadingPrs}
+          onclick={onRefreshPrs}
+        />
+      {/snippet}
+    </PanelBanner>
+  {/if}
+
   {#if selectedRepoSummary && !selectedRepoSummary.hasRemote}
     {@render note("No remote configured for this repository.")}
   {:else if selectedRepoSummary && !selectedRepoSummary.hasGithubRemote}
     {@render note("PRs are only available for GitHub remotes.")}
   {:else if !github}
     <PanelList ariaLabel="Loading pull requests" class="gap-1.5 py-0.5">
+      <GitPullRequestRowSkeleton />
+      <GitPullRequestRowSkeleton />
       <GitPullRequestRowSkeleton />
     </PanelList>
   {:else if !github.available}
@@ -130,6 +153,8 @@ function toggleChecks(pr: GithubPr) {
     {@render note("Not authenticated. Run `gh auth login`.")}
   {:else if loadingPrs && prs.length === 0}
     <PanelList ariaLabel="Loading pull requests" class="gap-1.5 py-0.5">
+      <GitPullRequestRowSkeleton />
+      <GitPullRequestRowSkeleton />
       <GitPullRequestRowSkeleton />
     </PanelList>
   {:else if displayedPrs.length === 0}

--- a/packages/workbench-app/src/lib/presentation/git/GitPullRequestsPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPullRequestsPanelView.svelte
@@ -54,6 +54,7 @@ function selectRepository(repository: string): void {
       github={model.github}
       {selectedRepoHasGithubRemote}
       loadingPrs={model.loadingPullRequests}
+      refreshError={model.pullRequestError}
       capabilities={model.capabilities}
       {expandedPr}
       onExpandedPrChange={selectExpandedPullRequest}

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrFiles.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrFiles.svelte
@@ -7,7 +7,7 @@ import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import * as Empty from "@nervekit/ui-kit/components/ui/empty";
 import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
-import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
 import { buildPanelTree, PanelTree } from "$lib/presentation/panel";
 import GithubPrDiff from "./GithubPrDiff.svelte";
 import GithubPrSection from "./GithubPrSection.svelte";
@@ -32,16 +32,37 @@ const fileUrl = $derived(`${detail.url}/files`);
 </script>
 
 {#if loading && !files}
-  <Empty.Root class="h-full min-h-0 gap-2 py-6">
-    <Empty.Media variant="icon" class="size-8 rounded-md">
-      <Spinner class="size-4" />
-    </Empty.Media>
-    <Empty.Header class="gap-1">
-      <Empty.Title class="text-sm font-medium"
-        >Loading changed files</Empty.Title
+  <div
+    class="@container h-full min-h-0 px-4 pt-1 pb-3"
+    role="status"
+    aria-label="Loading changed files"
+  >
+    <div
+      class="grid h-full min-h-0 grid-cols-1 grid-rows-[auto_minmax(0,1fr)] gap-2 @2xl:grid-cols-[18rem_minmax(0,1fr)] @2xl:grid-rows-1"
+    >
+      <div
+        class="flex h-56 flex-col gap-2 rounded-md border border-border/60 bg-card px-3 py-3 @2xl:h-auto"
       >
-    </Empty.Header>
-  </Empty.Root>
+        <Skeleton class="h-3 w-24" />
+        {#each [0, 1, 2, 3, 4, 5] as row (row)}
+          <div class="flex items-center gap-2 border-t border-border/60 pt-2">
+            <Skeleton class="size-3" />
+            <Skeleton class={row % 2 ? "h-3 w-2/3" : "h-3 w-4/5"} />
+          </div>
+        {/each}
+      </div>
+      <div
+        class="flex min-h-0 flex-col gap-2 rounded-md border border-border/60 bg-card px-3 py-3"
+      >
+        <Skeleton class="h-3 w-1/3" />
+        <Skeleton class="h-4 w-full" />
+        <Skeleton class="h-4 w-11/12" />
+        <Skeleton class="h-4 w-4/5" />
+        <Skeleton class="h-4 w-full" />
+      </div>
+    </div>
+    <span class="sr-only">Loading changed files</span>
+  </div>
 {:else if error && !files}
   <Empty.Root class="h-full min-h-0 gap-2 py-6">
     <Empty.Media variant="icon" class="size-8 rounded-md">

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrHeader.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrHeader.svelte
@@ -9,14 +9,17 @@ import GitMerge from "@lucide/svelte/icons/git-merge";
 import GitPullRequest from "@lucide/svelte/icons/git-pull-request";
 import GitPullRequestDraft from "@lucide/svelte/icons/git-pull-request-draft";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
-import type { GithubPrCore } from "@nervekit/contracts";
+import type { GithubPr, GithubPrCore } from "@nervekit/contracts";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
+import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import { formatPrDateCompact, stateLabel, stateTone } from "./pr-pane-helpers";
 
 type Props = {
-  detail: GithubPrCore;
+  number: number;
+  detail?: GithubPrCore;
+  summary?: GithubPr;
   loading: boolean;
   commitCount?: number;
   onRefresh?: () => void;
@@ -25,20 +28,22 @@ type Props = {
 };
 
 let {
+  number,
   detail,
+  summary,
   loading,
   commitCount,
   onRefresh,
   onCheckout,
   onOpenExternal,
 }: Props = $props();
-
+const display = $derived(detail ?? summary);
 const StateIcon = $derived(
-  detail.isDraft
+  display?.isDraft
     ? GitPullRequestDraft
-    : detail.state === "MERGED"
+    : display?.state === "MERGED"
       ? GitMerge
-      : detail.state === "CLOSED"
+      : display?.state === "CLOSED"
         ? CircleSlash
         : GitPullRequest,
 );
@@ -48,80 +53,99 @@ const StateIcon = $derived(
   <div class="flex items-start justify-between gap-3">
     <div class="min-w-0 flex-1">
       <div class="flex min-w-0 items-center gap-2">
-        <Badge tone={stateTone(detail)} size="sm" class="shrink-0">
-          <StateIcon class="size-3" aria-hidden="true" />
-          {stateLabel(detail)}
-        </Badge>
-        <h1
-          class="min-w-0 truncate text-base font-semibold leading-snug text-foreground"
-          title={detail.title}
-        >
-          {detail.title}
-          <span class="ml-1 font-normal text-muted-foreground"
-            >#{detail.number}</span
+        {#if display}
+          <Badge tone={stateTone(display)} size="sm" class="shrink-0">
+            <StateIcon class="size-3" aria-hidden="true" />
+            {stateLabel(display)}
+          </Badge>
+          <h1
+            class="min-w-0 truncate text-base font-semibold leading-snug text-foreground"
+            title={display.title}
           >
-        </h1>
+            {display.title}
+            <span class="ml-1 font-normal text-muted-foreground">#{number}</span
+            >
+          </h1>
+        {:else}
+          <Skeleton class="h-5 w-16 shrink-0 rounded-full" />
+          <Skeleton class="h-5 w-2/3" />
+          <span class="shrink-0 text-base text-muted-foreground">#{number}</span
+          >
+        {/if}
       </div>
 
-      <div
-        class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
-      >
-        <span>
-          Opened by <span class="font-medium text-foreground"
-            >{detail.author ?? "Unknown author"}</span
-          >
-        </span>
-        <span aria-hidden="true">·</span>
-        <span>{formatPrDateCompact(detail.createdAt)}</span>
-      </div>
+      {#if detail}
+        <div
+          class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
+        >
+          <span>
+            Opened by <span class="font-medium text-foreground"
+              >{detail.author ?? "Unknown author"}</span
+            >
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>{formatPrDateCompact(detail.createdAt)}</span>
+        </div>
+      {:else}
+        <div
+          class="mt-2 flex items-center gap-2"
+          aria-label="Loading pull request author"
+        >
+          <Skeleton class="h-3 w-28" />
+          <Skeleton class="h-3 w-16" />
+        </div>
+      {/if}
 
       <div
         class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground"
       >
-        <span
-          class="inline-flex items-center gap-1"
-          aria-label={`Merges ${detail.headRefName} into ${detail.baseRefName}`}
-        >
-          <Badge variant="outline" size="xs" class="font-mono"
-            >{detail.baseRefName}</Badge
+        {#if display}
+          <span
+            class="inline-flex items-center gap-1"
+            aria-label={`Merges ${display.headRefName} into ${display.baseRefName}`}
           >
-          <ArrowLeft class="size-3" aria-hidden="true" />
-          <Badge variant="outline" size="xs" class="font-mono"
-            >{detail.headRefName}</Badge
-          >
-        </span>
+            <Badge variant="outline" size="xs" class="font-mono"
+              >{display.baseRefName}</Badge
+            >
+            <ArrowLeft class="size-3" aria-hidden="true" />
+            <Badge variant="outline" size="xs" class="font-mono"
+              >{display.headRefName}</Badge
+            >
+          </span>
+        {:else}
+          <Skeleton class="h-5 w-40 rounded-full" />
+        {/if}
         {#if commitCount !== undefined}
           <span
             class="inline-flex items-center gap-1"
-            title={`${commitCount} ${commitCount === 1 ? "commit" : "commits"}`}
+            title={`${commitCount} commits`}
           >
             <GitCommitHorizontal class="size-3.5" aria-hidden="true" />
             <span class="font-medium text-foreground">{commitCount}</span>
-            <span class="sr-only"
-              >{commitCount === 1 ? "commit" : "commits"}</span
+          </span>
+        {:else if !detail}
+          <Skeleton class="h-3 w-10" />
+        {/if}
+        {#if detail}
+          <span
+            class="inline-flex items-center gap-1"
+            title={`${detail.changedFiles} changed files`}
+          >
+            <FileDiff class="size-3.5" aria-hidden="true" />
+            <span class="font-medium text-foreground"
+              >{detail.changedFiles}</span
             >
           </span>
+          <span
+            class="inline-flex items-center gap-1.5"
+            title={`${detail.additions} additions, ${detail.deletions} deletions`}
+          >
+            <span class="font-mono text-success">+{detail.additions}</span>
+            <span class="font-mono text-destructive">−{detail.deletions}</span>
+          </span>
+        {:else}
+          <Skeleton class="h-3 w-24" />
         {/if}
-        <span
-          class="inline-flex items-center gap-1"
-          title={`${detail.changedFiles} changed ${detail.changedFiles === 1 ? "file" : "files"}`}
-        >
-          <FileDiff class="size-3.5" aria-hidden="true" />
-          <span class="font-medium text-foreground">{detail.changedFiles}</span>
-          <span class="sr-only"
-            >changed {detail.changedFiles === 1 ? "file" : "files"}</span
-          >
-        </span>
-        <span
-          class="inline-flex items-center gap-1.5"
-          title={`${detail.additions} additions, ${detail.deletions} deletions`}
-        >
-          <span class="font-mono text-success">+{detail.additions}</span>
-          <span class="font-mono text-destructive">−{detail.deletions}</span>
-          <span class="sr-only"
-            >{detail.additions} additions and {detail.deletions} deletions</span
-          >
-        </span>
       </div>
     </div>
 
@@ -130,14 +154,20 @@ const StateIcon = $derived(
         size="xs"
         variant="outline"
         title="Refresh pull request"
-        aria-label="Refresh pull request"
+        aria-label={loading
+          ? `Refreshing pull request #${number}`
+          : "Refresh pull request"}
         disabled={loading}
         onclick={() => onRefresh?.()}
       >
         {#if loading}
-          <Spinner class="size-3" />
+          <Spinner
+            variant="refresh"
+            class="size-3"
+            aria-label={`Refreshing pull request #${number}`}
+          />
         {:else}
-          <RefreshCw class="size-3" />
+          <RefreshCw class="size-3" aria-hidden="true" />
         {/if}
         Refresh
       </Button>
@@ -146,6 +176,7 @@ const StateIcon = $derived(
         variant="ghost"
         title="Open pull request in browser"
         aria-label="Open pull request in browser"
+        disabled={!display}
         onclick={() => onOpenExternal?.()}
       >
         <ExternalLink class="size-3.5" />
@@ -155,6 +186,7 @@ const StateIcon = $derived(
         variant="ghost"
         title="Check out pull request branch"
         aria-label="Check out pull request branch"
+        disabled={!detail}
         onclick={() => onCheckout?.()}
       >
         <ArrowDownToLine class="size-3.5" />

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrLoadingPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrLoadingPane.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import * as Tabs from "@nervekit/ui-kit/components/ui/tabs";
+import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
+import GithubPrHeader from "./GithubPrHeader.svelte";
+import GithubPrSectionSkeleton from "./GithubPrSectionSkeleton.svelte";
+import type { PrViewState } from "./github-pr-types";
+
+type Props = {
+  view: PrViewState;
+  onRefresh?: () => void;
+  onOpenExternal?: () => void;
+};
+let { view, onRefresh, onOpenExternal }: Props = $props();
+const tabTriggerClass =
+  "h-full flex-none gap-1.5 rounded-sm px-2.5 text-xs font-medium data-active:bg-background data-active:shadow-xs data-active:ring-1 data-active:ring-border";
+</script>
+
+<GithubPrHeader
+  number={view.number}
+  summary={view.summary}
+  loading={view.core.loading || view.refreshing}
+  {onRefresh}
+  {onOpenExternal}
+/>
+<Tabs.Root value="conversation" class="min-h-0 flex-1 gap-0">
+  <div class="shrink-0 px-4 pt-3 pb-2">
+    <Tabs.List
+      class="h-8 gap-1 rounded-md bg-accent/35 p-1 ring-1 ring-border ring-inset"
+    >
+      <Tabs.Trigger value="conversation" class={tabTriggerClass}
+        >Conversation</Tabs.Trigger
+      >
+      <Tabs.Trigger value="commits" class={tabTriggerClass}
+        >Commits</Tabs.Trigger
+      >
+      <Tabs.Trigger value="checks" class={tabTriggerClass}>Checks</Tabs.Trigger>
+      <Tabs.Trigger value="files" class={tabTriggerClass}
+        >Files changed</Tabs.Trigger
+      >
+    </Tabs.List>
+  </div>
+  <Tabs.Content value="conversation" class="min-h-0 flex-1">
+    <ScrollArea class="h-full" viewportClass="@container px-4 pr-2 pt-1 pb-8">
+      <div
+        class="grid items-start gap-2 @3xl:grid-cols-[minmax(0,1fr)_18rem] @6xl:grid-cols-[minmax(0,1fr)_22rem]"
+      >
+        <GithubPrSectionSkeleton
+          variant="conversation"
+          label="Loading pull request conversation"
+        />
+        <aside class="flex flex-col gap-2">
+          <GithubPrSectionSkeleton
+            variant="overview"
+            label="Loading pull request overview"
+          />
+          <GithubPrSectionSkeleton
+            variant="merge"
+            label="Loading pull request merge status"
+          />
+        </aside>
+      </div>
+    </ScrollArea>
+  </Tabs.Content>
+</Tabs.Root>

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrPane.svelte
@@ -6,13 +6,13 @@ import type { GithubPrMergeMethod } from "@nervekit/contracts";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import * as Empty from "@nervekit/ui-kit/components/ui/empty";
 import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
-import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import * as Tabs from "@nervekit/ui-kit/components/ui/tabs";
 import GithubPrChecks from "./GithubPrChecks.svelte";
 import GithubPrCommits from "./GithubPrCommits.svelte";
 import GithubPrConversation from "./GithubPrConversation.svelte";
 import GithubPrFiles from "./GithubPrFiles.svelte";
 import GithubPrHeader from "./GithubPrHeader.svelte";
+import GithubPrLoadingPane from "./GithubPrLoadingPane.svelte";
 import GithubPrMergeBox from "./GithubPrMergeBox.svelte";
 import GithubPrOverview from "./GithubPrOverview.svelte";
 import GithubPrSectionSkeleton from "./GithubPrSectionSkeleton.svelte";
@@ -112,16 +112,7 @@ function confirmCheckout() {
       </Empty.Header>
     </Empty.Root>
   {:else if view.core.loading && !core}
-    <div class="flex h-full flex-col gap-4 px-4 py-4">
-      <div class="flex items-center gap-3" role="status">
-        <Spinner class="size-4" />
-        <span class="text-sm font-medium"
-          >Loading pull request #{view.number}</span
-        >
-      </div>
-      <GithubPrSectionSkeleton rows={2} label="Loading pull request header" />
-      <GithubPrSectionSkeleton rows={6} label="Loading pull request details" />
-    </div>
+    <GithubPrLoadingPane {view} {onRefresh} {onOpenExternal} />
   {:else if view.core.error && !core}
     <Empty.Root class="h-full min-h-0 gap-2 py-6">
       <Empty.Media variant="icon" class="size-8 rounded-md">
@@ -145,13 +136,29 @@ function confirmCheckout() {
     </Empty.Root>
   {:else if core}
     <GithubPrHeader
+      number={view.number}
       detail={core}
-      loading={view.core.refreshing}
+      summary={view.summary}
+      loading={view.refreshing}
       commitCount={commits?.commits.length}
       {onRefresh}
       onCheckout={confirmCheckout}
       {onOpenExternal}
     />
+
+    {#if view.refreshError}
+      <div
+        class="flex items-center gap-2 border-b border-destructive/30 bg-destructive/5 px-4 py-1.5 text-xs text-destructive"
+        role="alert"
+      >
+        <span class="min-w-0 flex-1 truncate"
+          >Could not fully refresh: {view.refreshError}</span
+        >
+        <Button size="xs" variant="ghost" onclick={() => onRefresh?.()}>
+          <RotateCcw class="size-3" /> Retry
+        </Button>
+      </div>
+    {/if}
 
     <Tabs.Root
       value={view.activeTab}
@@ -201,7 +208,10 @@ function confirmCheckout() {
             {:else if view.conversation.error}
               {@render sectionError(view.conversation.error, "conversation")}
             {:else}
-              <GithubPrSectionSkeleton rows={7} label="Loading conversation" />
+              <GithubPrSectionSkeleton
+                variant="conversation"
+                label="Loading conversation"
+              />
             {/if}
             <aside class="flex flex-col gap-2">
               {#if overview}
@@ -209,7 +219,10 @@ function confirmCheckout() {
               {:else if view.overview.error}
                 {@render sectionError(view.overview.error, "overview")}
               {:else}
-                <GithubPrSectionSkeleton rows={4} label="Loading overview" />
+                <GithubPrSectionSkeleton
+                  variant="overview"
+                  label="Loading overview"
+                />
               {/if}
               {#if overview && checks}
                 <GithubPrMergeBox
@@ -222,7 +235,7 @@ function confirmCheckout() {
                 />
               {:else}
                 <GithubPrSectionSkeleton
-                  rows={3}
+                  variant="merge"
                   label="Loading merge status"
                 />
               {/if}
@@ -241,7 +254,11 @@ function confirmCheckout() {
           {:else if view.commits.error}
             {@render sectionError(view.commits.error, "commits")}
           {:else}
-            <GithubPrSectionSkeleton rows={6} label="Loading commits" />
+            <GithubPrSectionSkeleton
+              variant="commits"
+              rows={6}
+              label="Loading commits"
+            />
           {/if}
         </ScrollArea>
       </Tabs.Content>
@@ -256,7 +273,11 @@ function confirmCheckout() {
           {:else if view.checks.error}
             {@render sectionError(view.checks.error, "checks")}
           {:else}
-            <GithubPrSectionSkeleton rows={6} label="Loading checks" />
+            <GithubPrSectionSkeleton
+              variant="checks"
+              rows={6}
+              label="Loading checks"
+            />
           {/if}
         </ScrollArea>
       </Tabs.Content>

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrSectionSkeleton.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrSectionSkeleton.svelte
@@ -1,8 +1,25 @@
 <script lang="ts">
 import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
 
-type Props = { rows?: number; card?: boolean; label?: string };
-let { rows = 4, card = true, label = "Loading section" }: Props = $props();
+type Variant =
+  | "section"
+  | "conversation"
+  | "overview"
+  | "merge"
+  | "commits"
+  | "checks";
+type Props = {
+  rows?: number;
+  card?: boolean;
+  label?: string;
+  variant?: Variant;
+};
+let {
+  rows = 4,
+  card = true,
+  label = "Loading section",
+  variant = "section",
+}: Props = $props();
 </script>
 
 <div
@@ -12,9 +29,51 @@ let { rows = 4, card = true, label = "Loading section" }: Props = $props();
   role="status"
   aria-label={label}
 >
-  <Skeleton class="h-3 w-1/3" />
-  {#each Array.from({ length: rows }, (_, index) => index) as index (index)}
-    <Skeleton class={index % 3 === 2 ? "h-3 w-2/3" : "h-3 w-full"} />
-  {/each}
+  {#if variant === "conversation"}
+    <div class="flex items-center gap-2 border-b border-border/60 pb-2">
+      <Skeleton class="size-5 rounded-full" />
+      <Skeleton class="h-3 w-40" />
+    </div>
+    <Skeleton class="h-3 w-full" />
+    <Skeleton class="h-3 w-11/12" />
+    <Skeleton class="h-3 w-2/3" />
+    <div class="mt-2 flex items-center gap-2 border-t border-border/60 pt-2">
+      <Skeleton class="size-5 rounded-full" />
+      <Skeleton class="h-3 w-32" />
+    </div>
+    <Skeleton class="h-3 w-4/5" />
+  {:else if variant === "overview"}
+    <Skeleton class="h-3 w-20" />
+    {#each [0, 1, 2, 3] as row (row)}
+      <div class="flex min-h-5 items-center gap-2">
+        <Skeleton class="h-3 w-20" />
+        <Skeleton class={row < 2 ? "h-5 w-24 rounded-full" : "h-3 w-28"} />
+      </div>
+    {/each}
+  {:else if variant === "merge"}
+    <Skeleton class="h-3 w-24" />
+    <div class="flex items-center gap-2">
+      <Skeleton class="size-4 rounded-full" />
+      <Skeleton class="h-3 w-3/4" />
+    </div>
+    <Skeleton class="h-8 w-full rounded-md" />
+  {:else if variant === "commits" || variant === "checks"}
+    <Skeleton class="h-3 w-24" />
+    {#each Array.from({ length: rows }, (_, index) => index) as index (index)}
+      <div class="flex items-center gap-2 border-t border-border/60 pt-2">
+        <Skeleton class="size-3.5 rounded-full" />
+        <Skeleton class="h-3 flex-1" />
+        <Skeleton class="h-3 w-16" />
+        {#if variant === "checks"}<Skeleton
+            class="h-5 w-14 rounded-full"
+          />{/if}
+      </div>
+    {/each}
+  {:else}
+    <Skeleton class="h-3 w-1/3" />
+    {#each Array.from({ length: rows }, (_, index) => index) as index (index)}
+      <Skeleton class={index % 3 === 2 ? "h-3 w-2/3" : "h-3 w-full"} />
+    {/each}
+  {/if}
   <span class="sr-only">{label}</span>
 </div>

--- a/packages/workbench-app/src/lib/presentation/git/git-panel-types.ts
+++ b/packages/workbench-app/src/lib/presentation/git/git-panel-types.ts
@@ -82,6 +82,7 @@ export interface GitPanelModel {
   readonly loadingOverview: boolean;
   readonly loadingBranches: boolean;
   readonly loadingPullRequests: boolean;
+  readonly pullRequestError?: string;
   readonly operations: GitPanelOperationState;
   readonly capabilities: GitPanelCapabilities;
 }

--- a/packages/workbench-app/src/lib/presentation/git/github-pr-types.ts
+++ b/packages/workbench-app/src/lib/presentation/git/github-pr-types.ts
@@ -1,4 +1,5 @@
 import type {
+  GithubPr,
   GithubPrChecksResponse,
   GithubPrCommitsResponse,
   GithubPrConversation,
@@ -21,6 +22,7 @@ export type GithubPrViewState = {
   id: string;
   repo: string;
   number: number;
+  summary?: GithubPr;
   core: PrSectionState<GithubPrCore>;
   conversation: PrSectionState<GithubPrConversation>;
   overview: PrSectionState<GithubPrOverview>;
@@ -30,6 +32,8 @@ export type GithubPrViewState = {
   activeTab: GithubPrTab;
   selectedFilePath?: string;
   selectedMergeMethod?: GithubPrMergeMethod;
+  refreshing: boolean;
+  refreshError?: string;
   merging: boolean;
   mergeError?: string;
 };

--- a/packages/workbench-app/src/lib/presentation/git/pr-pane-helpers.ts
+++ b/packages/workbench-app/src/lib/presentation/git/pr-pane-helpers.ts
@@ -33,7 +33,9 @@ export function checksTone(checks: GithubChecksSummary): BadgeTone {
   }
 }
 
-export function stateTone(detail: GithubPrCore | undefined): BadgeTone {
+type PrStateSummary = Pick<GithubPrCore, "isDraft" | "state">;
+
+export function stateTone(detail: PrStateSummary | undefined): BadgeTone {
   if (!detail) return "neutral";
   if (detail.isDraft) return "neutral";
   if (detail.state === "MERGED") return "accent";
@@ -41,7 +43,7 @@ export function stateTone(detail: GithubPrCore | undefined): BadgeTone {
   return "good";
 }
 
-export function stateLabel(detail: GithubPrCore | undefined): string {
+export function stateLabel(detail: PrStateSummary | undefined): string {
   if (!detail) return "";
   if (detail.isDraft) return "draft";
   return detail.state.toLowerCase();

--- a/packages/workbench-app/src/lib/presentation/panel/PanelToolbarButton.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelToolbarButton.svelte
@@ -17,6 +17,7 @@ let {
   active = false,
   disabled = false,
   loading = false,
+  loadingVariant = "ring",
   showLabel = false,
   dense = false,
   class: className,
@@ -35,6 +36,7 @@ let {
   disabled?: boolean;
   /** Swaps the icon for a spinner while an action is in flight. */
   loading?: boolean;
+  loadingVariant?: "ring" | "refresh";
   /** Renders the label next to the icon instead of icon-only. */
   showLabel?: boolean;
   /** Uses a compact icon-button size for dense rows. */
@@ -59,7 +61,7 @@ let {
   {onclick}
 >
   {#if loading}
-    <Spinner class="size-3" />
+    <Spinner variant={loadingVariant} class="size-3" aria-label={label} />
   {:else}
     <Icon aria-hidden="true" />
   {/if}

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -369,6 +369,17 @@ export function composeRuntime(
           },
         });
       },
+      onGithubRequestCompleted: (observation) => {
+        if (observation.durationMs < 250) return;
+        void gitLogger.warn("Slow GitHub API request", {
+          durationMs: Math.round(observation.durationMs),
+          context: {
+            operation: observation.operation,
+            status: observation.status,
+            succeeded: observation.succeeded,
+          },
+        });
+      },
       onOverviewCompleted: (observation) => {
         if (observation.durationMs < 500) return;
         void gitLogger.warn("Slow Git overview", {


### PR DESCRIPTION
## Summary
- replace GitHub CLI data commands with authenticated GraphQL and REST requests while retaining CLI checkout
- add token caching, one-time credential reacquisition, repository parsing, API error mapping, and request telemetry
- improve PR list and detail refresh feedback, cache hydration, provisional headers, and layout-matched skeletons

## Validation
- `pnpm fix && pnpm check && pnpm test`
- exercised direct API authentication, PR listing, PR details, checks, and files against GitHub
- visually verified PR loading, refresh, cache reuse, and light/dark themes