### PR TITLE
Improve composer file completions

### DIFF
--- a/packages/contracts/src/domains/completions/completion.schema.ts
+++ b/packages/contracts/src/domains/completions/completion.schema.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const FILE_COMPLETION_RESULT_LIMIT = 8;
+export const FILE_COMPLETION_QUERY_MAX_LENGTH = 512;
+
 export const completionKindSchema = z.enum(["slash", "file", "directory"]);
 export type CompletionKind = z.infer<typeof completionKindSchema>;
 
@@ -28,7 +31,13 @@ export type CompletionResponse = z.infer<typeof completionResponseSchema>;
 
 export const fileCompletionQuerySchema = z.object({
   projectId: z.string().min(1).optional(),
-  q: z.string().optional().default(""),
-  limit: z.coerce.number().int().positive().max(200).optional(),
+  q: z.string().max(FILE_COMPLETION_QUERY_MAX_LENGTH).optional().default(""),
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(FILE_COMPLETION_RESULT_LIMIT)
+    .optional()
+    .default(FILE_COMPLETION_RESULT_LIMIT),
 });
 export type FileCompletionQuery = z.infer<typeof fileCompletionQuerySchema>;

--- a/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
@@ -2,8 +2,13 @@
 import { onDestroy, onMount } from "svelte";
 import FileIcon from "@lucide/svelte/icons/file";
 import {
+  acceptCompletion,
   autocompletion,
+  closeCompletion,
   completionStatus,
+  currentCompletions,
+  selectedCompletionIndex,
+  setSelectedCompletion,
   type Completion,
   type CompletionContext,
   type CompletionSection,
@@ -26,6 +31,7 @@ import {
   type ViewUpdate,
 } from "@codemirror/view";
 import {
+  FILE_COMPLETION_RESULT_LIMIT,
   findExecutableCommandBlocks,
   type CompletionItem,
 } from "@nervekit/contracts";
@@ -285,6 +291,7 @@ async function completionSource(context: CompletionContext) {
           item.label.startsWith(rawToken) ||
           item.label.includes(rawToken.slice(1)),
       )
+      .slice(0, FILE_COMPLETION_RESULT_LIMIT)
       .map(toCompletion);
     return { from: tokenStart, options, validFor: /^\/[\w-]*$/ };
   }
@@ -292,7 +299,10 @@ async function completionSource(context: CompletionContext) {
   if (rawToken.startsWith("@")) {
     context.addEventListener("abort", () => undefined, { onDocChange: true });
     const query = rawToken.slice(1);
-    const options = ((await fileCompletions?.(query)) ?? []).map(toCompletion);
+    const options = ((await fileCompletions?.(query)) ?? [])
+      .slice(0, FILE_COMPLETION_RESULT_LIMIT)
+      .reverse()
+      .map(toCompletion);
     if (context.aborted) return null;
     return {
       from: tokenStart,
@@ -303,7 +313,12 @@ async function completionSource(context: CompletionContext) {
   }
 
   if (context.explicit) {
-    return { from: context.pos, options: slashCompletions.map(toCompletion) };
+    return {
+      from: context.pos,
+      options: slashCompletions
+        .slice(0, FILE_COMPLETION_RESULT_LIMIT)
+        .map(toCompletion),
+    };
   }
 
   return null;
@@ -335,6 +350,39 @@ function executableCommandBlockDecorations(state: EditorState): DecorationSet {
   );
 }
 
+const bestFileCompletionSelector = ViewPlugin.fromClass(
+  class {
+    private lastOptions: readonly Completion[] | undefined;
+
+    update(update: ViewUpdate): void {
+      if (completionStatus(update.state) !== "active") {
+        this.lastOptions = undefined;
+        return;
+      }
+      const options = currentCompletions(update.state);
+      const hasFileOptions = options.some((completion) => {
+        const kind = (completion as ComposerCompletion).nerveKind;
+        return kind === "file" || kind === "directory";
+      });
+      if (!hasFileOptions || options === this.lastOptions) return;
+      this.lastOptions = options;
+
+      queueMicrotask(() => {
+        if (!view || completionStatus(view.state) !== "active") return;
+        if (currentCompletions(view.state) !== options) return;
+        const bestIndex = options.length - 1;
+        if (
+          bestIndex < 0 ||
+          selectedCompletionIndex(view.state) === bestIndex
+        ) {
+          return;
+        }
+        view.dispatch({ effects: setSelectedCompletion(bestIndex) });
+      });
+    }
+  },
+);
+
 const executableCommandBlockHighlighter = ViewPlugin.fromClass(
   class {
     decorations: DecorationSet;
@@ -359,7 +407,8 @@ function completionExtensions() {
   return autocompletion({
     override: [completionSource],
     icons: false,
-    maxRenderedOptions: 80,
+    aboveCursor: true,
+    maxRenderedOptions: FILE_COMPLETION_RESULT_LIMIT,
     tooltipClass: () => "nerve-composer-completions",
     optionClass: completionOptionClass,
     addToOptions: [{ render: renderCompletionRow, position: 20 }],
@@ -376,6 +425,11 @@ function submitOnEnter(target: EditorView) {
   // Let the autocomplete keymap handle Enter when a completion popup is open.
   if (completionStatus(target.state) === "active") return false;
   return submit();
+}
+
+function acceptCompletionOnTab(target: EditorView): boolean {
+  if (completionStatus(target.state) !== "active") return false;
+  return acceptCompletion(target);
 }
 
 function insertAtRange(text: string, from?: number, to?: number) {
@@ -487,9 +541,12 @@ onMount(() => {
         editableCompartment.of(editableExtensions(disabled)),
         completionCompartment.of(completionExtensions()),
         executableCommandBlockHighlighter,
+        bestFileCompletionSelector,
         Prec.highest(
           keymap.of([
             { key: "Enter", run: submitOnEnter },
+            { key: "Tab", run: acceptCompletionOnTab },
+            { key: "Escape", run: closeCompletion },
             { key: "Mod-Enter", run: submit },
             { key: "Ctrl-Enter", run: submit },
             indentWithTab,
@@ -549,15 +606,15 @@ onMount(() => {
             overflow: "hidden",
           },
           ".cm-tooltip-autocomplete.nerve-composer-completions": {
-            minWidth: "min(28rem, calc(100vw - 2rem))",
-            maxWidth: "min(38rem, calc(100vw - 2rem))",
-            padding: "0.25rem",
+            minWidth: "min(24rem, calc(100vw - 2rem))",
+            maxWidth: "min(34rem, calc(100vw - 2rem))",
+            padding: "0.15rem",
           },
           ".cm-tooltip-autocomplete.nerve-composer-completions > ul": {
-            maxHeight: "min(42vh, 22rem)",
-            padding: "0.15rem",
+            maxHeight: "none",
+            overflow: "hidden",
+            padding: "0.1rem",
             fontFamily: "var(--font-mono)",
-            scrollbarWidth: "thin",
           },
           ".cm-tooltip-autocomplete.nerve-composer-completions > ul > completion-section":
             {
@@ -565,17 +622,17 @@ onMount(() => {
               color: "var(--muted-foreground)",
               fontFamily: "var(--font-sans)",
               fontSize: "var(--text-xs)",
-              fontWeight: "700",
+              fontWeight: "500",
               letterSpacing: "0.02em",
-              padding: "0.35rem 0.5rem 0.2rem",
+              padding: "0.25rem 0.4rem 0.15rem",
               textTransform: "uppercase",
             },
           ".cm-tooltip-autocomplete.nerve-composer-completions > ul > li": {
             display: "flex",
             alignItems: "center",
-            minHeight: "1.85rem",
+            minHeight: "1.55rem",
             borderRadius: "var(--radius-sm)",
-            padding: "0.28rem 0.5rem",
+            padding: "0.18rem 0.4rem",
             color: "var(--popover-foreground)",
           },
           ".cm-tooltip-autocomplete.nerve-composer-completions > ul > li[aria-selected]":
@@ -596,7 +653,7 @@ onMount(() => {
           ".cm-tooltip-autocomplete.nerve-composer-completions .cm-nerve-row": {
             display: "flex",
             alignItems: "center",
-            gap: "0.5rem",
+            gap: "0.4rem",
             minWidth: "0",
             width: "100%",
           },
@@ -619,7 +676,7 @@ onMount(() => {
             {
               display: "flex",
               alignItems: "baseline",
-              gap: "0.4rem",
+              gap: "0.3rem",
               flex: "1",
               minWidth: "0",
             },
@@ -642,13 +699,13 @@ onMount(() => {
               whiteSpace: "nowrap",
               fontFamily: "var(--font-mono)",
               fontSize: "var(--text-sm)",
-              fontWeight: "600",
+              fontWeight: "500",
               color: "var(--popover-foreground)",
             },
           ".cm-tooltip-autocomplete.nerve-composer-completions .cm-nerve-match":
             {
               color: "var(--primary)",
-              fontWeight: "700",
+              fontWeight: "600",
             },
           ".cm-tooltip.cm-completionInfo": {
             maxWidth: "min(30rem, calc(100vw - 2rem))",

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -38,14 +38,15 @@
     "@hono/node-server": "2.0.11",
     "@nervekit/contracts": "workspace:*",
     "@nervekit/harness": "workspace:*",
+    "@nervekit/protocol": "workspace:*",
     "@nervekit/tools": "workspace:*",
     "@peculiar/x509": "^2.0.0",
+    "fdir": "6.5.0",
     "hono": "4.12.32",
     "reflect-metadata": "^0.2.2",
     "ws": "8.21.0",
     "yaml": "2.9.0",
-    "zod": "4.1.12",
-    "@nervekit/protocol": "workspace:*"
+    "zod": "4.1.12"
   },
   "devDependencies": {
     "@types/node": "24.10.1",

--- a/packages/workbench-server/src/domains/completions/file-completion-candidates.ts
+++ b/packages/workbench-server/src/domains/completions/file-completion-candidates.ts
@@ -4,6 +4,7 @@ import { readdir } from "node:fs/promises";
 import {
   basename,
   dirname,
+  extname,
   isAbsolute,
   join,
   relative,
@@ -11,6 +12,7 @@ import {
 } from "node:path";
 import { promisify } from "node:util";
 import type { CompletionItem } from "@nervekit/contracts";
+import { fdir } from "fdir";
 import {
   labelNameOffset,
   toCompletionItem,
@@ -23,31 +25,87 @@ const gitMaxBuffer = 16 * 1024 * 1024;
 const maxWalkEntries = 20_000;
 const maxWalkDepth = 10;
 
-const skippedDirectoryNames = new Set([
-  ".git",
-  ".cache",
-  ".next",
-  ".nuxt",
-  ".parcel-cache",
-  ".pnpm-store",
-  ".svelte-kit",
-  ".turbo",
-  ".yarn",
-  "build",
-  "coverage",
-  "dist",
-  "node_modules",
-  "out",
-  "target",
-  "vendor",
+const skippedDirectoryNames = new Set(
+  [
+    ".angular",
+    ".cache",
+    ".dart_tool",
+    ".expo",
+    ".git",
+    ".gradle",
+    ".hg",
+    ".idea",
+    ".next",
+    ".nuxt",
+    ".output",
+    ".parcel-cache",
+    ".pnpm-store",
+    ".svn",
+    ".svelte-kit",
+    ".turbo",
+    ".venv",
+    ".vercel",
+    ".vite",
+    ".webpack",
+    ".yarn",
+    "__pycache__",
+    "bin",
+    "bower_components",
+    "build",
+    "coverage",
+    "deriveddata",
+    "dist",
+    "logs",
+    "node_modules",
+    "obj",
+    "out",
+    "pods",
+    "target",
+    "temp",
+    "tmp",
+    "vendor",
+    "venv",
+  ].map((name) => name.toLowerCase()),
+);
+
+const skippedFileExtensions = new Set([
+  ".7z",
+  ".a",
+  ".bin",
+  ".bz2",
+  ".class",
+  ".dll",
+  ".dylib",
+  ".exe",
+  ".gz",
+  ".jar",
+  ".lib",
+  ".o",
+  ".obj",
+  ".pyc",
+  ".pyo",
+  ".rar",
+  ".so",
+  ".tar",
+  ".tgz",
+  ".war",
+  ".wasm",
+  ".xz",
+  ".zip",
 ]);
 
 export type FileCandidateKind = "file" | "directory";
 
 export type FileCompletionCandidate = {
   relativePath: string;
+  pathLower: string;
   name: string;
+  nameLower: string;
+  stem: string;
+  stemLower: string;
   parentPath: string;
+  segments: string[];
+  segmentsLower: string[];
   depth: number;
   kind: FileCandidateKind;
 };
@@ -56,7 +114,7 @@ export async function discoverCandidates(
   root: string,
 ): Promise<FileCompletionCandidate[]> {
   const gitPaths = await gitFilePaths(root);
-  if (gitPaths && gitPaths.length > 0) return candidatesFromFilePaths(gitPaths);
+  if (gitPaths !== undefined) return candidatesFromFilePaths(gitPaths);
   return walkCandidates(root);
 }
 
@@ -75,6 +133,9 @@ export async function directDirectoryCompletionItems(
   const directoryPart = query.endsWith("/") ? normalizedQuery : parentOf(query);
   const basePart = query.endsWith("/") || directoryPart ? "" : query;
   const relativeDirectory = directoryPart === "." ? "" : directoryPart;
+  if (relativeDirectory && isExcludedRelativePath(relativeDirectory, true)) {
+    return [];
+  }
   const targetDirectory = resolve(root, relativeDirectory);
   if (!isInside(root, targetDirectory)) return [];
 
@@ -86,13 +147,17 @@ export async function directDirectoryCompletionItems(
   }
 
   return entries
-    .filter((entry) => !entry.name.startsWith("."))
     .filter((entry) => !entry.isSymbolicLink())
-    .filter(
-      (entry) =>
-        entry.isFile() ||
-        (entry.isDirectory() && !skippedDirectoryNames.has(entry.name)),
-    )
+    .filter((entry) => entry.isFile() || entry.isDirectory())
+    .filter((entry) => {
+      const relativePath = normalizeRelativePath(
+        join(relativeDirectory, entry.name),
+      );
+      return Boolean(
+        relativePath &&
+        !isExcludedRelativePath(relativePath, entry.isDirectory()),
+      );
+    })
     .filter((entry) =>
       entry.name.toLowerCase().startsWith(basePart.toLowerCase()),
     )
@@ -144,18 +209,22 @@ async function gitFilePaths(root: string): Promise<string[] | undefined> {
       .toString()
       .split("\0")
       .map(normalizeRelativePath)
-      .filter((path): path is string => Boolean(path));
+      .filter((path): path is string =>
+        Boolean(path && !isExcludedRelativePath(path, false)),
+      );
   } catch {
     return undefined;
   }
 }
 
-function candidatesFromFilePaths(paths: string[]): FileCompletionCandidate[] {
+function candidatesFromFilePaths(
+  paths: readonly string[],
+): FileCompletionCandidate[] {
   const candidates = new Map<string, FileCompletionCandidate>();
 
   for (const path of paths) {
     const relativePath = normalizeRelativePath(path);
-    if (!relativePath) continue;
+    if (!relativePath || isExcludedRelativePath(relativePath, false)) continue;
     const segments = relativePath.split("/").filter(Boolean);
     if (segments.length === 0) continue;
 
@@ -171,50 +240,26 @@ function candidatesFromFilePaths(paths: string[]): FileCompletionCandidate[] {
 async function walkCandidates(
   root: string,
 ): Promise<FileCompletionCandidate[]> {
+  const paths = await new fdir({ excludeSymlinks: true })
+    .withDirs()
+    .withRelativePaths()
+    .withPathSeparator("/")
+    .withMaxDepth(maxWalkDepth)
+    .withMaxFiles(maxWalkEntries)
+    .exclude((directoryName) => isSkippedDirectoryName(directoryName))
+    .crawl(root)
+    .withPromise();
+
   const candidates = new Map<string, FileCompletionCandidate>();
-  const state = { count: 0 };
-
-  async function visit(
-    relativeDirectory: string,
-    depth: number,
-  ): Promise<void> {
-    if (depth > maxWalkDepth || state.count >= maxWalkEntries) return;
-
-    const absoluteDirectory = resolve(root, relativeDirectory);
-    if (!isInside(root, absoluteDirectory)) return;
-
-    let entries: Dirent[];
-    try {
-      entries = await readdir(absoluteDirectory, { withFileTypes: true });
-    } catch {
-      return;
+  for (const rawPath of paths.slice(0, maxWalkEntries)) {
+    if (rawPath === ".") continue;
+    const isDirectory = rawPath.endsWith("/");
+    const relativePath = normalizeRelativePath(rawPath);
+    if (!relativePath || isExcludedRelativePath(relativePath, isDirectory)) {
+      continue;
     }
-
-    entries.sort((a, b) => a.name.localeCompare(b.name));
-    for (const entry of entries) {
-      if (state.count >= maxWalkEntries) return;
-      if (entry.isSymbolicLink()) continue;
-
-      const relativePath = normalizeRelativePath(
-        join(relativeDirectory, entry.name),
-      );
-      if (!relativePath) continue;
-
-      if (entry.isDirectory()) {
-        if (skippedDirectoryNames.has(entry.name)) continue;
-        addCandidate(candidates, relativePath, "directory");
-        state.count += 1;
-        await visit(relativePath, depth + 1);
-        continue;
-      }
-
-      if (!entry.isFile()) continue;
-      addCandidate(candidates, relativePath, "file");
-      state.count += 1;
-    }
+    addCandidate(candidates, relativePath, isDirectory ? "directory" : "file");
   }
-
-  await visit("", 0);
   return sortCandidates([...candidates.values()]);
 }
 
@@ -224,27 +269,42 @@ function addCandidate(
   kind: FileCandidateKind,
 ): void {
   const normalized = normalizeRelativePath(relativePath);
-  if (!normalized) return;
+  if (!normalized || isExcludedRelativePath(normalized, kind === "directory")) {
+    return;
+  }
   const key = `${kind}:${normalized}`;
   if (candidates.has(key)) return;
   candidates.set(key, candidateFromPath(normalized, kind));
 }
 
-function candidateFromPath(
+export function candidateFromPath(
   relativePath: string,
   kind: FileCandidateKind,
 ): FileCompletionCandidate {
+  const name = basename(relativePath);
+  const extension = kind === "file" ? extname(name) : "";
+  const stem = extension ? name.slice(0, -extension.length) : name;
+  const segments = relativePath.split("/");
   return {
     relativePath,
-    name: basename(relativePath),
+    pathLower: relativePath.toLowerCase(),
+    name,
+    nameLower: name.toLowerCase(),
+    stem,
+    stemLower: stem.toLowerCase(),
     parentPath: parentOf(relativePath),
-    depth: relativePath.split("/").length,
+    segments,
+    segmentsLower: segments.map((segment) => segment.toLowerCase()),
+    depth: segments.length,
     kind,
   };
 }
 
 function normalizeRelativePath(path: string): string | undefined {
-  const normalized = path.replaceAll("\\", "/").replace(/^\.\/+/, "");
+  const normalized = path
+    .replaceAll("\\", "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "");
   if (!normalized || normalized.includes("\0")) return undefined;
   if (
     normalized.startsWith("/") ||
@@ -257,7 +317,20 @@ function normalizeRelativePath(path: string): string | undefined {
   if (normalized.split("/").some((segment) => !segment || segment === "..")) {
     return undefined;
   }
-  return normalized.replace(/\/+$/, "");
+  return normalized;
+}
+
+function isExcludedRelativePath(path: string, isDirectory: boolean): boolean {
+  const segments = path.replaceAll("\\", "/").split("/").filter(Boolean);
+  if (segments.some(isSkippedDirectoryName)) return true;
+  if (isDirectory) return false;
+  return skippedFileExtensions.has(
+    extname(segments.at(-1) ?? "").toLowerCase(),
+  );
+}
+
+function isSkippedDirectoryName(name: string): boolean {
+  return skippedDirectoryNames.has(name.toLowerCase());
 }
 
 function parentOf(path: string): string {

--- a/packages/workbench-server/src/domains/completions/file-completion-ranking.ts
+++ b/packages/workbench-server/src/domains/completions/file-completion-ranking.ts
@@ -1,8 +1,11 @@
-import { extname, isAbsolute } from "node:path";
-import type { CompletionItem } from "@nervekit/contracts";
+import { isAbsolute } from "node:path";
+import {
+  FILE_COMPLETION_RESULT_LIMIT,
+  type CompletionItem,
+} from "@nervekit/contracts";
 import type { FileCompletionCandidate } from "./file-completion-candidates.js";
 
-export const defaultCompletionLimit = 60;
+export const defaultCompletionLimit = FILE_COMPLETION_RESULT_LIMIT;
 
 export type CompletionOptions = {
   limit?: number;
@@ -19,7 +22,12 @@ type RankedCandidate = CompletionItemInput;
 type TargetMatch = {
   score: number;
   ranges: Array<[number, number]>;
-  index: number;
+  segmentIndex: number;
+};
+
+type LocalMatch = {
+  score: number;
+  ranges: Array<[number, number]>;
 };
 
 export function completeFileCandidates(
@@ -34,10 +42,12 @@ export function completeFileCandidates(
     .map((candidate) => rankCandidate(candidate, query))
     .filter((candidate): candidate is RankedCandidate => Boolean(candidate))
     .sort(compareRankedCandidates);
+  const limit = Math.min(
+    options.limit ?? defaultCompletionLimit,
+    FILE_COMPLETION_RESULT_LIMIT,
+  );
 
-  return ranked
-    .slice(0, options.limit ?? defaultCompletionLimit)
-    .map(toCompletionItem);
+  return ranked.slice(0, limit).map(toCompletionItem);
 }
 
 export function normalizeCompletionQuery(query: string): string {
@@ -65,39 +75,44 @@ function rankCandidate(
   if (!query) return rankEmptyCandidate(candidate);
 
   const queryLower = query.toLowerCase();
-  const pathLower = candidate.relativePath.toLowerCase();
-  const nameLower = candidate.name.toLowerCase();
-  const queryWithoutTrailingSlash = queryLower.replace(/\/+$/, "");
+  const pathQuery = queryLower.replace(/\/+$/, "");
   const folderIntent = query.endsWith("/");
 
-  if (folderIntent && pathLower === queryWithoutTrailingSlash) return undefined;
+  if (folderIntent && candidate.pathLower === pathQuery) return undefined;
 
-  if (pathLower === queryWithoutTrailingSlash) {
+  if (candidate.pathLower === pathQuery) {
     return {
       candidate,
-      score: 14_000 + kindBoost(candidate, folderIntent) - candidate.depth,
-      matchRanges: [
-        [1, Math.min(label.length, 1 + queryWithoutTrailingSlash.length)],
-      ],
+      score: 20_000 + kindBoost(candidate, folderIntent) - candidate.depth,
+      matchRanges: [[1, Math.min(label.length, 1 + pathQuery.length)]],
     };
   }
 
-  if (nameLower === queryLower) {
+  if (
+    candidate.nameLower === queryLower ||
+    candidate.stemLower === queryLower
+  ) {
     const offset = labelNameOffset(candidate);
+    const length =
+      candidate.stemLower === queryLower
+        ? candidate.stem.length
+        : candidate.name.length;
     return {
       candidate,
-      score: 13_000 + kindBoost(candidate, folderIntent) - candidate.depth,
-      matchRanges: [[offset, offset + candidate.name.length]],
+      score: 18_000 + kindBoost(candidate, folderIntent) - candidate.depth,
+      matchRanges: [[offset, offset + length]],
     };
   }
 
-  if (pathLower.startsWith(queryLower)) {
-    const remainder = pathLower.slice(queryLower.length).replace(/^\/+/, "");
+  if (candidate.pathLower.startsWith(queryLower)) {
+    const remainder = candidate.pathLower
+      .slice(queryLower.length)
+      .replace(/^\/+/, "");
     const remainingDepth = remainder ? remainder.split("/").length : 0;
     return {
       candidate,
       score:
-        12_000 +
+        16_000 +
         kindBoost(candidate, folderIntent) -
         remainingDepth * 120 -
         candidate.depth * 6 -
@@ -107,31 +122,26 @@ function rankCandidate(
   }
 
   const terms = query
-    .split(/[\s/]+/)
+    .replace(/\/+$/, "")
+    .split(query.includes("/") ? /\/+/ : /\s+/)
     .map((term) => term.trim())
     .filter(Boolean);
   if (terms.length === 0) return rankEmptyCandidate(candidate);
+  if (terms.length > 6) return undefined;
 
-  const targets = targetsFor(candidate, query.includes("/"));
-  const matches: TargetMatch[] = [];
-
-  for (const term of terms) {
-    const match = bestMatchForTerm(term, targets);
-    if (!match) return undefined;
-    matches.push(match);
-  }
-
-  const score =
-    5_000 +
-    matches.reduce((total, match) => total + match.score, 0) +
-    orderedTermBoost(matches) +
-    kindBoost(candidate, folderIntent) -
-    candidate.depth * 14 -
-    candidate.relativePath.length / 10;
+  const matches = query.includes("/")
+    ? orderedPathMatches(candidate, terms)
+    : unorderedTermMatches(candidate, terms);
+  if (!matches) return undefined;
 
   return {
     candidate,
-    score,
+    score:
+      7_000 +
+      matches.reduce((total, match) => total + match.score, 0) +
+      kindBoost(candidate, folderIntent) -
+      candidate.depth * 16 -
+      candidate.relativePath.length / 8,
     matchRanges: mergeRanges(matches.flatMap((match) => match.ranges)),
   };
 }
@@ -203,167 +213,281 @@ function kindBoost(
   return candidate.kind === "file" ? 180 : 40;
 }
 
-type MatchTarget = {
-  value: string;
-  labelOffset: number;
-  weight: number;
-  scope: "stem" | "name" | "segment" | "path";
-};
-
-function stemOf(name: string): string {
-  const extension = extname(name);
-  return extension ? name.slice(0, -extension.length) : name;
-}
-
-function targetsFor(
+function orderedPathMatches(
   candidate: FileCompletionCandidate,
-  includeFullPath: boolean,
-): MatchTarget[] {
-  const targets: MatchTarget[] = [];
-  const nameOffset = labelNameOffset(candidate);
-  const stem =
-    candidate.kind === "file" ? stemOf(candidate.name) : candidate.name;
+  terms: string[],
+): TargetMatch[] | undefined {
+  const rows: Array<Array<TargetMatch | undefined>> = terms.map((term) =>
+    candidate.segments.map((_, segmentIndex) =>
+      matchSegment(candidate, term, segmentIndex),
+    ),
+  );
+  const scores = rows.map(() =>
+    candidate.segments.map(() => Number.NEGATIVE_INFINITY),
+  );
+  const previous = rows.map(() => candidate.segments.map(() => -1));
 
-  targets.push({
-    value: stem,
-    labelOffset: nameOffset,
-    weight: 900,
-    scope: "stem",
-  });
-
-  if (stem !== candidate.name) {
-    targets.push({
-      value: candidate.name,
-      labelOffset: nameOffset,
-      weight: 760,
-      scope: "name",
-    });
+  for (let segment = 0; segment < candidate.segments.length; segment += 1) {
+    const match = rows[0]?.[segment];
+    if (match) scores[0]![segment] = match.score - segment * 35;
   }
 
-  let offset = 0;
-  for (const segment of candidate.relativePath.split("/")) {
-    const isLeaf = offset + segment.length === candidate.relativePath.length;
-    const segmentStem =
-      isLeaf && candidate.kind === "file" ? stemOf(segment) : segment;
-    targets.push({
-      value: segmentStem,
-      labelOffset: 1 + offset,
-      weight: isLeaf ? 820 : 560,
-      scope: "segment",
-    });
-    if (segmentStem !== segment) {
-      targets.push({
-        value: segment,
-        labelOffset: 1 + offset,
-        weight: isLeaf ? 700 : 500,
-        scope: "segment",
-      });
+  for (let term = 1; term < terms.length; term += 1) {
+    let bestPreviousScore = Number.NEGATIVE_INFINITY;
+    let bestPreviousIndex = -1;
+    for (let segment = 0; segment < candidate.segments.length; segment += 1) {
+      const prior = scores[term - 1]?.[segment - 1];
+      if (prior !== undefined && prior > bestPreviousScore) {
+        bestPreviousScore = prior;
+        bestPreviousIndex = segment - 1;
+      }
+      const match = rows[term]?.[segment];
+      if (!match || bestPreviousIndex < 0) continue;
+      scores[term]![segment] =
+        bestPreviousScore +
+        match.score -
+        (segment - bestPreviousIndex - 1) * 45;
+      previous[term]![segment] = bestPreviousIndex;
     }
-    offset += segment.length + 1;
   }
 
-  if (includeFullPath) {
-    targets.push({
-      value: candidate.relativePath,
-      labelOffset: 1,
-      weight: 300,
-      scope: "path",
-    });
+  const lastScores = scores.at(-1) ?? [];
+  let segmentIndex = -1;
+  let best = Number.NEGATIVE_INFINITY;
+  for (let index = 0; index < lastScores.length; index += 1) {
+    const leafBonus = index === candidate.segments.length - 1 ? 500 : 0;
+    const score = (lastScores[index] ?? Number.NEGATIVE_INFINITY) + leafBonus;
+    if (score > best) {
+      best = score;
+      segmentIndex = index;
+    }
   }
+  if (segmentIndex < 0 || !Number.isFinite(best)) return undefined;
 
-  return targets;
+  const result: TargetMatch[] = [];
+  for (let term = terms.length - 1; term >= 0; term -= 1) {
+    const match = rows[term]?.[segmentIndex];
+    if (!match) return undefined;
+    result.push(match);
+    segmentIndex = previous[term]?.[segmentIndex] ?? -1;
+  }
+  return result.reverse();
 }
 
-function bestMatchForTerm(
-  term: string,
-  targets: MatchTarget[],
-): TargetMatch | undefined {
-  let best: TargetMatch | undefined;
-  for (const target of targets) {
-    const match = matchTermInTarget(term, target);
-    if (!match) continue;
-    if (!best || match.score > best.score) best = match;
+function unorderedTermMatches(
+  candidate: FileCompletionCandidate,
+  terms: string[],
+): TargetMatch[] | undefined {
+  const options = terms.map((term) =>
+    candidate.segments
+      .map((_, segmentIndex) => matchSegment(candidate, term, segmentIndex))
+      .filter((match): match is TargetMatch => Boolean(match))
+      .sort((a, b) => b.score - a.score),
+  );
+  if (options.some((matches) => matches.length === 0)) return undefined;
+
+  const order = terms
+    .map((_, index) => index)
+    .sort(
+      (a, b) =>
+        (options[a]?.length ?? 0) - (options[b]?.length ?? 0) ||
+        (options[b]?.[0]?.score ?? 0) - (options[a]?.[0]?.score ?? 0),
+    );
+  const remainingBest = Array(order.length + 1).fill(0) as number[];
+  for (let index = order.length - 1; index >= 0; index -= 1) {
+    const termIndex = order[index] ?? 0;
+    remainingBest[index] =
+      (remainingBest[index + 1] ?? 0) + (options[termIndex]?.[0]?.score ?? 0);
   }
+  let bestScore = Number.NEGATIVE_INFINITY;
+  let best: TargetMatch[] | undefined;
+
+  function assign(
+    orderIndex: number,
+    usedSegments: Set<number>,
+    chosen: TargetMatch[],
+    score: number,
+  ): void {
+    if (score + (remainingBest[orderIndex] ?? 0) <= bestScore) return;
+    if (orderIndex === order.length) {
+      if (score > bestScore) {
+        bestScore = score;
+        best = [...chosen];
+      }
+      return;
+    }
+    const termIndex = order[orderIndex] ?? 0;
+    for (const match of options[termIndex] ?? []) {
+      if (usedSegments.has(match.segmentIndex)) continue;
+      usedSegments.add(match.segmentIndex);
+      chosen[termIndex] = match;
+      assign(orderIndex + 1, usedSegments, chosen, score + match.score);
+      usedSegments.delete(match.segmentIndex);
+    }
+  }
+
+  assign(0, new Set(), [], 0);
   return best;
 }
 
-function matchTermInTarget(
+function matchSegment(
+  candidate: FileCompletionCandidate,
   term: string,
-  target: MatchTarget,
+  segmentIndex: number,
 ): TargetMatch | undefined {
-  if (!term) return undefined;
-
-  const termLower = term.toLowerCase();
-  const valueLower = target.value.toLowerCase();
-  const caseSensitiveQuery = /[A-Z]/.test(term);
-
-  if (valueLower === termLower) {
-    return {
-      score:
-        target.weight +
-        3_000 +
-        caseMatchBoost(target.value, term, 0, caseSensitiveQuery),
-      ranges: [[target.labelOffset, target.labelOffset + term.length]],
-      index: target.labelOffset,
-    };
+  const segment = candidate.segments[segmentIndex] ?? "";
+  const isLeaf = segmentIndex === candidate.segments.length - 1;
+  const offset = 1 + segmentOffset(candidate, segmentIndex);
+  const values = [{ value: segment, weight: isLeaf ? 1_500 : 350 }];
+  if (isLeaf && candidate.kind === "file" && candidate.stem !== segment) {
+    values.push({ value: candidate.stem, weight: 1_900 });
   }
 
-  if (valueLower.startsWith(termLower)) {
-    return {
-      score:
-        target.weight +
-        2_400 +
-        caseMatchBoost(target.value, term, 0, caseSensitiveQuery) -
-        term.length / 10,
-      ranges: [[target.labelOffset, target.labelOffset + term.length]],
-      index: target.labelOffset,
-    };
+  let best: LocalMatch | undefined;
+  for (const target of values) {
+    const match = matchText(term, target.value);
+    if (!match) continue;
+    const weighted = { ...match, score: match.score + target.weight };
+    if (!best || weighted.score > best.score) best = weighted;
   }
-
-  const substringIndex = valueLower.indexOf(termLower);
-  if (substringIndex >= 0) {
-    const boundary = isWordBoundary(target.value, substringIndex);
-    return {
-      score:
-        target.weight +
-        (boundary ? 2_150 : 1_650) +
-        caseMatchBoost(target.value, term, substringIndex, caseSensitiveQuery) -
-        substringIndex * (boundary ? 2 : 8) -
-        term.length / 10,
-      ranges: [
-        [
-          target.labelOffset + substringIndex,
-          target.labelOffset + substringIndex + term.length,
-        ],
-      ],
-      index: target.labelOffset + substringIndex,
-    };
-  }
-
-  if (target.scope === "path" || term.length < 3) return undefined;
-
-  const fuzzy = fuzzySubsequence(termLower, target.value);
-  if (!fuzzy || fuzzy.score < 260) return undefined;
-
+  if (!best) return undefined;
   return {
-    score: target.weight + 620 + fuzzy.score,
-    ranges: fuzzy.ranges.map(([from, to]) => [
-      target.labelOffset + from,
-      target.labelOffset + to,
-    ]),
-    index: target.labelOffset + fuzzy.firstIndex,
+    score: best.score,
+    ranges: best.ranges.map(([from, to]) => [offset + from, offset + to]),
+    segmentIndex,
   };
 }
 
-function caseMatchBoost(
-  value: string,
-  term: string,
-  index: number,
-  caseSensitiveQuery: boolean,
-): number {
-  const exactCase = value.slice(index, index + term.length) === term;
-  if (caseSensitiveQuery) return exactCase ? 520 : -760;
-  return exactCase ? 80 : 0;
+function matchText(term: string, value: string): LocalMatch | undefined {
+  if (!term || !value) return undefined;
+  const needle = term.toLowerCase();
+  const haystack = value.toLowerCase();
+  if (needle === haystack) {
+    return {
+      score: 3_600 + caseBonus(term, value),
+      ranges: [[0, value.length]],
+    };
+  }
+  if (haystack.startsWith(needle)) {
+    return {
+      score: 3_000 + caseBonus(term, value.slice(0, term.length)),
+      ranges: [[0, term.length]],
+    };
+  }
+  const index = haystack.indexOf(needle);
+  if (index >= 0) {
+    return {
+      score:
+        2_350 +
+        (isWordBoundary(value, index) ? 300 : 0) -
+        index * 10 +
+        caseBonus(term, value.slice(index, index + term.length)),
+      ranges: [[index, index + term.length]],
+    };
+  }
+  const fuzzy = fuzzySubsequence(term, value);
+  if (!fuzzy || fuzzy.score < 250) return undefined;
+  return fuzzy;
+}
+
+function fuzzySubsequence(
+  needle: string,
+  haystack: string,
+): LocalMatch | undefined {
+  if (needle.length > haystack.length || haystack.length > 512)
+    return undefined;
+  const needleLower = needle.toLowerCase();
+  const haystackLower = haystack.toLowerCase();
+  let searchFrom = 0;
+  for (const character of needleLower) {
+    searchFrom = haystackLower.indexOf(character, searchFrom);
+    if (searchFrom < 0) return undefined;
+    searchFrom += 1;
+  }
+
+  const scores = Array.from(
+    { length: needle.length },
+    () => Array(haystack.length).fill(Number.NEGATIVE_INFINITY) as number[],
+  );
+  const previous = Array.from(
+    { length: needle.length },
+    () => Array(haystack.length).fill(-1) as number[],
+  );
+
+  for (let column = 0; column < haystack.length; column += 1) {
+    if (needleLower[0] !== haystackLower[column]) continue;
+    scores[0]![column] =
+      420 +
+      (isWordBoundary(haystack, column) ? 260 : 0) -
+      column * 12 +
+      characterCaseBonus(needle[0] ?? "", haystack[column] ?? "");
+  }
+
+  for (let row = 1; row < needle.length; row += 1) {
+    let bestGapScore = Number.NEGATIVE_INFINITY;
+    let bestGapIndex = -1;
+    for (let column = 0; column < haystack.length; column += 1) {
+      const gapCandidate = scores[row - 1]?.[column - 2];
+      if (gapCandidate !== undefined) {
+        const normalized = gapCandidate + (column - 2) * 18;
+        if (normalized > bestGapScore) {
+          bestGapScore = normalized;
+          bestGapIndex = column - 2;
+        }
+      }
+      if (needleLower[row] !== haystackLower[column]) continue;
+
+      const boundaryBonus = isWordBoundary(haystack, column) ? 170 : 0;
+      const exactCaseBonus = characterCaseBonus(
+        needle[row] ?? "",
+        haystack[column] ?? "",
+      );
+      const consecutive = scores[row - 1]?.[column - 1];
+      let score =
+        consecutive === undefined || !Number.isFinite(consecutive)
+          ? Number.NEGATIVE_INFINITY
+          : consecutive + 260 + boundaryBonus + exactCaseBonus;
+      let predecessor = column - 1;
+      if (Number.isFinite(bestGapScore)) {
+        const gapped =
+          bestGapScore - (column - 1) * 18 + boundaryBonus + exactCaseBonus;
+        if (gapped > score) {
+          score = gapped;
+          predecessor = bestGapIndex;
+        }
+      }
+      scores[row]![column] = score;
+      previous[row]![column] = predecessor;
+    }
+  }
+
+  const lastRow = scores.at(-1) ?? [];
+  let bestScore = Number.NEGATIVE_INFINITY;
+  let column = -1;
+  for (let index = 0; index < lastRow.length; index += 1) {
+    const score = (lastRow[index] ?? Number.NEGATIVE_INFINITY) - index * 2;
+    if (score > bestScore) {
+      bestScore = score;
+      column = index;
+    }
+  }
+  if (column < 0 || !Number.isFinite(bestScore)) return undefined;
+
+  const indices: number[] = [];
+  for (let row = needle.length - 1; row >= 0; row -= 1) {
+    indices.push(column);
+    column = previous[row]?.[column] ?? -1;
+  }
+  indices.reverse();
+  return { score: bestScore, ranges: indicesToRanges(indices) };
+}
+
+function caseBonus(term: string, matched: string): number {
+  return term === matched ? 80 : 0;
+}
+
+function characterCaseBonus(needle: string, matched: string): number {
+  return needle === matched ? 25 : 0;
 }
 
 function isWordBoundary(value: string, index: number): boolean {
@@ -377,48 +501,15 @@ function isWordBoundary(value: string, index: number): boolean {
   );
 }
 
-function fuzzySubsequence(
-  needle: string,
-  haystack: string,
-):
-  | { score: number; ranges: Array<[number, number]>; firstIndex: number }
-  | undefined {
-  const indices: number[] = [];
-  const haystackLower = haystack.toLowerCase();
-  let searchFrom = 0;
-
-  for (const char of needle) {
-    const index = haystackLower.indexOf(char, searchFrom);
-    if (index < 0) return undefined;
-    indices.push(index);
-    searchFrom = index + 1;
+function segmentOffset(
+  candidate: FileCompletionCandidate,
+  segmentIndex: number,
+): number {
+  let offset = 0;
+  for (let index = 0; index < segmentIndex; index += 1) {
+    offset += (candidate.segments[index]?.length ?? 0) + 1;
   }
-
-  const firstIndex = indices[0] ?? 0;
-  let consecutive = 0;
-  let boundaryHits = 0;
-  let gapPenalty = 0;
-
-  for (let index = 0; index < indices.length; index += 1) {
-    const current = indices[index] ?? 0;
-    const previous = indices[index - 1];
-    if (previous !== undefined) {
-      if (current === previous + 1) consecutive += 1;
-      else gapPenalty += current - previous - 1;
-    }
-    if (isWordBoundary(haystack, current)) boundaryHits += 1;
-  }
-
-  return {
-    score:
-      180 +
-      consecutive * 35 +
-      boundaryHits * 45 -
-      firstIndex * 4 -
-      gapPenalty * 3,
-    ranges: indicesToRanges(indices),
-    firstIndex,
-  };
+  return offset;
 }
 
 function indicesToRanges(indices: number[]): Array<[number, number]> {
@@ -441,14 +532,4 @@ function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
     else merged.push([...range]);
   }
   return merged;
-}
-
-function orderedTermBoost(matches: TargetMatch[]): number {
-  if (matches.length <= 1) return 0;
-  for (let index = 1; index < matches.length; index += 1) {
-    if ((matches[index]?.index ?? 0) < (matches[index - 1]?.index ?? 0)) {
-      return 0;
-    }
-  }
-  return 240;
 }

--- a/packages/workbench-server/src/domains/completions/file-completion-service.ts
+++ b/packages/workbench-server/src/domains/completions/file-completion-service.ts
@@ -1,5 +1,9 @@
 import { resolve } from "node:path";
-import type { CompletionItem, ProjectRecord } from "@nervekit/contracts";
+import {
+  FILE_COMPLETION_RESULT_LIMIT,
+  type CompletionItem,
+  type ProjectRecord,
+} from "@nervekit/contracts";
 import {
   directDirectoryCompletionItems,
   discoverCandidates,
@@ -9,7 +13,6 @@ import {
 import {
   type CompletionOptions,
   completeFileCandidates,
-  defaultCompletionLimit,
   isUnsafeCompletionQuery,
   normalizeCompletionQuery,
 } from "./file-completion-ranking.js";
@@ -23,16 +26,30 @@ type CandidateSnapshot = {
 };
 
 type CacheEntry = {
+  snapshot?: CandidateSnapshot;
   expiresAt: number;
-  promise: Promise<CandidateSnapshot>;
+  refresh?: Promise<CandidateSnapshot>;
+};
+
+type FileCompletionServiceOptions = {
+  discover?: (root: string) => Promise<FileCompletionCandidate[]>;
+  now?: () => number;
 };
 
 export class FileCompletionService {
   private readonly cache = new Map<string, CacheEntry>();
+  private readonly discover: (
+    root: string,
+  ) => Promise<FileCompletionCandidate[]>;
+  private readonly now: () => number;
 
   constructor(
     private readonly getProject: (projectId: string) => ProjectRecord,
-  ) {}
+    options: FileCompletionServiceOptions = {},
+  ) {
+    this.discover = options.discover ?? discoverCandidates;
+    this.now = options.now ?? Date.now;
+  }
 
   async completeFiles(
     projectId: string | undefined,
@@ -43,10 +60,14 @@ export class FileCompletionService {
     const project = this.getProject(projectId);
     const root = resolve(project.dir);
     const normalizedQuery = normalizeCompletionQuery(query);
-    const limit = options.limit ?? defaultCompletionLimit;
+    const limit = Math.min(
+      options.limit ?? FILE_COMPLETION_RESULT_LIMIT,
+      FILE_COMPLETION_RESULT_LIMIT,
+    );
 
     if (isUnsafeCompletionQuery(normalizedQuery)) return [];
     if (shouldUseDirectoryListing(normalizedQuery)) {
+      this.prewarm(project.id, root);
       return directDirectoryCompletionItems(root, normalizedQuery, limit);
     }
 
@@ -56,14 +77,23 @@ export class FileCompletionService {
     });
   }
 
-  invalidate(projectId?: string): void {
+  dispose(projectId?: string): void {
     if (!projectId) {
       this.cache.clear();
       return;
     }
-    for (const key of this.cache.keys()) {
-      if (key.startsWith(`${projectId}:`)) this.cache.delete(key);
+    for (const [key, entry] of this.cache) {
+      if (
+        entry.snapshot?.projectId === projectId ||
+        key.startsWith(`${projectId}:`)
+      ) {
+        this.cache.delete(key);
+      }
     }
+  }
+
+  private prewarm(projectId: string, root: string): void {
+    void this.snapshot(projectId, root).catch(() => undefined);
   }
 
   private async snapshot(
@@ -71,22 +101,40 @@ export class FileCompletionService {
     root: string,
   ): Promise<CandidateSnapshot> {
     const key = `${projectId}:${root}`;
-    const now = Date.now();
-    const cached = this.cache.get(key);
-    if (cached && cached.expiresAt > now) return cached.promise;
+    const now = this.now();
+    const entry = this.cache.get(key) ?? { expiresAt: 0 };
+    if (!this.cache.has(key)) this.cache.set(key, entry);
 
-    const promise = discoverCandidates(root).then((candidates) => ({
-      projectId,
-      root,
-      candidates,
-    }));
-    this.cache.set(key, { expiresAt: now + cacheTtlMs, promise });
-
-    try {
-      return await promise;
-    } catch (error) {
-      if (this.cache.get(key)?.promise === promise) this.cache.delete(key);
-      throw error;
+    if (entry.snapshot && entry.expiresAt > now) return entry.snapshot;
+    if (entry.snapshot) {
+      void this.refresh(key, entry, projectId, root).catch(() => undefined);
+      return entry.snapshot;
     }
+    return this.refresh(key, entry, projectId, root);
+  }
+
+  private refresh(
+    key: string,
+    entry: CacheEntry,
+    projectId: string,
+    root: string,
+  ): Promise<CandidateSnapshot> {
+    if (entry.refresh) return entry.refresh;
+
+    const refresh = this.discover(root).then((candidates) => {
+      const snapshot = { projectId, root, candidates };
+      if (this.cache.get(key) === entry) {
+        entry.snapshot = snapshot;
+        entry.expiresAt = this.now() + cacheTtlMs;
+      }
+      return snapshot;
+    });
+    entry.refresh = refresh;
+    void refresh
+      .finally(() => {
+        if (entry.refresh === refresh) entry.refresh = undefined;
+      })
+      .catch(() => undefined);
+    return refresh;
   }
 }

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -5,7 +5,6 @@ import {
   providerOAuthSecretName,
 } from "../../domains/auth/index.js";
 import { listAvailableSkills } from "../../domains/agents/prompting/resource-loader.js";
-import { FileCompletionService } from "../../domains/completions/index.js";
 import { writeSettings } from "../../infrastructure/storage/index.js";
 import { directoryListing } from "../../routes/filesystem-routes.js";
 import {
@@ -117,16 +116,13 @@ export const platformMethodHandlers = defineWorkbenchMethodHandlers({
     usage: await state.registry.getSubscriptionUsage(),
   }),
   "completion.slash.list": () => ({ items: slashCompletionItems }),
-  "completion.files.list": async (state, params) => {
-    const files = new FileCompletionService((projectId) =>
-      state.registry.getProject(projectId),
-    );
-    return {
-      items: await files.completeFiles(params?.projectId, params?.q ?? "", {
-        limit: params?.limit as number | undefined,
-      }),
-    };
-  },
+  "completion.files.list": async (state, params) => ({
+    items: await state.registry.completeFiles(
+      params?.projectId,
+      params?.q ?? "",
+      { limit: params?.limit as number | undefined },
+    ),
+  }),
   "filesystem.directories.list": (_state, params) =>
     directoryListing(params?.path, params?.showHidden as boolean | undefined),
   "applicationLog.prune": (state, params) => state.logger.prune(params),

--- a/packages/workbench-server/src/routes/completion-routes.ts
+++ b/packages/workbench-server/src/routes/completion-routes.ts
@@ -2,7 +2,6 @@ import type { CompletionItem } from "@nervekit/contracts";
 import { fileCompletionQuerySchema } from "@nervekit/contracts";
 import { Hono } from "hono";
 import type { OrchestratorState } from "../app/orchestrator-state.js";
-import { FileCompletionService } from "../domains/completions/index.js";
 import { routeHandler } from "../http/responses.js";
 
 const slashCompletionItems: CompletionItem[] = [
@@ -34,9 +33,6 @@ const slashCompletionItems: CompletionItem[] = [
 
 export function createCompletionRoutes(state: OrchestratorState): Hono {
   const app = new Hono();
-  const files = new FileCompletionService((projectId) =>
-    state.registry.getProject(projectId),
-  );
 
   app.get("/completions/slash", (c) => c.json({ items: slashCompletionItems }));
   app.get(
@@ -48,7 +44,7 @@ export function createCompletionRoutes(state: OrchestratorState): Hono {
         limit: c.req.query("limit"),
       });
       return c.json({
-        items: await files.completeFiles(query.projectId, query.q, {
+        items: await state.registry.completeFiles(query.projectId, query.q, {
           limit: query.limit,
         }),
       });

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -13,6 +13,7 @@ import type { AgentBrowserSkillCatalog } from "../domains/agents/prompting/agent
 import type { AuthManager } from "../domains/auth/index.js";
 import { WorkbenchExploreAdmission } from "../domains/agents/run/workbench-explore-admission.js";
 import { WorkbenchSubagentExecutions } from "../domains/agents/run/workbench-subagent-executions.js";
+import { FileCompletionService } from "../domains/completions/index.js";
 import { ConversationService } from "../domains/conversations/conversation-service.js";
 import { ConversationHarnessStorage } from "../domains/conversations/conversation-harness-storage.js";
 import {
@@ -92,6 +93,7 @@ export interface RuntimeServices {
   plans: PlanService;
   tools: ToolService;
   git: GitService;
+  fileCompletions: FileCompletionService;
   promptSuggestions: PromptSuggestionService;
   taskDefinitions: TaskDefinitionService;
   scratchNotes: ScratchNoteService;
@@ -306,6 +308,7 @@ export function composeRuntime(
     state,
     removeConversation,
   );
+  services.fileCompletions = new FileCompletionService(getProject);
   services.conversationLifecycle = new ConversationLifecycleService(
     storage,
     events,

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -283,7 +283,20 @@ export class RuntimeRegistry {
   }
 
   async removeProject(projectId: string): Promise<void> {
-    return this.services.projectLifecycle.removeProject(projectId);
+    await this.services.projectLifecycle.removeProject(projectId);
+    this.services.fileCompletions.dispose(projectId);
+  }
+
+  completeFiles(
+    projectId: string | undefined,
+    query: string,
+    options: { limit?: number } = {},
+  ) {
+    return this.services.fileCompletions.completeFiles(
+      projectId,
+      query,
+      options,
+    );
   }
 
   async openProjectInEditor(

--- a/packages/workbench-server/test/file-completion-candidates.test.ts
+++ b/packages/workbench-server/test/file-completion-candidates.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  directDirectoryCompletionItems,
+  discoverCandidates,
+} from "../src/domains/completions/file-completion-candidates.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function fixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "nerve-file-completions-"));
+  roots.push(root);
+  await Promise.all([
+    mkdir(join(root, "src", "nested"), { recursive: true }),
+    mkdir(join(root, "node_modules", "dependency"), { recursive: true }),
+    mkdir(join(root, "dist"), { recursive: true }),
+    mkdir(join(root, ".github"), { recursive: true }),
+    mkdir(join(root, "empty"), { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(join(root, "src", "nested", "useful.ts"), "export {};"),
+    writeFile(join(root, "src", "compiled.wasm"), "binary"),
+    writeFile(join(root, "node_modules", "dependency", "index.js"), ""),
+    writeFile(join(root, "dist", "bundle.js"), ""),
+    writeFile(join(root, ".github", "workflows.yml"), ""),
+    writeFile(join(root, "README.md"), ""),
+  ]);
+  try {
+    await symlink(join(root, "src"), join(root, "linked-src"), "dir");
+  } catch {
+    // Windows may not grant symlink privileges to the test process.
+  }
+  return root;
+}
+
+describe("file completion candidate discovery", () => {
+  it("uses the bounded fallback while pruning generated trees and binaries", async () => {
+    const root = await fixture();
+    const candidates = await discoverCandidates(root);
+    const paths = candidates.map((candidate) => candidate.relativePath);
+
+    assert.equal(paths.includes("src/nested/useful.ts"), true);
+    assert.equal(paths.includes("src/nested"), true);
+    assert.equal(paths.includes(".github/workflows.yml"), true);
+    assert.equal(
+      paths.some((path) => path.includes("node_modules")),
+      false,
+    );
+    assert.equal(
+      paths.some((path) => path.startsWith("dist")),
+      false,
+    );
+    assert.equal(paths.includes("src/compiled.wasm"), false);
+    assert.equal(
+      paths.some((path) => path.startsWith("linked-src")),
+      false,
+    );
+  });
+
+  it("keeps direct navigation live, ordered, safe, and capped", async () => {
+    const root = await fixture();
+    const rootItems = await directDirectoryCompletionItems(root, "", 8);
+    const sourceItems = await directDirectoryCompletionItems(root, "src/", 8);
+
+    assert.equal(rootItems[0]?.kind, "directory");
+    assert.equal(
+      rootItems.some((item) => item.info === "node_modules"),
+      false,
+    );
+    assert.equal(
+      rootItems.some((item) => item.info === "dist"),
+      false,
+    );
+    assert.equal(
+      rootItems.some((item) => item.info === "empty"),
+      true,
+    );
+    assert.equal(
+      sourceItems.some((item) => item.info === "src/compiled.wasm"),
+      false,
+    );
+    assert.deepEqual(await directDirectoryCompletionItems(root, "../", 8), []);
+  });
+});

--- a/packages/workbench-server/test/file-completion-ranking.test.ts
+++ b/packages/workbench-server/test/file-completion-ranking.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { FILE_COMPLETION_RESULT_LIMIT } from "@nervekit/contracts";
+import { candidateFromPath } from "../src/domains/completions/file-completion-candidates.js";
+import {
+  completeFileCandidates,
+  isUnsafeCompletionQuery,
+} from "../src/domains/completions/file-completion-ranking.js";
+
+const files = (paths: string[]) =>
+  paths.map((path) => candidateFromPath(path, "file"));
+
+describe("file completion ranking", () => {
+  it("prioritizes exact basenames and disambiguates them with folder terms", () => {
+    const candidates = files([
+      "packages/server/package.json",
+      "packages/app/package.json",
+      "docs/server-packages.md",
+    ]);
+
+    assert.equal(
+      completeFileCandidates(candidates, "package")[0]?.info,
+      "packages/app/package.json",
+    );
+    assert.equal(
+      completeFileCandidates(candidates, "package server")[0]?.info,
+      "packages/server/package.json",
+    );
+    assert.equal(
+      completeFileCandidates(candidates, "server package")[0]?.info,
+      "packages/server/package.json",
+    );
+  });
+
+  it("treats slash terms as ordered path intent with skipped segments", () => {
+    const candidates = files([
+      "src/components/composer/ComposerEditor.svelte",
+      "composer/generated/src.ts",
+    ]);
+
+    assert.equal(
+      completeFileCandidates(candidates, "src/composer")[0]?.info,
+      "src/components/composer/ComposerEditor.svelte",
+    );
+    assert.equal(
+      completeFileCandidates(candidates, "composer/src")[0]?.info,
+      "composer/generated/src.ts",
+    );
+  });
+
+  it("uses distinct path segments for repeated whitespace terms", () => {
+    const candidates = files(["foo/item.ts", "foo/foo/item.ts"]);
+    const results = completeFileCandidates(candidates, "foo foo");
+
+    assert.equal(results[0]?.info, "foo/foo/item.ts");
+    assert.equal(
+      results.some((item) => item.info === "foo/item.ts"),
+      false,
+    );
+  });
+
+  it("prefers compact boundary-aware fuzzy alignments and highlights them", () => {
+    const candidates = files([
+      "src/ComposerEditor.svelte",
+      "src/c_o_m_p_o_s_e_r.txt",
+      "src/client-events-dispatcher.ts",
+    ]);
+    const composer = completeFileCandidates(candidates, "composer");
+    const initials = completeFileCandidates(candidates, "CED");
+
+    assert.equal(composer[0]?.info, "src/ComposerEditor.svelte");
+    assert.deepEqual(composer[0]?.matchRanges, [[5, 13]]);
+    assert.equal(initials[0]?.info, "src/ComposerEditor.svelte");
+    assert.equal((initials[0]?.matchRanges?.length ?? 0) >= 2, true);
+  });
+
+  it("is case-insensitive, stable, safe, and hard-capped", () => {
+    const candidates = files(
+      Array.from({ length: 20 }, (_, index) => `src/Result${index}.ts`),
+    );
+    const results = completeFileCandidates(candidates, "RESULT", {
+      limit: 100,
+    });
+
+    assert.equal(results.length, FILE_COMPLETION_RESULT_LIMIT);
+    assert.deepEqual(
+      results.map((item) => item.info),
+      completeFileCandidates(candidates, "RESULT", { limit: 100 }).map(
+        (item) => item.info,
+      ),
+    );
+    assert.equal(isUnsafeCompletionQuery("../secret"), true);
+    assert.equal(isUnsafeCompletionQuery("C:/secret"), true);
+    assert.deepEqual(completeFileCandidates(candidates, "../secret"), []);
+  });
+});

--- a/packages/workbench-server/test/file-completion-service.test.ts
+++ b/packages/workbench-server/test/file-completion-service.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import type { ProjectRecord } from "@nervekit/contracts";
+import { candidateFromPath } from "../src/domains/completions/file-completion-candidates.js";
+import { FileCompletionService } from "../src/domains/completions/file-completion-service.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function projectFixture(): Promise<ProjectRecord> {
+  const dir = await mkdtemp(join(tmpdir(), "nerve-file-service-"));
+  roots.push(dir);
+  await writeFile(join(dir, "README.md"), "");
+  return {
+    id: "proj_completion_test",
+    name: "Completion test",
+    dir,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe("FileCompletionService", () => {
+  it("coalesces concurrent initial discovery", async () => {
+    const project = await projectFixture();
+    const discovery = deferred<ReturnType<typeof candidateFromPath>[]>();
+    let calls = 0;
+    const service = new FileCompletionService(() => project, {
+      discover: async () => {
+        calls += 1;
+        return discovery.promise;
+      },
+    });
+
+    const first = service.completeFiles(project.id, "read");
+    const second = service.completeFiles(project.id, "read");
+    assert.equal(calls, 1);
+    discovery.resolve([candidateFromPath("README.md", "file")]);
+
+    assert.equal((await first)[0]?.info, "README.md");
+    assert.equal((await second)[0]?.info, "README.md");
+    assert.equal(calls, 1);
+  });
+
+  it("prewarms from direct listings and serves stale data during one refresh", async () => {
+    const project = await projectFixture();
+    const refresh = deferred<ReturnType<typeof candidateFromPath>[]>();
+    let now = 0;
+    let calls = 0;
+    const service = new FileCompletionService(() => project, {
+      now: () => now,
+      discover: async () => {
+        calls += 1;
+        if (calls === 1) return [candidateFromPath("README.md", "file")];
+        return refresh.promise;
+      },
+    });
+
+    await service.completeFiles(project.id, "");
+    await flush();
+    assert.equal(calls, 1);
+    assert.equal(
+      (await service.completeFiles(project.id, "read"))[0]?.info,
+      "README.md",
+    );
+
+    now = 120_001;
+    const stale = await service.completeFiles(project.id, "read");
+    const alsoStale = await service.completeFiles(project.id, "read");
+    assert.equal(stale[0]?.info, "README.md");
+    assert.equal(alsoStale[0]?.info, "README.md");
+    assert.equal(calls, 2);
+
+    refresh.resolve([candidateFromPath("reader.ts", "file")]);
+    await flush();
+    assert.equal(
+      (await service.completeFiles(project.id, "read"))[0]?.info,
+      "reader.ts",
+    );
+
+    service.dispose(project.id);
+    void service.completeFiles(project.id, "read");
+    assert.equal(calls, 3);
+  });
+
+  it("retries after an initial discovery failure", async () => {
+    const project = await projectFixture();
+    let calls = 0;
+    const service = new FileCompletionService(() => project, {
+      discover: async () => {
+        calls += 1;
+        if (calls === 1) throw new Error("scan failed");
+        return [candidateFromPath("README.md", "file")];
+      },
+    });
+
+    await assert.rejects(
+      service.completeFiles(project.id, "read"),
+      /scan failed/,
+    );
+    assert.equal(
+      (await service.completeFiles(project.id, "read"))[0]?.info,
+      "README.md",
+    );
+    assert.equal(calls, 2);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.83.0
-        version: 0.83.0(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
+        version: 0.83.0(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
     devDependencies:
       '@eslint/js':
         specifier: 10.0.1
@@ -401,6 +401,9 @@ importers:
       '@peculiar/x509':
         specifier: ^2.0.0
         version: 2.0.0
+      fdir:
+        specifier: 6.5.0
+        version: 6.5.0(picomatch@4.0.4)
       hono:
         specifier: 4.12.32
         version: 4.12.32


### PR DESCRIPTION
## Summary
- improve file candidate discovery with bounded traversal, generated/binary path filtering, and cached background refreshes
- add stable, path-aware fuzzy ranking with shared query and result limits
- refine the composer completion menu with best-match selection, compact rendering, and Tab/Escape keyboard handling
- add focused tests for candidate discovery, ranking, and service caching

## Validation
- `pnpm fix && pnpm check && pnpm test`