### PR TITLE
Show todo progress in the system prompt

### DIFF
--- a/packages/workbench-server/src/domains/agents/prompting/nerve-system-prompt.ts
+++ b/packages/workbench-server/src/domains/agents/prompting/nerve-system-prompt.ts
@@ -12,6 +12,7 @@ export interface BuildNerveSystemPromptOptions {
   contextFiles?: Array<{ path: string; content: string }>;
   skills?: Skill[];
   activeBackgroundTaskIds?: readonly string[];
+  todos?: readonly { done: boolean }[];
 }
 
 export function buildNerveSystemPrompt(
@@ -40,12 +41,14 @@ export function buildNerveSystemPrompt(
       ? buildPlanModeInstructions(options.planDir ?? "Nerve plan storage")
       : "";
   const taskToolsEnabled = tools.some((tool) => tool.startsWith("task_"));
+  const todoToolsEnabled = tools.some((tool) => tool.startsWith("todos_"));
   const environmentBlock = formatEnvironment({
     date,
     cwd,
     activeBackgroundTaskIds: taskToolsEnabled
       ? options.activeBackgroundTaskIds
       : undefined,
+    todos: todoToolsEnabled ? options.todos : undefined,
   });
 
   return [
@@ -179,6 +182,7 @@ function formatEnvironment(options: {
   date: string;
   cwd: string;
   activeBackgroundTaskIds?: readonly string[];
+  todos?: readonly { done: boolean }[];
 }): string {
   const lines = [
     "<environment>",
@@ -189,6 +193,13 @@ function formatEnvironment(options: {
   if (taskIds?.length) {
     lines.push(
       `Active background tasks (${taskIds.length}): ${taskIds.join(", ")}`,
+    );
+  }
+  const todos = options.todos;
+  if (todos?.length) {
+    const completed = todos.filter((todo) => todo.done).length;
+    lines.push(
+      `Todo progress: ${completed}/${todos.length} complete (${todos.length - completed} open)`,
     );
   }
   lines.push("</environment>");

--- a/packages/workbench-server/src/domains/agents/run/system-prompt-builder.ts
+++ b/packages/workbench-server/src/domains/agents/run/system-prompt-builder.ts
@@ -30,6 +30,7 @@ export async function buildAgentSystemPrompt(
     jiraEnabled?: boolean;
     confluenceEnabled?: boolean;
     tasks?: readonly TaskRecord[];
+    todos?: readonly { done: boolean }[];
   } = {},
 ): Promise<string> {
   const activeToolNames = activeToolNamesForAgent(agent, {
@@ -55,6 +56,7 @@ export async function buildAgentSystemPrompt(
         ? planDirForStorageHome(options.storageHome)
         : undefined,
       tasks: options.tasks,
+      todos: options.todos,
     },
   );
 }
@@ -68,7 +70,11 @@ export function composeAgentSystemPrompt(
   activeToolNames: ReturnType<typeof activeToolNamesForAgent>,
   promptMetadata: ReturnType<typeof toolPromptMetadata>,
   resources: Awaited<ReturnType<typeof loadHarnessResources>>,
-  options: { planDir?: string; tasks?: readonly TaskRecord[] } = {},
+  options: {
+    planDir?: string;
+    tasks?: readonly TaskRecord[];
+    todos?: readonly { done: boolean }[];
+  } = {},
 ): string {
   if (agent.systemPrompt) return agent.systemPrompt;
   return buildNerveSystemPrompt({
@@ -84,5 +90,6 @@ export function composeAgentSystemPrompt(
     activeBackgroundTaskIds: options.tasks
       ? activeBackgroundTaskIdsInDirectoryTree(options.tasks, agent.projectDir)
       : undefined,
+    todos: options.todos,
   });
 }

--- a/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
@@ -153,6 +153,7 @@ export async function executeWorkbenchHarness(
         {
           planDir: planDirForStorageHome(this.deps.storage.paths.home),
           tasks: this.deps.tasks.listTasks(),
+          todos: this.deps.tools.getTodos(currentAgent.id),
         },
       );
     };

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -236,6 +236,10 @@ export class ToolService {
     return this.toolCallRepository.list();
   }
 
+  getTodos(agentId: string) {
+    return this.todoState.get(agentId);
+  }
+
   /** Compact the persisted tool-call log, dropping superseded append rows. */
   async compactToolCallLog(): Promise<void> {
     await this.toolCallRepository.compactPersisted();

--- a/packages/workbench-server/src/routes/agent-routes.ts
+++ b/packages/workbench-server/src/routes/agent-routes.ts
@@ -48,6 +48,7 @@ export function createAgentRoutes(state: OrchestratorState): Hono {
         jiraEnabled: state.storage.settings.tools.jira.enabled,
         confluenceEnabled: state.storage.settings.tools.confluence.enabled,
         tasks: state.registry.tasks.listTasks(),
+        todos: state.registry.tools.getTodos(agent.id),
       });
       return c.body(prompt, 200, {
         "Content-Type": "text/markdown; charset=utf-8",

--- a/packages/workbench-server/test/nerve-system-prompt.test.ts
+++ b/packages/workbench-server/test/nerve-system-prompt.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildNerveSystemPrompt } from "../src/domains/agents/prompting/nerve-system-prompt.js";
+
+describe("Nerve system prompt environment", () => {
+  it("shows completed and open todo counts alongside active tasks", () => {
+    const prompt = buildNerveSystemPrompt({
+      cwd: "/workspace/project",
+      selectedTools: ["todos_get", "todos_set", "task_status"],
+      activeBackgroundTaskIds: ["task_1"],
+      todos: [{ done: true }, { done: true }, { done: false }],
+    });
+
+    assert.match(prompt, /Active background tasks \(1\): task_1/);
+    assert.match(prompt, /Todo progress: 2\/3 complete \(1 open\)/);
+  });
+
+  it("shows zero open items for a completed non-empty list", () => {
+    const prompt = buildNerveSystemPrompt({
+      cwd: "/workspace/project",
+      selectedTools: ["todos_get"],
+      todos: [{ done: true }, { done: true }],
+    });
+
+    assert.match(prompt, /Todo progress: 2\/2 complete \(0 open\)/);
+  });
+
+  it("omits todo progress for an empty or absent list", () => {
+    const emptyPrompt = buildNerveSystemPrompt({
+      cwd: "/workspace/project",
+      selectedTools: ["todos_get"],
+      todos: [],
+    });
+    const absentPrompt = buildNerveSystemPrompt({
+      cwd: "/workspace/project",
+      selectedTools: ["todos_get"],
+    });
+
+    assert.doesNotMatch(emptyPrompt, /Todo progress:/);
+    assert.doesNotMatch(absentPrompt, /Todo progress:/);
+  });
+
+  it("does not expose todo state when todo tools are unavailable", () => {
+    const prompt = buildNerveSystemPrompt({
+      cwd: "/workspace/project",
+      selectedTools: ["read"],
+      todos: [{ done: false }],
+    });
+
+    assert.doesNotMatch(prompt, /Todo progress:/);
+  });
+});


### PR DESCRIPTION
## Summary
- expose current agent todo snapshots to system-prompt construction
- show completed and open todo counts in the environment block when todo tools are enabled
- keep downloaded and runtime-generated prompts consistent
- add focused environment formatting tests

## Validation
- `pnpm fix && pnpm check && pnpm test`