### PR TITLE
Polish conversation history dialog and graph

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
+++ b/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
@@ -13,7 +13,7 @@ type Props = {
   description?: string;
   class?: string;
   closeLabel?: string;
-  size?: "sm" | "default" | "wide";
+  size?: "sm" | "default" | "wide" | "viewport";
   /** Removes the default body padding for edge-to-edge list/graph content. */
   flush?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -49,6 +49,7 @@ function handleOpenChange(next: boolean) {
         "dialog-content data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-open:zoom-in-95 data-closed:zoom-out-95 duration-100 outline-none",
         size === "sm" && "dialog-content-sm",
         size === "wide" && "dialog-content-wide",
+        size === "viewport" && "dialog-content-viewport",
         className,
       )}
     >

--- a/packages/ui-kit/src/styles/components/dialog.css
+++ b/packages/ui-kit/src/styles/components/dialog.css
@@ -50,6 +50,15 @@
   max-height: min(90dvh, calc(100dvh - 2rem));
 }
 
+.dialog-content-viewport {
+  width: min(1440px, calc(100vw - 3rem));
+  width: min(1440px, calc(100dvw - 3rem));
+  height: min(900px, calc(100vh - 3rem));
+  height: min(900px, calc(100dvh - 3rem));
+  max-height: calc(100vh - 3rem);
+  max-height: calc(100dvh - 3rem);
+}
+
 /* Confirmation dialogs: a miniature of the banded shell. */
 .dialog-content-confirm {
   width: min(26rem, calc(100vw - 32px));

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryDialog.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryDialog.svelte
@@ -61,9 +61,9 @@ function editAndClose(entry: ConversationEntry) {
 <Dialog
   flush
   bind:open
+  size="viewport"
   title="Conversation history"
   description="Explore branches, zoom into rich message and tool details, then jump to or fork from any point."
-  class="conversation-history-dialog"
   onOpenChange={handleOpenChange}
 >
   {#snippet headerActions()}
@@ -103,19 +103,3 @@ function editAndClose(entry: ConversationEntry) {
   confirmLabel="Compact context"
   onConfirm={() => onCompact?.()}
 />
-
-<style>
-:global(.conversation-history-dialog) {
-  top: 4vh;
-  /* Override the base dialog's vertical centering so the header stays on-screen. */
-  transform: translateX(-50%);
-  width: min(1440px, calc(100vw - 48px));
-  height: min(900px, calc(100vh - 48px));
-  max-height: calc(100vh - 8vh);
-}
-
-:global(.conversation-history-dialog .dialog-body) {
-  overflow: hidden;
-  background: var(--card);
-}
-</style>

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryGraph.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryGraph.svelte
@@ -243,82 +243,88 @@ function minimapNodeColor(node: Node): string {
   class="history-graph relative h-full min-h-0 overflow-hidden bg-background"
 >
   {#if hasConversation}
-    <SvelteFlow
-      nodes={flow.nodes}
-      edges={flow.edges}
-      {nodeTypes}
-      minZoom={0.12}
-      maxZoom={1.75}
-      onlyRenderVisibleElements
-      nodesDraggable={false}
-      nodesConnectable={false}
-      elementsSelectable
-      nodesFocusable
-      edgesFocusable={false}
-      selectionOnDrag={false}
-      selectNodesOnDrag={false}
-      deleteKey={null}
-      multiSelectionKey={null}
-      zoomOnDoubleClick={false}
-      onmove={handleMove}
-      onnodeclick={({ node }) => handleNodeClick(node)}
-      onselectionchange={({ nodes }) => handleSelectionChange(nodes)}
-      onpaneclick={() => (inspectorOpen = false)}
-      oninit={() =>
-        queueMicrotask(() => {
-          selectionEventsReady = true;
-        })}
-    >
-      <Background gap={24} size={1} />
-      <MiniMap
-        position="bottom-left"
-        pannable
-        zoomable
-        nodeColor={minimapNodeColor}
-        nodeStrokeColor={minimapNodeColor}
-        nodeStrokeWidth={2}
-        nodeBorderRadius={6}
-        ariaLabel="Conversation graph minimap"
-      />
-      <HistoryGraphControls
-        {activeNodeId}
-        hasSegments={visible.segments.length > 0}
-        {allExpanded}
-        onToggleAll={toggleAll}
-        {fitRequest}
-        {centerRequest}
-      />
-    </SvelteFlow>
-
-    {#if inspectorOpen && selection}
-      <aside
-        class="absolute inset-y-3 right-3 z-10 flex w-96 max-w-[calc(100%-1.5rem)] flex-col overflow-hidden rounded-lg border bg-card shadow-xl"
-        aria-label="Conversation entry details"
-      >
-        <div class="flex items-center justify-between border-b px-3 py-2">
-          <span class="text-xs font-medium text-muted-foreground">Details</span>
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            ariaLabel="Close details"
-            title="Close details"
-            onclick={() => (inspectorOpen = false)}
-          >
-            <X class="size-3.5" strokeWidth={2} />
-          </Button>
-        </div>
-        <div class="min-h-0 flex-1 overflow-y-auto">
-          <HistoryDetailPane
-            {selection}
-            {toolCallsById}
-            {onNavigateToEntry}
-            {onEditEntry}
-            onSelectRow={selectRow}
-            onExpandSegment={expandSegment}
+    <div class="flex h-full min-h-0">
+      <div class="relative min-w-0 flex-1">
+        <SvelteFlow
+          nodes={flow.nodes}
+          edges={flow.edges}
+          {nodeTypes}
+          minZoom={0.12}
+          maxZoom={1.75}
+          onlyRenderVisibleElements
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable
+          nodesFocusable
+          edgesFocusable={false}
+          selectionOnDrag={false}
+          selectNodesOnDrag={false}
+          deleteKey={null}
+          multiSelectionKey={null}
+          zoomOnDoubleClick={false}
+          onmove={handleMove}
+          onnodeclick={({ node }) => handleNodeClick(node)}
+          onselectionchange={({ nodes }) => handleSelectionChange(nodes)}
+          onpaneclick={() => (inspectorOpen = false)}
+          oninit={() =>
+            queueMicrotask(() => {
+              selectionEventsReady = true;
+            })}
+        >
+          <Background gap={24} size={1} />
+          <MiniMap
+            position="bottom-left"
+            pannable
+            zoomable
+            nodeColor={minimapNodeColor}
+            nodeStrokeColor={minimapNodeColor}
+            nodeStrokeWidth={2}
+            nodeBorderRadius={6}
+            ariaLabel="Conversation graph minimap"
           />
-        </div>
-      </aside>
-    {/if}
+          <HistoryGraphControls
+            {activeNodeId}
+            hasSegments={visible.segments.length > 0}
+            {allExpanded}
+            onToggleAll={toggleAll}
+            {fitRequest}
+            {centerRequest}
+          />
+        </SvelteFlow>
+      </div>
+
+      {#if inspectorOpen && selection}
+        <aside
+          class="flex min-w-80 w-1/3 max-w-md shrink-0 flex-col overflow-hidden border-l bg-card"
+          aria-label="Conversation entry details"
+        >
+          <div class="flex items-center justify-between border-b px-3 py-2">
+            <span class="text-xs font-medium text-muted-foreground"
+              >Entry details</span
+            >
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              ariaLabel="Close details"
+              title="Close details"
+              onclick={() => (inspectorOpen = false)}
+            >
+              <X class="size-3.5" strokeWidth={2} />
+            </Button>
+          </div>
+          <div class="min-h-0 flex-1 overflow-hidden">
+            <HistoryDetailPane
+              {selection}
+              {toolCallsById}
+              {onNavigateToEntry}
+              {onEditEntry}
+              onSelectRow={selectRow}
+              onExpandSegment={expandSegment}
+            />
+          </div>
+        </aside>
+      {/if}
+    </div>
   {:else}
     <div
       class="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground"

--- a/packages/workbench-app/src/lib/features/conversations/components/HistoryDetailPane.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/HistoryDetailPane.svelte
@@ -64,7 +64,7 @@ async function copyId(id: string) {
     Select an entry on the left to preview it here.
   </div>
 {:else if selection.kind === "root"}
-  <div class="flex flex-col gap-4 p-5">
+  <div class="flex h-full flex-col gap-4 overflow-y-auto p-5">
     <div class="flex items-center gap-2 text-primary">
       <GitBranch class="size-5" strokeWidth={2} />
       <h3 class="text-sm font-semibold text-foreground">
@@ -85,7 +85,7 @@ async function copyId(id: string) {
   </div>
 {:else if selection.kind === "segment"}
   {@const segment = selection.segment}
-  <div class="flex flex-col gap-4 p-5">
+  <div class="flex h-full flex-col gap-4 overflow-y-auto p-5">
     <div class="flex flex-col gap-1">
       <h3 class="text-sm font-semibold text-foreground">
         {segment.total} collapsed steps
@@ -182,13 +182,14 @@ async function copyId(id: string) {
           </span>
         {/if}
         <button
-          class="flex items-center gap-1 font-mono hover:text-foreground"
+          class="flex min-w-0 max-w-full items-center gap-1 font-mono hover:text-foreground"
           type="button"
-          title="Copy entry id"
+          title={entry.id}
+          aria-label="Copy entry id"
           onclick={() => copyId(entry.id)}
         >
-          <Copy class="size-3" strokeWidth={2} />
-          {entry.id}
+          <Copy class="size-3 shrink-0" strokeWidth={2} />
+          <span class="truncate">{entry.id}</span>
         </button>
       </div>
       <div class="flex flex-wrap gap-2">

--- a/packages/workbench-app/src/lib/features/conversations/components/HistoryGraphNode.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/HistoryGraphNode.svelte
@@ -28,8 +28,8 @@ const cardClass = $derived(
   data.kind === "entry"
     ? "h-48 w-80"
     : data.kind === "segment"
-      ? "h-28 w-72"
-      : "h-20 w-64",
+      ? "h-28 w-80"
+      : "h-20 w-80",
 );
 
 function stop(event: MouseEvent) {

--- a/packages/workbench-app/src/lib/features/conversations/components/history-flow.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/history-flow.ts
@@ -19,8 +19,8 @@ const BOTTOM_POSITION = "bottom" as Position;
  * card dimensions stay in lockstep while semantic zoom changes only content.
  */
 export const HISTORY_NODE_GEOMETRY = {
-  root: { width: 256, height: 80 },
-  segment: { width: 288, height: 112 },
+  root: { width: 320, height: 80 },
+  segment: { width: 320, height: 112 },
   entry: { width: 320, height: 192 },
   nodeGap: 48,
   rankGap: 64,
@@ -68,7 +68,7 @@ export type HistoryFlowNodeData =
   | HistorySegmentNodeData;
 
 export type HistoryFlowNode = Node<HistoryFlowNodeData, "history">;
-export type HistoryFlowEdge = Edge<{ isOnActivePath: boolean }, "smoothstep">;
+export type HistoryFlowEdge = Edge<{ isOnActivePath: boolean }, "default">;
 
 export type HistoryFlow = {
   nodes: HistoryFlowNode[];
@@ -280,7 +280,7 @@ export function buildHistoryFlow({
       id: `history-edge:${source}->${node.id}`,
       source,
       target: node.id,
-      type: "smoothstep",
+      type: "default",
       data: { isOnActivePath: active },
       class: active ? "history-edge-active" : undefined,
       selectable: false,

--- a/packages/workbench-app/src/styles/components/history-graph.css
+++ b/packages/workbench-app/src/styles/components/history-graph.css
@@ -27,6 +27,7 @@
 .history-graph .svelte-flow__edge-path {
   stroke: var(--border);
   stroke-width: 1.5;
+  stroke-linecap: round;
 }
 
 .history-graph .svelte-flow__edge.history-edge-active .svelte-flow__edge-path {
@@ -38,6 +39,7 @@
   width: 0.5rem;
   height: 0.5rem;
   border: 2px solid var(--card);
+  border-radius: 50%;
   background: var(--border);
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- restore the conversation history dialog as a large, centered viewport modal
- dock and refine the entry details preview without obscuring the graph
- standardize graph nodes and replace stepped connectors with curved Bezier edges

## Validation
- pnpm fix
- pnpm check
- pnpm test
- visually verified in light and dark themes at a desktop viewport