### PR TITLE
Fix responsive dialog sizing

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
+++ b/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
@@ -42,6 +42,7 @@ function handleOpenChange(next: boolean) {
 <Dialog.Root bind:open onOpenChange={handleOpenChange}>
   <Dialog.Content
     showCloseButton={false}
+    layout="shell"
     class={cn(
       "dialog-content data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-open:zoom-in-95 data-closed:zoom-out-95 duration-100 outline-none",
       size === "sm" && "dialog-content-sm",

--- a/packages/ui-kit/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/packages/ui-kit/src/lib/components/ui/dialog/dialog-content.svelte
@@ -14,11 +14,13 @@ let {
   portalProps,
   children,
   showCloseButton = true,
+  layout = "default",
   ...restProps
 }: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {
   portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DialogPortal>>;
   children: Snippet;
   showCloseButton?: boolean;
+  layout?: "default" | "shell";
 } = $props();
 </script>
 
@@ -28,7 +30,8 @@ let {
     bind:ref
     data-slot="dialog-content"
     class={cn(
-      "bg-card text-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 border-border grid max-w-[calc(100%-2rem)] gap-4 rounded-lg border p-4 text-sm shadow-xl duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+      "bg-card text-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 border-border grid rounded-lg border text-sm shadow-xl duration-100 fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+      layout === "default" && "max-w-[calc(100%-2rem)] gap-4 p-4 sm:max-w-md",
       className,
     )}
     {...restProps}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolCallDetailsDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolCallDetailsDialog.svelte
@@ -118,7 +118,7 @@ const description = $derived(
   bind:open
   title={`${displayToolCall.toolName} details`}
   {description}
-  class="max-w-5xl"
+  size="wide"
   {onOpenChange}
 >
   {#if loading && !toolCall}


### PR DESCRIPTION
## Summary
- isolate DialogShell from the shared dialog primitive’s standalone width and spacing defaults
- restore semantic default, wide, and viewport dialog sizes with mobile-safe bounds
- use the wide preset for tool-call details

## Validation
- `pnpm fix && pnpm check && pnpm test`