### PR TITLE
Prompt composer updates

### DIFF
--- a/packages/desktop-shell/src/preload.cjs
+++ b/packages/desktop-shell/src/preload.cjs
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- Electron preload runs as CommonJS by design.
-const { contextBridge, ipcRenderer } = require("electron");
+const { contextBridge, ipcRenderer, webUtils } = require("electron");
 
 contextBridge.exposeInMainWorld("nerveDesktop", {
   kind: "electron",
@@ -41,5 +41,8 @@ contextBridge.exposeInMainWorld("nerveDesktop", {
   clipboard: {
     writeText: (text) =>
       ipcRenderer.invoke("desktop.clipboard.writeText", text),
+  },
+  files: {
+    getPathForFile: (file) => webUtils.getPathForFile(file),
   },
 });

--- a/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
@@ -3,6 +3,8 @@ import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import Mic from "@lucide/svelte/icons/mic";
 import { isInlineCommandPrompt } from "@nervekit/contracts";
 import { uploadClipboardImage } from "$lib/api";
+import { getDesktopBridge } from "$lib/features/desktop/state/desktop-bridge.svelte";
+import { notify } from "$lib/features/notifications/notify.svelte";
 import TranscriptionActivity from "$lib/core/audio/TranscriptionActivity.svelte";
 import {
   voiceInputSession,
@@ -20,6 +22,7 @@ import {
   getShortcutLabel,
 } from "$lib/core/shortcuts/registry";
 import type { PromptComposerProps } from "../components/prompt-composer-props";
+import { resolveDroppedPaths } from "./dropped-paths";
 
 let {
   text = "",
@@ -129,6 +132,7 @@ const submitDisabled = $derived(
     (commandMode && sending),
 );
 const chatGptAudioConfigured = $derived(chatGptAudioAuth.configured);
+const fileDropSupported = $derived(Boolean(getDesktopBridge()?.files));
 const supportsAudioRecording = $derived(voiceInputSession.isSupported());
 const micDisabled = $derived(
   !interactive ||
@@ -218,6 +222,25 @@ async function submitComposer() {
 
 async function pasteImage(file: File): Promise<string> {
   return uploadClipboardImage(file);
+}
+
+async function dropFiles(files: readonly File[]): Promise<readonly string[]> {
+  try {
+    const bridge = getDesktopBridge();
+    if (!bridge?.files || !activeProject) {
+      throw new Error("Native file paths are unavailable in this window.");
+    }
+    return resolveDroppedPaths(
+      files,
+      activeProject.dir,
+      bridge.files.getPathForFile,
+    );
+  } catch (caught) {
+    const description =
+      caught instanceof Error ? caught.message : String(caught);
+    notify.error("Could not add dropped paths", { description });
+    throw caught;
+  }
 }
 
 const controlsDisabled = $derived(
@@ -357,6 +380,7 @@ function handleMicContextMenu(event: MouseEvent) {
     capabilities: {
       voice: true,
       imagePaste: true,
+      fileDrop: fileDropSupported,
       completions: true,
       suggestions: true,
       shortcuts: true,
@@ -374,6 +398,7 @@ function handleMicContextMenu(event: MouseEvent) {
     onPermissionChange,
     onApprovalPolicyChange,
     onPasteImage: pasteImage,
+    onDropFiles: fileDropSupported ? dropFiles : undefined,
   }}
 >
   {#snippet header()}

--- a/packages/workbench-app/src/lib/features/conversations/adapters/dropped-paths.test.ts
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/dropped-paths.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatDroppedPathMention, resolveDroppedPaths } from "./dropped-paths";
+
+function droppedItem(name: string): File {
+  return { name } as File;
+}
+
+describe("resolveDroppedPaths", () => {
+  it("preserves order and makes POSIX project paths relative", () => {
+    const files = [droppedItem("first.png"), droppedItem("folder")];
+    const paths = new Map<File, string>([
+      [files[0], "/home/me/project/assets/first.png"],
+      [files[1], "/home/me/project/docs"],
+    ]);
+
+    assert.deepEqual(
+      resolveDroppedPaths(
+        files,
+        "/home/me/project",
+        (file) => paths.get(file)!,
+      ),
+      ["assets/first.png", "docs"],
+    );
+  });
+
+  it("handles Windows project paths and keeps outside paths absolute", () => {
+    const files = [droppedItem("inside.txt"), droppedItem("outside.txt")];
+    const paths = new Map<File, string>([
+      [files[0], "C:\\Users\\me\\project\\src\\inside.txt"],
+      [files[1], "D:\\Reference\\outside.txt"],
+    ]);
+
+    assert.deepEqual(
+      resolveDroppedPaths(
+        files,
+        "C:\\Users\\me\\project",
+        (file) => paths.get(file)!,
+      ),
+      ["src/inside.txt", "D:/Reference/outside.txt"],
+    );
+  });
+
+  it("quotes path mentions containing whitespace", () => {
+    assert.equal(
+      formatDroppedPathMention("assets/reference image.png"),
+      '"assets/reference image.png"',
+    );
+    assert.equal(
+      formatDroppedPathMention("assets/image.png"),
+      "assets/image.png",
+    );
+    assert.equal(
+      formatDroppedPathMention('assets/a "quoted" image.png'),
+      '"assets/a \\"quoted\\" image.png"',
+    );
+  });
+
+  it("represents the project root as a dot", () => {
+    const root = droppedItem("project");
+    assert.deepEqual(
+      resolveDroppedPaths([root], "/home/me/project", () => "/home/me/project"),
+      ["."],
+    );
+  });
+
+  it("fails the whole drop when Electron cannot resolve an item", () => {
+    const files = [droppedItem("known.txt"), droppedItem("folder")];
+    assert.throws(
+      () =>
+        resolveDroppedPaths(files, "/home/me/project", (file) =>
+          file === files[0] ? "/home/me/project/known.txt" : "",
+        ),
+      /Could not resolve the native path for folder/,
+    );
+  });
+
+  it("returns no paths for an empty drop", () => {
+    assert.deepEqual(
+      resolveDroppedPaths([], "/project", () => "/unused"),
+      [],
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/features/conversations/adapters/dropped-paths.ts
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/dropped-paths.ts
@@ -1,0 +1,28 @@
+import { relativePathForDisplay } from "@nervekit/ui-kit/core/utils/path-links";
+
+export type NativeFilePathResolver = (file: File) => string;
+
+export function formatDroppedPathMention(path: string): string {
+  if (!/\s/.test(path)) return path;
+  return `"${path.replaceAll('"', '\\"')}"`;
+}
+
+export function resolveDroppedPaths(
+  files: readonly File[],
+  projectDir: string,
+  getPathForFile: NativeFilePathResolver,
+): string[] {
+  if (files.length === 0) return [];
+
+  return files.map((file) => {
+    const path = getPathForFile(file).trim();
+    if (!path) {
+      throw new Error(
+        `Could not resolve the native path for ${file.name || "a dropped item"}.`,
+      );
+    }
+    return formatDroppedPathMention(
+      relativePathForDisplay(path, projectDir) ?? path,
+    );
+  });
+}

--- a/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
@@ -2,6 +2,7 @@
 import { untrack } from "svelte";
 import { writeClipboardText } from "$lib/core/clipboard";
 import { notify } from "$lib/features/notifications/notify.svelte";
+import { getDesktopBridge } from "$lib/features/desktop/state/desktop-bridge.svelte";
 import type { WorkbenchConversationAdapterProps } from "./workbench-conversation-adapter-props";
 import { shortProjectLabel } from "$lib/core/utils/project-tree";
 import {
@@ -250,6 +251,7 @@ function menuForTranscript(
       capabilities: {
         voice: true,
         imagePaste: true,
+        fileDrop: Boolean(getDesktopBridge()?.files),
         completions: true,
         suggestions: true,
         shortcuts: true,

--- a/packages/workbench-app/src/lib/features/desktop/state/desktop-bridge.svelte.ts
+++ b/packages/workbench-app/src/lib/features/desktop/state/desktop-bridge.svelte.ts
@@ -33,6 +33,9 @@ export interface NerveDesktopBridge {
   clipboard: {
     writeText: (text: string) => Promise<{ ok: true }>;
   };
+  files: {
+    getPathForFile: (file: File) => string;
+  };
 }
 
 declare global {

--- a/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from "svelte";
+import FileIcon from "@lucide/svelte/icons/file";
 import {
   autocompletion,
   completionStatus,
@@ -39,6 +40,7 @@ type Props = {
   onChange?: (value: string) => void;
   onSubmit?: () => void;
   onPasteImage?: (file: File) => Promise<string>;
+  onDropFiles?: (files: readonly File[]) => Promise<readonly string[]>;
 };
 
 type ComposerCompletion = Completion & {
@@ -62,12 +64,15 @@ let {
   onChange,
   onSubmit,
   onPasteImage,
+  onDropFiles,
 }: Props = $props();
 
 let host: HTMLDivElement;
 let view: EditorView | undefined;
 let editorValue = $state("");
 let lastFocusToken = 0;
+let fileDragDepth = 0;
+let fileDragActive = $state(false);
 const editableCompartment = new Compartment();
 const completionCompartment = new Compartment();
 const placeholderCompartment = new Compartment();
@@ -373,15 +378,85 @@ function submitOnEnter(target: EditorView) {
   return submit();
 }
 
-function insertAtSelection(text: string) {
-  if (!view) return;
+function insertAtRange(text: string, from?: number, to?: number) {
+  if (!view || !text) return;
   const selection = view.state.selection.main;
+  const docLength = view.state.doc.length;
+  const insertFrom = Math.min(from ?? selection.from, docLength);
+  const insertTo = Math.min(to ?? selection.to, docLength);
   view.dispatch({
-    changes: { from: selection.from, to: selection.to, insert: text },
-    selection: { anchor: selection.from + text.length },
+    changes: { from: insertFrom, to: insertTo, insert: text },
+    selection: { anchor: insertFrom + text.length },
     scrollIntoView: true,
   });
   view.focus();
+}
+
+function insertDroppedPaths(
+  paths: readonly string[],
+  selection: { from: number; to: number },
+): void {
+  if (!view || paths.length === 0) return;
+  const doc = view.state.doc;
+  const from = Math.min(selection.from, doc.length);
+  const to = Math.min(selection.to, doc.length);
+  const before = from > 0 ? doc.sliceString(from - 1, from) : "";
+  const after = to < doc.length ? doc.sliceString(to, to + 1) : "";
+  const leadingSpace = before && !/\s/.test(before) ? " " : "";
+  const trailingSpace = after && !/\s/.test(after) ? " " : "";
+  insertAtRange(`${leadingSpace}${paths.join(" ")}${trailingSpace}`, from, to);
+}
+
+function hasFileItems(dataTransfer: DataTransfer | null): boolean {
+  if (!dataTransfer) return false;
+  return (
+    Array.from(dataTransfer.items).some((item) => item.kind === "file") ||
+    Array.from(dataTransfer.types).includes("Files")
+  );
+}
+
+function canHandleFileDrag(event: DragEvent): boolean {
+  return Boolean(!disabled && onDropFiles && hasFileItems(event.dataTransfer));
+}
+
+function handleFileDragEnter(event: DragEvent): void {
+  if (!canHandleFileDrag(event)) return;
+  event.preventDefault();
+  event.stopPropagation();
+  fileDragDepth += 1;
+  fileDragActive = true;
+}
+
+function handleFileDragOver(event: DragEvent): void {
+  if (!canHandleFileDrag(event)) return;
+  event.preventDefault();
+  event.stopPropagation();
+  if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+}
+
+function handleFileDragLeave(event: DragEvent): void {
+  if (!fileDragActive) return;
+  event.preventDefault();
+  event.stopPropagation();
+  fileDragDepth = Math.max(0, fileDragDepth - 1);
+  if (fileDragDepth === 0) fileDragActive = false;
+}
+
+function handleFileDrop(event: DragEvent): void {
+  if (!canHandleFileDrag(event) || !onDropFiles || !view) return;
+  event.preventDefault();
+  event.stopPropagation();
+  fileDragDepth = 0;
+  fileDragActive = false;
+
+  const files = Array.from(event.dataTransfer?.files ?? []);
+  if (files.length === 0) return;
+  const { from, to } = view.state.selection.main;
+  void onDropFiles(files)
+    .then((paths) => insertDroppedPaths(paths, { from, to }))
+    .catch((error: unknown) => {
+      console.error("Failed to resolve dropped file paths", error);
+    });
 }
 
 function handlePaste(event: ClipboardEvent) {
@@ -392,7 +467,7 @@ function handlePaste(event: ClipboardEvent) {
   if (!files.length) return false;
   event.preventDefault();
   void Promise.all(files.map((file) => onPasteImage(file)))
-    .then((paths) => insertAtSelection(paths.join("\n")))
+    .then((paths) => insertAtRange(paths.join("\n")))
     .catch((error: unknown) => {
       console.error("Failed to paste clipboard image", error);
     });
@@ -604,6 +679,10 @@ $effect(() => {
   view.dispatch({
     effects: editableCompartment.reconfigure(editableExtensions(disabled)),
   });
+  if (disabled) {
+    fileDragDepth = 0;
+    fileDragActive = false;
+  }
 });
 
 $effect(() => {
@@ -641,7 +720,27 @@ $effect(() => {
 onDestroy(() => view?.destroy());
 </script>
 
-<div class="composer-editor" class:disabled bind:this={host}></div>
+<div
+  class="composer-editor relative"
+  class:disabled
+  role="group"
+  aria-label="Prompt editor drop area"
+  ondragentercapture={handleFileDragEnter}
+  ondragovercapture={handleFileDragOver}
+  ondragleavecapture={handleFileDragLeave}
+  ondropcapture={handleFileDrop}
+>
+  <div bind:this={host}></div>
+  {#if fileDragActive}
+    <div
+      class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center gap-2 rounded-md border border-primary bg-background/95 px-4 text-sm font-medium text-foreground shadow-sm"
+      aria-hidden="true"
+    >
+      <FileIcon class="size-4 text-primary" />
+      <span>Drop files or folders to add their paths</span>
+    </div>
+  {/if}
+</div>
 
 <style>
 .composer-editor {

--- a/packages/workbench-app/src/lib/presentation/components/conversation/agent-composer.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/agent-composer.svelte
@@ -137,6 +137,7 @@ function submit(): void {
       onChange={actions.onComposerChange}
       onSubmit={submit}
       onPasteImage={actions.onPasteImage}
+      onDropFiles={actions.onDropFiles}
     />
   {/snippet}
 

--- a/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
@@ -29,6 +29,7 @@ import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-men
 export type ConversationComposerCapabilities = {
   voice?: boolean;
   imagePaste?: boolean;
+  fileDrop?: boolean;
   completions?: boolean;
   suggestions?: boolean;
   shortcuts?: boolean;
@@ -116,6 +117,7 @@ export type ConversationPaneActions = {
   onPermissionChange?: (value: PermissionLevel) => void;
   onApprovalPolicyChange?: (value: ApprovalPolicy) => void;
   onPasteImage?: (file: File) => Promise<string>;
+  onDropFiles?: (files: readonly File[]) => Promise<readonly string[]>;
   onOpenFile?: (path: string, line?: number) => void;
   onAnswerUserQuestion?: (id: string, answer: string) => void | Promise<void>;
   onDismissUserQuestion?: (id: string) => void | Promise<void>;


### PR DESCRIPTION
## Summary
- add desktop-native file and folder path resolution for the prompt composer
- support drag-and-drop insertion with visual drop feedback and project-relative paths
- add coverage for dropped-path formatting and resolution

This PR uses a broad prompt-composer scope so follow-up composer updates can land in subsequent commits.

## Validation
- `pnpm fix && pnpm check && pnpm test`