### PR TITLE
Improve responsive settings navigation

### DIFF
--- a/packages/ui-kit/src/styles/components/settings.css
+++ b/packages/ui-kit/src/styles/components/settings.css
@@ -3,15 +3,22 @@
  * body is built from the workbench settings primitives with Tailwind token
  * utilities; do not add content styling here.
  */
+.settings-page-container {
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  /* The pane is resizable, so the layout follows its own width. */
+  container: settings-page / inline-size;
+}
+
 .settings-page {
   display: grid;
   height: 100%;
+  min-width: 0;
   min-height: 0;
   grid-template-columns: 13.5rem minmax(0, 1fr);
   background: var(--background);
   color: var(--foreground);
-  /* The pane is resizable, so the layout follows its own width. */
-  container: settings-page / inline-size;
 }
 
 .settings-sidebar {
@@ -34,6 +41,16 @@
   color: var(--foreground);
   font-size: var(--text-sm);
   font-weight: 600;
+}
+
+.settings-nav-carousel {
+  display: grid;
+  min-height: 0;
+}
+
+/* Carousel arrows only exist in the compact horizontal layout. */
+.settings-nav-arrow {
+  display: none;
 }
 
 .settings-nav {
@@ -113,6 +130,20 @@
   font-weight: 500;
 }
 
+/* Compact-layout submenu row; hidden while the nested submenu is in use. */
+.settings-subnav-row {
+  display: none;
+}
+
+.settings-sidebar-status {
+  display: grid;
+  align-items: start;
+  gap: 0.5rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  padding: 0.75rem 0.375rem 0;
+}
+
 .settings-nav :where(button) :where(svg) {
   flex: none;
   opacity: 0.85;
@@ -171,33 +202,119 @@
     grid-template-rows: auto minmax(0, 1fr);
   }
 
+  /* Two columns so the save status shares the title row on the right,
+   * freeing the vertical space its own footer row used to take. */
   .settings-sidebar {
-    grid-template-rows: auto auto auto;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-rows: none;
+    grid-auto-rows: auto;
     border-right: 0;
     border-bottom: 1px solid var(--border);
   }
 
+  .settings-sidebar > * {
+    grid-column: 1 / -1;
+  }
+
+  .settings-sidebar-title {
+    grid-row: 1;
+    grid-column: 1;
+  }
+
+  .settings-sidebar-status {
+    grid-row: 1;
+    grid-column: 2;
+    align-self: start;
+    border-top: 0;
+    padding: 0;
+  }
+
+  .settings-nav-carousel {
+    position: relative;
+    min-width: 0;
+  }
+
+  /* Arrows float over the nav edges with a scrim fading into the sidebar
+   * surface, and only render on sides that have clipped items. */
+  .settings-nav-arrow {
+    display: grid;
+    place-items: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+    width: 1.75rem;
+    border: 0;
+    color: var(--muted-foreground);
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .settings-nav-arrow:hover {
+    color: var(--sidebar-foreground);
+  }
+
+  .settings-nav-arrow-back {
+    left: 0;
+    background: linear-gradient(to right, var(--sidebar) 55%, transparent);
+    justify-items: start;
+  }
+
+  .settings-nav-arrow-forward {
+    right: 0;
+    background: linear-gradient(to left, var(--sidebar) 55%, transparent);
+    justify-items: end;
+  }
+
+  /* Nav becomes a scrollbarless carousel: items snap into place and the
+   * arrows above are the affordance that more pages exist. */
   .settings-nav {
     grid-auto-flow: column;
-    grid-auto-columns: minmax(9rem, 1fr);
+    grid-auto-columns: max-content;
+    gap: 0.25rem;
+    justify-content: start;
     overflow-x: auto;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+
+  .settings-nav::-webkit-scrollbar {
+    display: none;
   }
 
   .settings-nav-item {
     align-content: start;
+    scroll-snap-align: start;
   }
 
   .settings-nav-chevron {
     display: none;
   }
 
-  .settings-subnav {
-    grid-auto-flow: column;
-    grid-auto-columns: max-content;
-    overflow-x: auto;
+  /* The nested submenu is replaced by the standalone chip row below. */
+  .settings-nav .settings-subnav {
+    display: none;
   }
 
-  .settings-subnav {
-    margin-left: 0;
+  .settings-subnav-row {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: max-content;
+    gap: 0.3rem;
+    justify-content: start;
+    margin: 0.45rem 0 0;
+    overflow-x: auto;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+
+  .settings-subnav-row::-webkit-scrollbar {
+    display: none;
+  }
+
+  .settings-subnav-row a {
+    background: color-mix(in oklab, var(--sidebar-accent) 25%, transparent);
+    padding: 0.3rem 0.65rem;
+    scroll-snap-align: start;
   }
 }

--- a/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
@@ -209,37 +209,43 @@ function save(): void {
   </div>
 
   {#snippet footer()}
-    <div class="mr-auto flex flex-wrap items-center gap-2">
-      <span
-        class="text-xs font-medium tracking-wide text-muted-foreground uppercase"
-        >Thinking level</span
+    <div class="flex w-full flex-wrap items-center justify-end gap-2">
+      <div
+        class="mr-auto flex w-fit max-w-full flex-none flex-wrap items-center gap-2"
       >
-      <ToggleGroup.Root
-        type="single"
-        size="xs"
-        spacing={1}
-        variant="outline"
-        value={thinkingLevel}
-        aria-label="Thinking level"
-        class="flex-wrap"
-        onValueChange={(value) => {
-          if (value) thinkingLevel = value as ThinkingLevel;
-        }}
-      >
-        {#each thinkingLevels as level (level)}
-          <ToggleGroup.Item value={level} class="text-xs capitalize"
-            >{level}</ToggleGroup.Item
-          >
-        {/each}
-      </ToggleGroup.Root>
+        <span
+          class="text-xs font-medium tracking-wide text-muted-foreground uppercase"
+          >Thinking level</span
+        >
+        <ToggleGroup.Root
+          type="single"
+          size="xs"
+          spacing={1}
+          variant="outline"
+          value={thinkingLevel}
+          aria-label="Thinking level"
+          class="min-w-0 flex-wrap"
+          onValueChange={(value) => {
+            if (value) thinkingLevel = value as ThinkingLevel;
+          }}
+        >
+          {#each thinkingLevels as level (level)}
+            <ToggleGroup.Item value={level} class="text-xs capitalize"
+              >{level}</ToggleGroup.Item
+            >
+          {/each}
+        </ToggleGroup.Root>
+      </div>
+      <div class="flex flex-none items-center gap-2">
+        <Button size="sm" variant="ghost" onclick={() => (open = false)}
+          >Cancel</Button
+        >
+        <Button
+          size="sm"
+          onclick={save}
+          disabled={!hasFallback && !selectedModelInfo}>{confirmLabel}</Button
+        >
+      </div>
     </div>
-    <Button size="sm" variant="ghost" onclick={() => (open = false)}
-      >Cancel</Button
-    >
-    <Button
-      size="sm"
-      onclick={save}
-      disabled={!hasFallback && !selectedModelInfo}>{confirmLabel}</Button
-    >
   {/snippet}
 </Dialog>

--- a/packages/workbench-app/src/lib/presentation/components/settings/settings-shell.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/settings/settings-shell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
 import { tick } from "svelte";
+import ChevronLeft from "@lucide/svelte/icons/chevron-left";
 import ChevronRight from "@lucide/svelte/icons/chevron-right";
 import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
 import { cn } from "@nervekit/ui-kit/core/utils";
@@ -49,6 +50,9 @@ let {
 
 let viewportElement = $state<HTMLElement | null>(null);
 let collapsedPageIds = $state<string[]>([]);
+let navElement = $state<HTMLElement | null>(null);
+let canScrollNavBack = $state(false);
+let canScrollNavForward = $state(false);
 
 const activePage = $derived(
   pages.find((page) => page.id === activePageId) ?? pages[0],
@@ -118,6 +122,35 @@ $effect(() => {
   };
 });
 
+// Carousel affordance for the compact horizontal nav: arrows appear only on
+// the sides that have clipped items. On desktop the nav is vertical and never
+// overflows horizontally, so both flags stay false.
+$effect(() => {
+  const nav = navElement;
+  if (!nav) return;
+
+  const update = () => {
+    const maxScroll = nav.scrollWidth - nav.clientWidth;
+    canScrollNavBack = nav.scrollLeft > 1;
+    canScrollNavForward = nav.scrollLeft < maxScroll - 1;
+  };
+
+  update();
+  nav.addEventListener("scroll", update, { passive: true });
+  const observer = new ResizeObserver(update);
+  observer.observe(nav);
+  return () => {
+    nav.removeEventListener("scroll", update);
+    observer.disconnect();
+  };
+});
+
+function scrollNav(direction: -1 | 1): void {
+  const nav = navElement;
+  if (!nav) return;
+  nav.scrollBy({ left: direction * nav.clientWidth * 0.7, behavior: "smooth" });
+}
+
 async function scrollPanelToTop(): Promise<void> {
   await tick();
   viewportElement?.scrollTo({ top: 0 });
@@ -170,95 +203,134 @@ async function selectSection(sectionId: string): Promise<void> {
 }
 </script>
 
-<section class={cn("settings-page", className)}>
-  <aside class="settings-sidebar" aria-label={ariaLabel}>
-    <div class="settings-sidebar-title">
-      <strong>{title}</strong>
-    </div>
+{#snippet sectionLinks(page: SettingsPageDef)}
+  {#each page.sections as section (section.id)}
+    <li>
+      <a
+        href={`#${settingsSectionDomId(section.id)}`}
+        aria-current={activeSectionId === section.id ? "location" : undefined}
+        class:active={activeSectionId === section.id}
+        onclick={(event) => {
+          event.preventDefault();
+          void selectSection(section.id);
+        }}>{section.label}</a
+      >
+    </li>
+  {/each}
+{/snippet}
 
-    <nav class="settings-nav">
-      {#each pages as page (page.id)}
-        {@const Icon = page.icon}
-        {@const active = activePage?.id === page.id}
-        {@const expandable = page.sections.length > 1}
-        {@const expanded = active && expandable && !isCollapsed(page.id)}
-        <div class="settings-nav-item">
+<section class={cn("settings-page-container", className)}>
+  <div class="settings-page">
+    <aside class="settings-sidebar" aria-label={ariaLabel}>
+      <div class="settings-sidebar-title">
+        <strong>{title}</strong>
+      </div>
+
+      <div class="settings-nav-carousel">
+        {#if canScrollNavBack}
           <button
             type="button"
-            class:active
-            aria-current={active ? "page" : undefined}
-            aria-expanded={expandable ? expanded : undefined}
-            aria-controls={expandable
-              ? `settings-submenu-${page.id}`
-              : undefined}
-            onclick={() => selectPage(page)}
+            class="settings-nav-arrow settings-nav-arrow-back"
+            aria-label="Scroll pages back"
+            onclick={() => scrollNav(-1)}
           >
-            <Icon size={16} strokeWidth={2} />
-            <span class="settings-nav-label">{page.label}</span>
-            {#if expandable}
-              <ChevronRight
-                size={13}
-                strokeWidth={2.2}
-                class={cn(
-                  "settings-nav-chevron",
-                  expanded && "settings-nav-chevron-open",
-                )}
-              />
-            {/if}
+            <ChevronLeft size={15} strokeWidth={2.2} />
           </button>
-
-          {#if expanded}
-            <ul id={`settings-submenu-${page.id}`} class="settings-subnav">
-              {#each page.sections as section (section.id)}
-                <li>
-                  <a
-                    href={`#${settingsSectionDomId(section.id)}`}
-                    aria-current={activeSectionId === section.id
-                      ? "location"
-                      : undefined}
-                    class:active={activeSectionId === section.id}
-                    onclick={(event) => {
-                      event.preventDefault();
-                      void selectSection(section.id);
-                    }}>{section.label}</a
-                  >
-                </li>
-              {/each}
-            </ul>
-          {/if}
-        </div>
-      {/each}
-    </nav>
-
-    {#if sidebarFooter}
-      {@render sidebarFooter()}
-    {/if}
-  </aside>
-
-  <ScrollArea
-    class="settings-scroll"
-    bind:viewportRef={viewportElement}
-    viewportClass="settings-viewport"
-  >
-    <div class={cn("settings-main", mainClass)}>
-      {#if activePage}
-        {#if showHeader}
-          <SettingsPageHeader
-            title={activePage.label}
-            description={activePage.description}
-          >
-            {#snippet actions()}
-              {#if pageActions}
-                {@render pageActions(activePage)}
-              {/if}
-            {/snippet}
-          </SettingsPageHeader>
         {/if}
 
-        <div class={cn("grid min-w-0", hasSubmenu ? "gap-5" : "gap-3")}>
-          {@render children(activePage)}
-        </div>
+        <nav class="settings-nav" bind:this={navElement}>
+          {#each pages as page (page.id)}
+            {@const Icon = page.icon}
+            {@const active = activePage?.id === page.id}
+            {@const expandable = page.sections.length > 1}
+            {@const expanded = active && expandable && !isCollapsed(page.id)}
+            <div class="settings-nav-item">
+              <button
+                type="button"
+                class:active
+                aria-current={active ? "page" : undefined}
+                aria-expanded={expandable ? expanded : undefined}
+                aria-controls={expandable
+                  ? `settings-submenu-${page.id}`
+                  : undefined}
+                onclick={() => selectPage(page)}
+              >
+                <Icon size={16} strokeWidth={2} />
+                <span class="settings-nav-label">{page.label}</span>
+                {#if expandable}
+                  <ChevronRight
+                    size={13}
+                    strokeWidth={2.2}
+                    class={cn(
+                      "settings-nav-chevron",
+                      expanded && "settings-nav-chevron-open",
+                    )}
+                  />
+                {/if}
+              </button>
+
+              {#if expanded}
+                <ul id={`settings-submenu-${page.id}`} class="settings-subnav">
+                  {@render sectionLinks(page)}
+                </ul>
+              {/if}
+            </div>
+          {/each}
+        </nav>
+
+        {#if canScrollNavForward}
+          <button
+            type="button"
+            class="settings-nav-arrow settings-nav-arrow-forward"
+            aria-label="Scroll pages forward"
+            onclick={() => scrollNav(1)}
+          >
+            <ChevronRight size={15} strokeWidth={2.2} />
+          </button>
+        {/if}
+      </div>
+
+      {#if activePage && activePage.sections.length > 1}
+        <!-- Compact layout only: the nested submenu is hidden and the active
+             page's sections render as a chip row under the nav instead. -->
+        <ul
+          class="settings-subnav settings-subnav-row"
+          aria-label="Page sections"
+        >
+          {@render sectionLinks(activePage)}
+        </ul>
       {/if}
-    </div>
-  </ScrollArea>
+
+      {#if sidebarFooter}
+        {@render sidebarFooter()}
+      {/if}
+    </aside>
+
+    <ScrollArea
+      class="settings-scroll"
+      bind:viewportRef={viewportElement}
+      viewportClass="settings-viewport"
+    >
+      <div class={cn("settings-main", mainClass)}>
+        {#if activePage}
+          {#if showHeader}
+            <SettingsPageHeader
+              title={activePage.label}
+              description={activePage.description}
+            >
+              {#snippet actions()}
+                {#if pageActions}
+                  {@render pageActions(activePage)}
+                {/if}
+              {/snippet}
+            </SettingsPageHeader>
+          {/if}
+
+          <div class={cn("grid min-w-0", hasSubmenu ? "gap-5" : "gap-3")}>
+            {@render children(activePage)}
+          </div>
+        {/if}
+      </div>
+    </ScrollArea>
+  </div>
 </section>

--- a/packages/workbench-app/src/lib/presentation/components/settings/settings-sidebar-status.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/settings/settings-sidebar-status.svelte
@@ -24,9 +24,7 @@ const tones: Record<SaveStatus, StatusTone> = {
 const tone = $derived(tones[(status as SaveStatus) ?? "idle"] ?? "neutral");
 </script>
 
-<div
-  class="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-2 border-t border-border/70 px-1.5 pt-3"
->
+<div class="settings-sidebar-status">
   <StatusDot {tone} class="mt-1" />
   <p class="text-xs text-muted-foreground">{text}</p>
 </div>


### PR DESCRIPTION
## Summary
- add a compact horizontal settings navigation carousel with overflow controls
- render section links as a dedicated compact subnavigation row
- reposition save status and tighten responsive settings layout

## Validation
- `pnpm fix && pnpm check && pnpm test`