### PR TITLE
Keep the composer editable during startup

### DIFF
--- a/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
+++ b/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
@@ -88,8 +88,7 @@ export async function initializeWorkbench(): Promise<void> {
     await loadSlashCommands();
     await connectWebsocket(workspaceState.config.wsUrl);
     startReleasePolling();
-    await restoreConversationTabs();
-    await loadSettingsPanel();
+    await Promise.all([restoreConversationTabs(), loadSettingsPanel()]);
     startSubscriptionUsagePolling();
     clientLog("info", "workbench", "Workbench initialized");
   } catch (caught) {

--- a/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
@@ -22,6 +22,7 @@ import {
   getShortcutLabel,
 } from "$lib/core/shortcuts/registry";
 import type { PromptComposerProps } from "../components/prompt-composer-props";
+import { deriveComposerAvailability } from "./composer-availability";
 import { resolveDroppedPaths } from "./dropped-paths";
 
 let {
@@ -113,24 +114,24 @@ const pendingPlan = $derived(pendingPlanReviews.length > 0);
 const blockedForReview = $derived(
   pendingApproval || pendingQuestion || pendingPlan,
 );
-const canPrompt = $derived(
-  Boolean(
-    activeProject &&
-    (activeConversation || pendingConversationActive) &&
-    models.length > 0 &&
-    !blockedForReview &&
-    !compacting,
-  ),
-);
-const editorDisabled = $derived(!interactive || !canPrompt || stopping);
 const commandMode = $derived(isInlineCommandPrompt(text));
-const submitDisabled = $derived(
-  !interactive ||
-    !canPrompt ||
-    stopping ||
-    voiceSubmitPending ||
-    (commandMode && sending),
+const availability = $derived(
+  deriveComposerAvailability({
+    interactive,
+    hasProject: Boolean(activeProject),
+    hasConversation: Boolean(activeConversation || pendingConversationActive),
+    hasModels: models.length > 0,
+    blockedForReview,
+    compacting,
+    stopping,
+    sending,
+    commandMode,
+    voiceSubmitPending,
+  }),
 );
+const canPrompt = $derived(availability.canPrompt);
+const editorDisabled = $derived(!availability.canEdit);
+const submitDisabled = $derived(!availability.canSubmit);
 const chatGptAudioConfigured = $derived(chatGptAudioAuth.configured);
 const fileDropSupported = $derived(Boolean(getDesktopBridge()?.files));
 const supportsAudioRecording = $derived(voiceInputSession.isSupported());
@@ -166,11 +167,13 @@ const sendAriaLabel = $derived(
       ? "Transcribe and send prompt"
       : compacting
         ? "Compacting context"
-        : commandMode
-          ? "Run command"
-          : sending
-            ? "Queue prompt"
-            : "Send prompt",
+        : availability.canEdit && models.length === 0
+          ? "Waiting for an available model"
+          : commandMode
+            ? "Run command"
+            : sending
+              ? "Queue prompt"
+              : "Send prompt",
 );
 const sendTitle = $derived(
   voiceSubmitPending
@@ -179,13 +182,15 @@ const sendTitle = $derived(
       ? "Stop recording, transcribe, and send prompt"
       : compacting
         ? "Compacting context"
-        : commandMode
-          ? sending
-            ? "Wait for the current agent turn before running a command"
-            : "Run command"
-          : sending
-            ? "Queue prompt for the next agent turn"
-            : "Send prompt",
+        : availability.canEdit && models.length === 0
+          ? "Models are loading; you can continue drafting"
+          : commandMode
+            ? sending
+              ? "Wait for the current agent turn before running a command"
+              : "Run command"
+            : sending
+              ? "Queue prompt for the next agent turn"
+              : "Send prompt",
 );
 
 function formatElapsed(ms: number): string {
@@ -196,15 +201,7 @@ function formatElapsed(ms: number): string {
 }
 
 async function submitComposer() {
-  if (
-    !interactive ||
-    blockedForReview ||
-    compacting ||
-    stopping ||
-    voiceSubmitPending ||
-    (commandMode && sending)
-  )
-    return;
+  if (!availability.canSubmit) return;
 
   if (recording && voiceTarget) {
     voiceSubmitPending = true;

--- a/packages/workbench-app/src/lib/features/conversations/adapters/composer-availability.test.ts
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/composer-availability.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { deriveComposerAvailability } from "./composer-availability";
+
+const ready = {
+  interactive: true,
+  hasProject: true,
+  hasConversation: true,
+  hasModels: true,
+  blockedForReview: false,
+  compacting: false,
+  stopping: false,
+  sending: false,
+  commandMode: false,
+  voiceSubmitPending: false,
+};
+
+describe("composer availability", () => {
+  it("allows drafting while models are still loading", () => {
+    const availability = deriveComposerAvailability({
+      ...ready,
+      hasModels: false,
+    });
+
+    assert.equal(availability.canEdit, true);
+    assert.equal(availability.canPrompt, false);
+    assert.equal(availability.canSubmit, false);
+  });
+
+  it("allows editing and submission when the target and models are ready", () => {
+    const availability = deriveComposerAvailability(ready);
+
+    assert.equal(availability.hasTarget, true);
+    assert.equal(availability.canEdit, true);
+    assert.equal(availability.canSubmit, true);
+  });
+
+  it("blocks editing without an active target or interactive pane", () => {
+    for (const patch of [
+      { interactive: false },
+      { hasProject: false },
+      { hasConversation: false },
+    ]) {
+      const availability = deriveComposerAvailability({ ...ready, ...patch });
+      assert.equal(availability.canEdit, false);
+      assert.equal(availability.canSubmit, false);
+    }
+  });
+
+  it("blocks editing during reviews, compaction, and stopping", () => {
+    for (const patch of [
+      { blockedForReview: true },
+      { compacting: true },
+      { stopping: true },
+    ]) {
+      const availability = deriveComposerAvailability({ ...ready, ...patch });
+      assert.equal(availability.canEdit, false);
+      assert.equal(availability.canSubmit, false);
+    }
+  });
+
+  it("keeps a running non-command prompt editable and queueable", () => {
+    const availability = deriveComposerAvailability({
+      ...ready,
+      sending: true,
+    });
+
+    assert.equal(availability.canEdit, true);
+    assert.equal(availability.canSubmit, true);
+  });
+
+  it("does not run commands or submit while voice transcription is pending", () => {
+    assert.equal(
+      deriveComposerAvailability({
+        ...ready,
+        sending: true,
+        commandMode: true,
+      }).canSubmit,
+      false,
+    );
+    assert.equal(
+      deriveComposerAvailability({
+        ...ready,
+        voiceSubmitPending: true,
+      }).canSubmit,
+      false,
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/features/conversations/adapters/composer-availability.ts
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/composer-availability.ts
@@ -1,0 +1,43 @@
+export type ComposerAvailabilityInput = {
+  interactive: boolean;
+  hasProject: boolean;
+  hasConversation: boolean;
+  hasModels: boolean;
+  blockedForReview: boolean;
+  compacting: boolean;
+  stopping: boolean;
+  sending: boolean;
+  commandMode: boolean;
+  voiceSubmitPending: boolean;
+};
+
+export type ComposerAvailability = {
+  hasTarget: boolean;
+  canEdit: boolean;
+  canPrompt: boolean;
+  canSubmit: boolean;
+};
+
+export function deriveComposerAvailability(
+  input: ComposerAvailabilityInput,
+): ComposerAvailability {
+  const hasTarget = input.hasProject && input.hasConversation;
+  const canEdit = Boolean(
+    input.interactive &&
+    hasTarget &&
+    !input.blockedForReview &&
+    !input.compacting &&
+    !input.stopping,
+  );
+  const canPrompt = canEdit && input.hasModels;
+  return {
+    hasTarget,
+    canEdit,
+    canPrompt,
+    canSubmit: Boolean(
+      canPrompt &&
+      !input.voiceSubmitPending &&
+      !(input.commandMode && input.sending),
+    ),
+  };
+}

--- a/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
@@ -46,6 +46,8 @@ let saveTimer: ReturnType<typeof setTimeout> | undefined;
 let saveInFlight = false;
 let savedServerSettingsSinceLoad = false;
 let skillsRequestId = 0;
+let settingsLoadInFlight: Promise<void> | undefined;
+let settingsReloadRequested = false;
 
 function currentActiveAgent(): AgentRecord | undefined {
   return workspaceState.agents.find((agent) => agent.id === selection.agentId);
@@ -105,21 +107,16 @@ export async function loadSettingsSkills(projectId = selection.projectId) {
   }
 }
 
-export async function loadSettingsPanel() {
-  const [settings, modelList, auth, subscriptionUsage] = await Promise.all([
+async function loadCoreSettings(): Promise<void> {
+  const [settings, modelList, auth] = await Promise.all([
     getSettings(),
     getModels(),
     getAuthProviders(),
-    getSubscriptionUsage().catch(() => []),
-    loadSettingsSkills(),
   ]);
   settingsState.settingsDraft = settings;
   applyZoomLevel(settings.ui.zoomLevel);
   settingsState.models = modelList;
   settingsState.authProviders = auth;
-  usageState.subscriptionUsage = Object.fromEntries(
-    subscriptionUsage.map((usage) => [usage.provider, usage]),
-  );
   const usable = scopedUsableModelOptions(
     modelList,
     auth,
@@ -166,6 +163,30 @@ export async function loadSettingsPanel() {
     settingsState.settingsSaveStatus = "idle";
     settingsState.settingsMessage = undefined;
   }
+}
+
+function refreshAncillarySettingsData(): void {
+  void refreshSubscriptionUsage().catch(() => undefined);
+  void loadSettingsSkills();
+}
+
+async function runSettingsLoadCycle(): Promise<void> {
+  do {
+    settingsReloadRequested = false;
+    await loadCoreSettings();
+    refreshAncillarySettingsData();
+  } while (settingsReloadRequested);
+}
+
+export function loadSettingsPanel(): Promise<void> {
+  if (settingsLoadInFlight) {
+    settingsReloadRequested = true;
+    return settingsLoadInFlight;
+  }
+  settingsLoadInFlight = runSettingsLoadCycle().finally(() => {
+    settingsLoadInFlight = undefined;
+  });
+  return settingsLoadInFlight;
 }
 
 function mergeSettingsPatch(

--- a/packages/workbench-server/src/domains/auth/auth-manager.ts
+++ b/packages/workbench-server/src/domains/auth/auth-manager.ts
@@ -13,7 +13,6 @@ import { builtinModels } from "@earendil-works/pi-ai/providers/all";
 import type {
   AgentRequestAuth,
   AuthProviderMetadata,
-  ModelInfo,
   ModelSelection,
 } from "@nervekit/contracts";
 import type { SecretProvider } from "../../infrastructure/secrets/index.js";
@@ -202,15 +201,14 @@ export class AuthManager {
   }
 
   async listProviderMetadata(
-    models: ModelInfo[],
     customProviderNames?: ReadonlyMap<string, string>,
   ): Promise<AuthProviderMetadata[]> {
     const runtimeProviders = new Map(
       this.models.getProviders().map((provider) => [provider.id, provider]),
     );
     const providers = new Set<string>(runtimeProviders.keys());
-    for (const model of models) {
-      if (model.provider !== "nerve-faux") providers.add(model.provider);
+    for (const providerId of customProviderNames?.keys() ?? []) {
+      providers.add(providerId);
     }
     providers.add("tavily");
     providers.add("jira");

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -59,7 +59,6 @@ export const platformMethodHandlers = defineWorkbenchMethodHandlers({
   },
   "auth.providers.list": async (state) => ({
     providers: await state.auth.listProviderMetadata(
-      state.registry.listModels(),
       state.providerCatalog.providerDisplayNames(),
     ),
   }),

--- a/packages/workbench-server/src/routes/auth-routes.ts
+++ b/packages/workbench-server/src/routes/auth-routes.ts
@@ -14,7 +14,6 @@ export function createAuthRoutes(state: OrchestratorState): Hono {
   app.get("/auth/providers", async (c) =>
     c.json({
       providers: await state.auth.listProviderMetadata(
-        state.registry.listModels(),
         state.providerCatalog.providerDisplayNames(),
       ),
     }),
@@ -64,7 +63,6 @@ export function createAuthRoutes(state: OrchestratorState): Hono {
   );
   app.get("/provider-keys", async (c) => {
     const providers = await state.auth.listProviderMetadata(
-      state.registry.listModels(),
       state.providerCatalog.providerDisplayNames(),
     );
     return c.json({

--- a/packages/workbench-server/test/auth.test.ts
+++ b/packages/workbench-server/test/auth.test.ts
@@ -76,7 +76,7 @@ describe("AuthManager", () => {
       new EncryptedFileSecretProvider(await tempHome()),
     );
 
-    const providers = await auth.listProviderMetadata([]);
+    const providers = await auth.listProviderMetadata();
     const subscriptions = providers
       .filter((provider) => provider.supportsOAuth)
       .map((provider) => provider.provider)
@@ -93,6 +93,23 @@ describe("AuthManager", () => {
     ]);
   });
 
+  it("advertises custom providers without enumerating their models", async () => {
+    const auth = new AuthManager(
+      new EncryptedFileSecretProvider(await tempHome()),
+    );
+
+    const providers = await auth.listProviderMetadata(
+      new Map([["custom-compatible", "Custom Compatible"]]),
+    );
+    const custom = providers.find(
+      (provider) => provider.provider === "custom-compatible",
+    );
+
+    assert.ok(custom);
+    assert.equal(custom.displayName, "Custom Compatible");
+    assert.equal(custom.supportsApiKey, true);
+  });
+
   it("includes Atlassian provider metadata", async () => {
     const auth = new AuthManager(
       new EncryptedFileSecretProvider(await tempHome()),
@@ -100,7 +117,7 @@ describe("AuthManager", () => {
     await auth.setApiKey("jira", "jira-token");
     await auth.setApiKey("confluence", "confluence-token");
 
-    const providers = await auth.listProviderMetadata([]);
+    const providers = await auth.listProviderMetadata();
     const jira = providers.find((provider) => provider.provider === "jira");
     assert.ok(jira);
     assert.equal(jira.displayName, "Jira");


### PR DESCRIPTION
## Summary
- load core settings and model metadata concurrently with restored conversations
- stop subscription usage and skill discovery from delaying model readiness
- coalesce settings reloads and avoid duplicate full-catalog enumeration for auth metadata
- allow prompt drafting while models load, while keeping submission gated
- add composer availability and custom provider metadata regression tests

## Validation
- `pnpm fix && pnpm check && pnpm test`