### PR TITLE
chore(deps): update pi-ai to 0.83.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "check:boundaries": "node scripts/check-package-boundaries.mjs"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.1"
+    "@earendil-works/pi-ai": "0.83.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -37,11 +37,11 @@
     "test": "tsx --test \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.1",
+    "@earendil-works/pi-ai": "0.83.0",
     "@nervekit/contracts": "workspace:*",
     "ignore": "7.0.5",
     "sharp": "^0.35.3",
-    "typebox": "1.1.38",
+    "typebox": "1.3.7",
     "yaml": "2.9.0"
   },
   "devDependencies": {

--- a/packages/harness/src/transport/proxy.ts
+++ b/packages/harness/src/transport/proxy.ts
@@ -136,7 +136,7 @@ export function streamProxy(
     // Initialize the partial message that we'll build up from events
     const partial: AssistantMessage = {
       role: "assistant",
-      stopReason: "stop",
+      stopReason: "pending",
       content: [],
       api: model.api,
       provider: model.provider,

--- a/packages/harness/test/transport/proxy.test.ts
+++ b/packages/harness/test/transport/proxy.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Usage } from "@earendil-works/pi-ai";
+import type { AnyModel } from "../../src/agent/types/index.js";
+import { streamProxy } from "../../src/transport/proxy.js";
+
+const usage: Usage = {
+  input: 1,
+  output: 2,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 3,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+const model = {
+  id: "test-model",
+  name: "Test model",
+  api: "anthropic-messages",
+  provider: "anthropic",
+  baseUrl: "https://example.test",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 100_000,
+  maxTokens: 1024,
+} as unknown as AnyModel;
+
+const encoder = new TextEncoder();
+
+function sse(event: unknown): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(event)}\n`);
+}
+
+describe("proxy streaming", () => {
+  it("keeps partial messages pending until a terminal event arrives", async () => {
+    const originalFetch = globalThis.fetch;
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+        controller.enqueue(sse({ type: "start" }));
+      },
+    });
+    globalThis.fetch = async () => new Response(body, { status: 200 });
+
+    try {
+      const stream = streamProxy(
+        model,
+        { messages: [] },
+        { authToken: "test-token", proxyUrl: "https://proxy.test" },
+      );
+      const iterator = stream[Symbol.asyncIterator]();
+
+      const start = await iterator.next();
+      assert.equal(start.done, false);
+      assert.equal(start.value?.type, "start");
+      if (start.value?.type === "start") {
+        assert.equal(start.value.partial.stopReason, "pending");
+      }
+
+      controller.enqueue(sse({ type: "done", reason: "stop", usage }));
+      controller.close();
+
+      const done = await iterator.next();
+      assert.equal(done.done, false);
+      assert.equal(done.value?.type, "done");
+      if (done.value?.type === "done") {
+        assert.equal(done.value.message.stopReason, "stop");
+      }
+      assert.equal((await iterator.next()).done, true);
+      assert.equal((await stream.result()).stopReason, "stop");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -34,7 +34,7 @@
     "diff": "^8.0.4",
     "node-html-markdown": "^2.0.0",
     "shell-quote": "^1.10.0",
-    "typebox": "1.1.38"
+    "typebox": "1.3.7"
   },
   "devDependencies": {
     "@types/node": "24.10.1",

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -31,7 +31,7 @@
     "check": "tsc -b --pretty false",
     "dev": "tsx src/main.ts",
     "test": "tsx --test test/*.test.ts",
-    "test:native": "tsx --test test/explore-subagent-isolation.test.ts test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/storage-json.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts"
+    "test:native": "tsx --test test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/storage-json.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "0.83.0",

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -34,7 +34,7 @@
     "test:native": "tsx --test test/explore-subagent-isolation.test.ts test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/storage-json.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.82.1",
+    "@earendil-works/pi-ai": "0.83.0",
     "@hono/node-server": "2.0.11",
     "@nervekit/contracts": "workspace:*",
     "@nervekit/harness": "workspace:*",

--- a/packages/workbench-server/test/auth.test.ts
+++ b/packages/workbench-server/test/auth.test.ts
@@ -29,7 +29,7 @@ describe("AuthManager", () => {
     await auth.setOAuth("openai-codex", {
       access: "access-token",
       refresh: "refresh-token",
-      expires: Date.now() + 60_000,
+      expires: Date.now() + 60 * 60_000,
     });
 
     assert.equal(await auth.credentialType("openai-codex"), "oauth");
@@ -43,7 +43,7 @@ describe("AuthManager", () => {
       access:
         "tid=test;proxy-ep=proxy.business.githubcopilot.com;exp=9999999999;",
       refresh: "github-token",
-      expires: Date.now() + 60_000,
+      expires: Date.now() + 60 * 60_000,
       enterpriseUrl: "github.example.com",
     });
     const model = auth.models.getModels("github-copilot")[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.1
-        version: 0.82.1(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.83.0
+        version: 0.83.0(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -84,8 +84,8 @@ importers:
   packages/harness:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.1
-        version: 0.82.1(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.83.0
+        version: 0.83.0(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
       '@nervekit/contracts':
         specifier: workspace:*
         version: link:../contracts
@@ -96,8 +96,8 @@ importers:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@24.10.1)
       typebox:
-        specifier: 1.1.38
-        version: 1.1.38
+        specifier: 1.3.7
+        version: 1.3.7
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -146,8 +146,8 @@ importers:
         specifier: ^1.10.0
         version: 1.10.0
       typebox:
-        specifier: 1.1.38
-        version: 1.1.38
+        specifier: 1.3.7
+        version: 1.3.7
     devDependencies:
       '@types/node':
         specifier: 24.10.1
@@ -381,8 +381,8 @@ importers:
   packages/workbench-server:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.82.1
-        version: 0.82.1(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.83.0
+        version: 0.83.0(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
       '@hono/node-server':
         specifier: 2.0.11
         version: 2.0.11(hono@4.12.32)
@@ -1286,8 +1286,8 @@ packages:
   '@dagrejs/graphlib@4.0.1':
     resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
-  '@earendil-works/pi-ai@0.82.1':
-    resolution: {integrity: sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==}
+  '@earendil-works/pi-ai@0.83.0':
+    resolution: {integrity: sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -5927,8 +5927,8 @@ packages:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
 
-  typebox@1.1.38:
-    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -7804,7 +7804,7 @@ snapshots:
 
   '@dagrejs/graphlib@4.0.1': {}
 
-  '@earendil-works/pi-ai@0.82.1(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)':
+  '@earendil-works/pi-ai@0.83.0(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.1.12)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -7816,7 +7816,7 @@ snapshots:
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
       openai: 6.26.0(ws@8.21.0)(zod@4.1.12)
       partial-json: 0.1.7
-      typebox: 1.1.38
+      typebox: 1.3.7
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -7825,7 +7825,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.82.1(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.83.0(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -7837,7 +7837,7 @@ snapshots:
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
       openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
-      typebox: 1.1.38
+      typebox: 1.3.7
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -13402,7 +13402,7 @@ snapshots:
 
   type-fest@0.16.0: {}
 
-  typebox@1.1.38: {}
+  typebox@1.3.7: {}
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ allowBuilds:
   protobufjs: true
   sharp: true
 minimumReleaseAgeExclude:
-  - "@earendil-works/pi-ai@0.82.1"
+  - "@earendil-works/pi-ai@0.83.0"
   - "@astrojs/internal-helpers@0.10.2"
   - "@astrojs/markdown-satteri@0.3.5"
   - astro@7.1.5


### PR DESCRIPTION
## Summary
- upgrade `@earendil-works/pi-ai` to 0.83.0 and align TypeBox at 1.3.7
- adopt the new `pending` stop reason for partial proxy messages
- add proxy stream coverage and update OAuth fixtures for the new refresh window

## Validation
- `pnpm fix && pnpm check && pnpm test`