### PR TITLE
feat(workbench): orchestrate critical renderer startup

### DIFF
--- a/packages/workbench-app/AGENTS.md
+++ b/packages/workbench-app/AGENTS.md
@@ -111,6 +111,14 @@ src/styles/
   `triggerClass`/`class` (e.g. `.composer-tab`) always wins regardless of CSS
   bundle order: `:global(:where(.popover-trigger)) { … }`.
 
+## Startup loading policy
+
+- Composer-critical startup resources are settings, models, auth metadata, workspace hydration, and restoration of the active conversation.
+- New mount or project-restoration effects must not initiate network or filesystem work before `workbenchStartupState.progressiveActive` unless the work is explicitly added to the orchestrator's reviewed critical lane.
+- Restored inactive tabs are metadata-only during startup. A restored active conversation is critical; non-conversation active-tab loaders are progressive.
+- Background features should also honor panel visibility or explicit demand wherever possible.
+- Startup ordering tests use deferred dependencies and phase events, never timing thresholds.
+
 ## Misc
 
 - Icons: `@lucide/svelte`, sized/colored via `class` on the icon. Loading

--- a/packages/workbench-app/src/lib/app/providers/WorkbenchProvider.svelte
+++ b/packages/workbench-app/src/lib/app/providers/WorkbenchProvider.svelte
@@ -33,6 +33,7 @@ import {
   refreshGitContext,
   refreshPrPane,
   startGitRefreshCoordinator,
+  createGitStartupPolicy,
 } from "$lib/features/git";
 import {
   loadSettingsPanel,
@@ -44,6 +45,7 @@ import {
   disconnectWorkbench,
   initializeWorkbench,
 } from "$lib/core/events/websocket-client.svelte";
+import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
 import {
   centerTabsExcept,
   closeCenterTab,
@@ -152,23 +154,30 @@ $effect(() => {
   void syncDesktopCloseToTray(value);
 });
 
-let lastGitProjectId: string | undefined;
-$effect(() => {
-  const projectId = activeProject?.id;
-  if (projectId === lastGitProjectId) return;
-  lastGitProjectId = projectId;
+const gitStartupPolicy = createGitStartupPolicy((projectId) => {
   if (projectId)
     void refreshGitContext(projectId, { reason: "project", force: true });
   else clearGitContext();
+});
+
+$effect(() => {
+  gitStartupPolicy.update(
+    workbenchStartupState.progressiveActive,
+    activeProject?.id,
+  );
+});
+
+$effect(() => {
+  if (!workbenchStartupState.progressiveActive) return;
+  return startGitRefreshCoordinator(
+    () => void refreshGitContext(undefined, { reason: "focus" }),
+  );
 });
 
 onMount(() => {
   const unregisterFeatureEvents = registerFeatureEventHandlers();
   const stopNotificationAudio = initializeNotificationAudio();
   const unsubscribeDesktop = initializeDesktopRuntime();
-  const stopGitRefreshCoordinator = startGitRefreshCoordinator(
-    () => void refreshGitContext(undefined, { reason: "focus" }),
-  );
   const startedOnSettings =
     window.location.pathname === "/settings" ||
     window.location.pathname === "/settings/";
@@ -183,10 +192,13 @@ onMount(() => {
     capture: true,
   });
 
-  void initializeWorkbench().then(() => {
-    initializeNotifications();
-    if (startedOnSettings) void openSettingsPane();
-  });
+  void initializeWorkbench()
+    .then((initialized) => {
+      if (!initialized) return;
+      initializeNotifications();
+      if (startedOnSettings) void openSettingsPane();
+    })
+    .catch(() => undefined);
 
   return () => {
     window.removeEventListener(
@@ -196,7 +208,6 @@ onMount(() => {
     );
     unsubscribeDesktop();
     stopNotificationAudio();
-    stopGitRefreshCoordinator();
     unregisterFeatureEvents();
     disconnectWorkbench();
   };

--- a/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
+++ b/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
@@ -40,7 +40,9 @@ import {
 import { restoreConversationTabs } from "$lib/features/conversations/state/conversation-flow.svelte";
 import { refreshConversationView } from "$lib/features/conversations/state/selection";
 import {
-  loadSettingsPanel,
+  loadCoreSettings,
+  reconcileComposerSelectionFromSettings,
+  refreshAncillarySettingsData,
   refreshSubscriptionUsage,
 } from "$lib/features/settings/state/settings-actions.svelte";
 import {
@@ -52,7 +54,19 @@ import {
   loadSlashCommands,
   recoverWorkspaceSnapshotFromNetwork,
 } from "$lib/features/workspace/state/workspace-actions.svelte";
-import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import {
+  workspaceState,
+  type CenterTabIdentity,
+} from "$lib/features/workspace/state/workspace-state.svelte";
+import { selectCenterTab } from "$lib/features/workspace/state/center-tabs.svelte";
+import { runWorkbenchStartupSequence } from "$lib/core/startup/workbench-startup-sequence";
+import {
+  beginWorkbenchStartup,
+  failWorkbenchStartup,
+  isWorkbenchStartupGenerationCurrent,
+  stopWorkbenchStartup,
+  transitionWorkbenchStartup,
+} from "$lib/core/startup/workbench-startup-state.svelte";
 
 const PROTOCOL_CAPABILITIES = [
   "encoding.json",
@@ -70,33 +84,54 @@ let intentionallyDisconnected = false;
 let workspaceSnapshotLoaded = false;
 let subscriptionUsagePollTimer: ReturnType<typeof setInterval> | undefined;
 
-export async function initializeWorkbench(): Promise<void> {
+export async function initializeWorkbench(): Promise<boolean> {
   intentionallyDisconnected = false;
   workspaceSnapshotLoaded = false;
+  const generation = beginWorkbenchStartup();
+  applyTheme(loadThemePreference());
   try {
-    applyTheme(loadThemePreference());
-    workspaceState.config = await retryDuringStartup(
-      "load client config",
-      getClientConfig,
-    );
-    if (workspaceState.config.status.capabilities.applicationLogs) {
-      installClientLogging();
-    }
-    workspaceState.status = workspaceState.config.status;
-    workspaceState.error = undefined;
-    composerDraft.projectDir = workspaceState.config.status.storage.home;
-    await loadSlashCommands();
-    await connectWebsocket(workspaceState.config.wsUrl);
-    startReleasePolling();
-    await Promise.all([restoreConversationTabs(), loadSettingsPanel()]);
-    startSubscriptionUsagePolling();
-    clientLog("info", "workbench", "Workbench initialized");
+    const diagnostics = await runWorkbenchStartupSequence({
+      loadClientConfig: () =>
+        retryDuringStartup("load client config", getClientConfig),
+      applyClientConfig: (config) => {
+        workspaceState.config = config;
+        if (config.status.capabilities.applicationLogs) installClientLogging();
+        workspaceState.status = config.status;
+        workspaceState.error = undefined;
+        composerDraft.projectDir = config.status.storage.home;
+      },
+      loadCoreSettings,
+      recoverWorkspace: () => connectWebsocket(workspaceState.config!.wsUrl),
+      restoreCriticalConversation: restoreConversationTabs,
+      reconcileComposerSelection: reconcileComposerSelectionFromSettings,
+      activateDeferredTab: async (desiredTab, conversationRestored) => {
+        if (desiredTab && !conversationRestored)
+          await selectCenterTab(desiredTab);
+      },
+      startProgressiveWork: () => {
+        void loadSlashCommands().catch(() => undefined);
+        startReleasePolling();
+        refreshAncillarySettingsData();
+        startSubscriptionUsagePolling();
+      },
+      transition: (phase) => transitionWorkbenchStartup(generation, phase),
+      isCurrent: () => isWorkbenchStartupGenerationCurrent(generation),
+    });
+    if (!isWorkbenchStartupGenerationCurrent(generation)) return false;
+    clientLog("info", "workbench", "Workbench initialized", {
+      context: diagnostics,
+    });
+    return true;
   } catch (caught) {
+    if (!isWorkbenchStartupGenerationCurrent(generation)) return false;
+    failWorkbenchStartup(generation, caught);
     workspaceState.error = errorMessage(caught);
     workspaceState.connection = "error";
     clientLog("error", "workbench", "Workbench initialization failed", {
+      context: { criticalBeforeProgressive: true },
       error: caught,
     });
+    throw caught;
   }
 }
 
@@ -109,19 +144,23 @@ function protocolSource(): PeerDescriptor {
   };
 }
 
-async function connectWebsocket(wsUrl: string): Promise<void> {
+async function connectWebsocket(
+  wsUrl: string,
+): Promise<CenterTabIdentity | undefined> {
   await connection?.close();
   unbindSubscriptionSync?.();
   const messages = createMessageFactory({
     source: protocolSource(),
     target: protocolTarget,
   });
-  let resolveInitialReady!: () => void;
+  let resolveInitialReady!: (desiredTab: CenterTabIdentity | undefined) => void;
   let rejectInitialReady!: (error: unknown) => void;
-  const initialReady = new Promise<void>((resolve, reject) => {
-    resolveInitialReady = resolve;
-    rejectInitialReady = reject;
-  });
+  const initialReady = new Promise<CenterTabIdentity | undefined>(
+    (resolve, reject) => {
+      resolveInitialReady = resolve;
+      rejectInitialReady = reject;
+    },
+  );
 
   connection = new ProtocolClientConnection({
     transport: browserWebSocketTransportFactory(resolveWebsocketUrl(wsUrl)),
@@ -143,19 +182,26 @@ async function connectWebsocket(wsUrl: string): Promise<void> {
         onDisconnect,
         onReady: async (welcome) => {
           workspaceState.protocolSessionId = welcome.sessionId;
+          let desiredTab: CenterTabIdentity | undefined;
           if (!workspaceSnapshotLoaded) {
-            const cursor = await recoverWorkspaceSnapshotFromNetwork();
-            installEventCursors(cursor.streams, { replace: true, sync: false });
+            const recovered = await recoverWorkspaceSnapshotFromNetwork({
+              deferTabActivation: true,
+            });
+            installEventCursors(recovered.cursor.streams, {
+              replace: true,
+              sync: false,
+            });
+            desiredTab = recovered.desiredTab;
             workspaceSnapshotLoaded = true;
           }
           workspaceState.connection = "live";
           requestSubscriptionSync();
-          resolveInitialReady();
+          resolveInitialReady(desiredTab);
         },
         onSnapshotRequired: async (stream) => {
           if (stream === "workspace") {
-            const cursor = await recoverWorkspaceSnapshotFromNetwork();
-            installEventCursors(cursor.streams, { sync: false });
+            const recovered = await recoverWorkspaceSnapshotFromNetwork();
+            installEventCursors(recovered.cursor.streams, { sync: false });
             requestSubscriptionSync();
             return;
           }
@@ -200,7 +246,7 @@ async function connectWebsocket(wsUrl: string): Promise<void> {
     return "applied";
   });
   void connection.start().catch(rejectInitialReady);
-  await initialReady;
+  return initialReady;
 }
 
 function setConnectionState(state: ProtocolClientConnectionState): void {
@@ -266,6 +312,7 @@ function stopSubscriptionUsagePolling(): void {
 
 export function disconnectWorkbench(): void {
   intentionallyDisconnected = true;
+  stopWorkbenchStartup();
   stopSubscriptionUsagePolling();
   stopReleasePolling();
   flushNotifyEvents();

--- a/packages/workbench-app/src/lib/core/startup/workbench-startup-machine.ts
+++ b/packages/workbench-app/src/lib/core/startup/workbench-startup-machine.ts
@@ -1,0 +1,59 @@
+import type { WorkbenchStartupPhase } from "./workbench-startup-sequence";
+
+const phaseOrder: Partial<Record<WorkbenchStartupPhase, number>> = {
+  idle: 0,
+  critical: 1,
+  "core-ready": 2,
+  progressive: 3,
+};
+
+export class WorkbenchStartupMachine {
+  phase: WorkbenchStartupPhase = "idle";
+  generation = 0;
+  error: unknown;
+
+  begin(): number {
+    this.generation += 1;
+    this.phase = "idle";
+    this.error = undefined;
+    return this.generation;
+  }
+
+  isCurrent(generation: number): boolean {
+    return this.generation === generation && this.phase !== "stopped";
+  }
+
+  transition(
+    generation: number,
+    phase: WorkbenchStartupPhase,
+    error?: unknown,
+  ): boolean {
+    if (!this.isCurrent(generation)) return false;
+    if (phase === "failed") {
+      if (this.phase === "progressive") return false;
+      this.phase = phase;
+      if (error !== undefined) this.error = error;
+      return true;
+    }
+    if (phase === "stopped") return this.stop(generation);
+    const currentOrder = phaseOrder[this.phase];
+    const nextOrder = phaseOrder[phase];
+    if (
+      currentOrder === undefined ||
+      nextOrder === undefined ||
+      nextOrder !== currentOrder + 1
+    ) {
+      return false;
+    }
+    this.phase = phase;
+    return true;
+  }
+
+  stop(generation?: number): boolean {
+    if (generation !== undefined && generation !== this.generation)
+      return false;
+    this.generation += 1;
+    this.phase = "stopped";
+    return true;
+  }
+}

--- a/packages/workbench-app/src/lib/core/startup/workbench-startup-sequence.test.ts
+++ b/packages/workbench-app/src/lib/core/startup/workbench-startup-sequence.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  runWorkbenchStartupSequence,
+  type WorkbenchStartupPhase,
+} from "./workbench-startup-sequence";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+function tick() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+test("starts critical dependencies together and blocks progressive activation", async () => {
+  const settings = deferred<void>();
+  const workspace = deferred<string | undefined>();
+  const conversation = deferred<boolean>();
+  const events: string[] = [];
+  const current = true;
+  const run = runWorkbenchStartupSequence({
+    loadClientConfig: async () => "config",
+    applyClientConfig: () => events.push("config"),
+    loadCoreSettings: () => {
+      events.push("settings:start");
+      return settings.promise;
+    },
+    recoverWorkspace: () => {
+      events.push("workspace:start");
+      return workspace.promise;
+    },
+    restoreCriticalConversation: () => {
+      events.push("conversation:start");
+      return conversation.promise;
+    },
+    reconcileComposerSelection: () => {
+      events.push("reconcile");
+    },
+    activateDeferredTab: () => {
+      events.push("tab:activate");
+    },
+    startProgressiveWork: () => events.push("progressive:work"),
+    transition: (phase) => {
+      events.push(`phase:${phase}`);
+      return current;
+    },
+    isCurrent: () => current,
+  });
+
+  await tick();
+  assert.deepEqual(events.slice(0, 4), [
+    "config",
+    "phase:critical",
+    "settings:start",
+    "workspace:start",
+  ]);
+  workspace.resolve("conversation:1");
+  await tick();
+  assert.ok(events.includes("conversation:start"));
+  conversation.resolve(true);
+  await tick();
+  assert.ok(!events.includes("phase:core-ready"));
+  settings.resolve();
+  await run;
+  assert.ok(
+    events.indexOf("phase:core-ready") < events.indexOf("phase:progressive"),
+  );
+  assert.ok(
+    events.indexOf("phase:progressive") < events.indexOf("progressive:work"),
+  );
+});
+
+test("keeps progressive work blocked while workspace recovery remains pending", async () => {
+  const workspace = deferred<undefined>();
+  const events: string[] = [];
+  const run = runWorkbenchStartupSequence({
+    loadClientConfig: async () => undefined,
+    applyClientConfig: () => undefined,
+    loadCoreSettings: async () => undefined,
+    recoverWorkspace: () => workspace.promise,
+    restoreCriticalConversation: async () => false,
+    reconcileComposerSelection: () => undefined,
+    activateDeferredTab: () => undefined,
+    startProgressiveWork: () => events.push("progressive"),
+    transition: () => true,
+    isCurrent: () => true,
+  });
+  await tick();
+  assert.deepEqual(events, []);
+  workspace.resolve(undefined);
+  await run;
+  assert.deepEqual(events, ["progressive"]);
+});
+
+test("progressive feature failures do not reject core readiness", async () => {
+  const result = await runWorkbenchStartupSequence({
+    loadClientConfig: async () => undefined,
+    applyClientConfig: () => undefined,
+    loadCoreSettings: async () => undefined,
+    recoverWorkspace: async () => undefined,
+    restoreCriticalConversation: async () => false,
+    reconcileComposerSelection: () => undefined,
+    activateDeferredTab: () => {
+      throw new Error("tab failed");
+    },
+    startProgressiveWork: () => {
+      throw new Error("feature failed");
+    },
+    transition: () => true,
+    isCurrent: () => true,
+  });
+  assert.equal(result.criticalBeforeProgressive, true);
+});
+
+test("critical failure suppresses progressive work", async () => {
+  const events: string[] = [];
+  await assert.rejects(
+    runWorkbenchStartupSequence({
+      loadClientConfig: async () => undefined,
+      applyClientConfig: () => undefined,
+      loadCoreSettings: async () => {
+        throw new Error("models unavailable");
+      },
+      recoverWorkspace: async () => undefined,
+      restoreCriticalConversation: async () => false,
+      reconcileComposerSelection: () => undefined,
+      activateDeferredTab: () => {
+        events.push("tab");
+      },
+      startProgressiveWork: () => events.push("progressive"),
+      transition: (phase) => {
+        events.push(phase);
+        return true;
+      },
+      isCurrent: () => true,
+    }),
+    /models unavailable/,
+  );
+  assert.ok(events.includes("failed"));
+  assert.ok(!events.includes("progressive"));
+});
+
+test("stopping a generation invalidates late critical completions", async () => {
+  const workspace = deferred<undefined>();
+  const events: WorkbenchStartupPhase[] = [];
+  let current = true;
+  const run = runWorkbenchStartupSequence({
+    loadClientConfig: async () => undefined,
+    applyClientConfig: () => undefined,
+    loadCoreSettings: async () => undefined,
+    recoverWorkspace: () => workspace.promise,
+    restoreCriticalConversation: async () => false,
+    reconcileComposerSelection: () => undefined,
+    activateDeferredTab: () => assert.fail("must not activate"),
+    startProgressiveWork: () => assert.fail("must not start"),
+    transition: (phase) => {
+      events.push(phase);
+      return current;
+    },
+    isCurrent: () => current,
+  });
+  await tick();
+  current = false;
+  workspace.resolve(undefined);
+  await run;
+  assert.deepEqual(events, ["critical"]);
+});

--- a/packages/workbench-app/src/lib/core/startup/workbench-startup-sequence.ts
+++ b/packages/workbench-app/src/lib/core/startup/workbench-startup-sequence.ts
@@ -1,0 +1,147 @@
+export type WorkbenchStartupPhase =
+  | "idle"
+  | "critical"
+  | "core-ready"
+  | "progressive"
+  | "failed"
+  | "stopped";
+
+export type StartupMilestone = {
+  name: string;
+  at: number;
+};
+
+export type StartupPhaseDuration = {
+  phase: "config" | "critical";
+  durationMs: number;
+};
+
+export type WorkbenchStartupResult = {
+  milestones: StartupMilestone[];
+  phaseDurations: StartupPhaseDuration[];
+  criticalBeforeProgressive: true;
+};
+
+export type WorkbenchStartupSequenceDependencies<TConfig, TRestoredTab> = {
+  loadClientConfig: () => Promise<TConfig>;
+  applyClientConfig: (config: TConfig) => void;
+  loadCoreSettings: () => Promise<void>;
+  recoverWorkspace: () => Promise<TRestoredTab | undefined>;
+  restoreCriticalConversation: (
+    desiredTab: TRestoredTab | undefined,
+  ) => Promise<boolean>;
+  reconcileComposerSelection: () => void | Promise<void>;
+  activateDeferredTab: (
+    desiredTab: TRestoredTab | undefined,
+    conversationRestored: boolean,
+  ) => void | Promise<void>;
+  startProgressiveWork: () => void;
+  transition: (phase: WorkbenchStartupPhase) => boolean;
+  isCurrent: () => boolean;
+  now?: () => number;
+  observeMilestone?: (milestone: StartupMilestone) => void;
+};
+
+export async function runWorkbenchStartupSequence<TConfig, TRestoredTab>(
+  deps: WorkbenchStartupSequenceDependencies<TConfig, TRestoredTab>,
+): Promise<WorkbenchStartupResult> {
+  const now = deps.now ?? (() => performance.now());
+  const milestones: StartupMilestone[] = [];
+  const mark = (name: string) => {
+    const milestone = { name, at: now() };
+    milestones.push(milestone);
+    deps.observeMilestone?.(milestone);
+  };
+  const startedAt = now();
+  let criticalAt: number;
+
+  try {
+    mark("config:start");
+    const config = await deps.loadClientConfig();
+    if (!deps.isCurrent()) return stoppedResult(milestones, startedAt, now());
+    deps.applyClientConfig(config);
+    mark("config:ready");
+
+    if (!deps.transition("critical"))
+      return stoppedResult(milestones, startedAt, now());
+    criticalAt = now();
+    mark("critical:start");
+
+    const coreSettings = deps
+      .loadCoreSettings()
+      .then(() => mark("core-settings:ready"));
+    // Workspace recovery determines whether conversation restoration is needed;
+    // attach a handler now so an early settings failure is never unobserved.
+    void coreSettings.catch(() => undefined);
+    const workspace = deps.recoverWorkspace().then((desiredTab) => {
+      mark("workspace:ready");
+      return desiredTab;
+    });
+    mark("critical:started-concurrently");
+
+    const desiredTab = await workspace;
+    if (!deps.isCurrent()) return stoppedResult(milestones, startedAt, now());
+    const conversationRestoration = deps
+      .restoreCriticalConversation(desiredTab)
+      .then((restored) => {
+        mark("conversation-restoration:ready");
+        return restored;
+      });
+
+    const [, conversationRestored] = await Promise.all([
+      coreSettings,
+      conversationRestoration,
+    ]);
+    if (!deps.isCurrent()) return stoppedResult(milestones, startedAt, now());
+    await deps.reconcileComposerSelection();
+    mark("composer-selection:reconciled");
+
+    if (!deps.transition("core-ready"))
+      return stoppedResult(milestones, startedAt, now());
+    mark("core-ready");
+    if (!deps.transition("progressive"))
+      return stoppedResult(milestones, startedAt, now());
+    mark("progressive");
+    try {
+      void Promise.resolve(
+        deps.activateDeferredTab(desiredTab, conversationRestored),
+      ).catch(() => undefined);
+    } catch {
+      // Progressive feature errors cannot regress composer readiness.
+    }
+    try {
+      deps.startProgressiveWork();
+    } catch {
+      // Progressive feature errors remain feature-local.
+    }
+    mark("progressive-work:started");
+
+    return {
+      milestones,
+      phaseDurations: [
+        { phase: "config", durationMs: criticalAt - startedAt },
+        { phase: "critical", durationMs: now() - criticalAt },
+      ],
+      criticalBeforeProgressive: true,
+    };
+  } catch (error) {
+    if (deps.isCurrent()) deps.transition("failed");
+    mark("failed");
+    throw error;
+  }
+}
+
+function stoppedResult(
+  milestones: StartupMilestone[],
+  startedAt: number,
+  stoppedAt: number,
+): WorkbenchStartupResult {
+  return {
+    milestones,
+    phaseDurations: [
+      { phase: "config", durationMs: stoppedAt - startedAt },
+      { phase: "critical", durationMs: 0 },
+    ],
+    criticalBeforeProgressive: true,
+  };
+}

--- a/packages/workbench-app/src/lib/core/startup/workbench-startup-state.svelte.ts
+++ b/packages/workbench-app/src/lib/core/startup/workbench-startup-state.svelte.ts
@@ -1,0 +1,55 @@
+import type { WorkbenchStartupPhase } from "./workbench-startup-sequence";
+import { WorkbenchStartupMachine } from "./workbench-startup-machine";
+
+class WorkbenchStartupState {
+  phase = $state<WorkbenchStartupPhase>("idle");
+  generation = $state(0);
+  error = $state<unknown>();
+
+  get coreReady(): boolean {
+    return this.phase === "core-ready" || this.phase === "progressive";
+  }
+
+  get progressiveActive(): boolean {
+    return this.phase === "progressive";
+  }
+}
+
+const machine = new WorkbenchStartupMachine();
+export const workbenchStartupState = new WorkbenchStartupState();
+
+function publishMachineState(): void {
+  workbenchStartupState.phase = machine.phase;
+  workbenchStartupState.generation = machine.generation;
+  workbenchStartupState.error = machine.error;
+}
+
+export function beginWorkbenchStartup(): number {
+  const generation = machine.begin();
+  publishMachineState();
+  return generation;
+}
+
+export function isWorkbenchStartupGenerationCurrent(generation: number) {
+  return machine.isCurrent(generation);
+}
+
+export function transitionWorkbenchStartup(
+  generation: number,
+  phase: WorkbenchStartupPhase,
+  error?: unknown,
+): boolean {
+  const transitioned = machine.transition(generation, phase, error);
+  if (transitioned) publishMachineState();
+  return transitioned;
+}
+
+export function failWorkbenchStartup(generation: number, error: unknown) {
+  return transitionWorkbenchStartup(generation, "failed", error);
+}
+
+export function stopWorkbenchStartup(generation?: number): boolean {
+  const stopped = machine.stop(generation);
+  if (stopped) publishMachineState();
+  return stopped;
+}

--- a/packages/workbench-app/src/lib/core/startup/workbench-startup-state.test.ts
+++ b/packages/workbench-app/src/lib/core/startup/workbench-startup-state.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { WorkbenchStartupMachine } from "./workbench-startup-machine";
+
+test("startup phases are monotonic and cannot skip or regress", () => {
+  const state = new WorkbenchStartupMachine();
+  const generation = state.begin();
+  assert.equal(state.transition(generation, "core-ready"), false);
+  assert.equal(state.transition(generation, "critical"), true);
+  assert.equal(state.transition(generation, "idle"), false);
+  assert.equal(state.transition(generation, "core-ready"), true);
+  assert.equal(state.transition(generation, "progressive"), true);
+  assert.equal(state.transition(generation, "failed"), false);
+  assert.equal(state.phase, "progressive");
+});
+
+test("stop invalidates the active generation", () => {
+  const state = new WorkbenchStartupMachine();
+  const generation = state.begin();
+  assert.equal(state.stop(generation), true);
+  assert.equal(state.isCurrent(generation), false);
+  assert.equal(state.transition(generation, "critical"), false);
+  assert.equal(state.phase, "stopped");
+});

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
@@ -59,6 +59,7 @@ import Sparkles from "@lucide/svelte/icons/sparkles";
 import { gitState } from "$lib/features/git/state/git-state.svelte";
 import { gitContextFingerprint } from "$lib/features/git/state/git-context.svelte";
 import { promptSuggestionsState } from "$lib/features/prompt-suggestions/state/prompt-suggestions-state.svelte";
+import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
 import { refreshPromptSuggestions } from "$lib/features/prompt-suggestions/state/prompt-suggestions-actions.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import PromptSuggestionTrustDialog from "$lib/features/prompt-suggestions/components/PromptSuggestionTrustDialog.svelte";
@@ -306,7 +307,8 @@ function openToolFile(path: string, line?: number) {
 }
 
 $effect(() => {
-  if (!active || !activeProject?.id) return;
+  if (!workbenchStartupState.progressiveActive || !active || !activeProject?.id)
+    return;
   void promptSuggestionRefreshKey;
   void refreshPromptSuggestions(activeProject.id, {
     conversationId,

--- a/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
@@ -16,7 +16,6 @@ import {
 import { getToolCall } from "$lib/features/tools/api/tools.api";
 import {
   confluenceSiteUrl,
-  ensureAtlassianSiteUrls,
   jiraSiteUrl,
 } from "$lib/features/conversations/state/atlassian-site-urls.svelte";
 
@@ -26,7 +25,6 @@ import {
  * input). Kept in web because it wires app-only services.
  */
 export function workbenchConversationUiCapabilities(): ConversationUiCapabilities {
-  ensureAtlassianSiteUrls();
   return {
     fetchToolCall: (toolCallId) => getToolCall(toolCallId),
     atlassian: { jiraSiteUrl, confluenceSiteUrl },

--- a/packages/workbench-app/src/lib/features/conversations/state/atlassian-site-urls.svelte.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/atlassian-site-urls.svelte.ts
@@ -1,29 +1,10 @@
-import { getSettings } from "$lib/features/settings/api/settings.api";
+import { settingsState } from "$lib/features/settings/state/settings-state.svelte";
 
-/**
- * Lazily fetched Atlassian site URLs used by the shared conversation UI to
- * build external Jira/Confluence links. Fetched once per app session; a fetch
- * failure simply leaves the URLs undefined so links degrade to plain text.
- */
-const state = $state<{ jira?: string; confluence?: string }>({});
-
-let inflight: Promise<void> | undefined;
-
-export function ensureAtlassianSiteUrls(): void {
-  inflight ??= getSettings()
-    .then((settings) => {
-      state.jira = settings.tools?.jira?.siteUrl;
-      state.confluence = settings.tools?.confluence?.siteUrl;
-    })
-    .catch(() => {
-      // Links are optional decoration; keep URLs undefined on failure.
-    });
-}
-
+/** Optional link decoration derived from the orchestrated core settings load. */
 export function jiraSiteUrl(): string | undefined {
-  return state.jira;
+  return settingsState.settingsDraft?.tools?.jira?.siteUrl;
 }
 
 export function confluenceSiteUrl(): string | undefined {
-  return state.confluence;
+  return settingsState.settingsDraft?.tools?.confluence?.siteUrl;
 }

--- a/packages/workbench-app/src/lib/features/conversations/state/tabs.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/tabs.ts
@@ -49,7 +49,9 @@ export async function openConversation(conversationId: string) {
   workspaceState.error = view.error;
 }
 
-export async function restoreConversationTabs() {
+export async function restoreConversationTabs(
+  desiredTab = workspaceState.activeCenterTab,
+): Promise<boolean> {
   const tabIds = workspaceState.openCenterTabs
     .filter(
       (tab): tab is Extract<typeof tab, { kind: "conversation" }> =>
@@ -57,10 +59,11 @@ export async function restoreConversationTabs() {
     )
     .map((tab) => tab.id);
   for (const conversationId of tabIds) ensureConversationView(conversationId);
-  const active = workspaceState.activeCenterTab;
   conversationState.activeConversationTabId =
-    active?.kind === "conversation" ? active.id : tabIds[0];
-  if (active) await selectCenterTab(active);
+    desiredTab?.kind === "conversation" ? desiredTab.id : tabIds[0];
+  if (desiredTab?.kind !== "conversation") return false;
+  await selectCenterTab(desiredTab);
+  return true;
 }
 
 export async function closeConversationTab(conversationId: string) {

--- a/packages/workbench-app/src/lib/features/git/index.ts
+++ b/packages/workbench-app/src/lib/features/git/index.ts
@@ -10,4 +10,5 @@ export type { GitContext, PrViewState } from "./state/git-state.svelte";
 export { gitState } from "./state/git-state.svelte";
 export { refreshPrPane } from "./state/pr-tabs.svelte";
 export { startGitRefreshCoordinator } from "./state/git-refresh-coordinator.svelte";
+export { createGitStartupPolicy } from "./state/git-startup-policy";
 export { createWorkbenchGitPanelAdapter } from "./state/workbench-git-panel-adapter.svelte";

--- a/packages/workbench-app/src/lib/features/git/state/git-startup-policy.test.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-startup-policy.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createGitStartupPolicy,
+  shouldActivateGitPanel,
+} from "./git-startup-policy";
+
+test("refreshes the latest project once when progressive activation opens", () => {
+  const refreshed: Array<string | undefined> = [];
+  const policy = createGitStartupPolicy((projectId) =>
+    refreshed.push(projectId),
+  );
+  policy.update(false, "old");
+  policy.update(false, "latest");
+  assert.deepEqual(refreshed, []);
+  policy.update(true, "latest");
+  policy.update(true, "latest");
+  assert.deepEqual(refreshed, ["latest"]);
+  policy.update(true, "next");
+  assert.deepEqual(refreshed, ["latest", "next"]);
+});
+
+test("a hidden panel cannot activate Git detail loading", () => {
+  assert.equal(
+    shouldActivateGitPanel({
+      progressiveActive: true,
+      enabled: false,
+      projectId: "project",
+      lastProjectId: undefined,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldActivateGitPanel({
+      progressiveActive: true,
+      enabled: true,
+      projectId: "project",
+      lastProjectId: undefined,
+    }),
+    true,
+  );
+});

--- a/packages/workbench-app/src/lib/features/git/state/git-startup-policy.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-startup-policy.ts
@@ -1,0 +1,34 @@
+export type GitStartupPolicy = {
+  update(progressiveActive: boolean, projectId: string | undefined): void;
+};
+
+/** Admits automatic project refreshes only after progressive startup opens. */
+export function createGitStartupPolicy(
+  activate: (projectId: string | undefined) => void,
+): GitStartupPolicy {
+  let lastActivatedProjectId: string | undefined;
+  let activated = false;
+  return {
+    update(progressiveActive, projectId) {
+      if (!progressiveActive) return;
+      if (activated && projectId === lastActivatedProjectId) return;
+      activated = true;
+      lastActivatedProjectId = projectId;
+      activate(projectId);
+    },
+  };
+}
+
+export function shouldActivateGitPanel(input: {
+  progressiveActive: boolean;
+  enabled: boolean;
+  projectId: string | undefined;
+  lastProjectId: string | undefined;
+}): boolean {
+  return Boolean(
+    input.progressiveActive &&
+    input.enabled &&
+    input.projectId &&
+    input.projectId !== input.lastProjectId,
+  );
+}

--- a/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
@@ -17,6 +17,8 @@ import {
   gitRepoStateKey,
 } from "$lib/core/state/state-keys";
 import { GIT_AUTO_REFRESH_COOLDOWN_MS } from "./git-refresh-policy";
+import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
+import { shouldActivateGitPanel } from "./git-startup-policy";
 import {
   autoRefreshGitOverview,
   bulkStageGitFiles,
@@ -238,13 +240,26 @@ export function createWorkbenchGitPanelAdapter(
   let lastProjectId: string | undefined;
   $effect(() => {
     const project = activeProject();
-    if (project?.id === lastProjectId) return;
+    const panelEnabled = enabled();
+    if (
+      !shouldActivateGitPanel({
+        progressiveActive: workbenchStartupState.progressiveActive,
+        enabled: panelEnabled,
+        projectId: project?.id,
+        lastProjectId,
+      })
+    )
+      return;
     lastProjectId = project?.id;
-    if (project) queueMicrotask(() => selectGitProject(project));
+    if (project)
+      queueMicrotask(() => {
+        if (workbenchStartupState.progressiveActive && enabled())
+          selectGitProject(project);
+      });
   });
 
   $effect(() => {
-    const active = enabled();
+    const active = workbenchStartupState.progressiveActive && enabled();
     const project = activeProject();
     const projectState = project
       ? gitPanelState.projects[gitProjectStateKey(project.id)]
@@ -268,7 +283,7 @@ export function createWorkbenchGitPanelAdapter(
   });
 
   $effect(() => {
-    const active = enabled();
+    const active = workbenchStartupState.progressiveActive && enabled();
     const project = activeProject();
     const projectState = project
       ? gitPanelState.projects[gitProjectStateKey(project.id)]

--- a/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
@@ -46,6 +46,7 @@ let saveTimer: ReturnType<typeof setTimeout> | undefined;
 let saveInFlight = false;
 let savedServerSettingsSinceLoad = false;
 let skillsRequestId = 0;
+let coreSettingsLoadInFlight: Promise<void> | undefined;
 let settingsLoadInFlight: Promise<void> | undefined;
 let settingsReloadRequested = false;
 
@@ -107,7 +108,7 @@ export async function loadSettingsSkills(projectId = selection.projectId) {
   }
 }
 
-async function loadCoreSettings(): Promise<void> {
+async function performCoreSettingsLoad(): Promise<void> {
   const [settings, modelList, auth] = await Promise.all([
     getSettings(),
     getModels(),
@@ -117,6 +118,27 @@ async function loadCoreSettings(): Promise<void> {
   applyZoomLevel(settings.ui.zoomLevel);
   settingsState.models = modelList;
   settingsState.authProviders = auth;
+  reconcileComposerSelectionFromSettings();
+  if (!hasPendingSettingsSave()) {
+    savedServerSettingsSinceLoad = false;
+    settingsState.settingsSaveStatus = "idle";
+    settingsState.settingsMessage = undefined;
+  }
+}
+
+export function loadCoreSettings(): Promise<void> {
+  if (coreSettingsLoadInFlight) return coreSettingsLoadInFlight;
+  coreSettingsLoadInFlight = performCoreSettingsLoad().finally(() => {
+    coreSettingsLoadInFlight = undefined;
+  });
+  return coreSettingsLoadInFlight;
+}
+
+export function reconcileComposerSelectionFromSettings(): void {
+  const settings = settingsState.settingsDraft;
+  if (!settings) return;
+  const modelList = settingsState.models;
+  const auth = settingsState.authProviders;
   const usable = scopedUsableModelOptions(
     modelList,
     auth,
@@ -158,19 +180,17 @@ async function loadCoreSettings(): Promise<void> {
     conversationState.selectedThinkingLevel,
     currentSelectedModelInfo(),
   );
-  if (!hasPendingSettingsSave()) {
-    savedServerSettingsSinceLoad = false;
-    settingsState.settingsSaveStatus = "idle";
-    settingsState.settingsMessage = undefined;
-  }
 }
 
-function refreshAncillarySettingsData(): void {
+export function refreshAncillarySettingsData(): void {
   void refreshSubscriptionUsage().catch(() => undefined);
   void loadSettingsSkills();
 }
 
-async function runSettingsLoadCycle(): Promise<void> {
+async function runSettingsLoadCycle(
+  coreLoadAtStart: Promise<void> | undefined,
+): Promise<void> {
+  if (coreLoadAtStart) await coreLoadAtStart;
   do {
     settingsReloadRequested = false;
     await loadCoreSettings();
@@ -183,9 +203,11 @@ export function loadSettingsPanel(): Promise<void> {
     settingsReloadRequested = true;
     return settingsLoadInFlight;
   }
-  settingsLoadInFlight = runSettingsLoadCycle().finally(() => {
-    settingsLoadInFlight = undefined;
-  });
+  settingsLoadInFlight = runSettingsLoadCycle(coreSettingsLoadInFlight).finally(
+    () => {
+      settingsLoadInFlight = undefined;
+    },
+  );
   return settingsLoadInFlight;
 }
 

--- a/packages/workbench-app/src/lib/features/workspace/state/tab-session-helpers.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/tab-session-helpers.ts
@@ -4,6 +4,13 @@ export function tabIdentityKey(tab: CenterTabIdentity): string {
   return `${tab.kind}:${tab.id}`;
 }
 
+export function startupTabActivationLane(
+  tab: CenterTabIdentity | undefined,
+): "critical" | "progressive" | "none" {
+  if (!tab) return "none";
+  return tab.kind === "conversation" ? "critical" : "progressive";
+}
+
 export function reorderTabs(
   tabs: CenterTabIdentity[],
   tab: CenterTabIdentity,

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
@@ -30,7 +30,10 @@ import { loadTaskLogWindow } from "$lib/features/tasks/state/task-logs.svelte";
 import { resolveSelectedTaskId } from "$lib/features/tasks/state/task-reducers";
 import { taskState } from "$lib/features/tasks/state/task-state.svelte";
 import { selection } from "$lib/features/workspace/state/selection.svelte";
-import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import {
+  workspaceState,
+  type CenterTabIdentity,
+} from "$lib/features/workspace/state/workspace-state.svelte";
 import { mergeAgentsByUpdatedAt } from "./agent-freshness";
 import { closeCenterTabs } from "./center-tab-actions.svelte";
 import { selectCenterTab, setActiveCenterTab } from "./center-tabs.svelte";
@@ -49,17 +52,26 @@ export async function loadWorkspaceState() {
   return applyWorkspaceSnapshot(snapshot);
 }
 
-export async function recoverWorkspaceSnapshotFromNetwork() {
-  return recoverSnapshotFromNetwork({
+export async function recoverWorkspaceSnapshotFromNetwork(
+  options: { deferTabActivation?: boolean } = {},
+) {
+  let desiredTab: CenterTabIdentity | undefined;
+  const cursor = await recoverSnapshotFromNetwork({
     fetch: getWorkspaceSnapshot,
-    apply: applyWorkspaceSnapshot,
+    apply: async (snapshot) => {
+      const applied = await applyWorkspaceSnapshot(snapshot, options);
+      desiredTab = applied.desiredTab;
+      return applied.cursor;
+    },
     cache: (snapshot) =>
       queryClient.setQueryData(queryKeys.workspace, snapshot),
   });
+  return { cursor, desiredTab };
 }
 
 async function applyWorkspaceSnapshot(
   snapshot: Awaited<ReturnType<typeof getWorkspaceSnapshot>>,
+  options: { deferTabActivation?: boolean } = {},
 ) {
   const agents = mergeAgentsByUpdatedAt(
     snapshot.snapshot.agents,
@@ -69,11 +81,14 @@ async function applyWorkspaceSnapshot(
   workspaceState.conversations = snapshot.snapshot.conversations;
   workspaceState.agents = agents;
   taskState.tasks = snapshot.snapshot.tasks;
-  hydrateWorkspaceTabSessions({
-    projects: snapshot.snapshot.projects,
-    conversations: snapshot.snapshot.conversations,
-    tasks: snapshot.snapshot.tasks,
-  });
+  let desiredTab = hydrateWorkspaceTabSessions(
+    {
+      projects: snapshot.snapshot.projects,
+      conversations: snapshot.snapshot.conversations,
+      tasks: snapshot.snapshot.tasks,
+    },
+    { deferActivation: options.deferTabActivation },
+  );
   const taskEntryIds = new SvelteSet(
     taskState.tasks.map(
       (task) => task.definitionId ?? task.restartRootTaskId ?? task.id,
@@ -106,7 +121,8 @@ async function applyWorkspaceSnapshot(
     (conversationId) => !conversationIds.has(conversationId),
   );
   if (staleOpenTabIds.length) await removeConversationTabs(staleOpenTabIds);
-  if (selectedTaskId) await loadTaskLogWindow(selectedTaskId);
+  if (selectedTaskId && !options.deferTabActivation)
+    await loadTaskLogWindow(selectedTaskId);
   const selectedStillExists = workspaceState.projects.some(
     (project) => projectKey(project) === workspaceState.selectedProjectKey,
   );
@@ -114,7 +130,11 @@ async function applyWorkspaceSnapshot(
     const fallback = [...workspaceState.projects].sort((a, b) =>
       b.updatedAt.localeCompare(a.updatedAt),
     )[0];
-    if (fallback) await selectProject(fallback.id);
+    if (fallback)
+      desiredTab =
+        (await selectProject(fallback.id, {
+          deferTabActivation: options.deferTabActivation,
+        })) ?? desiredTab;
   } else if (
     workspaceState.selectedProjectKey &&
     !workspaceState.selectedProjectId
@@ -122,9 +142,13 @@ async function applyWorkspaceSnapshot(
     const selected = workspaceState.projects.find(
       (project) => projectKey(project) === workspaceState.selectedProjectKey,
     );
-    if (selected) await selectProject(selected.id);
+    if (selected)
+      desiredTab =
+        (await selectProject(selected.id, {
+          deferTabActivation: options.deferTabActivation,
+        })) ?? desiredTab;
   }
-  return snapshot.cursor;
+  return { cursor: snapshot.cursor, desiredTab };
 }
 
 function syncSelectedAgentConfig(
@@ -192,7 +216,10 @@ export async function completeFiles(query: string): Promise<CompletionItem[]> {
   });
 }
 
-export async function selectProject(projectId: string) {
+export async function selectProject(
+  projectId: string,
+  options: { deferTabActivation?: boolean } = {},
+): Promise<CenterTabIdentity | undefined> {
   const project = workspaceState.projects.find(
     (candidate) => candidate.id === projectId,
   );
@@ -214,14 +241,18 @@ export async function selectProject(projectId: string) {
   workspaceState.selectedProjectId = project.id;
   workspaceState.selectedProjectKey = key;
   workspaceState.projectRecency[key] = Date.now();
-  const session = applyVisibleSession(key);
+  const session = applyVisibleSession(key, {
+    deferActivation: options.deferTabActivation,
+  });
   selection.projectId = project.id;
   selection.conversationId = undefined;
   selection.agentId = undefined;
   selection.entryId = undefined;
   persistWorkspaceTabSessions();
+  if (options.deferTabActivation) return session.active;
   if (session.active) await selectCenterTab(session.active);
   else setActiveCenterTab(undefined);
+  return session.active;
 }
 
 export async function openProjectDirectory(dir: string) {

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.test.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.test.ts
@@ -4,6 +4,7 @@ import type { CenterTabIdentity } from "./workspace-state.svelte";
 import {
   mostRecentTab,
   reorderTabs,
+  startupTabActivationLane,
   tabIdentityKey,
 } from "./tab-session-helpers";
 
@@ -39,4 +40,17 @@ test("supports global singleton identities in the same ordering model", () => {
     b,
     settings,
   ]);
+});
+
+test("only restored conversations activate in the critical lane", () => {
+  const cases: Array<[CenterTabIdentity | undefined, string]> = [
+    [undefined, "none"],
+    [{ kind: "conversation", id: "conversation" }, "critical"],
+    [{ kind: "pr", id: "pr" }, "progressive"],
+    [{ kind: "task", id: "task" }, "progressive"],
+    [{ kind: "file", id: "file" }, "progressive"],
+    [{ kind: "settings", id: "settings" }, "progressive"],
+  ];
+  for (const [tab, expected] of cases)
+    assert.equal(startupTabActivationLane(tab), expected);
 });

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-tab-sessions.ts
@@ -88,11 +88,16 @@ export function visibleSessionFor(key: string): ProjectTabSession {
   return normalizeSession(session);
 }
 
-export function applyVisibleSession(key: string): ProjectTabSession {
+export function applyVisibleSession(
+  key: string,
+  options: { deferActivation?: boolean } = {},
+): ProjectTabSession {
   const session = visibleSessionFor(key);
   workspaceState.selectedProjectKey = key;
   workspaceState.openCenterTabs = [...session.tabs];
-  workspaceState.activeCenterTab = session.active;
+  workspaceState.activeCenterTab = options.deferActivation
+    ? undefined
+    : session.active;
   workspaceState.centerTabMru = [...session.mru];
   workspaceState.projectTabSessions[key] = session;
   syncCenterTabMirrors();
@@ -324,11 +329,14 @@ function legacySessions(
   }
 }
 
-export function hydrateWorkspaceTabSessions(input: {
-  projects: ProjectRecord[];
-  conversations: ConversationRecord[];
-  tasks: TaskRecord[];
-}): void {
+export function hydrateWorkspaceTabSessions(
+  input: {
+    projects: ProjectRecord[];
+    conversations: ConversationRecord[];
+    tasks: TaskRecord[];
+  },
+  options: { deferActivation?: boolean } = {},
+): CenterTabIdentity | undefined {
   if (hydrated) return;
   hydrated = true;
   const projectKeys = new Set(input.projects.map(projectKey));
@@ -362,9 +370,13 @@ export function hydrateWorkspaceTabSessions(input: {
   workspaceState.globalCenterTabs = (stored?.globals ?? [])
     .filter(isIdentity)
     .filter(isGlobalCenterTab);
+  let desiredTab: CenterTabIdentity | undefined;
   if (!stored?.selectedProjectKey) {
     workspaceState.openCenterTabs = [...workspaceState.globalCenterTabs];
-    workspaceState.activeCenterTab = workspaceState.globalCenterTabs[0];
+    desiredTab = workspaceState.globalCenterTabs[0];
+    workspaceState.activeCenterTab = options.deferActivation
+      ? undefined
+      : desiredTab;
     workspaceState.centerTabMru = workspaceState.globalCenterTabs.map(tabKey);
     syncCenterTabMirrors();
   }
@@ -375,6 +387,7 @@ export function hydrateWorkspaceTabSessions(input: {
       : undefined;
   if (typeof localStorage !== "undefined" && !stored)
     localStorage.removeItem(legacyStorageKey);
+  return desiredTab;
 }
 
 export function persistWorkspaceTabSessions(): void {


### PR DESCRIPTION
## Summary
- add a typed, monotonic renderer startup sequence that makes settings/models/auth, workspace hydration, and restored-conversation correctness the critical lane
- defer restored non-conversation tabs and progressive startup work until `core-ready`, including Git/GitHub, releases, usage, skills, slash completions, and prompt suggestions
- gate Git startup by progressive readiness and panel visibility, add structured startup diagnostics, and document the invariant for future features
- add deterministic deferred-promise tests for ordering, generation/stop protection, restored-tab policy, and Git activation policy

## Validation
- `pnpm fix && pnpm check && pnpm test`
- cold-start UI smoke test against the local daemon; no browser errors
- inspected startup network ordering: settings/model/auth and workspace recovery preceded slash/release/usage/skills/prompt-suggestion/Git activation
