### PR TITLE
Add swipe dismissal for mobile panel drawers

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/packages/ui-kit/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,22 +1,217 @@
 <script lang="ts">
 import { Dialog as DialogPrimitive } from "bits-ui";
 import type { ComponentProps, Snippet } from "svelte";
+import { cn, type WithoutChildrenOrChild } from "@nervekit/ui-kit/core/utils";
 import SheetOverlay from "./sheet-overlay.svelte";
 import SheetPortal from "./sheet-portal.svelte";
-import { cn, type WithoutChildrenOrChild } from "@nervekit/ui-kit/core/utils";
+import {
+  outwardSheetSwipeDistance,
+  SHEET_SWIPE_AXIS_DOMINANCE,
+  SHEET_SWIPE_INTENT_DISTANCE,
+  sheetSwipeTranslation,
+  shouldDismissSheetSwipe,
+  type SheetSwipeSide,
+} from "./sheet-swipe";
 
 let {
   ref = $bindable(null),
   class: className,
+  style: styleProp,
   side = "right",
   portalProps,
+  swipeToDismiss = false,
+  onSwipeDismiss,
   children,
   ...restProps
 }: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {
   portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetPortal>>;
   side?: "top" | "right" | "bottom" | "left";
+  swipeToDismiss?: boolean;
+  onSwipeDismiss?: () => void;
   children: Snippet;
 } = $props();
+
+const swipeEnabled = $derived(
+  swipeToDismiss && (side === "left" || side === "right"),
+);
+
+let swipeTranslate = $state<number>();
+let swiping = $state(false);
+let settling = $state(false);
+let settleTimer: ReturnType<typeof setTimeout> | undefined;
+let dismissAfterSettlement = false;
+let gesture:
+  | {
+      pointerId: number;
+      startX: number;
+      startY: number;
+      startTime: number;
+      horizontal: boolean;
+    }
+  | undefined;
+
+function clearSettleTimer() {
+  if (settleTimer === undefined) return;
+  clearTimeout(settleTimer);
+  settleTimer = undefined;
+}
+
+function finishSettlement() {
+  if (!settling) return;
+  const dismiss = dismissAfterSettlement;
+  clearSettleTimer();
+  dismissAfterSettlement = false;
+  settling = false;
+  swiping = false;
+  swipeTranslate = undefined;
+  if (dismiss) onSwipeDismiss?.();
+}
+
+function resetGesture() {
+  gesture = undefined;
+  clearSettleTimer();
+  dismissAfterSettlement = false;
+  settling = false;
+  swiping = false;
+  swipeTranslate = undefined;
+}
+
+$effect(() => {
+  const element = ref;
+  if (!element || !swipeEnabled) return;
+
+  const contentElement = element as HTMLElement;
+  const swipeSide = side as SheetSwipeSide;
+
+  function releasePointer(pointerId: number) {
+    if (contentElement.hasPointerCapture(pointerId)) {
+      contentElement.releasePointerCapture(pointerId);
+    }
+  }
+
+  function settle(dismiss: boolean) {
+    const activeGesture = gesture;
+    gesture = undefined;
+    if (activeGesture) releasePointer(activeGesture.pointerId);
+
+    swiping = false;
+    settling = true;
+    dismissAfterSettlement = dismiss;
+    swipeTranslate = dismiss
+      ? (swipeSide === "left" ? -1 : 1) *
+        contentElement.getBoundingClientRect().width
+      : 0;
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      finishSettlement();
+      return;
+    }
+
+    clearSettleTimer();
+    settleTimer = setTimeout(finishSettlement, 240);
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (
+      settling ||
+      gesture ||
+      !event.isPrimary ||
+      event.pointerType === "mouse"
+    ) {
+      return;
+    }
+
+    gesture = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startTime: event.timeStamp,
+      horizontal: false,
+    };
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    const activeGesture = gesture;
+    if (!activeGesture || event.pointerId !== activeGesture.pointerId) return;
+
+    const deltaX = event.clientX - activeGesture.startX;
+    const deltaY = event.clientY - activeGesture.startY;
+
+    if (!activeGesture.horizontal) {
+      const absoluteX = Math.abs(deltaX);
+      const absoluteY = Math.abs(deltaY);
+      if (
+        absoluteX < SHEET_SWIPE_INTENT_DISTANCE &&
+        absoluteY < SHEET_SWIPE_INTENT_DISTANCE
+      ) {
+        return;
+      }
+      if (absoluteY > absoluteX) {
+        gesture = undefined;
+        return;
+      }
+      if (absoluteX < absoluteY * SHEET_SWIPE_AXIS_DOMINANCE) return;
+
+      activeGesture.horizontal = true;
+      contentElement.setPointerCapture(event.pointerId);
+      swiping = true;
+    }
+
+    event.preventDefault();
+    swipeTranslate = sheetSwipeTranslation(swipeSide, deltaX);
+  }
+
+  function handlePointerEnd(event: PointerEvent) {
+    const activeGesture = gesture;
+    if (!activeGesture || event.pointerId !== activeGesture.pointerId) return;
+    if (!activeGesture.horizontal) {
+      gesture = undefined;
+      return;
+    }
+
+    const deltaX = event.clientX - activeGesture.startX;
+    const distance = outwardSheetSwipeDistance(swipeSide, deltaX);
+    const elapsed = Math.max(1, event.timeStamp - activeGesture.startTime);
+    settle(
+      shouldDismissSheetSwipe({
+        distance,
+        width: contentElement.getBoundingClientRect().width,
+        velocity: distance / elapsed,
+      }),
+    );
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    if (!gesture || event.pointerId !== gesture.pointerId) return;
+    if (gesture.horizontal) settle(false);
+    else gesture = undefined;
+  }
+
+  function handleTransitionEnd(event: TransitionEvent) {
+    if (event.target === contentElement && event.propertyName === "translate") {
+      finishSettlement();
+    }
+  }
+
+  contentElement.addEventListener("pointerdown", handlePointerDown, true);
+  contentElement.addEventListener("pointermove", handlePointerMove, true);
+  contentElement.addEventListener("pointerup", handlePointerEnd, true);
+  contentElement.addEventListener("pointercancel", handlePointerCancel, true);
+  contentElement.addEventListener("transitionend", handleTransitionEnd);
+
+  return () => {
+    contentElement.removeEventListener("pointerdown", handlePointerDown, true);
+    contentElement.removeEventListener("pointermove", handlePointerMove, true);
+    contentElement.removeEventListener("pointerup", handlePointerEnd, true);
+    contentElement.removeEventListener(
+      "pointercancel",
+      handlePointerCancel,
+      true,
+    );
+    contentElement.removeEventListener("transitionend", handleTransitionEnd);
+    resetGesture();
+  };
+});
 </script>
 
 <SheetPortal {...portalProps}>
@@ -35,8 +230,14 @@ let {
         "data-open:slide-in-from-top data-closed:slide-out-to-top inset-x-0 top-0 h-auto max-h-[85vh] border-b",
       side === "bottom" &&
         "data-open:slide-in-from-bottom data-closed:slide-out-to-bottom inset-x-0 bottom-0 h-auto max-h-[85vh] border-t",
+      swipeEnabled && "touch-pan-y [&_*]:touch-pan-y",
+      swiping && "transition-none will-change-[translate]",
+      settling && "transition-[translate] ease-out",
       className,
     )}
+    style={swipeTranslate === undefined
+      ? styleProp
+      : `${styleProp ? `${styleProp};` : ""}translate:${swipeTranslate}px 0`}
     {...restProps}
   >
     {@render children?.()}

--- a/packages/ui-kit/src/lib/components/ui/sheet/sheet-swipe.test.ts
+++ b/packages/ui-kit/src/lib/components/ui/sheet/sheet-swipe.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  outwardSheetSwipeDistance,
+  sheetSwipeTranslation,
+  shouldDismissSheetSwipe,
+} from "./sheet-swipe";
+
+describe("sheet swipe direction", () => {
+  it("moves a left sheet only toward the left edge", () => {
+    assert.equal(outwardSheetSwipeDistance("left", -48), 48);
+    assert.equal(sheetSwipeTranslation("left", -48), -48);
+    assert.equal(sheetSwipeTranslation("left", 48), 0);
+  });
+
+  it("moves a right sheet only toward the right edge", () => {
+    assert.equal(outwardSheetSwipeDistance("right", 48), 48);
+    assert.equal(sheetSwipeTranslation("right", 48), 48);
+    assert.equal(sheetSwipeTranslation("right", -48), 0);
+  });
+
+  it("treats invalid displacement as no movement", () => {
+    assert.equal(sheetSwipeTranslation("left", Number.NaN), 0);
+    assert.equal(sheetSwipeTranslation("right", Number.POSITIVE_INFINITY), 0);
+  });
+});
+
+describe("sheet swipe dismissal", () => {
+  it("keeps a short, slow drag open", () => {
+    assert.equal(
+      shouldDismissSheetSwipe({ distance: 50, width: 320, velocity: 0.2 }),
+      false,
+    );
+  });
+
+  it("dismisses a drag that crosses the distance threshold", () => {
+    assert.equal(
+      shouldDismissSheetSwipe({ distance: 96, width: 320, velocity: 0.2 }),
+      true,
+    );
+  });
+
+  it("dismisses a short, fast outward flick", () => {
+    assert.equal(
+      shouldDismissSheetSwipe({ distance: 40, width: 320, velocity: 0.6 }),
+      true,
+    );
+  });
+
+  it("rejects invalid measurements", () => {
+    assert.equal(
+      shouldDismissSheetSwipe({ distance: 100, width: 0, velocity: 1 }),
+      false,
+    );
+    assert.equal(
+      shouldDismissSheetSwipe({
+        distance: Number.NaN,
+        width: 320,
+        velocity: 1,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldDismissSheetSwipe({
+        distance: 100,
+        width: 320,
+        velocity: Number.POSITIVE_INFINITY,
+      }),
+      false,
+    );
+  });
+});

--- a/packages/ui-kit/src/lib/components/ui/sheet/sheet-swipe.ts
+++ b/packages/ui-kit/src/lib/components/ui/sheet/sheet-swipe.ts
@@ -1,0 +1,51 @@
+export type SheetSwipeSide = "left" | "right";
+
+export const SHEET_SWIPE_INTENT_DISTANCE = 8;
+export const SHEET_SWIPE_AXIS_DOMINANCE = 1.2;
+export const SHEET_SWIPE_DISMISS_RATIO = 0.3;
+export const SHEET_SWIPE_DISMISS_VELOCITY = 0.5;
+
+function sideDirection(side: SheetSwipeSide): -1 | 1 {
+  return side === "left" ? -1 : 1;
+}
+
+export function outwardSheetSwipeDistance(
+  side: SheetSwipeSide,
+  deltaX: number,
+): number {
+  if (!Number.isFinite(deltaX)) return 0;
+  return Math.max(0, deltaX * sideDirection(side));
+}
+
+export function sheetSwipeTranslation(
+  side: SheetSwipeSide,
+  deltaX: number,
+): number {
+  const distance = outwardSheetSwipeDistance(side, deltaX);
+  return distance === 0 ? 0 : distance * sideDirection(side);
+}
+
+export function shouldDismissSheetSwipe({
+  distance,
+  width,
+  velocity,
+}: {
+  distance: number;
+  width: number;
+  velocity: number;
+}): boolean {
+  if (
+    !Number.isFinite(distance) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(velocity) ||
+    distance <= 0 ||
+    width <= 0
+  ) {
+    return false;
+  }
+
+  return (
+    distance >= width * SHEET_SWIPE_DISMISS_RATIO ||
+    velocity >= SHEET_SWIPE_DISMISS_VELOCITY
+  );
+}

--- a/packages/workbench-app/src/lib/app/shell/VersionIndicator.svelte
+++ b/packages/workbench-app/src/lib/app/shell/VersionIndicator.svelte
@@ -68,7 +68,7 @@ onDestroy(() => {
   side="bottom"
   align="end"
   class="popover-md"
-  triggerClass={`version-trigger rounded-sm font-mono text-xs font-medium leading-none transition-colors ${outdated ? "version-trigger-warning" : ""}`}
+  triggerClass={`version-trigger rounded-sm font-mono text-xs font-medium leading-none transition-colors ${outdated ? "version-trigger-warning" : "version-trigger-current"}`}
 >
   {#snippet trigger()}{currentLabel}{/snippet}
 

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -64,7 +64,7 @@ function tabLabel(item: ProjectSwitcherItem): string {
       <ContextMenu
         items={buildMenuItems?.(item) ?? []}
         disabled={!buildMenuItems}
-        triggerClass="block min-w-0 max-w-56 flex-1 overflow-hidden"
+        triggerClass="block min-w-0 max-w-56 overflow-hidden"
       >
         <Button
           variant="ghost"

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -43,7 +43,7 @@ function tabLabel(item: ProjectSwitcherItem): string {
 </script>
 
 <nav
-  class="project-switcher flex min-w-0 items-center gap-1"
+  class="project-switcher flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
   aria-label="Projects"
 >
   <Button
@@ -57,14 +57,14 @@ function tabLabel(item: ProjectSwitcherItem): string {
   >
     <FolderSearch class="size-4" aria-hidden="true" />
   </Button>
-  <div class="flex min-w-0 items-center gap-0.5">
+  <div class="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
     {#each items as item (item.key)}
       {@const indicator = projectActivityIndicator(item.activity)}
       {@const active = item.key === activeKey}
       <ContextMenu
         items={buildMenuItems?.(item) ?? []}
         disabled={!buildMenuItems}
-        triggerClass="block min-w-0 max-w-56"
+        triggerClass="block min-w-0 max-w-56 flex-1 overflow-hidden"
       >
         <Button
           variant="ghost"

--- a/packages/workbench-app/src/lib/presentation/shell/ShellTitlebar.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/ShellTitlebar.svelte
@@ -12,8 +12,8 @@ let {
 } = $props();
 </script>
 
-<header class="titlebar" class:desktop>
-  <div class="title-left">
+<header class="titlebar min-w-0" class:desktop>
+  <div class="title-left overflow-hidden">
     {@render left()}
   </div>
   {#if actions}

--- a/packages/workbench-app/src/lib/presentation/shell/WorkbenchShell.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/WorkbenchShell.svelte
@@ -125,7 +125,12 @@ function dropOnStrip(event: DragEvent, dock: DockId) {
         open={primarySheetOpen}
         onOpenChange={(open) => actions.onSheetOpenChange?.("primary", open)}
       >
-        <Sheet.Content side="left" class="sheet-pane">
+        <Sheet.Content
+          side="left"
+          class="sheet-pane"
+          swipeToDismiss
+          onSwipeDismiss={() => actions.onSheetOpenChange?.("primary", false)}
+        >
           <Sheet.Title class="sr-only">{DOCK_LABELS.left}</Sheet.Title>
           <DockPanel
             dock="left"
@@ -145,7 +150,12 @@ function dropOnStrip(event: DragEvent, dock: DockId) {
         open={secondarySheetOpen}
         onOpenChange={(open) => actions.onSheetOpenChange?.("secondary", open)}
       >
-        <Sheet.Content side="right" class="sheet-pane">
+        <Sheet.Content
+          side="right"
+          class="sheet-pane"
+          swipeToDismiss
+          onSwipeDismiss={() => actions.onSheetOpenChange?.("secondary", false)}
+        >
           <Sheet.Title class="sr-only">Panels</Sheet.Title>
           <section class="dock-panel" data-dock="right" aria-label="Panels">
             <DockTabStrip

--- a/packages/workbench-app/src/styles/components/popovers.css
+++ b/packages/workbench-app/src/styles/components/popovers.css
@@ -53,3 +53,9 @@
 :where(.popover-trigger.version-trigger-warning:hover) {
   background: color-mix(in oklab, var(--warning) 16%, var(--card));
 }
+
+@media (max-width: 639px) {
+  .title-actions :where(.popover-trigger.version-trigger-current) {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add opt-in touch and pen swipe-to-dismiss behavior to side sheets
- enable responsive workbench panel drawers to follow outward drag gestures
- preserve vertical scrolling across nested panel content and honor reduced motion
- cover swipe direction, distance, velocity, and invalid measurements with unit tests

## Validation
- pnpm fix
- pnpm check
- pnpm test
- manually verified left and right drawers across Git, Context, Notes, and Tasks panels