### PR TITLE
Show release status in the titlebar

### DIFF
--- a/packages/contracts/src/domains/protocol/operation-catalog.schema.ts
+++ b/packages/contracts/src/domains/protocol/operation-catalog.schema.ts
@@ -20,6 +20,7 @@ import { scratchNotesOperationDefinitions } from "../scratch-notes/scratch-note.
 import { settingsOperationDefinitions } from "../settings/settings.operations.schema.js";
 import { skillOperationDefinitions } from "../skills/skill.operations.schema.js";
 import { snapshotsOperationDefinitions } from "../snapshots/snapshot.operations.schema.js";
+import { statusOperationDefinitions } from "../status/status.operations.schema.js";
 import { storageOperationDefinitions } from "../storage/storage.operations.schema.js";
 import { taskDefinitionOperationDefinitions } from "../task-definitions/task-definition.operations.schema.js";
 import { tasksOperationDefinitions } from "../tasks/task.operations.schema.js";
@@ -44,6 +45,7 @@ const methodDefinitions = [
   ...settingsOperationDefinitions,
   ...skillOperationDefinitions,
   ...snapshotsOperationDefinitions,
+  ...statusOperationDefinitions,
   ...storageOperationDefinitions,
   ...taskDefinitionOperationDefinitions,
   ...tasksOperationDefinitions,

--- a/packages/contracts/src/domains/status/index.ts
+++ b/packages/contracts/src/domains/status/index.ts
@@ -1,2 +1,3 @@
 export * from "./status.schema.js";
+export * from "./status.operations.schema.js";
 export * from "./daemon.events.schema.js";

--- a/packages/contracts/src/domains/status/status.operations.schema.ts
+++ b/packages/contracts/src/domains/status/status.operations.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { defineOperation } from "../protocol/operation-definition.schema.js";
+import { latestReleaseSchema } from "./status.schema.js";
+
+const emptyParamsSchema = z.object({}).optional();
+
+export const statusOperationDefinitions = [
+  defineOperation(
+    "status.latestRelease.get",
+    emptyParamsSchema,
+    latestReleaseSchema,
+    "read",
+    "none",
+    ["workbench_server"] as const,
+    "operation.status.latestRelease.get",
+  ),
+] as const;

--- a/packages/contracts/src/domains/status/status.schema.ts
+++ b/packages/contracts/src/domains/status/status.schema.ts
@@ -53,6 +53,13 @@ export const statusResponseSchema = z.object({
 });
 export type StatusResponse = z.infer<typeof statusResponseSchema>;
 
+export const latestReleaseSchema = z.object({
+  version: z.string().min(1),
+  releaseUrl: z.string().url(),
+  publishedAt: z.string().datetime(),
+});
+export type LatestRelease = z.infer<typeof latestReleaseSchema>;
+
 export const daemonFileSchema = z.object({
   daemonId: z.string().startsWith("daemon_"),
   pid: z.number().int().positive(),

--- a/packages/ui-kit/src/lib/components/ui/popover-panel/popover-panel.svelte
+++ b/packages/ui-kit/src/lib/components/ui/popover-panel/popover-panel.svelte
@@ -95,7 +95,7 @@ function handleOpenChange(next: boolean) {
   border-radius: var(--radius-lg);
   background: var(--card);
   color: var(--foreground);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-lg);
 }
 
 :global(.popover-content:focus-visible) {

--- a/packages/workbench-app/src/lib/app/shell/StatusPopover.svelte
+++ b/packages/workbench-app/src/lib/app/shell/StatusPopover.svelte
@@ -61,7 +61,7 @@ const uptime = $derived.by(() => {
       <Badge size="xs" tone={connectionTone}>{summary}</Badge>
     </header>
 
-    <dl class="flex flex-col gap-2 text-xs">
+    <dl class="flex flex-col gap-1.5 text-xs">
       <div class="flex items-center justify-between gap-3">
         <dt class="text-muted-foreground">Connection</dt>
         <dd class="flex items-center gap-1.5 font-medium">

--- a/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
+++ b/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
@@ -16,6 +16,8 @@ import {
 } from "$lib/features/projects";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
+import type { LatestRelease } from "@nervekit/contracts";
+import VersionIndicator from "$lib/app/shell/VersionIndicator.svelte";
 
 type Props = {
   projects?: ProjectSwitcherItem[];
@@ -28,6 +30,8 @@ type Props = {
   authActive?: boolean;
   logsActive?: boolean;
   applicationLogsEnabled?: boolean;
+  currentVersion?: string;
+  latestRelease?: LatestRelease;
   buildProjectMenuItems?: (item: ProjectSwitcherItem) => ContextMenuItem[];
   onOpenProject?: () => void;
   onSelectProject?: (projectId: string) => void;
@@ -50,6 +54,8 @@ let {
   authActive = false,
   logsActive = false,
   applicationLogsEnabled = false,
+  currentVersion,
+  latestRelease,
   buildProjectMenuItems,
   onOpenProject,
   onSelectProject,
@@ -79,6 +85,9 @@ let {
 
   {#snippet actions()}
     <Toolbar.Root class="title-actions" aria-label="Application actions">
+      {#if currentVersion}
+        <VersionIndicator {currentVersion} {latestRelease} />
+      {/if}
       {#if applicationLogsEnabled}
         <Button
           variant="ghost"

--- a/packages/workbench-app/src/lib/app/shell/TitlebarContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/TitlebarContainer.svelte
@@ -24,6 +24,7 @@ import {
   toggleMaximizeDesktopWindow,
 } from "$lib/features/desktop";
 import { openAuthPane } from "$lib/features/auth";
+import { releaseState } from "$lib/features/releases";
 import { openLogsPane } from "$lib/features/logs";
 import { openSettingsPane, settingsSelectors } from "$lib/features/settings";
 import {
@@ -130,6 +131,8 @@ async function handleDesktopClose() {
   authActive={activeCenterTab?.kind === "auth"}
   logsActive={activeCenterTab?.kind === "logs"}
   applicationLogsEnabled={status?.capabilities.applicationLogs ?? false}
+  currentVersion={status?.version}
+  latestRelease={releaseState.latest}
   buildProjectMenuItems={projectMenuItems}
   onOpenProject={openProjectPicker}
   onSelectProject={(projectId) => void selectProject(projectId)}

--- a/packages/workbench-app/src/lib/app/shell/VersionIndicator.svelte
+++ b/packages/workbench-app/src/lib/app/shell/VersionIndicator.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+import type { LatestRelease } from "@nervekit/contracts";
+import Check from "@lucide/svelte/icons/check";
+import Copy from "@lucide/svelte/icons/copy";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import Popover from "@nervekit/ui-kit/components/ui/popover-panel";
+import { onDestroy } from "svelte";
+import { scale } from "svelte/transition";
+import { writeClipboardText } from "$lib/core/clipboard";
+import { displayVersion, isVersionOutdated } from "$lib/features/releases";
+
+type Props = {
+  currentVersion: string;
+  latestRelease?: LatestRelease;
+};
+
+let { currentVersion, latestRelease }: Props = $props();
+
+const currentLabel = $derived(displayVersion(currentVersion));
+const latestLabel = $derived(
+  latestRelease ? displayVersion(latestRelease.version) : undefined,
+);
+const outdated = $derived(
+  isVersionOutdated(currentVersion, latestRelease?.version),
+);
+const accessibleLabel = $derived(
+  outdated && latestLabel
+    ? `Nerve ${currentLabel}; update available: ${latestLabel}`
+    : latestLabel
+      ? `Nerve ${currentLabel}; no newer stable release detected`
+      : `Nerve ${currentLabel}; latest release check unavailable`,
+);
+const latestCommand = "npx @nervekit/desktop@latest";
+const pinnedCommand = $derived(
+  latestRelease ? `npx @nervekit/desktop@${latestRelease.version}` : "",
+);
+let copiedCommand = $state<"latest" | "pinned" | undefined>();
+let copyResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+async function copyCommand(
+  command: string,
+  commandId: "latest" | "pinned",
+): Promise<void> {
+  try {
+    await writeClipboardText(command);
+  } catch {
+    return;
+  }
+  copiedCommand = commandId;
+  if (copyResetTimer !== undefined) clearTimeout(copyResetTimer);
+  copyResetTimer = setTimeout(() => {
+    copiedCommand = undefined;
+    copyResetTimer = undefined;
+  }, 1_500);
+}
+
+onDestroy(() => {
+  if (copyResetTimer !== undefined) clearTimeout(copyResetTimer);
+});
+</script>
+
+<Popover
+  ariaLabel={accessibleLabel}
+  side="bottom"
+  align="end"
+  class="version-popover p-3 text-xs"
+  triggerClass={`version-trigger rounded-sm font-mono text-xs font-medium leading-none transition-colors ${outdated ? "version-trigger-warning" : ""}`}
+>
+  {#snippet trigger()}{currentLabel}{/snippet}
+
+  <div class="grid gap-2.5">
+    <div class="flex items-center justify-between gap-4">
+      <strong class="text-sm font-semibold">Nerve {currentLabel}</strong>
+      {#if latestLabel && latestRelease}
+        <a
+          href={latestRelease.releaseUrl}
+          target="_blank"
+          rel="noreferrer"
+          class="cursor-pointer text-muted-foreground underline-offset-2 hover:underline focus-visible:underline focus-visible:outline-none"
+          >Latest {latestLabel}</a
+        >
+      {/if}
+    </div>
+
+    {#if outdated && latestLabel && latestRelease}
+      <p class="text-warning">
+        This version is out of date. Update to {latestLabel} to use the latest stable
+        release.
+      </p>
+      <div class="grid gap-1.5 border-t border-border/60 pt-2.5">
+        <span class="text-muted-foreground">Run the latest release</span>
+        <div class="flex items-center rounded-sm bg-muted pl-2 pr-1">
+          <code class="min-w-0 flex-1 select-text py-1.5 text-foreground"
+            >{latestCommand}</code
+          >
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            ariaLabel={copiedCommand === "latest"
+              ? "Latest release command copied"
+              : "Copy latest release command"}
+            title={copiedCommand === "latest" ? "Copied" : "Copy command"}
+            onclick={() => void copyCommand(latestCommand, "latest")}
+          >
+            {#key copiedCommand === "latest"}
+              {#if copiedCommand === "latest"}
+                <span class="inline-flex" transition:scale={{ duration: 120 }}>
+                  <Check class="size-3.5 text-success" aria-hidden="true" />
+                </span>
+              {:else}
+                <span class="inline-flex" transition:scale={{ duration: 120 }}>
+                  <Copy class="size-3.5" aria-hidden="true" />
+                </span>
+              {/if}
+            {/key}
+          </Button>
+        </div>
+        <span class="mt-1 text-muted-foreground">Or pin this release</span>
+        <div class="flex items-center rounded-sm bg-muted pl-2 pr-1">
+          <code class="min-w-0 flex-1 select-text py-1.5 text-foreground"
+            >{pinnedCommand}</code
+          >
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            ariaLabel={copiedCommand === "pinned"
+              ? "Pinned release command copied"
+              : "Copy pinned release command"}
+            title={copiedCommand === "pinned" ? "Copied" : "Copy command"}
+            onclick={() => void copyCommand(pinnedCommand, "pinned")}
+          >
+            {#key copiedCommand === "pinned"}
+              {#if copiedCommand === "pinned"}
+                <span class="inline-flex" transition:scale={{ duration: 120 }}>
+                  <Check class="size-3.5 text-success" aria-hidden="true" />
+                </span>
+              {:else}
+                <span class="inline-flex" transition:scale={{ duration: 120 }}>
+                  <Copy class="size-3.5" aria-hidden="true" />
+                </span>
+              {/if}
+            {/key}
+          </Button>
+        </div>
+      </div>
+      <span class="text-muted-foreground"
+        >Select the latest version above to open the release notes.</span
+      >
+    {:else if latestLabel}
+      <p class="text-muted-foreground">
+        No newer stable release is available. Select the latest version above to
+        open the release notes.
+      </p>
+    {:else}
+      <p class="text-muted-foreground">
+        The latest release could not be checked. Nerve will retry automatically.
+      </p>
+    {/if}
+  </div>
+</Popover>
+
+<style>
+/* Popover owns its trigger element, so these scoped classes override its reset. */
+:global(.popover-content.version-popover) {
+  width: min(17.5rem, calc(100vw - 1.5rem));
+}
+
+:global(.popover-trigger.version-trigger) {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted-foreground);
+  padding: 0.125rem 0.375rem;
+  cursor: pointer;
+}
+
+:global(.popover-trigger.version-trigger:hover) {
+  background: var(--accent);
+}
+
+:global(.popover-trigger.version-trigger-warning) {
+  border-color: var(--warning);
+  background: color-mix(in oklab, var(--warning) 10%, var(--card));
+  color: var(--warning);
+}
+
+:global(.popover-trigger.version-trigger-warning:hover) {
+  background: color-mix(in oklab, var(--warning) 16%, var(--card));
+}
+</style>

--- a/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
+++ b/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
@@ -43,6 +43,10 @@ import {
   loadSettingsPanel,
   refreshSubscriptionUsage,
 } from "$lib/features/settings/state/settings-actions.svelte";
+import {
+  startReleasePolling,
+  stopReleasePolling,
+} from "$lib/features/releases";
 import { composerDraft } from "$lib/features/workspace/state/selection.svelte";
 import {
   loadSlashCommands,
@@ -83,6 +87,7 @@ export async function initializeWorkbench(): Promise<void> {
     composerDraft.projectDir = workspaceState.config.status.storage.home;
     await loadSlashCommands();
     await connectWebsocket(workspaceState.config.wsUrl);
+    startReleasePolling();
     await restoreConversationTabs();
     await loadSettingsPanel();
     startSubscriptionUsagePolling();
@@ -263,6 +268,7 @@ function stopSubscriptionUsagePolling(): void {
 export function disconnectWorkbench(): void {
   intentionallyDisconnected = true;
   stopSubscriptionUsagePolling();
+  stopReleasePolling();
   flushNotifyEvents();
   unbindSubscriptionSync?.();
   unbindSubscriptionSync = undefined;

--- a/packages/workbench-app/src/lib/core/query.ts
+++ b/packages/workbench-app/src/lib/core/query.ts
@@ -13,6 +13,7 @@ export const queryClient = new QueryClient({
 export const queryKeys = {
   clientConfig: ["client-config"] as const,
   workspace: ["workspace"] as const,
+  latestRelease: ["status", "latest-release"] as const,
   slashCompletions: ["completions", "slash"] as const,
   fileCompletions: (projectId: string | undefined, query: string) =>
     ["completions", "files", projectId ?? "none", query] as const,

--- a/packages/workbench-app/src/lib/features/releases/api/releases.api.ts
+++ b/packages/workbench-app/src/lib/features/releases/api/releases.api.ts
@@ -1,0 +1,6 @@
+import type { LatestRelease } from "@nervekit/contracts";
+import { protocolRequest } from "@nervekit/protocol";
+
+export async function getLatestRelease(): Promise<LatestRelease> {
+  return (await protocolRequest("status.latestRelease.get", {})).result;
+}

--- a/packages/workbench-app/src/lib/features/releases/index.ts
+++ b/packages/workbench-app/src/lib/features/releases/index.ts
@@ -1,0 +1,6 @@
+export { releaseState } from "./state/release-state.svelte";
+export {
+  startReleasePolling,
+  stopReleasePolling,
+} from "./state/release-polling.svelte";
+export { displayVersion, isVersionOutdated } from "./state/release-version";

--- a/packages/workbench-app/src/lib/features/releases/state/release-polling.svelte.ts
+++ b/packages/workbench-app/src/lib/features/releases/state/release-polling.svelte.ts
@@ -1,0 +1,38 @@
+import { queryClient, queryKeys } from "$lib/core/query";
+import { clientLog } from "$lib/core/logger/client-logger";
+import { getLatestRelease } from "../api/releases.api";
+import { releaseState } from "./release-state.svelte";
+
+const RELEASE_REFRESH_INTERVAL_MS = 60 * 60_000;
+let refreshTimer: ReturnType<typeof setInterval> | undefined;
+let refreshing = false;
+
+export function startReleasePolling(): void {
+  stopReleasePolling();
+  void refreshLatestRelease();
+  refreshTimer = setInterval(
+    () => void refreshLatestRelease(),
+    RELEASE_REFRESH_INTERVAL_MS,
+  );
+}
+
+export function stopReleasePolling(): void {
+  if (refreshTimer !== undefined) clearInterval(refreshTimer);
+  refreshTimer = undefined;
+}
+
+async function refreshLatestRelease(): Promise<void> {
+  if (refreshing) return;
+  refreshing = true;
+  try {
+    releaseState.latest = await queryClient.fetchQuery({
+      queryKey: queryKeys.latestRelease,
+      queryFn: getLatestRelease,
+      staleTime: 0,
+    });
+  } catch (error) {
+    clientLog("warn", "releases", "Latest release check failed", { error });
+  } finally {
+    refreshing = false;
+  }
+}

--- a/packages/workbench-app/src/lib/features/releases/state/release-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/releases/state/release-state.svelte.ts
@@ -1,0 +1,5 @@
+import type { LatestRelease } from "@nervekit/contracts";
+
+export const releaseState = $state({
+  latest: undefined as LatestRelease | undefined,
+});

--- a/packages/workbench-app/src/lib/features/releases/state/release-version.test.ts
+++ b/packages/workbench-app/src/lib/features/releases/state/release-version.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { displayVersion, isVersionOutdated } from "./release-version";
+
+describe("release version comparison", () => {
+  it("warns only when the latest version is strictly newer", () => {
+    assert.equal(isVersionOutdated("0.15.0", "0.16.0"), true);
+    assert.equal(isVersionOutdated("0.15.0", "1.0.0"), true);
+    assert.equal(isVersionOutdated("0.15.0", "0.15.1"), true);
+    assert.equal(isVersionOutdated("0.15.0", "0.15.0"), false);
+    assert.equal(isVersionOutdated("0.16.0", "0.15.0"), false);
+  });
+
+  it("accepts v prefixes and ignores build metadata", () => {
+    assert.equal(isVersionOutdated("v0.15.0", "v0.16.0"), true);
+    assert.equal(isVersionOutdated("0.15.0+local", "0.15.0+release"), false);
+    assert.equal(displayVersion("v0.15.0"), "v0.15.0");
+    assert.equal(displayVersion("0.15.0"), "v0.15.0");
+  });
+
+  it("uses semantic prerelease precedence", () => {
+    assert.equal(isVersionOutdated("0.16.0-beta.1", "0.16.0"), true);
+    assert.equal(isVersionOutdated("0.16.0-beta.2", "0.16.0-beta.10"), true);
+    assert.equal(isVersionOutdated("0.16.0", "0.16.0-beta.1"), false);
+    assert.equal(
+      isVersionOutdated("0.16.0-beta.alpha", "0.16.0-beta.2"),
+      false,
+    );
+  });
+
+  it("stays neutral when either version is missing or malformed", () => {
+    assert.equal(isVersionOutdated(undefined, "0.16.0"), false);
+    assert.equal(isVersionOutdated("0.15.0", undefined), false);
+    assert.equal(isVersionOutdated("development", "0.16.0"), false);
+    assert.equal(isVersionOutdated("0.15", "0.16.0"), false);
+  });
+});

--- a/packages/workbench-app/src/lib/features/releases/state/release-version.ts
+++ b/packages/workbench-app/src/lib/features/releases/state/release-version.ts
@@ -1,0 +1,71 @@
+type SemanticVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+};
+
+const VERSION_PATTERN =
+  /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function displayVersion(version: string): string {
+  return `v${version.replace(/^v/, "")}`;
+}
+
+export function isVersionOutdated(
+  currentVersion: string | undefined,
+  latestVersion: string | undefined,
+): boolean {
+  const current = parseSemanticVersion(currentVersion);
+  const latest = parseSemanticVersion(latestVersion);
+  if (!current || !latest) return false;
+  return compareSemanticVersions(current, latest) < 0;
+}
+
+function parseSemanticVersion(
+  version: string | undefined,
+): SemanticVersion | undefined {
+  if (!version) return undefined;
+  const match = VERSION_PATTERN.exec(version.trim());
+  if (!match) return undefined;
+  const prerelease = match[4]?.split(".") ?? [];
+  if (prerelease.some((identifier) => identifier.length === 0))
+    return undefined;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease,
+  };
+}
+
+function compareSemanticVersions(
+  left: SemanticVersion,
+  right: SemanticVersion,
+): number {
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1;
+  }
+
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) return 0;
+  if (left.prerelease.length === 0) return 1;
+  if (right.prerelease.length === 0) return -1;
+
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    if (leftIdentifier === rightIdentifier) continue;
+
+    const leftNumeric = /^\d+$/.test(leftIdentifier);
+    const rightNumeric = /^\d+$/.test(rightIdentifier);
+    if (leftNumeric && rightNumeric) {
+      return Number(leftIdentifier) < Number(rightIdentifier) ? -1 : 1;
+    }
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftIdentifier < rightIdentifier ? -1 : 1;
+  }
+  return 0;
+}

--- a/packages/workbench-app/src/lib/features/usage/components/SubscriptionUsageChip.svelte
+++ b/packages/workbench-app/src/lib/features/usage/components/SubscriptionUsageChip.svelte
@@ -257,6 +257,11 @@ const title = $derived.by(() => {
 {/if}
 
 <style>
+/* Compound selector outweighs the shared popover width default. */
+:global(.popover-content.subscription-popover) {
+  width: min(19.2rem, calc(100vw - 1.5rem));
+}
+
 .subscription-trigger {
   display: inline-flex;
   align-items: center;

--- a/packages/workbench-server/src/app/orchestrator-state.ts
+++ b/packages/workbench-server/src/app/orchestrator-state.ts
@@ -24,6 +24,7 @@ import {
   StorageCleanupService,
   StorageUsageService,
 } from "../domains/storage/index.js";
+import { LatestReleaseService } from "../domains/status/latest-release-service.js";
 import { SubscriptionUsageService } from "../domains/usage/subscription-usage-service.js";
 import { ApplicationLogger } from "../infrastructure/diagnostics/index.js";
 import { StreamLogRegistry } from "../infrastructure/events/index.js";
@@ -50,6 +51,7 @@ export interface OrchestratorState {
   index: IndexStore;
   storageUsage: StorageUsageService;
   storageCleanup: StorageCleanupService;
+  latestRelease: LatestReleaseService;
   secrets: SecretProvider;
   auth: AuthManager;
   providerCatalog: ProviderCatalogStore;
@@ -149,6 +151,7 @@ export function createOrchestratorState(
     paths: storage.paths,
     getRegistry: () => registry,
   });
+  const latestRelease = new LatestReleaseService();
   const storageCleanup = new StorageCleanupService({
     paths: storage.paths,
     repository: new StorageCleanupRepository(
@@ -172,6 +175,7 @@ export function createOrchestratorState(
     index,
     storageUsage,
     storageCleanup,
+    latestRelease,
     secrets,
     auth,
     providerCatalog,

--- a/packages/workbench-server/src/domains/status/latest-release-service.ts
+++ b/packages/workbench-server/src/domains/status/latest-release-service.ts
@@ -1,0 +1,79 @@
+import type { LatestRelease } from "@nervekit/contracts";
+import { latestReleaseSchema } from "@nervekit/contracts";
+import { z } from "zod";
+
+const LATEST_RELEASE_URL =
+  "https://api.github.com/repos/ThilinaTLM/nerve/releases/latest";
+const RELEASE_CACHE_TTL_MS = 60 * 60_000;
+const RELEASE_REQUEST_TIMEOUT_MS = 10_000;
+
+const githubLatestReleaseSchema = z.object({
+  tag_name: z.string().min(1),
+  html_url: z.string().url(),
+  published_at: z.string().datetime(),
+});
+
+type ReleaseFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+type LatestReleaseServiceOptions = {
+  fetch?: ReleaseFetch;
+  now?: () => number;
+  cacheTtlMs?: number;
+};
+
+export class LatestReleaseService {
+  readonly #fetch: ReleaseFetch;
+  readonly #now: () => number;
+  readonly #cacheTtlMs: number;
+  #cached?: { value: LatestRelease; fetchedAt: number };
+  #inFlight?: Promise<LatestRelease>;
+
+  constructor(options: LatestReleaseServiceOptions = {}) {
+    this.#fetch = options.fetch ?? fetch;
+    this.#now = options.now ?? Date.now;
+    this.#cacheTtlMs = options.cacheTtlMs ?? RELEASE_CACHE_TTL_MS;
+  }
+
+  async getLatestRelease(): Promise<LatestRelease> {
+    if (
+      this.#cached &&
+      this.#now() - this.#cached.fetchedAt < this.#cacheTtlMs
+    ) {
+      return this.#cached.value;
+    }
+    if (this.#inFlight) return this.#inFlight;
+
+    const request = this.#loadLatestRelease();
+    this.#inFlight = request;
+    try {
+      const value = await request;
+      this.#cached = { value, fetchedAt: this.#now() };
+      return value;
+    } finally {
+      if (this.#inFlight === request) this.#inFlight = undefined;
+    }
+  }
+
+  async #loadLatestRelease(): Promise<LatestRelease> {
+    const response = await this.#fetch(LATEST_RELEASE_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "nerve-workbench-server",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: AbortSignal.timeout(RELEASE_REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub latest release request failed (${response.status} ${response.statusText})`,
+      );
+    }
+
+    const release = githubLatestReleaseSchema.parse(await response.json());
+    return latestReleaseSchema.parse({
+      version: release.tag_name.replace(/^v/, ""),
+      releaseUrl: release.html_url,
+      publishedAt: release.published_at,
+    });
+  }
+}

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -41,6 +41,7 @@ const slashCompletionItems: CompletionItem[] = [
 ];
 
 export const platformMethodHandlers = defineWorkbenchMethodHandlers({
+  "status.latestRelease.get": (state) => state.latestRelease.getLatestRelease(),
   "snapshot.workspace.get": (state) => getWorkspaceSnapshotResponse(state),
   "snapshot.conversation.get": (state, params) =>
     getConversationSnapshotResponse(state, params.conversationId),

--- a/packages/workbench-server/test/latest-release-service.test.ts
+++ b/packages/workbench-server/test/latest-release-service.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { LatestReleaseService } from "../src/domains/status/latest-release-service.js";
+
+const githubRelease = {
+  tag_name: "v0.16.0",
+  html_url: "https://github.com/ThilinaTLM/nerve/releases/tag/v0.16.0",
+  published_at: "2026-08-01T10:00:00Z",
+};
+
+function response(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("LatestReleaseService", () => {
+  it("normalizes the GitHub tag and caches successful results for one hour", async () => {
+    let now = 0;
+    let calls = 0;
+    const service = new LatestReleaseService({
+      now: () => now,
+      fetch: async () => {
+        calls += 1;
+        return response(githubRelease);
+      },
+    });
+
+    assert.deepEqual(await service.getLatestRelease(), {
+      version: "0.16.0",
+      releaseUrl: githubRelease.html_url,
+      publishedAt: githubRelease.published_at,
+    });
+    now = 60 * 60_000 - 1;
+    await service.getLatestRelease();
+    assert.equal(calls, 1);
+
+    now += 2;
+    await service.getLatestRelease();
+    assert.equal(calls, 2);
+  });
+
+  it("coalesces concurrent refreshes", async () => {
+    const pending = deferred<Response>();
+    let calls = 0;
+    const service = new LatestReleaseService({
+      fetch: () => {
+        calls += 1;
+        return pending.promise;
+      },
+    });
+
+    const first = service.getLatestRelease();
+    const second = service.getLatestRelease();
+    assert.equal(calls, 1);
+    pending.resolve(response(githubRelease));
+
+    assert.deepEqual(await first, await second);
+    assert.equal(calls, 1);
+  });
+
+  it("does not cache HTTP or payload failures", async () => {
+    let calls = 0;
+    const service = new LatestReleaseService({
+      fetch: async () => {
+        calls += 1;
+        if (calls === 1) return response({}, { status: 503 });
+        if (calls === 2) return response({ tag_name: "v0.16.0" });
+        return response(githubRelease);
+      },
+    });
+
+    await assert.rejects(() => service.getLatestRelease(), /503/);
+    await assert.rejects(() => service.getLatestRelease());
+    assert.equal((await service.getLatestRelease()).version, "0.16.0");
+    assert.equal(calls, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- show the running Nerve version in the titlebar with an outdated warning state
- fetch and cache the latest stable GitHub release through the daemon, refreshing hourly
- add a click-only update popover with release notes and animated command copy actions
- cover semantic version comparison and release-service caching/failure behavior

## Validation
- pnpm fix
- pnpm check
- pnpm test