### PR TITLE
Fix scalable provider model selection

### DIFF
--- a/packages/harness/src/models/resolution.ts
+++ b/packages/harness/src/models/resolution.ts
@@ -198,23 +198,6 @@ export function clampAgentThinkingLevel(
   return clampThinkingLevel(model, requested ?? "off") as ThinkingLevel;
 }
 
-const COMPLETE_MODEL_LIST_PROVIDERS = new Set<string>([
-  // Subscription-backed and first-party providers expose the complete catalog.
-  "anthropic",
-  "github-copilot",
-  "openai",
-  "openai-codex",
-  "radius",
-  "xai",
-]);
-
-function visibleModelsForProvider(provider: string): readonly Model<string>[] {
-  const models = getRegisteredModels(provider) as readonly Model<string>[];
-  return COMPLETE_MODEL_LIST_PROVIDERS.has(provider)
-    ? models
-    : models.slice(0, 8);
-}
-
 export function listAvailableModels(
   customModels?: AgentCustomModel[],
 ): AgentModelInfo[] {
@@ -222,7 +205,9 @@ export function listAvailableModels(
     getAgentModelInfo(model),
   );
   const configured = getBuiltinProviderIds().flatMap((provider) =>
-    visibleModelsForProvider(provider).map((model) => getAgentModelInfo(model)),
+    getRegisteredModels(provider).map((model) =>
+      getAgentModelInfo(model as Model<string>),
+    ),
   );
   const custom = (activeCustomModels(customModels) ?? [])
     .map((model) => customModelInfo(model))

--- a/packages/harness/test/models/resolution.test.ts
+++ b/packages/harness/test/models/resolution.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { listAvailableModels } from "../../src/models/resolution.js";
+
+describe("model resolution", () => {
+  it("lists complete provider catalogs without silently truncating them", () => {
+    const openRouterModels = listAvailableModels().filter(
+      (model) => model.provider === "openrouter",
+    );
+
+    assert.ok(
+      openRouterModels.length > 8,
+      "expected the registered OpenRouter catalog beyond its first eight models",
+    );
+    assert.ok(openRouterModels[8]);
+    assert.equal(
+      new Set(openRouterModels.map((model) => model.modelId)).size,
+      openRouterModels.length,
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/features/settings/components/pages/models/AddScopedModelsDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/models/AddScopedModelsDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { SvelteMap, SvelteSet } from "svelte/reactivity";
+import { SvelteSet } from "svelte/reactivity";
 import type { AuthProviderMetadata, ModelInfo, ModelSelection } from "$lib/api";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
@@ -7,14 +7,17 @@ import { Checkbox } from "@nervekit/ui-kit/components/ui/checkbox";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
 import { Label } from "@nervekit/ui-kit/components/ui/label";
 import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
+import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
 import {
   authenticatedRealModelOptions,
-  modelDisplayName,
   modelKey,
-  providerDisplayName,
 } from "$lib/presentation/utils/model";
-
-type ProviderChip = { id: string; label: string; count: number };
+import {
+  buildModelCatalog,
+  filterModelCatalog,
+  modelProviderFacets,
+  type ModelCatalogEntry,
+} from "$lib/presentation/utils/model-catalog";
 
 type Props = {
   open?: boolean;
@@ -51,45 +54,17 @@ $effect(() => {
   lastOpen = open;
 });
 
-const providerChips = $derived.by<ProviderChip[]>(() => {
-  const counts = new SvelteMap<string, number>();
-  for (const model of availableModels) {
-    counts.set(model.provider, (counts.get(model.provider) ?? 0) + 1);
-  }
-  const chips = [...counts.entries()]
-    .map(([id, count]) => ({ id, label: providerDisplayName(id), count }))
-    .sort((left, right) => left.label.localeCompare(right.label));
-  return [{ id: "all", label: "All", count: availableModels.length }, ...chips];
-});
-
-const filteredModels = $derived.by<ModelInfo[]>(() => {
-  const needle = query.trim().toLowerCase();
-  return [...availableModels]
-    .filter((model) => {
-      if (providerFilter !== "all" && model.provider !== providerFilter) {
-        return false;
-      }
-      if (!needle) return true;
-      const haystack =
-        `${modelDisplayName(model)} ${model.modelId} ${providerDisplayName(model.provider)}`.toLowerCase();
-      return haystack.includes(needle);
-    })
-    .sort((left, right) => {
-      const provider = providerDisplayName(left.provider).localeCompare(
-        providerDisplayName(right.provider),
-      );
-      return (
-        provider ||
-        modelDisplayName(left).localeCompare(modelDisplayName(right))
-      );
-    });
-});
+const catalog = $derived(buildModelCatalog(availableModels));
+const providerChips = $derived(modelProviderFacets(catalog));
+const filteredModels = $derived(
+  filterModelCatalog(catalog, query, providerFilter),
+);
 
 const selectedCount = $derived(selectedKeys.size);
 
-function toggleModel(model: ModelInfo, checked: boolean): void {
+function toggleModel(entry: ModelCatalogEntry, checked: boolean): void {
   const next = new SvelteSet(selectedKeys);
-  const key = modelKey(model);
+  const key = entry.key;
   if (checked) next.add(key);
   else next.delete(key);
   selectedKeys = next;
@@ -141,7 +116,7 @@ function save(): void {
       {/if}
     </div>
 
-    <div class="min-h-0 overflow-y-auto p-1.5">
+    <div class="min-h-0 p-1.5">
       {#if availableModels.length === 0}
         <p class="px-1 py-2 text-sm text-muted-foreground">
           Authenticate a provider before choosing scoped models.
@@ -151,33 +126,36 @@ function save(): void {
           No models match the current filters.
         </p>
       {:else}
-        <ul class="grid gap-0.5" aria-label="Authenticated models">
-          {#each filteredModels as model (modelKey(model))}
-            {@const checked = selectedKeys.has(modelKey(model))}
-            <li>
-              <Label
-                class="flex cursor-pointer items-center gap-3 rounded-md border border-transparent px-2 py-1.5 font-normal hover:bg-accent/50 has-data-[state=checked]:border-primary/60 has-data-[state=checked]:bg-primary/8"
-              >
-                <Checkbox
-                  size="sm"
-                  {checked}
-                  onCheckedChange={(value) =>
-                    toggleModel(model, value === true)}
-                  aria-label={modelDisplayName(model)}
-                />
-                <span class="grid min-w-0 gap-0.5">
-                  <span class="truncate text-sm text-foreground"
-                    >{modelDisplayName(model)}</span
-                  >
-                  <span class="truncate text-xs text-muted-foreground">
-                    {providerDisplayName(model.provider)} ·
-                    <span class="font-mono">{model.modelId}</span>
-                  </span>
+        <VirtualScroller
+          items={filteredModels}
+          getKey={(entry) => entry.key}
+          estimateSize={() => 48}
+          viewportClass="max-h-[min(52vh,24rem)]"
+          viewportAriaLabel="Authenticated models"
+        >
+          {#snippet row({ item: entry })}
+            {@const checked = selectedKeys.has(entry.key)}
+            <Label
+              class="flex cursor-pointer items-center gap-3 rounded-md border border-transparent px-2 py-1.5 font-normal hover:bg-accent/50 has-data-[state=checked]:border-primary/60 has-data-[state=checked]:bg-primary/8"
+            >
+              <Checkbox
+                size="sm"
+                {checked}
+                onCheckedChange={(value) => toggleModel(entry, value === true)}
+                aria-label={entry.displayName}
+              />
+              <span class="grid min-w-0 gap-0.5">
+                <span class="truncate text-sm text-foreground"
+                  >{entry.displayName}</span
+                >
+                <span class="truncate text-xs text-muted-foreground">
+                  {entry.providerLabel} ·
+                  <span class="font-mono">{entry.model.modelId}</span>
                 </span>
-              </Label>
-            </li>
-          {/each}
-        </ul>
+              </span>
+            </Label>
+          {/snippet}
+        </VirtualScroller>
       {/if}
     </div>
   </div>

--- a/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { SvelteMap } from "svelte/reactivity";
 import type {
   AuthProviderMetadata,
   ModelInfo,
@@ -10,13 +9,13 @@ import { Button } from "@nervekit/ui-kit/components/ui/button";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
 import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
+import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
+import { modelKey } from "$lib/presentation/utils/model";
 import {
-  modelDisplayName,
-  modelKey,
-  providerDisplayName,
-} from "$lib/presentation/utils/model";
-
-type ProviderChip = { id: string; label: string; count: number };
+  buildModelCatalog,
+  filterModelCatalog,
+  modelProviderFacets,
+} from "$lib/presentation/utils/model-catalog";
 type FallbackOption = { label: string; detail: string };
 type SaveSelection = {
   model?: ModelSelection;
@@ -86,39 +85,11 @@ $effect(() => {
   }
 });
 
-const providerChips = $derived.by<ProviderChip[]>(() => {
-  const counts = new SvelteMap<string, number>();
-  for (const model of models) {
-    counts.set(model.provider, (counts.get(model.provider) ?? 0) + 1);
-  }
-  const chips = [...counts.entries()]
-    .map(([id, count]) => ({ id, label: providerDisplayName(id), count }))
-    .sort((left, right) => left.label.localeCompare(right.label));
-  return [{ id: "all", label: "All", count: models.length }, ...chips];
-});
-
-const filteredModels = $derived.by<ModelInfo[]>(() => {
-  const needle = query.trim().toLowerCase();
-  return [...models]
-    .filter((model) => {
-      if (providerFilter !== "all" && model.provider !== providerFilter) {
-        return false;
-      }
-      if (!needle) return true;
-      const haystack =
-        `${modelDisplayName(model)} ${model.modelId} ${providerDisplayName(model.provider)}`.toLowerCase();
-      return haystack.includes(needle);
-    })
-    .sort((left, right) => {
-      const provider = providerDisplayName(left.provider).localeCompare(
-        providerDisplayName(right.provider),
-      );
-      return (
-        provider ||
-        modelDisplayName(left).localeCompare(modelDisplayName(right))
-      );
-    });
-});
+const catalog = $derived(buildModelCatalog(models));
+const providerChips = $derived(modelProviderFacets(catalog));
+const filteredModels = $derived(
+  filterModelCatalog(catalog, query, providerFilter),
+);
 
 function formatTokens(tokens: number): string {
   if (tokens <= 0) return "Unknown context";
@@ -170,7 +141,7 @@ function save(): void {
       {/if}
     </div>
 
-    <div class="min-h-0 overflow-y-auto p-1.5">
+    <div class="min-h-0 p-1.5">
       {#if models.length === 0 && !hasFallback}
         <p class="px-1 py-2 text-sm text-muted-foreground">
           Authenticate a provider before choosing a model.
@@ -180,9 +151,9 @@ function save(): void {
           No models match the current filters.
         </p>
       {:else}
-        <ul class="grid gap-0.5" aria-label="Available models">
+        <div class="grid gap-0.5">
           {#if hasFallback}
-            <li>
+            <div>
               <button
                 type="button"
                 class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-transparent px-2 py-1.5 text-left hover:bg-accent/50 aria-pressed:border-primary/60 aria-pressed:bg-primary/8"
@@ -198,35 +169,41 @@ function save(): void {
                   >
                 </span>
               </button>
-            </li>
+            </div>
           {/if}
-          {#each filteredModels as model (modelKey(model))}
-            {@const key = modelKey(model)}
-            <li>
-              <button
-                type="button"
-                class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-transparent px-2 py-1.5 text-left hover:bg-accent/50 aria-pressed:border-primary/60 aria-pressed:bg-primary/8"
-                aria-pressed={selectedKey === key}
-                onclick={() => (selectedKey = key)}
-              >
-                <span class="grid min-w-0 gap-0.5">
-                  <span class="truncate text-sm text-foreground"
-                    >{modelDisplayName(model)}</span
-                  >
-                  <span class="truncate text-xs text-muted-foreground">
-                    {providerDisplayName(model.provider)} ·
-                    <span class="font-mono">{model.modelId}</span>
+          <VirtualScroller
+            items={filteredModels}
+            getKey={(entry) => entry.key}
+            estimateSize={() => 48}
+            viewportClass="max-h-[min(52vh,24rem)]"
+            viewportAriaLabel="Available models"
+          >
+            {#snippet row({ item: entry })}
+              <div>
+                <button
+                  type="button"
+                  class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-transparent px-2 py-1.5 text-left hover:bg-accent/50 aria-pressed:border-primary/60 aria-pressed:bg-primary/8"
+                  aria-pressed={selectedKey === entry.key}
+                  onclick={() => (selectedKey = entry.key)}
+                >
+                  <span class="grid min-w-0 gap-0.5">
+                    <span class="truncate text-sm text-foreground"
+                      >{entry.displayName}</span
+                    >
+                    <span class="truncate text-xs text-muted-foreground">
+                      {entry.providerLabel} ·
+                      <span class="font-mono">{entry.model.modelId}</span>
+                    </span>
                   </span>
-                </span>
-                <span class="flex-none text-xs text-muted-foreground">
-                  {model.reasoning ? "Reasoning" : "Standard"} · {formatTokens(
-                    model.contextWindow,
-                  )}
-                </span>
-              </button>
-            </li>
-          {/each}
-        </ul>
+                  <span class="flex-none text-xs text-muted-foreground">
+                    {entry.model.reasoning ? "Reasoning" : "Standard"} ·
+                    {formatTokens(entry.model.contextWindow)}
+                  </span>
+                </button>
+              </div>
+            {/snippet}
+          </VirtualScroller>
+        </div>
       {/if}
     </div>
   </div>

--- a/packages/workbench-app/src/lib/features/settings/registry/settings-pages.ts
+++ b/packages/workbench-app/src/lib/features/settings/registry/settings-pages.ts
@@ -38,6 +38,13 @@ export const settingsPages: SettingsPageDef[] = [
     sections: [{ id: "shortcuts", label: "Shortcuts" }],
   },
   {
+    id: "models",
+    label: "Scoped Models",
+    icon: ShieldCheck,
+    description: "Scoped models limit which models the composer offers.",
+    sections: [{ id: "models", label: "Scoped Models" }],
+  },
+  {
     id: "agents",
     label: "Agents",
     icon: Bot,
@@ -54,13 +61,6 @@ export const settingsPages: SettingsPageDef[] = [
     description:
       "Project suggestions override user and built-in suggestions with the same name.",
     sections: [{ id: "suggestions", label: "Suggestions" }],
-  },
-  {
-    id: "models",
-    label: "Models",
-    icon: ShieldCheck,
-    description: "Scoped models limit which models the composer offers.",
-    sections: [{ id: "models", label: "Models" }],
   },
   {
     id: "tools",

--- a/packages/workbench-app/src/lib/presentation/components/composer/ComposerModelPicker.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ComposerModelPicker.svelte
@@ -3,7 +3,15 @@ import Check from "@lucide/svelte/icons/check";
 import ChevronDown from "@lucide/svelte/icons/chevron-down";
 import type { ModelInfo, ThinkingLevel } from "@nervekit/contracts";
 import Popover from "@nervekit/ui-kit/components/ui/popover-panel";
+import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
+import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
+import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
 import { contextualModelLabel, modelKey } from "$lib/presentation/utils/model";
+import {
+  buildModelCatalog,
+  filterModelCatalog,
+  modelProviderFacets,
+} from "$lib/presentation/utils/model-catalog";
 
 type Props = {
   models?: ModelInfo[];
@@ -29,8 +37,21 @@ let {
   onThinkingLevelChange,
 }: Props = $props();
 
-let open = $state(false);
+const SEARCH_THRESHOLD = 10;
 
+let open = $state(false);
+let query = $state("");
+let providerFilter = $state("all");
+
+const catalog = $derived(buildModelCatalog(models));
+const providerChips = $derived(modelProviderFacets(catalog));
+const filteredModels = $derived(
+  filterModelCatalog(
+    catalog,
+    models.length > SEARCH_THRESHOLD ? query : "",
+    models.length > SEARCH_THRESHOLD ? providerFilter : "all",
+  ),
+);
 const selectedModel = $derived(
   models.find((model) => modelKey(model) === selectedModelKey),
 );
@@ -96,6 +117,10 @@ const triggerTitle = $derived(
 
 function handleOpenChange(next: boolean) {
   open = disabled ? false : next;
+  if (open) {
+    query = "";
+    providerFilter = "all";
+  }
 }
 
 function selectModel(model: ModelInfo) {
@@ -143,27 +168,67 @@ $effect(() => {
       {#if models.length === 0}
         <p class="model-picker-empty">{emptyMessage}</p>
       {:else}
-        <ul class="model-list">
-          {#each models as model (modelKey(model))}
-            {@const active = modelKey(model) === selectedModelKey}
-            {@const label = contextualModelLabel(model, models)}
-            <li>
-              <button
-                type="button"
-                class="model-row"
-                class:active
-                aria-pressed={active}
-                {disabled}
-                onclick={() => selectModel(model)}
+        <div class="grid gap-2">
+          {#if models.length > SEARCH_THRESHOLD}
+            <SearchInput
+              bind:value={query}
+              placeholder="Search models"
+              ariaLabel="Search models"
+            />
+            {#if providerChips.length > 2}
+              <ToggleGroup.Root
+                type="single"
+                size="xs"
+                spacing={1}
+                variant="outline"
+                value={providerFilter}
+                aria-label="Filter by provider"
+                class="flex-nowrap overflow-x-auto"
+                onValueChange={(value) => {
+                  if (value) providerFilter = value;
+                }}
               >
-                <span class="model-row-text">
-                  <span class="model-row-label">{label}</span>
-                </span>
-                {#if active}<Check size={14} strokeWidth={2.4} />{/if}
-              </button>
-            </li>
-          {/each}
-        </ul>
+                {#each providerChips as chip (chip.id)}
+                  <ToggleGroup.Item
+                    value={chip.id}
+                    class="flex-none gap-1.5 text-xs"
+                  >
+                    {chip.label}
+                    <span class="text-muted-foreground">{chip.count}</span>
+                  </ToggleGroup.Item>
+                {/each}
+              </ToggleGroup.Root>
+            {/if}
+          {/if}
+          {#if filteredModels.length === 0}
+            <p class="model-picker-empty">No models match.</p>
+          {:else}
+            <VirtualScroller
+              items={filteredModels}
+              getKey={(entry) => entry.key}
+              estimateSize={() => 34}
+              viewportClass="max-h-[min(44vh,18rem)]"
+              viewportAriaLabel="Available models"
+            >
+              {#snippet row({ item: entry })}
+                {@const active = entry.key === selectedModelKey}
+                <button
+                  type="button"
+                  class="model-row"
+                  class:active
+                  aria-pressed={active}
+                  {disabled}
+                  onclick={() => selectModel(entry.model)}
+                >
+                  <span class="model-row-text">
+                    <span class="model-row-label">{entry.contextualLabel}</span>
+                  </span>
+                  {#if active}<Check size={14} strokeWidth={2.4} />{/if}
+                </button>
+              {/snippet}
+            </VirtualScroller>
+          {/if}
+        </div>
       {/if}
     </div>
 
@@ -264,16 +329,6 @@ $effect(() => {
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--text-xs);
-}
-
-.model-list {
-  display: grid;
-  gap: 0.15rem;
-  margin: 0;
-  max-height: min(48vh, 18rem);
-  overflow-y: auto;
-  padding: 0;
-  list-style: none;
 }
 
 .model-row {

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanImplementationModelDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanImplementationModelDialog.svelte
@@ -7,11 +7,15 @@ import type {
 } from "../../../state/tool-types";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import DialogShell from "@nervekit/ui-kit/components/ui/dialog-shell";
+import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
+import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
+import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
+import { modelKey, parseModelKey } from "$lib/presentation/utils/model";
 import {
-  contextualModelLabel,
-  modelKey,
-  parseModelKey,
-} from "$lib/presentation/utils/model";
+  buildModelCatalog,
+  filterModelCatalog,
+  modelProviderFacets,
+} from "$lib/presentation/utils/model-catalog";
 import {
   clampThinkingLevelForModel,
   supportedThinkingLevelsForModel,
@@ -45,7 +49,14 @@ let {
 
 let selectedModelKey = $state("");
 let selectedThinkingLevel = $state<ThinkingLevel>("off");
+let query = $state("");
+let providerFilter = $state("all");
 
+const catalog = $derived(buildModelCatalog(models));
+const providerChips = $derived(modelProviderFacets(catalog));
+const filteredModels = $derived(
+  filterModelCatalog(catalog, query, providerFilter),
+);
 const selectedModel = $derived(
   models.find((model) => modelKey(model) === selectedModelKey),
 );
@@ -67,6 +78,8 @@ function thinkingLevelLabel(level: ThinkingLevel): string {
 }
 
 function resetSelection() {
+  query = "";
+  providerFilter = "all";
   const initialModel = models.find(
     (model) => modelKey(model) === initialModelKey,
   );
@@ -137,31 +150,69 @@ $effect(() => {
           Settings.
         </p>
       {:else}
-        <div
-          class="grid gap-1"
-          role="listbox"
-          aria-label="Implementation model"
-        >
-          {#each models as model (modelKey(model))}
-            {@const key = modelKey(model)}
-            {@const active = key === selectedModelKey}
-            <button
-              type="button"
-              class={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
-                active
-                  ? "border-primary/40 bg-primary/10 text-primary"
-                  : "border-transparent text-foreground hover:bg-accent"
-              }`}
-              aria-selected={active}
-              role="option"
-              onclick={() => selectModel(model)}
+        <div class="grid gap-2">
+          <SearchInput
+            bind:value={query}
+            placeholder="Search models"
+            ariaLabel="Search models"
+          />
+          {#if providerChips.length > 2}
+            <ToggleGroup.Root
+              type="single"
+              size="xs"
+              spacing={1}
+              variant="outline"
+              value={providerFilter}
+              aria-label="Filter by provider"
+              class="flex-nowrap overflow-x-auto"
+              onValueChange={(value) => {
+                if (value) providerFilter = value;
+              }}
             >
-              <span class="min-w-0 truncate font-medium"
-                >{contextualModelLabel(model, models)}</span
-              >
-              {#if active}<Check class="size-4" strokeWidth={2.4} />{/if}
-            </button>
-          {/each}
+              {#each providerChips as chip (chip.id)}
+                <ToggleGroup.Item
+                  value={chip.id}
+                  class="flex-none gap-1.5 text-xs"
+                >
+                  {chip.label}
+                  <span class="text-muted-foreground">{chip.count}</span>
+                </ToggleGroup.Item>
+              {/each}
+            </ToggleGroup.Root>
+          {/if}
+          {#if filteredModels.length === 0}
+            <p class="m-0 px-1 py-2 text-sm text-muted-foreground">
+              No models match the current filters.
+            </p>
+          {:else}
+            <VirtualScroller
+              items={filteredModels}
+              getKey={(entry) => entry.key}
+              estimateSize={() => 38}
+              viewportClass="max-h-[min(45vh,20rem)]"
+              viewportAriaLabel="Implementation model"
+            >
+              {#snippet row({ item: entry })}
+                {@const active = entry.key === selectedModelKey}
+                <button
+                  type="button"
+                  class={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                    active
+                      ? "border-primary/40 bg-primary/10 text-primary"
+                      : "border-transparent text-foreground hover:bg-accent"
+                  }`}
+                  aria-selected={active}
+                  role="option"
+                  onclick={() => selectModel(entry.model)}
+                >
+                  <span class="min-w-0 truncate font-medium"
+                    >{entry.contextualLabel}</span
+                  >
+                  {#if active}<Check class="size-4" strokeWidth={2.4} />{/if}
+                </button>
+              {/snippet}
+            </VirtualScroller>
+          {/if}
         </div>
       {/if}
     </section>

--- a/packages/workbench-app/src/lib/presentation/utils/model-catalog.test.ts
+++ b/packages/workbench-app/src/lib/presentation/utils/model-catalog.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ModelInfo } from "@nervekit/contracts";
+import {
+  buildModelCatalog,
+  filterModelCatalog,
+  modelProviderFacets,
+} from "./model-catalog";
+
+function model(provider: string, modelId: string, name: string): ModelInfo {
+  return {
+    provider,
+    modelId,
+    name,
+    label: name,
+    reasoning: false,
+    supportedThinkingLevels: ["off"],
+    contextWindow: 0,
+    maxOutputTokens: 0,
+  };
+}
+
+describe("model catalog", () => {
+  const models = [
+    model("openrouter", "vendor/zeta", "Shared"),
+    model("anthropic", "claude-shared", "Shared"),
+    model("openrouter", "vendor/alpha", "Alpha"),
+  ];
+
+  it("sorts deterministically and precomputes duplicate-aware labels", () => {
+    const entries = buildModelCatalog(models);
+
+    assert.deepEqual(
+      entries.map((entry) => entry.key),
+      [
+        "anthropic:claude-shared",
+        "openrouter:vendor/alpha",
+        "openrouter:vendor/zeta",
+      ],
+    );
+    assert.equal(entries[0]?.contextualLabel, "Anthropic / Shared");
+    assert.equal(entries[2]?.contextualLabel, "OpenRouter / Shared");
+  });
+
+  it("searches names, raw model ids, and providers and filters facets", () => {
+    const entries = buildModelCatalog(models);
+
+    assert.deepEqual(
+      filterModelCatalog(entries, "vendor/zeta").map((entry) => entry.key),
+      ["openrouter:vendor/zeta"],
+    );
+    assert.equal(filterModelCatalog(entries, "anthropic").length, 1);
+    assert.deepEqual(
+      filterModelCatalog(entries, "shared", "openrouter").map(
+        (entry) => entry.key,
+      ),
+      ["openrouter:vendor/zeta"],
+    );
+    assert.deepEqual(modelProviderFacets(entries), [
+      { id: "all", label: "All", count: 3 },
+      { id: "anthropic", label: "Anthropic", count: 1 },
+      { id: "openrouter", label: "OpenRouter", count: 2 },
+    ]);
+  });
+
+  it("keeps every entry in a large provider catalog", () => {
+    const entries = buildModelCatalog(
+      Array.from({ length: 500 }, (_, index) =>
+        model("openrouter", `vendor/model-${index}`, `Model ${index}`),
+      ),
+    );
+
+    assert.equal(entries.length, 500);
+    assert.deepEqual(
+      filterModelCatalog(entries, "vendor/model-499").map(
+        (entry) => entry.model.modelId,
+      ),
+      ["vendor/model-499"],
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/utils/model-catalog.ts
+++ b/packages/workbench-app/src/lib/presentation/utils/model-catalog.ts
@@ -1,0 +1,85 @@
+import type { ModelInfo } from "@nervekit/contracts";
+import {
+  modelDisplayName,
+  modelKey,
+  modelNameCounts,
+  providerDisplayName,
+} from "./model";
+
+export type ModelCatalogEntry = {
+  key: string;
+  model: ModelInfo;
+  displayName: string;
+  contextualLabel: string;
+  providerLabel: string;
+  searchText: string;
+};
+
+export type ModelProviderFacet = {
+  id: string;
+  label: string;
+  count: number;
+};
+
+export function buildModelCatalog(models: ModelInfo[]): ModelCatalogEntry[] {
+  const nameCounts = modelNameCounts(models);
+  return models
+    .map((model) => {
+      const displayName = modelDisplayName(model);
+      const providerLabel = providerDisplayName(model.provider);
+      return {
+        key: modelKey(model),
+        model,
+        displayName,
+        contextualLabel:
+          (nameCounts.get(displayName) ?? 0) > 1
+            ? `${providerLabel} / ${displayName}`
+            : displayName,
+        providerLabel,
+        searchText:
+          `${displayName} ${model.modelId} ${providerLabel} ${model.provider}`.toLowerCase(),
+      };
+    })
+    .sort((left, right) => {
+      const provider = left.providerLabel.localeCompare(right.providerLabel);
+      const name = left.displayName.localeCompare(right.displayName);
+      return provider || name || left.key.localeCompare(right.key);
+    });
+}
+
+export function filterModelCatalog(
+  entries: ModelCatalogEntry[],
+  query: string,
+  provider = "all",
+): ModelCatalogEntry[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle && provider === "all") return entries;
+  return entries.filter(
+    (entry) =>
+      (provider === "all" || entry.model.provider === provider) &&
+      (!needle || entry.searchText.includes(needle)),
+  );
+}
+
+export function modelProviderFacets(
+  entries: ModelCatalogEntry[],
+): ModelProviderFacet[] {
+  const facets = new Map<string, ModelProviderFacet>();
+  for (const entry of entries) {
+    const current = facets.get(entry.model.provider);
+    if (current) current.count += 1;
+    else {
+      facets.set(entry.model.provider, {
+        id: entry.model.provider,
+        label: entry.providerLabel,
+        count: 1,
+      });
+    }
+  }
+  return [
+    { id: "all", label: "All", count: entries.length },
+    ...[...facets.values()].sort((left, right) =>
+      left.label.localeCompare(right.label),
+    ),
+  ];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3080,14 +3080,14 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.4:
@@ -9691,16 +9691,16 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11966,19 +11966,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,9 @@ allowBuilds:
   protobufjs: true
   sharp: true
 minimumReleaseAgeExclude:
+  - brace-expansion@1.1.18
+  - brace-expansion@2.1.4
+  - brace-expansion@5.0.9
   - "@earendil-works/pi-ai@0.83.0"
   - "@astrojs/internal-helpers@0.10.2"
   - "@astrojs/markdown-satteri@0.3.5"


### PR DESCRIPTION
## Summary
- remove the arbitrary eight-model provider catalog cap so OpenRouter and other providers expose their complete catalogs
- add indexed search, provider filtering, and virtualized model lists across composer, plan, and settings pickers
- show composer search controls only when more than 10 models are available
- rename the settings page to Scoped Models and place it before Agents
- add regression coverage for complete and 500-model catalogs
- refresh patched brace-expansion lockfile resolutions

## Validation
- `pnpm fix && pnpm check && pnpm test`
- browser-verified compact composer behavior and Scoped Models navigation

Closes #56