### PR TITLE
Unify brand mark on splash screen and empty states

### DIFF
--- a/packages/desktop-shell/src/window/loading-pages.ts
+++ b/packages/desktop-shell/src/window/loading-pages.ts
@@ -23,7 +23,7 @@ export function loadingHtml(statusText = LOADING_STAGES.starting): string {
   </head>
   <body>
     <main class="loading" aria-busy="true" aria-label="Starting Nerve">
-      <div class="loading-mark-frame" aria-hidden="true">
+      <div class="loading-mark-badge" aria-hidden="true">
         <svg
           class="loading-mark"
           viewBox="120 120 272 272"
@@ -140,6 +140,7 @@ function shellStyles(): string {
       --border: oklch(0.8847 0.0069 97.3627);
       --destructive: oklch(0.5 0.19 27);
       --radius: 0.625rem;
+      --radius-lg: 0.625rem;
       --font-sans: "Outfit", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       --font-mono: "Iosevka", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
       --text-xs: 0.75rem;
@@ -182,18 +183,26 @@ function shellStyles(): string {
     .loading {
       gap: 0;
     }
-    .loading-mark-frame {
+    .loading-mark-badge {
       display: grid;
-      width: 6rem;
-      height: 6rem;
+      width: 3rem;
+      height: 3rem;
       place-items: center;
-      border: 1px solid var(--border);
-      border-radius: 999px;
+      border-radius: var(--radius-lg);
+      background: var(--foreground);
+      color: var(--background);
+      animation: loading-breathe 2.4s ease-in-out infinite;
     }
     .loading-mark {
-      width: 2.5rem;
-      height: 2.5rem;
-      color: var(--foreground);
+      /* 62.5% of the badge, matching the titlebar brand mark proportions.
+         No optical nudge: the mark's ink is already centered in its viewBox. */
+      width: 1.875rem;
+      height: 1.875rem;
+    }
+    @keyframes loading-breathe {
+      0%,
+      100% { opacity: 1; }
+      50% { opacity: 0.72; }
     }
     .error-title {
       margin: 0;
@@ -210,12 +219,12 @@ function shellStyles(): string {
       line-height: 1.625;
     }
     .loading-progress {
-      width: min(20rem, 100%);
-      margin-top: 1.25rem;
+      width: min(12rem, 100%);
+      margin-top: 1.5rem;
     }
     .loading .status {
       margin-bottom: 0.5rem;
-      text-align: left;
+      text-align: center;
     }
     .loading-progressbar {
       width: 100%;
@@ -254,6 +263,7 @@ function shellStyles(): string {
     }
     @media (prefers-reduced-motion: reduce) {
       .loading-progress-fill { transition: none; }
+      .loading-mark-badge { animation: none; }
     }
   `;
 }

--- a/packages/ui-kit/src/styles/animation.css
+++ b/packages/ui-kit/src/styles/animation.css
@@ -196,3 +196,21 @@
     background-position: -120% 0;
   }
 }
+
+/* One-time entrance for large brand surfaces (conversation empty states).
+ * Applied via class="brand-signal-enter". Idle views must not loop motion. */
+.brand-signal-enter {
+  animation: brand-signal-enter var(--motion-enter-duration)
+    var(--motion-enter-easing) both;
+}
+
+@keyframes brand-signal-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/workbench-app/src/lib/presentation/components/brand/NerveBadge.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/brand/NerveBadge.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { cn } from "@nervekit/ui-kit/core/utils";
+import NerveMark from "./NerveMark.svelte";
+
+let {
+  label,
+  class: className,
+}: {
+  label?: string;
+  class?: string;
+} = $props();
+</script>
+
+<span
+  class={cn(
+    "nerve-badge inline-flex items-center justify-center rounded-lg bg-foreground text-background",
+    className,
+  )}
+>
+  <NerveMark compact {label} />
+</span>
+
+<style>
+/* Matches the titlebar mark-to-badge ratio in
+   packages/ui-kit/src/styles/components/shell.css (.brand-mark).
+   No optical nudge here: the compact mark's ink (stroke included) is already
+   centered in its viewBox, so plain flex centering is balanced. The titlebar's
+   translate() is a sub-pixel correction for 1rem rendering and visibly skews the
+   mark right and down once scaled up. */
+.nerve-badge :global(svg) {
+  width: 62.5%;
+  height: 62.5%;
+}
+</style>

--- a/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
-import NerveMark from "../brand/NerveMark.svelte";
+import NerveBadge from "../brand/NerveBadge.svelte";
 
 let {
-  label = "Nerve is ready",
   title,
   message,
   footer,
 }: {
-  label?: string;
   title: string;
   message: string;
   footer?: Snippet;
@@ -16,32 +14,10 @@ let {
 </script>
 
 <div class="flex h-full min-h-full items-center justify-center p-6 text-center">
-  <div class="flex w-full max-w-xl flex-col items-center">
-    <div
-      class="relative mb-6 grid size-28 place-items-center"
-      aria-hidden="true"
-    >
-      <div class="absolute inset-0 rounded-full border border-border/60"></div>
-      <div
-        class="absolute inset-3 rounded-full border border-dashed border-primary/30"
-      ></div>
-      <div class="absolute inset-6 rounded-full bg-primary/10 blur-lg"></div>
-      <div class="signal-orbit absolute inset-1">
-        <span
-          class="absolute left-1/2 top-0 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary shadow-sm"
-        ></span>
-      </div>
-      <div
-        class="relative grid size-14 place-items-center rounded-xl border border-primary/30 bg-card shadow-sm"
-      >
-        <NerveMark class="size-7 text-primary" />
-      </div>
-    </div>
+  <div class="brand-signal-enter flex w-full max-w-xl flex-col items-center">
+    <NerveBadge class="size-12" />
 
-    <p class="text-xs font-medium uppercase tracking-wider text-primary">
-      {label}
-    </p>
-    <h2 class="mt-2 text-xl font-semibold tracking-tight text-foreground">
+    <h2 class="mt-5 text-xl font-semibold tracking-tight text-foreground">
       {title}
     </h2>
     <p class="mt-2 max-w-lg text-sm leading-relaxed text-muted-foreground">
@@ -55,9 +31,3 @@ let {
     {/if}
   </div>
 </div>
-
-<style>
-.signal-orbit {
-  animation: spin 12s linear infinite;
-}
-</style>

--- a/packages/workbench-app/src/lib/presentation/index.ts
+++ b/packages/workbench-app/src/lib/presentation/index.ts
@@ -1,4 +1,5 @@
 export { default as NerveMark } from "./components/brand/NerveMark.svelte";
+export { default as NerveBadge } from "./components/brand/NerveBadge.svelte";
 export { default as ConversationPaneLayout } from "./components/ConversationPaneLayout.svelte";
 export { default as ComposerEditor } from "./components/composer/ComposerEditor.svelte";
 export { default as ComposerModelPicker } from "./components/composer/ComposerModelPicker.svelte";


### PR DESCRIPTION
## Summary

The desktop splash and the two conversation empty states each rendered the Nerve mark differently, and more decoratively than the rest of the app. This aligns all three on the monochrome brand badge already used in the titlebar.

The empty states previously stacked a solid ring, a dashed primary ring, a blurred primary glow, a 12s infinite orbiting dot, and a bordered tile holding an orange mark. That is now a single monochrome badge. Looping motion in a persistent idle view was the main thing making the surface feel decorative, so it is replaced by a one-time entrance; the breathing pulse is kept only on the splash, which is genuinely transient.

## Changes

- **New `NerveBadge`** (`packages/workbench-app/src/lib/presentation/components/brand/NerveBadge.svelte`) — reusable badge filling `--foreground` with the mark knocked out in `--background`. Size is caller-controlled, so it hard-codes no box dimensions.
- **Empty states** (`conversation-signal.svelte`, used by both the empty middle column and the empty transcript) — decoration replaced with a `size-12` badge; `NERVE IS READY` eyebrow removed so the heading carries the view. The `label` prop is dropped, which is an API narrowing rather than a break since neither call site passed it.
- **Splash** (`packages/desktop-shell/src/window/loading-pages.ts`) — bordered circle swapped for the same badge, progress bar shortened from `min(20rem, 100%)` to `min(12rem, 100%)`, status text centered above it.
- **Motion** (`packages/ui-kit/src/styles/animation.css`) — added `brand-signal-enter` (fade + 4px rise) using the existing `--motion-enter-*` tokens, per the file's rule that keyframes live centrally.

## Logo centering

The badge deliberately omits the titlebar's `translate(5%, 5%)`. That nudge is documented as compensating for the mark's "top-left visual weight," but the premise does not hold: the compact mark's ink, stroke included, is already symmetric in its `viewBox` (14/14 units horizontal, 26/26 vertical). It is invisible at the titlebar's 1rem (~0.5px) but becomes ~1.6px of visible drift at 3rem.

Confirmed by measuring a render — badge 52x52px, mark margins left 13 / right 9, top 15 / bottom 11. Modeling predicted 13.0/9.8 and 14.5/11.2 with the translate versus 11.4/11.4 and 12.9/12.9 without, matching the measurement. The titlebar rule is left untouched.

## Accessibility

Reduced motion is covered on both surfaces: the workbench inherits the global clamp in `base.css`, and the splash gets an explicit `animation: none` since it renders pre-daemon and cannot reach ui-kit styles. Splash element ids and the `window.nerveLoadingProgress` contract used by `main.ts` are unchanged.

## Validation

`pnpm fix && pnpm check && pnpm test` passes clean — 0 errors across svelte-check, tsc, and astro check.

Verified visually in the workbench for both empty states. The splash was verified by geometry only, as it renders before the web bundle loads; worth a glance on next desktop launch.