### PR TITLE
Simplify conversation history actions

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/ProjectDialogs.svelte
+++ b/packages/workbench-app/src/lib/app/shell/ProjectDialogs.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import {
-  compactActiveConversation,
   composerSignals,
   conversationSelectors,
   focusComposer,
@@ -25,11 +24,8 @@ const activeConversation = $derived(conversationSelectors.activeConversation);
 const treeNodes = $derived(conversationSelectors.treeNodes);
 const toolCalls = $derived(conversationSelectors.toolCalls);
 
-async function jumpToConversationEntry(
-  entryId: string | undefined,
-  summarize = false,
-) {
-  await navigateToEntry(entryId, summarize);
+async function branchFromConversationEntry(entryId: string | undefined) {
+  await navigateToEntry(entryId);
   focusComposer();
 }
 
@@ -59,11 +55,10 @@ async function editConversationEntry(entry: {
   {activeConversation}
   {treeNodes}
   {toolCalls}
-  onNavigateToEntry={(entryId, summarize) => {
-    void jumpToConversationEntry(entryId, summarize);
+  onNavigateToEntry={(entryId) => {
+    void branchFromConversationEntry(entryId);
   }}
   onEditEntry={(entry) => {
     void editConversationEntry(entry);
   }}
-  onCompact={() => void compactActiveConversation()}
 />

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryDialog.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryDialog.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-import FoldVertical from "@lucide/svelte/icons/fold-vertical";
-import MoreHorizontal from "@lucide/svelte/icons/more-horizontal";
 import type {
   ConversationEntry,
   ConversationRecord,
   ConversationTreeNode,
   ToolCallTranscriptRecord,
 } from "$lib/api";
-import { buttonVariants } from "@nervekit/ui-kit/components/ui/button";
-import ConfirmDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
-import * as DropdownMenu from "@nervekit/ui-kit/components/ui/dropdown-menu";
 import ConversationHistoryGraph from "./ConversationHistoryGraph.svelte";
 
 type Props = {
@@ -18,12 +13,8 @@ type Props = {
   activeConversation?: ConversationRecord;
   treeNodes?: ConversationTreeNode[];
   toolCalls?: ToolCallTranscriptRecord[];
-  onNavigateToEntry?: (
-    entryId: string | undefined,
-    summarize?: boolean,
-  ) => void;
+  onNavigateToEntry?: (entryId: string | undefined) => void;
   onEditEntry?: (entry: ConversationEntry) => void;
-  onCompact?: () => void;
   onOpenChange?: (open: boolean) => void;
 };
 
@@ -34,19 +25,16 @@ let {
   toolCalls = [],
   onNavigateToEntry,
   onEditEntry,
-  onCompact,
   onOpenChange,
 }: Props = $props();
-
-let confirmCompactOpen = $state(false);
 
 function handleOpenChange(next: boolean) {
   open = next;
   onOpenChange?.(next);
 }
 
-function navigateAndClose(entryId: string | undefined, summarize?: boolean) {
-  onNavigateToEntry?.(entryId, summarize);
+function navigateAndClose(entryId: string | undefined) {
+  onNavigateToEntry?.(entryId);
   open = false;
   onOpenChange?.(false);
 }
@@ -63,30 +51,9 @@ function editAndClose(entry: ConversationEntry) {
   bind:open
   size="viewport"
   title="Conversation history"
-  description="Explore branches, zoom into rich message and tool details, then jump to or fork from any point."
+  description="Explore branches, inspect message and tool details, then branch from any point."
   onOpenChange={handleOpenChange}
 >
-  {#snippet headerActions()}
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger
-        class={buttonVariants({ variant: "ghost", size: "icon-sm" })}
-        aria-label="History actions"
-        disabled={!activeConversation}
-      >
-        <MoreHorizontal class="size-4" strokeWidth={2} />
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content align="end" class="w-48">
-        <DropdownMenu.Item
-          disabled={!activeConversation}
-          onSelect={() => (confirmCompactOpen = true)}
-        >
-          <FoldVertical />
-          <span>Compact context</span>
-        </DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu.Root>
-  {/snippet}
-
   <ConversationHistoryGraph
     {activeConversation}
     {treeNodes}
@@ -95,11 +62,3 @@ function editAndClose(entry: ConversationEntry) {
     onEditEntry={editAndClose}
   />
 </Dialog>
-
-<ConfirmDialog
-  bind:open={confirmCompactOpen}
-  title="Compact conversation"
-  description="This summarizes earlier messages to reduce context size. The full history stays available in the branch tree."
-  confirmLabel="Compact context"
-  onConfirm={() => onCompact?.()}
-/>

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryGraph.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryGraph.svelte
@@ -40,10 +40,7 @@ type Props = {
   activeConversation?: ConversationRecord;
   treeNodes?: ConversationTreeNode[];
   toolCalls?: ToolCallTranscriptRecord[];
-  onNavigateToEntry?: (
-    entryId: string | undefined,
-    summarize?: boolean,
-  ) => void;
+  onNavigateToEntry?: (entryId: string | undefined) => void;
   onEditEntry?: (entry: ConversationEntry) => void;
 };
 

--- a/packages/workbench-app/src/lib/features/conversations/components/HistoryDetailPane.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/HistoryDetailPane.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import ArrowRight from "@lucide/svelte/icons/arrow-right";
 import Copy from "@lucide/svelte/icons/copy";
 import GitBranch from "@lucide/svelte/icons/git-branch";
 import Pencil from "@lucide/svelte/icons/pencil";
@@ -20,10 +19,7 @@ import type { HistorySelection } from "./history-segments";
 type Props = {
   selection?: HistorySelection;
   toolCallsById: Map<string, ToolCallTranscriptRecord>;
-  onNavigateToEntry?: (
-    entryId: string | undefined,
-    summarize?: boolean,
-  ) => void;
+  onNavigateToEntry?: (entryId: string | undefined) => void;
   onEditEntry?: (entry: ConversationEntry) => void;
   onSelectRow?: (row: HistoryGraphRow) => void;
   onExpandSegment?: (id: string) => void;
@@ -72,9 +68,9 @@ async function copyId(id: string) {
       </h3>
     </div>
     <p class="text-sm text-muted-foreground">
-      Jump here to fork a brand-new branch from the very beginning. Your next
-      message becomes the first entry of that branch; the existing history stays
-      available in the tree.
+      Branch from the beginning to start a new path. Your next message becomes
+      the first entry of that branch; the existing history stays available in
+      the tree.
     </p>
     <div>
       <Button size="sm" onclick={() => onNavigateToEntry?.(undefined)}>
@@ -194,16 +190,8 @@ async function copyId(id: string) {
       </div>
       <div class="flex flex-wrap gap-2">
         <Button size="sm" onclick={() => onNavigateToEntry?.(entry.id)}>
-          <ArrowRight class="size-4" strokeWidth={2} />
-          Jump here
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onclick={() => onNavigateToEntry?.(entry.id, true)}
-        >
-          <Sparkles class="size-4" strokeWidth={2} />
-          Jump + summarize
+          <GitBranch class="size-4" strokeWidth={2} />
+          Branch from here
         </Button>
         {#if entry.role === "user"}
           <Button

--- a/packages/workbench-app/src/lib/features/conversations/components/HistoryGraphNode.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/HistoryGraphNode.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-import ArrowRight from "@lucide/svelte/icons/arrow-right";
 import Copy from "@lucide/svelte/icons/copy";
 import GitBranch from "@lucide/svelte/icons/git-branch";
 import Pencil from "@lucide/svelte/icons/pencil";
-import Sparkles from "@lucide/svelte/icons/sparkles";
 import UnfoldVertical from "@lucide/svelte/icons/unfold-vertical";
 import { Handle, Position, type NodeProps } from "@xyflow/svelte";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
@@ -49,14 +47,9 @@ function entryMenu(entryData: HistoryEntryNodeData): ContextMenuItem[] {
   const entry = entryData.row.node.entry;
   const items: ContextMenuItem[] = [
     {
-      label: "Jump here",
-      icon: ArrowRight,
+      label: "Branch from here",
+      icon: GitBranch,
       onSelect: () => entryData.actions?.onNavigateToEntry?.(entry.id),
-    },
-    {
-      label: "Jump + summarize from here",
-      icon: Sparkles,
-      onSelect: () => entryData.actions?.onNavigateToEntry?.(entry.id, true),
     },
   ];
   if (entry.role === "user") {
@@ -77,11 +70,11 @@ function entryMenu(entryData: HistoryEntryNodeData): ContextMenuItem[] {
   return items;
 }
 
-function jump(data: HistoryFlowNodeData, summarize = false) {
+function branch(data: HistoryFlowNodeData) {
   if (data.kind === "entry") {
-    data.actions?.onNavigateToEntry?.(data.row.node.entry.id, summarize);
+    data.actions?.onNavigateToEntry?.(data.row.node.entry.id);
   } else if (data.kind === "root") {
-    data.actions?.onNavigateToEntry?.(undefined, summarize);
+    data.actions?.onNavigateToEntry?.(undefined);
   }
 }
 </script>
@@ -95,7 +88,7 @@ function jump(data: HistoryFlowNodeData, summarize = false) {
     class:ring-ring={selected}
     class:opacity-65={!data.isOnActivePath && !selected}
     role="group"
-    ondblclick={() => jump(data)}
+    ondblclick={() => branch(data)}
   >
     {#if data.kind !== "root"}
       <Handle type="target" position={Position.Top} isConnectable={false} />
@@ -237,27 +230,14 @@ function jump(data: HistoryFlowNodeData, summarize = false) {
             class="nodrag nopan"
             variant="ghost"
             size="icon-xs"
-            ariaLabel="Jump here"
-            title="Jump here"
+            ariaLabel="Branch from here"
+            title="Branch from here"
             onclick={(event) => {
               stop(event);
-              jump(data);
+              branch(data);
             }}
           >
-            <ArrowRight class="size-3.5" strokeWidth={2} />
-          </Button>
-          <Button
-            class="nodrag nopan"
-            variant="ghost"
-            size="icon-xs"
-            ariaLabel="Jump and summarize"
-            title="Jump and summarize"
-            onclick={(event) => {
-              stop(event);
-              jump(data, true);
-            }}
-          >
-            <Sparkles class="size-3.5" strokeWidth={2} />
+            <GitBranch class="size-3.5" strokeWidth={2} />
           </Button>
           {#if data.row.node.entry.role === "user"}
             <Button

--- a/packages/workbench-app/src/lib/features/conversations/components/history-flow.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/history-flow.ts
@@ -30,10 +30,7 @@ export type HistoryZoomTier = "overview" | "summary" | "detail";
 
 export type HistoryGraphNodeActions = {
   onToggleSegment: (segment: HistorySegment) => void;
-  onNavigateToEntry?: (
-    entryId: string | undefined,
-    summarize?: boolean,
-  ) => void;
+  onNavigateToEntry?: (entryId: string | undefined) => void;
   onEditEntry?: (entry: ConversationEntry) => void;
 };
 


### PR DESCRIPTION
## Summary
- remove the Conversation History compact-context overflow menu
- replace Jump here with the clearer Branch from here action
- remove Jump + summarize while retaining Edit & resend for user messages
- simplify the history component navigation callback chain

## Validation
- pnpm fix && pnpm check && pnpm test