### PR TITLE
fix(release): harden workbench smoke testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,9 @@ jobs:
 
       - name: Run complete test suite
         run: pnpm test
+
+      - name: Build workbench runtime
+        run: pnpm build:workbench-runtime
+
+      - name: Smoke built workbench HTTP and WebSocket parity
+        run: pnpm release:smoke:workbench

--- a/scripts/smoke-workbench-release.mjs
+++ b/scripts/smoke-workbench-release.mjs
@@ -89,8 +89,14 @@ try {
 
   const htmlResponse = await fetch(`${origin}/`);
   const html = await htmlResponse.text();
-  if (!htmlResponse.ok || !html.includes('<div id="app"></div>'))
-    throw new Error("bundled workbench index.html was not served");
+  if (!htmlResponse.ok)
+    throw new Error(
+      `bundled workbench index request failed: ${describeResponse(htmlResponse, html)}`,
+    );
+  if (!/<div\b[^>]*\bid=(["'])app\1[^>]*>/i.test(html))
+    throw new Error(
+      `bundled workbench index has no #app mount: ${describeResponse(htmlResponse, html)}`,
+    );
   const assetPath = html.match(/(?:src|href)="(\/assets\/[^"]+)"/)?.[1];
   if (!assetPath)
     throw new Error("bundled workbench index has no static asset");
@@ -212,6 +218,12 @@ async function stopChild(process_) {
       if (process_.exitCode === null) process_.kill("SIGKILL");
     }),
   ]);
+}
+
+function describeResponse(response, body) {
+  const contentType = response.headers.get("content-type") ?? "unknown";
+  const preview = body.slice(0, 500).replace(/\s+/g, " ").trim();
+  return `HTTP ${response.status}, content-type ${contentType}, body ${JSON.stringify(preview)}`;
 }
 
 function delay(ms) {


### PR DESCRIPTION
## Summary
- accept a populated `#app` mount in the built workbench smoke test
- include bounded HTTP diagnostics when the served entry point is invalid
- build and smoke the workbench runtime in PR/main CI so failures are caught before release tags

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `pnpm build:workbench-runtime && pnpm release:smoke:workbench`
- `git diff --check`