### PR TITLE
Polish the model selection dialog

### DIFF
--- a/packages/contracts/src/domains/models/models.schema.ts
+++ b/packages/contracts/src/domains/models/models.schema.ts
@@ -19,12 +19,17 @@ export const modelSelectionSchema = z.object({
 });
 export type ModelSelection = z.infer<typeof modelSelectionSchema>;
 
+export const modelInputSchema = z.enum(["text", "image"]);
+export type ModelInputModality = z.infer<typeof modelInputSchema>;
+
 export const modelInfoSchema = z.object({
   provider: z.string(),
   modelId: z.string(),
   name: z.string(),
   label: z.string(),
   reasoning: z.boolean().default(false),
+  /** Accepted input modalities; `["text", "image"]` means vision input works. */
+  input: z.array(modelInputSchema).default(["text"]),
   supportedThinkingLevels: z.array(thinkingLevelSchema).default(["off"]),
   faux: z.boolean().optional(),
   contextWindow: z.number().int().nonnegative().default(0),

--- a/packages/contracts/src/domains/providers/providers.schema.ts
+++ b/packages/contracts/src/domains/providers/providers.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { thinkingLevelSchema } from "../models/index.js";
+import { modelInputSchema, thinkingLevelSchema } from "../models/index.js";
 
 /**
  * pi-ai `KnownApi` values. Custom providers pick one of these API
@@ -19,9 +19,6 @@ export const piApiSchema = z.enum([
   "pi-messages",
 ]);
 export type PiApi = z.infer<typeof piApiSchema>;
-
-export const modelInputSchema = z.enum(["text", "image"]);
-export type ModelInputModality = z.infer<typeof modelInputSchema>;
 
 export const modelCostSchema = z.object({
   input: z.number().nonnegative().default(0),

--- a/packages/harness/src/models/resolution.ts
+++ b/packages/harness/src/models/resolution.ts
@@ -174,6 +174,7 @@ export function getAgentModelInfo(model: Model<string>): AgentModelInfo {
     supportedThinkingLevels: getSupportedThinkingLevels(
       model,
     ) as ThinkingLevel[],
+    input: (model.input ?? ["text"]) as ("text" | "image")[],
     contextWindow: model.contextWindow ?? 0,
     maxOutputTokens: model.maxTokens ?? 0,
   };

--- a/packages/harness/src/models/types.ts
+++ b/packages/harness/src/models/types.ts
@@ -10,6 +10,8 @@ export interface AgentModelInfo extends AgentModelSelection {
   name: string;
   reasoning: boolean;
   supportedThinkingLevels: ThinkingLevel[];
+  /** Accepted input modalities from the model catalog; `["text"]` when unknown. */
+  input: ("text" | "image")[];
   contextWindow: number;
   maxOutputTokens: number;
 }

--- a/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
+++ b/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
@@ -13,7 +13,7 @@ type Props = {
   description?: string;
   class?: string;
   closeLabel?: string;
-  size?: "sm" | "default" | "wide" | "viewport";
+  size?: "sm" | "md" | "default" | "wide" | "viewport";
   /** Removes the default body padding for edge-to-edge list/graph content. */
   flush?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -46,6 +46,7 @@ function handleOpenChange(next: boolean) {
     class={cn(
       "dialog-content data-open:animate-in data-closed:animate-out data-open:fade-in-0 data-closed:fade-out-0 data-open:zoom-in-95 data-closed:zoom-out-95 duration-100 outline-none",
       size === "sm" && "dialog-content-sm",
+      size === "md" && "dialog-content-md",
       size === "wide" && "dialog-content-wide",
       size === "viewport" && "dialog-content-viewport",
       className,

--- a/packages/ui-kit/src/lib/components/ui/popover-panel/popover-row.svelte
+++ b/packages/ui-kit/src/lib/components/ui/popover-panel/popover-row.svelte
@@ -15,7 +15,8 @@ let {
   onclick,
 }: {
   label: string;
-  detail?: string;
+  /** Secondary line: plain text, or a snippet for richer markup (e.g. mono ids). */
+  detail?: string | Snippet;
   selected?: boolean;
   disabled?: boolean;
   title?: string;
@@ -42,8 +43,10 @@ let {
   {@render icon?.()}
   <span class="grid min-w-0 flex-1 gap-0.5">
     <span class="truncate text-xs font-medium text-foreground">{label}</span>
-    {#if detail}
-      <span class="text-xs text-muted-foreground">{detail}</span>
+    {#if typeof detail === "string"}
+      <span class="truncate text-xs text-muted-foreground">{detail}</span>
+    {:else if detail}
+      {@render detail()}
     {/if}
   </span>
   {@render trailing?.()}

--- a/packages/ui-kit/src/styles/components/dialog.css
+++ b/packages/ui-kit/src/styles/components/dialog.css
@@ -43,6 +43,13 @@
   width: min(30rem, calc(100dvw - 2rem));
 }
 
+.dialog-content-md {
+  width: min(672px, calc(100vw - 32px));
+  width: min(672px, calc(100dvw - 2rem));
+  max-height: 90vh;
+  max-height: min(90dvh, calc(100dvh - 2rem));
+}
+
 .dialog-content-wide {
   width: min(960px, calc(100vw - 32px));
   width: min(960px, calc(100dvw - 2rem));
@@ -148,6 +155,9 @@
   padding: 0.75rem 0.875rem;
 }
 
+/* Flush bodies host edge-to-edge lists that own their scrolling, so the shell
+ * must not add a second scrollbar around them. */
 .dialog-body-flush {
+  overflow: hidden;
   padding: 0;
 }

--- a/packages/workbench-app/src/lib/features/settings/components/pages/agents/AgentDefaultsSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/agents/AgentDefaultsSection.svelte
@@ -199,6 +199,7 @@ function setAutoApproveReadOnly(autoApproveReadOnly: boolean): void {
     fallbackOption={{
       label: "First available scoped model",
       detail: "Use the first configured model allowed by Scoped Models",
+      actionLabel: "Use first available",
     }}
     {fallbackThinkingLevels}
     dialogTitle="Choose default model"

--- a/packages/workbench-app/src/lib/features/settings/components/pages/agents/ExploreAgentSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/agents/ExploreAgentSection.svelte
@@ -77,6 +77,7 @@ function saveExploreModel(selection: {
     fallbackOption={{
       label: "Default model",
       detail: "Use the platform fallback model",
+      actionLabel: "Use default model",
     }}
     fallbackThinkingLevels={[...thinkingLevels]}
     dialogTitle="Choose explore model"

--- a/packages/workbench-app/src/lib/features/settings/components/pages/agents/ModelPickerRow.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/agents/ModelPickerRow.svelte
@@ -21,7 +21,7 @@ type Props = {
   selectedThinkingLevel: ThinkingLevel;
   summaryTitle: string;
   summaryMeta: Snippet;
-  fallbackOption: { label: string; detail: string };
+  fallbackOption: { label: string; detail: string; actionLabel: string };
   fallbackThinkingLevels: ThinkingLevel[];
   dialogTitle: string;
   dialogDescription?: string;

--- a/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
@@ -1,22 +1,32 @@
 <script lang="ts">
-import type {
-  AuthProviderMetadata,
-  ModelInfo,
-  ModelSelection,
-  ThinkingLevel,
-} from "$lib/api";
+import type { ModelInfo, ModelSelection, ThinkingLevel } from "$lib/api";
+import ArrowUpFromLine from "@lucide/svelte/icons/arrow-up-from-line";
+import Braces from "@lucide/svelte/icons/braces";
+import Brain from "@lucide/svelte/icons/brain";
+import Image from "@lucide/svelte/icons/image";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
+import { PopoverRow } from "@nervekit/ui-kit/components/ui/popover-panel";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
 import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
-import { modelKey } from "$lib/presentation/utils/model";
+import {
+  formatTokenCapacity,
+  modelKey,
+  supportsImageInput,
+} from "$lib/presentation/utils/model";
 import {
   buildModelCatalog,
   filterModelCatalog,
   modelProviderFacets,
 } from "$lib/presentation/utils/model-catalog";
-type FallbackOption = { label: string; detail: string };
+type FallbackOption = {
+  label: string;
+  detail: string;
+  /** Footer button copy, e.g. "Use default model". */
+  actionLabel: string;
+};
 type SaveSelection = {
   model?: ModelSelection;
   thinkingLevel: ThinkingLevel;
@@ -27,7 +37,6 @@ type Props = {
   title: string;
   description?: string;
   models?: ModelInfo[];
-  authProviders?: AuthProviderMetadata[];
   selectedModel?: ModelSelection;
   selectedThinkingLevel: ThinkingLevel;
   fallbackOption?: FallbackOption;
@@ -55,10 +64,8 @@ let query = $state("");
 let providerFilter = $state("all");
 let lastOpen = false;
 
-const fallbackKey = "__fallback__";
-const hasFallback = $derived(!!fallbackOption);
 const selectedModelInfo = $derived(
-  selectedKey && selectedKey !== fallbackKey
+  selectedKey
     ? models.find((model) => modelKey(model) === selectedKey)
     : undefined,
 );
@@ -70,7 +77,7 @@ const thinkingLevels = $derived<ThinkingLevel[]>(
 
 $effect(() => {
   if (open && !lastOpen) {
-    selectedKey = selectedModel ? modelKey(selectedModel) : fallbackKey;
+    selectedKey = selectedModel ? modelKey(selectedModel) : undefined;
     thinkingLevel = selectedThinkingLevel;
     query = "";
     providerFilter = "all";
@@ -91,28 +98,46 @@ const filteredModels = $derived(
   filterModelCatalog(catalog, query, providerFilter),
 );
 
-function formatTokens(tokens: number): string {
-  if (tokens <= 0) return "Unknown context";
-  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M context`;
-  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K context`;
-  return `${tokens.toLocaleString()} context`;
+function capabilitySummary(model: ModelInfo): string {
+  const parts = [
+    model.contextWindow > 0
+      ? `Context ${model.contextWindow.toLocaleString()} tokens`
+      : "Context window unknown",
+  ];
+  if (model.maxOutputTokens > 0)
+    parts.push(`Max output ${model.maxOutputTokens.toLocaleString()} tokens`);
+  parts.push(model.reasoning ? "Reasoning model" : "No reasoning");
+  parts.push(
+    supportsImageInput(model) ? "Accepts image input" : "Text input only",
+  );
+  return parts.join(" · ");
 }
 
 function save(): void {
-  const model = selectedModelInfo
-    ? {
-        provider: selectedModelInfo.provider,
-        modelId: selectedModelInfo.modelId,
-      }
-    : undefined;
-  onSave?.({ model, thinkingLevel });
+  if (!selectedModelInfo) return;
+  onSave?.({
+    model: {
+      provider: selectedModelInfo.provider,
+      modelId: selectedModelInfo.modelId,
+    },
+    thinkingLevel,
+  });
+  open = false;
+}
+
+/** Clears the explicit model so the caller falls back to its platform default. */
+function useFallback(): void {
+  const level = fallbackThinkingLevels.includes(thinkingLevel)
+    ? thinkingLevel
+    : (fallbackThinkingLevels[0] ?? "off");
+  onSave?.({ model: undefined, thinkingLevel: level });
   open = false;
 }
 </script>
 
-<Dialog bind:open {title} {description} size="wide" flush>
-  <div class="grid max-h-[min(70vh,36rem)] grid-rows-[auto_minmax(0,1fr)]">
-    <div class="grid gap-2 border-b border-border/50 px-3.5 pt-3 pb-2.5">
+<Dialog bind:open {title} {description} size="md" flush>
+  <div class="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+    <div class="grid gap-1.5 border-b border-border/50 px-3 pt-2.5 pb-2">
       <SearchInput
         bind:value={query}
         placeholder="Search models"
@@ -141,82 +166,90 @@ function save(): void {
       {/if}
     </div>
 
-    <div class="min-h-0 p-1.5">
-      {#if models.length === 0 && !hasFallback}
-        <p class="px-1 py-2 text-sm text-muted-foreground">
-          Authenticate a provider before choosing a model.
-        </p>
-      {:else if filteredModels.length === 0 && !hasFallback}
-        <p class="px-1 py-2 text-sm text-muted-foreground">
-          No models match the current filters.
-        </p>
-      {:else}
-        <div class="grid gap-0.5">
-          {#if hasFallback}
-            <div>
-              <button
-                type="button"
-                class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-transparent px-2 py-1.5 text-left hover:bg-accent/50 aria-pressed:border-primary/60 aria-pressed:bg-primary/8"
-                aria-pressed={selectedKey === fallbackKey}
-                onclick={() => (selectedKey = fallbackKey)}
-              >
-                <span class="grid min-w-0 gap-0.5">
-                  <span class="truncate text-sm text-foreground"
-                    >{fallbackOption?.label}</span
-                  >
-                  <span class="truncate text-xs text-muted-foreground"
-                    >{fallbackOption?.detail}</span
-                  >
-                </span>
-              </button>
-            </div>
-          {/if}
-          <VirtualScroller
-            items={filteredModels}
-            getKey={(entry) => entry.key}
-            estimateSize={() => 48}
-            viewportClass="max-h-[min(52vh,24rem)]"
-            viewportAriaLabel="Available models"
-          >
-            {#snippet row({ item: entry })}
-              <div>
-                <button
-                  type="button"
-                  class="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-transparent px-2 py-1.5 text-left hover:bg-accent/50 aria-pressed:border-primary/60 aria-pressed:bg-primary/8"
-                  aria-pressed={selectedKey === entry.key}
+    <Tooltip.Provider delayDuration={200} disableHoverableContent>
+      <div class="grid min-h-0 grid-rows-[minmax(0,1fr)] px-3 py-2">
+        {#if models.length === 0}
+          <p class="py-1 text-sm text-muted-foreground">
+            Authenticate a provider before choosing a model.
+          </p>
+        {:else if filteredModels.length === 0}
+          <p class="py-1 text-sm text-muted-foreground">
+            No models match the current filters.
+          </p>
+        {:else}
+          <div class="grid min-h-0">
+            <VirtualScroller
+              items={filteredModels}
+              getKey={(entry) => entry.key}
+              estimateSize={() => 46}
+              gap={6}
+              viewportClass="h-full max-h-[min(52vh,22rem)]"
+              viewportAriaLabel="Available models"
+            >
+              {#snippet row({ item: entry })}
+                <PopoverRow
+                  label={entry.displayName}
+                  selected={selectedKey === entry.key}
+                  class="px-2 py-1.5 aria-pressed:border-primary/60"
                   onclick={() => (selectedKey = entry.key)}
                 >
-                  <span class="grid min-w-0 gap-0.5">
-                    <span class="truncate text-sm text-foreground"
-                      >{entry.displayName}</span
-                    >
+                  {#snippet detail()}
                     <span class="truncate text-xs text-muted-foreground">
                       {entry.providerLabel} ·
                       <span class="font-mono">{entry.model.modelId}</span>
                     </span>
-                  </span>
-                  <span class="flex-none text-xs text-muted-foreground">
-                    {entry.model.reasoning ? "Reasoning" : "Standard"} ·
-                    {formatTokens(entry.model.contextWindow)}
-                  </span>
-                </button>
-              </div>
-            {/snippet}
-          </VirtualScroller>
-        </div>
-      {/if}
-    </div>
+                  {/snippet}
+                  {#snippet trailing()}
+                    <Tooltip.Root>
+                      <Tooltip.Trigger>
+                        {#snippet child({ props })}
+                          <span
+                            {...props}
+                            class="flex flex-none items-center gap-1 text-[0.6875rem] text-muted-foreground tabular-nums"
+                            aria-label={capabilitySummary(entry.model)}
+                          >
+                            <span class="inline-flex items-center gap-0.5">
+                              <Braces class="size-3" aria-hidden="true" />
+                              {formatTokenCapacity(entry.model.contextWindow)}
+                            </span>
+                            {#if entry.model.maxOutputTokens > 0}
+                              <span class="inline-flex items-center gap-0.5">
+                                <ArrowUpFromLine
+                                  class="size-3"
+                                  aria-hidden="true"
+                                />
+                                {formatTokenCapacity(
+                                  entry.model.maxOutputTokens,
+                                )}
+                              </span>
+                            {/if}
+                            {#if entry.model.reasoning}
+                              <Brain class="size-3" aria-hidden="true" />
+                            {/if}
+                            {#if supportsImageInput(entry.model)}
+                              <Image class="size-3" aria-hidden="true" />
+                            {/if}
+                          </span>
+                        {/snippet}
+                      </Tooltip.Trigger>
+                      <Tooltip.Content side="left">
+                        {capabilitySummary(entry.model)}
+                      </Tooltip.Content>
+                    </Tooltip.Root>
+                  {/snippet}
+                </PopoverRow>
+              {/snippet}
+            </VirtualScroller>
+          </div>
+        {/if}
+      </div>
+    </Tooltip.Provider>
   </div>
 
   {#snippet footer()}
-    <div class="flex w-full flex-wrap items-center justify-end gap-2">
-      <div
-        class="mr-auto flex w-fit max-w-full flex-none flex-wrap items-center gap-2"
-      >
-        <span
-          class="text-xs font-medium tracking-wide text-muted-foreground uppercase"
-          >Thinking level</span
-        >
+    <div class="grid w-full gap-2">
+      <div class="grid gap-1">
+        <span class="text-xs text-muted-foreground">Thinking level</span>
         <ToggleGroup.Root
           type="single"
           size="xs"
@@ -224,26 +257,34 @@ function save(): void {
           variant="outline"
           value={thinkingLevel}
           aria-label="Thinking level"
-          class="min-w-0 flex-wrap"
+          class="min-w-0 flex-wrap justify-start"
           onValueChange={(value) => {
             if (value) thinkingLevel = value as ThinkingLevel;
           }}
         >
           {#each thinkingLevels as level (level)}
-            <ToggleGroup.Item value={level} class="text-xs capitalize"
+            <ToggleGroup.Item
+              value={level}
+              class="flex-none rounded-full text-xs capitalize data-[state=on]:text-primary"
               >{level}</ToggleGroup.Item
             >
           {/each}
         </ToggleGroup.Root>
       </div>
-      <div class="flex flex-none items-center gap-2">
+      <div class="flex flex-wrap items-center justify-end gap-2">
         <Button size="sm" variant="ghost" onclick={() => (open = false)}
           >Cancel</Button
         >
-        <Button
-          size="sm"
-          onclick={save}
-          disabled={!hasFallback && !selectedModelInfo}>{confirmLabel}</Button
+        {#if fallbackOption}
+          <Button
+            size="sm"
+            variant="outline"
+            title={fallbackOption.detail}
+            onclick={useFallback}>{fallbackOption.actionLabel}</Button
+          >
+        {/if}
+        <Button size="sm" onclick={save} disabled={!selectedModelInfo}
+          >{confirmLabel}</Button
         >
       </div>
     </div>

--- a/packages/workbench-app/src/lib/presentation/utils/model-catalog.test.ts
+++ b/packages/workbench-app/src/lib/presentation/utils/model-catalog.test.ts
@@ -14,6 +14,7 @@ function model(provider: string, modelId: string, name: string): ModelInfo {
     name,
     label: name,
     reasoning: false,
+    input: ["text"],
     supportedThinkingLevels: ["off"],
     contextWindow: 0,
     maxOutputTokens: 0,

--- a/packages/workbench-app/src/lib/presentation/utils/model.ts
+++ b/packages/workbench-app/src/lib/presentation/utils/model.ts
@@ -58,6 +58,26 @@ export function modelDisplayName(model: ModelInfo): string {
   return model.name || model.label || model.modelId;
 }
 
+function trimDecimal(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+}
+
+/**
+ * Compact model-capacity formatting for catalog metadata: exact multiples render
+ * without decimals (1_000_000 -> "1M", 272_000 -> "272K", 1_500_000 -> "1.5M").
+ */
+export function formatTokenCapacity(tokens: number): string {
+  if (!Number.isFinite(tokens) || tokens <= 0) return "—";
+  if (tokens >= 1_000_000) return `${trimDecimal(tokens / 1_000_000)}M`;
+  if (tokens >= 1_000) return `${trimDecimal(tokens / 1_000)}K`;
+  return `${tokens}`;
+}
+
+export function supportsImageInput(model: ModelInfo): boolean {
+  return model.input?.includes("image") ?? false;
+}
+
 export function modelNameCounts(models: ModelInfo[]): Map<string, number> {
   const counts = new Map<string, number>();
   for (const model of models) {

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -680,6 +680,7 @@ export class RuntimeRegistry {
         name: model.name,
         label: model.provider === "nerve-faux" ? "Nerve Faux Fast" : model.name,
         reasoning: model.reasoning,
+        input: model.input,
         supportedThinkingLevels: model.supportedThinkingLevels,
         faux: model.provider === "nerve-faux",
         contextWindow: model.contextWindow,


### PR DESCRIPTION
## Summary
- make the model selection dialog 30% narrower and adopt the compact, bordered row styling used by the prompt composer
- show compact context, output, reasoning, and image-input capability indicators with accessible detail tooltips
- carry image-input metadata from the model catalog through contracts, harness, and server APIs
- move fallback model selection into a footer action and prevent nested dialog scrollbars
- add a reusable medium dialog size and richer secondary content support for `PopoverRow`

## Validation
- `pnpm fix && pnpm check && pnpm test`
- manually verified model selection, fallback selection, filtering, and scrolling in the running workbench UI
