### PR TITLE
Make application logging developer opt-in

### DIFF
--- a/packages/contracts/src/domains/status/status.schema.ts
+++ b/packages/contracts/src/domains/status/status.schema.ts
@@ -43,6 +43,9 @@ export const statusResponseSchema = z.object({
     sqlitePath: z.string(),
     indexHealthy: z.boolean(),
   }),
+  capabilities: z.object({
+    applicationLogs: z.boolean(),
+  }),
   runtime: z.object({
     python: pythonRuntimeStatusSchema,
     editors: externalEditorStatusesSchema,

--- a/packages/desktop-shell/src/logging.ts
+++ b/packages/desktop-shell/src/logging.ts
@@ -9,6 +9,12 @@ import {
 
 let seq = 0;
 
+export function applicationLoggingEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.NERVE_LOGGING_ENABLED === "1";
+}
+
 export async function desktopLog(
   level: ApplicationLogLevel,
   component: string,
@@ -19,6 +25,7 @@ export async function desktopLog(
     durationMs?: number;
   } = {},
 ): Promise<void> {
+  if (!applicationLoggingEnabled()) return;
   const ts = new Date().toISOString();
   seq += 1;
   const record: ApplicationLogRecord = {

--- a/packages/desktop-shell/test/logging.test.ts
+++ b/packages/desktop-shell/test/logging.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { applicationLoggingEnabled } from "../src/logging.js";
+
+describe("desktop application logging gate", () => {
+  it("requires an exact explicit opt-in", () => {
+    assert.equal(applicationLoggingEnabled({}), false);
+    assert.equal(
+      applicationLoggingEnabled({ NERVE_LOGGING_ENABLED: "true" }),
+      false,
+    );
+    assert.equal(
+      applicationLoggingEnabled({ NERVE_LOGGING_ENABLED: "0" }),
+      false,
+    );
+    assert.equal(
+      applicationLoggingEnabled({ NERVE_LOGGING_ENABLED: "1" }),
+      true,
+    );
+  });
+});

--- a/packages/website/src/content/docs/operations/diagnostics.md
+++ b/packages/website/src/content/docs/operations/diagnostics.md
@@ -5,13 +5,17 @@ sidebar:
   order: 7
 ---
 
-## In the workbench
+## Application logs
 
-The Nerve Logs tab can filter, expand, copy, refresh, and prune application logs. Task tabs have their own streaming/backfilled terminal output and retention/truncation indicators.
+Nerve application logging is disabled by default. Developers can explicitly enable it for a launch by setting `NERVE_LOGGING_ENABLED=1`. When enabled, the Nerve Logs button and tab can filter, expand, copy, refresh, and prune application logs.
 
-## Files
+Desktop and daemon application logs are JSONL under `<NERVE_HOME>/logs`, including daily desktop files. Existing files are retained but are not read or appended while application logging is disabled.
 
-Desktop and daemon logs are JSONL under `<NERVE_HOME>/logs`, including daily desktop files. Crash and Node diagnostic reports are under `<NERVE_HOME>/crashes`.
+Task tabs have separate streaming/backfilled terminal output and retention/truncation indicators. Task logs are not controlled by `NERVE_LOGGING_ENABLED`.
+
+## Crash diagnostics
+
+Crash and Node diagnostic reports are under `<NERVE_HOME>/crashes` and remain enabled independently of application logging.
 
 The daemon writes structured reports for handled fatal errors, enables Node reports for runtime/native fatal conditions, and leaves a heartbeat marker. On the next start, an unclean prior exit can produce a fallback report.
 

--- a/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
+++ b/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
@@ -27,6 +27,7 @@ type Props = {
   settingsActive?: boolean;
   authActive?: boolean;
   logsActive?: boolean;
+  applicationLogsEnabled?: boolean;
   buildProjectMenuItems?: (item: ProjectSwitcherItem) => ContextMenuItem[];
   onOpenProject?: () => void;
   onSelectProject?: (projectId: string) => void;
@@ -48,6 +49,7 @@ let {
   settingsActive = false,
   authActive = false,
   logsActive = false,
+  applicationLogsEnabled = false,
   buildProjectMenuItems,
   onOpenProject,
   onSelectProject,
@@ -77,17 +79,19 @@ let {
 
   {#snippet actions()}
     <Toolbar.Root class="title-actions" aria-label="Application actions">
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        ariaLabel="Open Nerve logs"
-        title="Open Nerve logs"
-        active={logsActive}
-        pressed={logsActive}
-        onclick={() => onOpenLogs?.()}
-      >
-        <Logs size={16} strokeWidth={2.1} />
-      </Button>
+      {#if applicationLogsEnabled}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          ariaLabel="Open Nerve logs"
+          title="Open Nerve logs"
+          active={logsActive}
+          pressed={logsActive}
+          onclick={() => onOpenLogs?.()}
+        >
+          <Logs size={16} strokeWidth={2.1} />
+        </Button>
+      {/if}
       <Button
         variant="ghost"
         size="icon-sm"

--- a/packages/workbench-app/src/lib/app/shell/TitlebarContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/TitlebarContainer.svelte
@@ -129,6 +129,7 @@ async function handleDesktopClose() {
   settingsActive={activeCenterTab?.kind === "settings"}
   authActive={activeCenterTab?.kind === "auth"}
   logsActive={activeCenterTab?.kind === "logs"}
+  applicationLogsEnabled={status?.capabilities.applicationLogs ?? false}
   buildProjectMenuItems={projectMenuItems}
   onOpenProject={openProjectPicker}
   onSelectProject={(projectId) => void selectProject(projectId)}

--- a/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
+++ b/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
@@ -70,12 +70,14 @@ export async function initializeWorkbench(): Promise<void> {
   intentionallyDisconnected = false;
   workspaceSnapshotLoaded = false;
   try {
-    installClientLogging();
     applyTheme(loadThemePreference());
     workspaceState.config = await retryDuringStartup(
       "load client config",
       getClientConfig,
     );
+    if (workspaceState.config.status.capabilities.applicationLogs) {
+      installClientLogging();
+    }
     workspaceState.status = workspaceState.config.status;
     workspaceState.error = undefined;
     composerDraft.projectDir = workspaceState.config.status.storage.home;

--- a/packages/workbench-app/src/lib/core/logger/client-logger.ts
+++ b/packages/workbench-app/src/lib/core/logger/client-logger.ts
@@ -13,6 +13,7 @@ type ClientLog = {
 const queue: ClientLog[] = [];
 let flushTimer: ReturnType<typeof setTimeout> | undefined;
 let installed = false;
+let enabled = false;
 let flushing = false;
 let flushRetryDelayMs = 1_000;
 const NORMAL_FLUSH_DELAY_MS = 500;
@@ -33,6 +34,7 @@ function isBenignBrowserError(message: unknown): boolean {
 export function installClientLogging(): void {
   if (installed || typeof window === "undefined") return;
   installed = true;
+  enabled = true;
   window.addEventListener("error", (event) => {
     const message =
       (event.error instanceof Error ? event.error.message : undefined) ??
@@ -64,6 +66,7 @@ export function clientLog(
     error?: unknown;
   } = {},
 ): void {
+  if (!enabled) return;
   queue.push({
     level,
     component,

--- a/packages/workbench-app/src/lib/features/logs/state/logs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/logs/state/logs.svelte.ts
@@ -10,11 +10,13 @@ import { workspaceState } from "$lib/features/workspace/state/workspace-state.sv
 const LOGS_TAB = { kind: "logs" as const, id: "logs" as const };
 
 export function openLogsPane() {
+  if (!workspaceState.status?.capabilities.applicationLogs) return;
   addCenterTab(LOGS_TAB);
   setActiveCenterTab(LOGS_TAB);
 }
 
 export function selectCenterLogsTab() {
+  if (!workspaceState.status?.capabilities.applicationLogs) return;
   addCenterTab(LOGS_TAB);
   setActiveCenterTab(LOGS_TAB);
 }

--- a/packages/workbench-server/src/app/orchestrator-state.ts
+++ b/packages/workbench-server/src/app/orchestrator-state.ts
@@ -45,6 +45,7 @@ export interface OrchestratorState {
   storage: InitializedStorage;
   events: StreamLogRegistry;
   logger: ApplicationLogger;
+  applicationLogsEnabled: boolean;
   registry: RuntimeRegistry;
   index: IndexStore;
   storageUsage: StorageUsageService;
@@ -62,6 +63,7 @@ export function createOrchestratorState(
   storage: InitializedStorage,
   host: string,
   port: number,
+  options: { applicationLogsEnabled?: boolean } = {},
 ): OrchestratorState {
   const index = new IndexStore(storage.paths.sqlitePath);
   index.initialize();
@@ -72,6 +74,7 @@ export function createOrchestratorState(
     level: storage.settings.logging.level,
     retentionDays: storage.settings.logging.retentionDays,
     maxBufferedLogs: storage.settings.logging.maxBufferedLogs,
+    enabled: options.applicationLogsEnabled ?? false,
   });
   const events = new StreamLogRegistry(storage.paths.home, {
     onPublishFailed: ({ type, context, error }) =>
@@ -164,6 +167,7 @@ export function createOrchestratorState(
     storage,
     events,
     logger,
+    applicationLogsEnabled: options.applicationLogsEnabled ?? false,
     registry,
     index,
     storageUsage,
@@ -237,6 +241,9 @@ export function statusResponse(state: OrchestratorState): StatusResponse {
       home: state.storage.paths.home,
       sqlitePath: state.storage.paths.sqlitePath,
       indexHealthy: state.index.isHealthy,
+    },
+    capabilities: {
+      applicationLogs: state.applicationLogsEnabled,
     },
     runtime: {
       python: state.registry.pythonRuntime.statusSnapshot(),

--- a/packages/workbench-server/src/app/server.ts
+++ b/packages/workbench-server/src/app/server.ts
@@ -148,36 +148,38 @@ function escapeHtml(value: string): string {
 export function createApp(state: OrchestratorState): Hono {
   const app = new Hono();
 
-  app.use("/api/*", async (c, next) => {
-    const requestId = c.req.header("x-request-id") ?? createId("log");
-    const started = performance.now();
-    const logger = state.logger.child({
-      component: "http",
-      requestId,
-      context: {
-        method: c.req.method,
-        path: new URL(c.req.url).pathname,
-      },
-    });
-    setRequestContext(c.req.raw, { requestId, logger });
-    c.header("x-request-id", requestId);
-    try {
-      await next();
-    } finally {
-      const status = c.res.status;
-      const durationMs = Math.round(performance.now() - started);
-      const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
-      await logger[level]("HTTP request completed", {
-        durationMs,
+  if (state.applicationLogsEnabled) {
+    app.use("/api/*", async (c, next) => {
+      const requestId = c.req.header("x-request-id") ?? createId("log");
+      const started = performance.now();
+      const logger = state.logger.child({
+        component: "http",
+        requestId,
         context: {
-          status,
           method: c.req.method,
           path: new URL(c.req.url).pathname,
         },
-      }).catch(() => undefined);
-      clearRequestContext(c.req.raw);
-    }
-  });
+      });
+      setRequestContext(c.req.raw, { requestId, logger });
+      c.header("x-request-id", requestId);
+      try {
+        await next();
+      } finally {
+        const status = c.res.status;
+        const durationMs = Math.round(performance.now() - started);
+        const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
+        await logger[level]("HTTP request completed", {
+          durationMs,
+          context: {
+            status,
+            method: c.req.method,
+            path: new URL(c.req.url).pathname,
+          },
+        }).catch(() => undefined);
+        clearRequestContext(c.req.raw);
+      }
+    });
+  }
   app.use("/api/*", createApiAuthMiddleware(state.storage.localToken));
   mountApiRoutes(app, state);
 

--- a/packages/workbench-server/src/infrastructure/diagnostics/logging.ts
+++ b/packages/workbench-server/src/infrastructure/diagnostics/logging.ts
@@ -44,6 +44,7 @@ interface ApplicationLoggerOptions {
   maxBufferedLogs?: number;
   inherited?: ApplicationLogContext;
   mirrorToConsole?: boolean;
+  enabled?: boolean;
   root?: ApplicationLogger;
 }
 
@@ -71,6 +72,7 @@ export class ApplicationLogger {
   private readonly maxBufferedLogs: number;
   private readonly inherited: ApplicationLogContext;
   private readonly mirrorToConsole: boolean;
+  private readonly enabled: boolean;
 
   constructor(options: ApplicationLoggerOptions) {
     this.root = options.root ?? this;
@@ -82,6 +84,7 @@ export class ApplicationLogger {
     this.maxBufferedLogs = options.maxBufferedLogs ?? 2000;
     this.inherited = options.inherited ?? {};
     this.mirrorToConsole = options.mirrorToConsole ?? true;
+    this.enabled = options.enabled ?? true;
   }
 
   child(
@@ -100,11 +103,13 @@ export class ApplicationLogger {
       maxBufferedLogs: this.maxBufferedLogs,
       inherited: mergeContext(this.inherited, rest),
       mirrorToConsole: this.mirrorToConsole,
+      enabled: this.enabled,
       root: this.root,
     });
   }
 
   async hydrate(): Promise<void> {
+    if (!this.enabled) return;
     if (this.root !== this) return this.root.hydrate();
     await mkdir(this.logsDir(), { recursive: true });
     const logs = await this.readRecentLogs();
@@ -113,6 +118,7 @@ export class ApplicationLogger {
   }
 
   async pruneRetention(): Promise<void> {
+    if (!this.enabled) return;
     if (this.root !== this) return this.root.pruneRetention();
     const cutoff = Date.now() - this.retentionDays * 24 * 60 * 60 * 1000;
     for (const file of await this.applicationLogFiles()) {
@@ -146,6 +152,7 @@ export class ApplicationLogger {
     operation: () => Promise<T>,
     context?: ApplicationLogContext,
   ): Promise<T> {
+    if (!this.enabled) return operation();
     const started = performance.now();
     try {
       const result = await operation();
@@ -168,6 +175,7 @@ export class ApplicationLogger {
     logs: ApplicationLogRecord[];
     nextCursor: number;
   }> {
+    if (!this.enabled) return { logs: [], nextCursor: 0 };
     const limit = query.limit ?? 100;
     let logs = await this.root.readAllLogs();
     if (query.sinceSeq !== undefined) {
@@ -204,6 +212,7 @@ export class ApplicationLogger {
   async prune(
     query: ApplicationLogPruneRequest = {},
   ): Promise<ApplicationLogPruneResponse> {
+    if (!this.enabled) return { pruned: 0, remaining: 0 };
     if (this.root !== this) return this.root.prune(query);
     if (!hasPruneFilter(query)) {
       const logs = await this.readAllLogs();
@@ -236,6 +245,7 @@ export class ApplicationLogger {
   async removeLogsForConversations(
     conversationIds: Iterable<string>,
   ): Promise<void> {
+    if (!this.enabled) return;
     if (this.root !== this)
       return this.root.removeLogsForConversations(conversationIds);
     const conversations = new Set(conversationIds);
@@ -263,7 +273,7 @@ export class ApplicationLogger {
     message: string,
     context: ApplicationLogContext = {},
   ): Promise<void> {
-    if (!this.shouldLog(level)) return;
+    if (!this.enabled || !this.shouldLog(level)) return;
     const merged = mergeContext(this.inherited, context);
     const record: ApplicationLogRecord = {
       seq: this.root.nextSeq(),

--- a/packages/workbench-server/src/main.ts
+++ b/packages/workbench-server/src/main.ts
@@ -148,7 +148,9 @@ async function main() {
   if (mobileHttpsEnabled && (!Number.isFinite(httpsPort) || httpsPort <= 0)) {
     throw new Error(`Invalid Nerve HTTPS port: ${String(httpsPort)}`);
   }
-  const state = createOrchestratorState(storage, host, port);
+  const state = createOrchestratorState(storage, host, port, {
+    applicationLogsEnabled: process.env.NERVE_LOGGING_ENABLED === "1",
+  });
   const loggerHydrateStartedAt = performance.now();
   await state.logger.hydrate();
   const loggerHydrateDurationMs = Math.round(

--- a/packages/workbench-server/src/routes/index.ts
+++ b/packages/workbench-server/src/routes/index.ts
@@ -59,7 +59,12 @@ export function mountApiRoutes(app: Hono, state: OrchestratorState): void {
   app.route("/api", createWorkerRoutes(state));
   app.route("/api", createWorkspaceRoutes(state));
 
-  app.route("/api", createLogRoutes(state));
+  if (state.applicationLogsEnabled) {
+    app.route("/api", createLogRoutes(state));
+  } else {
+    app.all("/api/logs", (c) => c.notFound());
+    app.all("/api/logs/*", (c) => c.notFound());
+  }
   app.route("/api", createTaskRoutes(state));
   app.route("/api", createCompletionRoutes(state));
   app.route("/api", createFilesystemRoutes(state));

--- a/packages/workbench-server/test/application-logging-gate.test.ts
+++ b/packages/workbench-server/test/application-logging-gate.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type {
+  ApplicationLogQueryResponse,
+  StatusResponse,
+} from "@nervekit/contracts";
+import { createAuthenticatedApp } from "./helpers/server-routes.js";
+
+describe("application logging gate", () => {
+  it("reports logging unavailable and does not mount log routes by default", async () => {
+    const { app, headers } = await createAuthenticatedApp();
+
+    const configResponse = await app.request("/api/client-config", { headers });
+    const config = (await configResponse.json()) as { status: StatusResponse };
+    assert.equal(config.status.capabilities.applicationLogs, false);
+
+    const logsResponse = await app.request("/api/logs", { headers });
+    assert.equal(logsResponse.status, 404);
+  });
+
+  it("reports and mounts application logs after explicit enablement", async () => {
+    const { app, headers } = await createAuthenticatedApp("127.0.0.1", {
+      applicationLogsEnabled: true,
+    });
+
+    const configResponse = await app.request("/api/client-config", { headers });
+    const config = (await configResponse.json()) as { status: StatusResponse };
+    assert.equal(config.status.capabilities.applicationLogs, true);
+
+    const logsResponse = await app.request("/api/logs", { headers });
+    assert.equal(logsResponse.status, 200);
+    const logs = (await logsResponse.json()) as ApplicationLogQueryResponse;
+    assert.ok(logs.logs.length >= 1);
+  });
+});

--- a/packages/workbench-server/test/helpers/server-routes.ts
+++ b/packages/workbench-server/test/helpers/server-routes.ts
@@ -28,11 +28,14 @@ export async function tempHome(prefix: string): Promise<string> {
   return root;
 }
 
-export async function createAuthenticatedApp(host = "127.0.0.1") {
+export async function createAuthenticatedApp(
+  host = "127.0.0.1",
+  options: { applicationLogsEnabled?: boolean } = {},
+) {
   const storage = await initializeStorage(
     await tempHome("nerve-server-routes-"),
   );
-  const state = createOrchestratorState(storage, host, 0);
+  const state = createOrchestratorState(storage, host, 0, options);
   states.push(state);
   await state.logger.hydrate();
   await state.registry.hydrate();

--- a/packages/workbench-server/test/logging.test.ts
+++ b/packages/workbench-server/test/logging.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
@@ -23,6 +23,30 @@ async function tempHome(): Promise<string> {
 }
 
 describe("ApplicationLogger", () => {
+  it("does no application-log work when disabled", async () => {
+    const home = await tempHome();
+    const logger = new ApplicationLogger({
+      dataDir: home,
+      component: "test",
+      enabled: false,
+      mirrorToConsole: false,
+    });
+    const child = logger.child({ component: "child" });
+
+    await logger.hydrate();
+    await logger.pruneRetention();
+    await logger.info("ignored");
+    await child.error("also ignored", { error: new Error("ignored") });
+    const result = await logger.withTiming("info", "operation", async () => 42);
+    await logger.removeLogsForConversations(["conv_test"]);
+    await logger.flush();
+
+    assert.equal(result, 42);
+    assert.deepEqual(await logger.query(), { logs: [], nextCursor: 0 });
+    assert.deepEqual(await logger.prune(), { pruned: 0, remaining: 0 });
+    await assert.rejects(access(join(home, "logs")));
+  });
+
   it("writes, queries, and redacts structured application logs", async () => {
     const home = await tempHome();
     const logger = new ApplicationLogger({


### PR DESCRIPTION
## Summary
- disable Nerve application logging by default and enable it explicitly with `NERVE_LOGGING_ENABLED=1`
- avoid daemon, desktop, browser, and request logging overhead when disabled
- hide and guard the Logs UI and expose availability through daemon capabilities
- preserve task logs, event persistence, and crash diagnostics
- document the developer opt-in and add focused gate coverage

## Validation
- `pnpm fix && pnpm check && pnpm test`