### PR TITLE
Fix startup readiness and background request blocking

### DIFF
--- a/packages/desktop-shell/src/main.ts
+++ b/packages/desktop-shell/src/main.ts
@@ -42,6 +42,7 @@ import {
   type LoadingStage,
   loadingHtml,
   loadingStageScript,
+  loadingWindowBackground,
   ShellPageUrlRegistry,
 } from "./window/loading-pages.js";
 import { installNavigationGuards } from "./window/navigation-guards.js";
@@ -488,6 +489,7 @@ function createMainWindow(): BrowserWindowType {
     autoHideMenuBar: true,
     frame: false,
     title: DESKTOP_APP_NAME,
+    backgroundColor: loadingWindowBackground(nativeTheme.shouldUseDarkColors),
     ...(process.platform === "darwin" ? {} : { icon: resolveAppIconPath() }),
     webPreferences: {
       contextIsolation: true,

--- a/packages/desktop-shell/src/window/loading-pages.ts
+++ b/packages/desktop-shell/src/window/loading-pages.ts
@@ -22,6 +22,12 @@ export function createDataUrl(html: string): string {
   return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
 }
 
+// Native BrowserWindow fallback used before either loading document can paint.
+// These mirror the light/dark --background tokens in shellStyles().
+export function loadingWindowBackground(dark: boolean): string {
+  return dark ? "#262624" : "#faf9f5";
+}
+
 export type LoadingStage = "starting" | "preparing" | "opening";
 
 const LOADING_STAGES: Record<LoadingStage, string> = {

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -17,6 +17,7 @@ import type {
 import {
   RESYNC_REQUIRED_CLOSE_REASON,
   STREAM_SUBSCRIPTION_CAPABILITY,
+  operationDefinition,
   publicEventDefinition,
 } from "@nervekit/contracts";
 import {
@@ -52,6 +53,7 @@ export class ProtocolServerSession {
   readonly #pendingLive = new Map<string, EventEnvelope[]>();
   readonly #replayBufferedLive = new Map<string, EventEnvelope[]>();
   readonly #notifyQueue: NotifyEvent[] = [];
+  readonly #detachedReads = new Set<Promise<void>>();
 
   #negotiatedTarget?: PeerDescriptor;
   #rpcDispatcher?: RpcDispatcher;
@@ -174,28 +176,11 @@ export class ProtocolServerSession {
       return;
     }
     if (message.kind === "request" && this.#rpcDispatcher) {
-      const result = await this.#rpcDispatcher.dispatch(message);
-      await this.#sendControl(
-        result.ok
-          ? this.#options.createMessage(
-              "response",
-              {
-                ok: true,
-                method: message.data.method,
-                result: result.result,
-              },
-              {
-                target: message.source,
-                replyTo: message.id,
-                correlationId: message.id,
-              },
-            )
-          : this.#options.createMessage("error", result.error, {
-              target: message.source,
-              replyTo: message.id,
-              correlationId: message.id,
-            }),
-      );
+      if (operationDefinition(message.data.method).kind === "read") {
+        this.#startDetachedRead(message);
+      } else {
+        await this.#dispatchRequest(message);
+      }
       return;
     }
     if (message.kind === "heartbeat") {
@@ -205,6 +190,45 @@ export class ProtocolServerSession {
       return;
     }
     await this.#options.onMessage?.(message);
+  }
+
+  #startDetachedRead(message: ProtocolV1Message & { kind: "request" }): void {
+    const request = this.#dispatchRequest(message)
+      .catch(() => {
+        if (this.state === "ready") {
+          void this.shutdown("server_shutdown", "RPC response send failed");
+        }
+      })
+      .finally(() => this.#detachedReads.delete(request));
+    this.#detachedReads.add(request);
+  }
+
+  async #dispatchRequest(
+    message: ProtocolV1Message & { kind: "request" },
+  ): Promise<void> {
+    const result = await this.#rpcDispatcher!.dispatch(message);
+    if (this.state !== "ready") return;
+    await this.#sendControl(
+      result.ok
+        ? this.#options.createMessage(
+            "response",
+            {
+              ok: true,
+              method: message.data.method,
+              result: result.result,
+            },
+            {
+              target: message.source,
+              replyTo: message.id,
+              correlationId: message.id,
+            },
+          )
+        : this.#options.createMessage("error", result.error, {
+            target: message.source,
+            replyTo: message.id,
+            correlationId: message.id,
+          }),
+    );
   }
 
   async publish(stream: string, event: EventEnvelope): Promise<void> {

--- a/packages/protocol/test/server-rpc-concurrency.test.ts
+++ b/packages/protocol/test/server-rpc-concurrency.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { NerveMessage, ProtocolV1Message } from "@nervekit/contracts";
+import {
+  ProtocolConnection,
+  ProtocolServerSession,
+  RpcDispatcher,
+  createMessageFactory,
+} from "../src/index.js";
+import { ManualTransport } from "./test-runtime.js";
+
+const capabilities = [
+  "stream.subscription.v1",
+  "operation.status.latestRelease.get",
+  "operation.project.create",
+];
+const clientMessages = createMessageFactory({
+  source: { role: "ui", id: "ui_rpc_concurrency" },
+  target: { role: "workbench_server", id: "server_rpc_concurrency" },
+});
+const serverMessages = createMessageFactory({
+  source: { role: "workbench_server", id: "server_rpc_concurrency" },
+  target: { role: "ui", id: "ui_rpc_concurrency" },
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+async function fixture(
+  handlers: ConstructorParameters<typeof RpcDispatcher>[0]["handlers"],
+) {
+  const outbound: ProtocolV1Message[] = [];
+  const server = new ProtocolServerSession({
+    acceptingPeer: { role: "workbench_server", id: "server_rpc_concurrency" },
+    createMessage: serverMessages,
+    capabilities,
+    limits: {
+      maxMessageBytes: 1_000_000,
+      maxBatchEvents: 100,
+      maxBatchBytes: 1_000_000,
+    },
+    heartbeat: { intervalMs: 60_000, timeoutMs: 120_000 },
+    sessionId: () => "session_rpc_concurrency",
+    send: (message: NerveMessage) =>
+      outbound.push(message as ProtocolV1Message),
+    rpcDispatcher: new RpcDispatcher({
+      handlers,
+      acceptedCapabilities: capabilities,
+    }),
+  });
+  const transport = new ManualTransport();
+  const connection = new ProtocolConnection({
+    transport,
+    onMessage: (message) => server.receive(message),
+  });
+  await transport.emit(
+    clientMessages("hello", {
+      requestedVersion: 1,
+      capabilities,
+      requiredCapabilities: capabilities,
+      encodings: ["json"],
+    }) as ProtocolV1Message,
+  );
+  await transport.emit(
+    clientMessages("ready", {
+      sessionId: "session_rpc_concurrency",
+    }) as ProtocolV1Message,
+  );
+  assert.equal(server.state, "ready", JSON.stringify(outbound));
+  await connection.drain();
+  outbound.splice(0);
+  return { connection, outbound, server, transport };
+}
+
+function request(
+  method: "status.latestRelease.get" | "project.create",
+  params: unknown,
+): ProtocolV1Message {
+  return clientMessages("request", { method, params }) as ProtocolV1Message;
+}
+
+function project(dir: string) {
+  return {
+    project: {
+      id: `proj_${dir.replaceAll("/", "_")}`,
+      name: dir,
+      dir,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+  };
+}
+
+test("a slow read does not block a later mutation", async () => {
+  const readGate = deferred<void>();
+  const started: string[] = [];
+  const { connection, outbound, server, transport } = await fixture({
+    "status.latestRelease.get": async () => {
+      started.push("read");
+      await readGate.promise;
+      return {
+        version: "1.0.0",
+        releaseUrl: "https://example.com/release",
+        publishedAt: "2026-01-01T00:00:00.000Z",
+      };
+    },
+    "project.create": async ({ dir }) => {
+      started.push("mutation");
+      return project(dir);
+    },
+  });
+
+  const read = request("status.latestRelease.get", {});
+  const mutation = request("project.create", { dir: "/project" });
+  void transport.emit(read);
+  void transport.emit(mutation);
+  await tick();
+  await tick();
+
+  assert.deepEqual(started, ["read", "mutation"]);
+  assert.ok(
+    outbound.some(
+      (message) =>
+        message.kind === "response" && message.replyTo === mutation.id,
+    ),
+  );
+  assert.equal(
+    outbound.some((message) => message.replyTo === read.id),
+    false,
+  );
+
+  readGate.resolve();
+  await tick();
+  assert.ok(
+    outbound.some(
+      (message) => message.kind === "response" && message.replyTo === read.id,
+    ),
+  );
+  connection.dispose();
+  server.dispose();
+});
+
+test("mutations remain ordered by the connection receive queue", async () => {
+  const firstGate = deferred<void>();
+  const started: string[] = [];
+  const { connection, server, transport } = await fixture({
+    "project.create": async ({ dir }) => {
+      started.push(dir);
+      if (dir === "/first") await firstGate.promise;
+      return project(dir);
+    },
+  });
+
+  void transport.emit(request("project.create", { dir: "/first" }));
+  void transport.emit(request("project.create", { dir: "/second" }));
+  await tick();
+  assert.deepEqual(started, ["/first"]);
+
+  firstGate.resolve();
+  await tick();
+  await tick();
+  assert.deepEqual(started, ["/first", "/second"]);
+  connection.dispose();
+  server.dispose();
+});
+
+test("a detached read does not send after session disposal", async () => {
+  const readGate = deferred<void>();
+  const { connection, outbound, server, transport } = await fixture({
+    "status.latestRelease.get": async () => {
+      await readGate.promise;
+      return {
+        version: "1.0.0",
+        releaseUrl: "https://example.com/release",
+        publishedAt: "2026-01-01T00:00:00.000Z",
+      };
+    },
+  });
+
+  void transport.emit(request("status.latestRelease.get", {}));
+  await tick();
+  server.dispose();
+  readGate.resolve();
+  await tick();
+  assert.deepEqual(outbound, []);
+  connection.dispose();
+});

--- a/packages/ui-kit/src/styles/animation.css
+++ b/packages/ui-kit/src/styles/animation.css
@@ -1,6 +1,21 @@
 /* Centralized keyframes and animation utility classes.
  * Never define @keyframes inside a component; add them here. */
 
+/* Native startup badge breathing shared by shell-level loading surfaces. */
+.startup-breathe {
+  animation: startup-breathe 2.4s ease-in-out infinite;
+}
+
+@keyframes startup-breathe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.72;
+  }
+}
+
 /* Shared rotation used by every spinner. Apply with class="spin". */
 .spin {
   animation: spin 0.9s linear infinite;

--- a/packages/workbench-app/index.html
+++ b/packages/workbench-app/index.html
@@ -17,9 +17,14 @@
         const parsedLevel = Number(rawLevel);
         if (!Number.isInteger(parsedLevel)) return;
         const level = Math.min(8, Math.max(-8, parsedLevel));
+        const scale = 1.1 ** level;
         document.documentElement.style.setProperty(
           "--nerve-zoom-scale",
-          (1.1 ** level).toFixed(4),
+          scale.toFixed(4),
+        );
+        document.documentElement.style.setProperty(
+          "--nerve-inverse-zoom-scale",
+          (1 / scale).toFixed(4),
         );
         try {
           window.sessionStorage.setItem(
@@ -47,10 +52,137 @@
       content="black-translucent"
     />
     <meta name="apple-mobile-web-app-title" content="Nerve" />
+    <!-- Pre-stylesheet startup bridge: the Svelte splash replaces this node
+         immediately after mount, before critical workspace hydration. -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --startup-background: oklch(0.9818 0.0054 95.0986);
+        --startup-foreground: oklch(0.3438 0.0269 95.7226);
+        --startup-primary: oklch(0.57 0.1375 39.0427);
+        --startup-muted: oklch(0.5341 0.0078 97.4503);
+        --startup-border: oklch(0.8847 0.0069 97.3627);
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --startup-background: oklch(0.2679 0.0036 106.6427);
+          --startup-foreground: oklch(0.9576 0.0027 106.4494);
+          --startup-primary: oklch(0.6724 0.1308 38.7559);
+          --startup-muted: oklch(0.7713 0.0169 99.0657);
+          --startup-border: oklch(0.3618 0.0101 106.8928);
+        }
+      }
+      html,
+      body,
+      #app {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        background: var(--startup-background);
+        color: var(--startup-foreground);
+      }
+      #startup-bootstrap,
+      #startup-bootstrap * {
+        box-sizing: border-box;
+      }
+      #startup-bootstrap {
+        position: fixed;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        background: var(--startup-background);
+        color: var(--startup-foreground);
+        font-family: "Outfit", ui-sans-serif, system-ui, sans-serif;
+      }
+      #startup-bootstrap-content {
+        display: grid;
+        width: min(12rem, calc(100vw - 3rem));
+        justify-items: center;
+        padding: 1.5rem;
+        text-align: center;
+        transform: scale(var(--nerve-inverse-zoom-scale, 1));
+        transform-origin: center;
+      }
+      #startup-bootstrap-badge {
+        display: grid;
+        width: 3rem;
+        height: 3rem;
+        place-items: center;
+        border-radius: 0.625rem;
+        background: var(--startup-foreground);
+        color: var(--startup-background);
+        animation: startup-bootstrap-breathe 2.4s ease-in-out infinite;
+      }
+      #startup-bootstrap-badge svg {
+        width: 62.5%;
+        height: 62.5%;
+      }
+      #startup-bootstrap-status {
+        margin: 1.5rem 0 0.5rem;
+        color: var(--startup-muted);
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+      }
+      #startup-bootstrap-track {
+        width: 100%;
+        height: 0.25rem;
+        overflow: hidden;
+        border-radius: 999px;
+        background: var(--startup-border);
+      }
+      #startup-bootstrap-fill {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border-radius: inherit;
+        background: var(--startup-primary);
+      }
+      @keyframes startup-bootstrap-breathe {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.72;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #startup-bootstrap-badge {
+          animation: none;
+        }
+      }
+    </style>
     <title>nerve</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <main id="startup-bootstrap" aria-busy="true" aria-label="Starting Nerve">
+        <div id="startup-bootstrap-content">
+          <span id="startup-bootstrap-badge" aria-hidden="true">
+            <svg viewBox="120 120 272 272" fill="none">
+              <g
+                stroke="currentColor"
+                stroke-width="32"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M150 350V162" />
+                <path d="M362 350V162" />
+                <path d="M150 162L232 235L258 208L284 288L362 350" />
+              </g>
+            </svg>
+          </span>
+          <p id="startup-bootstrap-status" role="status">Opening Nerve</p>
+          <div
+            id="startup-bootstrap-track"
+            role="progressbar"
+            aria-label="Starting Nerve"
+          >
+            <span id="startup-bootstrap-fill"></span>
+          </div>
+        </div>
+      </main>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/packages/workbench-app/src/lib/app/providers/WorkbenchProvider.svelte
+++ b/packages/workbench-app/src/lib/app/providers/WorkbenchProvider.svelte
@@ -42,6 +42,8 @@ import {
   initializeWorkbench,
 } from "$lib/core/events/websocket-client.svelte";
 import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
+import { shouldRevealWorkbench } from "$lib/core/startup/workbench-startup-machine";
+import StartupSplash from "$lib/app/shell/StartupSplash.svelte";
 import {
   centerTabsExcept,
   closeCenterTab,
@@ -80,6 +82,9 @@ const settingsDraft = $derived(settingsSelectors.settingsDraft);
 const usableModels = $derived(conversationSelectors.usableModels);
 const currentZoomLevel = $derived(
   settingsDraft?.ui.zoomLevel ?? zoomState.level,
+);
+const revealWorkbench = $derived(
+  shouldRevealWorkbench(workbenchStartupState.phase),
 );
 
 function openProjectPicker() {
@@ -201,4 +206,8 @@ onMount(() => {
 });
 </script>
 
-{@render children?.()}
+{#if revealWorkbench}
+  {@render children?.()}
+{:else}
+  <StartupSplash />
+{/if}

--- a/packages/workbench-app/src/lib/app/shell/StartupSplash.svelte
+++ b/packages/workbench-app/src/lib/app/shell/StartupSplash.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import NerveBadge from "$lib/presentation/components/brand/NerveBadge.svelte";
+
+let { status = "Opening Nerve" }: { status?: string } = $props();
+</script>
+
+<main
+  class="fixed inset-0 grid place-items-center bg-background text-foreground"
+  aria-busy="true"
+  aria-label="Starting Nerve"
+>
+  <!-- Startup chrome stays at native size while the workbench honors user zoom. -->
+  <div
+    class="grid w-full max-w-lg justify-items-center p-6 text-center"
+    style="transform: scale(var(--nerve-inverse-zoom-scale, 1)); transform-origin: center;"
+  >
+    <NerveBadge class="startup-breathe size-12" />
+    <div class="mt-6 w-full max-w-48">
+      <p
+        class="mb-2 text-sm leading-relaxed text-muted-foreground"
+        role="status"
+        aria-live="polite"
+      >
+        {status}
+      </p>
+      <div
+        class="h-1 w-full overflow-hidden rounded-full bg-border"
+        role="progressbar"
+        aria-label="Starting Nerve"
+      >
+        <span class="block h-full w-full rounded-full bg-primary"></span>
+      </div>
+    </div>
+  </div>
+</main>

--- a/packages/workbench-app/src/lib/app/shell/appearance.svelte.ts
+++ b/packages/workbench-app/src/lib/app/shell/appearance.svelte.ts
@@ -36,11 +36,16 @@ export function zoomPercentForLevel(level: number): number {
 
 export function applyZoomLevel(level: number) {
   const next = clampZoomLevel(level);
+  const scale = zoomScaleForLevel(next);
   zoomState.level = next;
   if (typeof document === "undefined") return;
   document.documentElement.style.setProperty(
     "--nerve-zoom-scale",
-    zoomScaleForLevel(next).toFixed(4),
+    scale.toFixed(4),
+  );
+  document.documentElement.style.setProperty(
+    "--nerve-inverse-zoom-scale",
+    (1 / scale).toFixed(4),
   );
 }
 

--- a/packages/workbench-app/src/lib/core/startup/workbench-startup-machine.ts
+++ b/packages/workbench-app/src/lib/core/startup/workbench-startup-machine.ts
@@ -7,6 +7,12 @@ const phaseOrder: Partial<Record<WorkbenchStartupPhase, number>> = {
   progressive: 3,
 };
 
+export function shouldRevealWorkbench(phase: WorkbenchStartupPhase): boolean {
+  return (
+    phase === "core-ready" || phase === "progressive" || phase === "failed"
+  );
+}
+
 export class WorkbenchStartupMachine {
   phase: WorkbenchStartupPhase = "idle";
   generation = 0;

--- a/packages/workbench-app/src/lib/core/startup/workbench-startup-state.test.ts
+++ b/packages/workbench-app/src/lib/core/startup/workbench-startup-state.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { WorkbenchStartupMachine } from "./workbench-startup-machine";
+import {
+  shouldRevealWorkbench,
+  WorkbenchStartupMachine,
+} from "./workbench-startup-machine";
 
 test("startup phases are monotonic and cannot skip or regress", () => {
   const state = new WorkbenchStartupMachine();
@@ -12,6 +15,15 @@ test("startup phases are monotonic and cannot skip or regress", () => {
   assert.equal(state.transition(generation, "progressive"), true);
   assert.equal(state.transition(generation, "failed"), false);
   assert.equal(state.phase, "progressive");
+});
+
+test("reveals the workbench only after critical readiness or failure", () => {
+  assert.equal(shouldRevealWorkbench("idle"), false);
+  assert.equal(shouldRevealWorkbench("critical"), false);
+  assert.equal(shouldRevealWorkbench("core-ready"), true);
+  assert.equal(shouldRevealWorkbench("progressive"), true);
+  assert.equal(shouldRevealWorkbench("failed"), true);
+  assert.equal(shouldRevealWorkbench("stopped"), false);
 });
 
 test("stop invalidates the active generation", () => {

--- a/packages/workbench-app/src/lib/features/workspace/state/new-conversation-project.test.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/new-conversation-project.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ProjectRecord } from "$lib/api";
+import { projectForNewConversation } from "./new-conversation-project";
+
+const projects: ProjectRecord[] = [
+  {
+    id: "proj_existing",
+    name: "existing",
+    dir: "/projects/existing",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+test("uses an existing workspace project for a known directory", () => {
+  assert.equal(
+    projectForNewConversation(projects, "/projects/existing"),
+    projects[0],
+  );
+});
+
+test("requires project creation for an unknown directory", () => {
+  assert.equal(projectForNewConversation(projects, "/projects/new"), undefined);
+});

--- a/packages/workbench-app/src/lib/features/workspace/state/new-conversation-project.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/new-conversation-project.ts
@@ -1,0 +1,8 @@
+import type { ProjectRecord } from "$lib/api";
+
+export function projectForNewConversation(
+  projects: readonly ProjectRecord[],
+  projectDir: string,
+): ProjectRecord | undefined {
+  return projects.find((project) => project.dir === projectDir);
+}

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
@@ -14,6 +14,7 @@ import {
   getWorkspaceSnapshot,
   openProjectInEditor,
   type ProjectEditor,
+  type ProjectRecord,
   type PruneProjectConversationsRequest,
   pruneProjectConversations,
 } from "$lib/api";
@@ -35,6 +36,7 @@ import {
   type CenterTabIdentity,
 } from "$lib/features/workspace/state/workspace-state.svelte";
 import { mergeAgentsByUpdatedAt } from "./agent-freshness";
+import { projectForNewConversation } from "./new-conversation-project";
 import { closeCenterTabs } from "./center-tab-actions.svelte";
 import { selectCenterTab, setActiveCenterTab } from "./center-tabs.svelte";
 import {
@@ -285,10 +287,18 @@ export function newConversation() {
     workspaceState.projectPickerOpen = true;
     return;
   }
-  void createConversationForDirectory(activeProject.dir);
+  void openPendingConversationForProject(activeProject);
 }
 
 export function newConversationInProject(projectDir: string) {
+  const project = projectForNewConversation(
+    workspaceState.projects,
+    projectDir,
+  );
+  if (project) {
+    void openPendingConversationForProject(project);
+    return;
+  }
   void createConversationForDirectory(projectDir);
 }
 
@@ -390,6 +400,15 @@ export async function pruneProjectConversationsAndRefresh(
   }
 }
 
+async function openPendingConversationForProject(
+  project: ProjectRecord,
+): Promise<void> {
+  workspaceState.error = undefined;
+  workspaceState.projectPickerOpen = false;
+  await selectProject(project.id, { deferTabActivation: true });
+  openPendingConversation(project);
+}
+
 export async function createConversationForDirectory(dir: string) {
   workspaceState.error = undefined;
   try {
@@ -400,9 +419,7 @@ export async function createConversationForDirectory(dir: string) {
         (candidate) => candidate.id !== project.id,
       ),
     ];
-    workspaceState.projectPickerOpen = false;
-    await selectProject(project.id);
-    openPendingConversation(project);
+    await openPendingConversationForProject(project);
   } catch (caught) {
     const message = caught instanceof Error ? caught.message : String(caught);
     workspaceState.error = message;

--- a/packages/workbench-app/src/main.ts
+++ b/packages/workbench-app/src/main.ts
@@ -22,9 +22,11 @@ if (shouldRegisterServiceWorker()) {
   registerSW({ immediate: true });
 }
 
+const startupBootstrap = document.getElementById("startup-bootstrap");
 const app = mount(Root, {
   target,
 });
+startupBootstrap?.remove();
 
 function shouldRegisterServiceWorker(): boolean {
   return (


### PR DESCRIPTION
## Summary
- keep the startup splash visible until critical workspace and conversation state is restored
- align Electron, bootstrap, and renderer splash rendering while preventing white navigation flashes
- allow protocol read RPCs such as pull request loading to run without blocking ordered mutations
- open new conversations immediately for projects already loaded in the workspace

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `pnpm --filter @nervekit/workbench-app build`