### PR TITLE
Improve subagent transparency and transcript observability

### DIFF
--- a/packages/contracts/src/domains/agents/agent.events.schema.ts
+++ b/packages/contracts/src/domains/agents/agent.events.schema.ts
@@ -1,4 +1,11 @@
 import { z } from "zod";
+import {
+  contentBlockIdSchema,
+  liveMessageIdSchema,
+  runIdSchema,
+  turnIdSchema,
+} from "../conversations/conversation.schema.js";
+import { PUBLIC_EVENT_MAX_STRING_CHARS } from "../events/bounded-public-data.schema.js";
 import { definePublicEvent } from "../events/event-definition.schema.js";
 import { modeSchema } from "../settings/settings.schema.js";
 import { agentSuspensionRecordSchema } from "../suspensions/suspension.schema.js";
@@ -7,6 +14,31 @@ import { agentRecordSchema, agentStatusSchema } from "./agent.schema.js";
 
 const workbenchRoles = ["workbench_server"] as const;
 const agentIdSchema = z.string().startsWith("agent_");
+const transcriptIdentitySchema = z
+  .object({
+    conversationId: z.string().startsWith("conv_"),
+    projectId: z.string().startsWith("proj_"),
+    parentAgentId: agentIdSchema,
+    childAgentId: agentIdSchema,
+    runId: runIdSchema,
+  })
+  .strict();
+const transcriptTurnSchema = transcriptIdentitySchema.extend({
+  turnId: turnIdSchema,
+});
+const transcriptMessageSchema = transcriptTurnSchema.extend({
+  liveMessageId: liveMessageIdSchema,
+});
+const transcriptContentSchema = transcriptMessageSchema.extend({
+  contentBlockId: contentBlockIdSchema,
+  contentIndex: z.number().int().nonnegative(),
+  kind: z.enum(["text", "thinking"]),
+});
+const subagentTranscriptEvent = (name: string, schema: z.ZodType) =>
+  definePublicEvent(name, schema, {
+    allowedSourceRoles: workbenchRoles,
+    scope: ["parentAgentId", "childAgentId", "runId"],
+  });
 
 export const agentEventDefinitions = [
   definePublicEvent(
@@ -76,6 +108,51 @@ export const agentEventDefinitions = [
       allowedSourceRoles: workbenchRoles,
       scope: ["parentAgentId", "childAgentId"],
     },
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.run.started",
+    transcriptIdentitySchema.extend({ startedAt: z.string().datetime() }),
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.turn.started",
+    transcriptTurnSchema.extend({ ordinal: z.number().int().nonnegative() }),
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.message.started",
+    transcriptMessageSchema.extend({
+      messageOrdinal: z.number().int().nonnegative(),
+      startedAt: z.string().datetime(),
+    }),
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.content.delta",
+    transcriptContentSchema.extend({
+      offset: z.number().int().nonnegative(),
+      delta: z.string().max(PUBLIC_EVENT_MAX_STRING_CHARS),
+    }),
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.content.done",
+    transcriptContentSchema.extend({
+      finalText: z.string().max(PUBLIC_EVENT_MAX_STRING_CHARS).optional(),
+      redacted: z.boolean().optional(),
+    }),
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.message.completed",
+    transcriptMessageSchema.extend({ status: z.enum(["completed", "failed"]) }),
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.turn.completed",
+    transcriptTurnSchema.extend({ status: z.enum(["completed", "failed"]) }),
+  ),
+  subagentTranscriptEvent(
+    "agent.subagent_transcript.run.completed",
+    transcriptIdentitySchema.extend({
+      status: z.enum(["completed", "failed", "aborted"]),
+      completedAt: z.string().datetime(),
+      message: z.string().max(PUBLIC_EVENT_MAX_STRING_CHARS).optional(),
+    }),
   ),
   definePublicEvent(
     "agent.subagent_completed",

--- a/packages/contracts/src/domains/agents/agent.operations.schema.ts
+++ b/packages/contracts/src/domains/agents/agent.operations.schema.ts
@@ -9,6 +9,7 @@ import {
   queuedPromptRecordSchema,
   updateAgentRequestSchema,
 } from "./agent.schema.js";
+import { subagentTranscriptSnapshotSchema } from "./subagent-transcript.schema.js";
 import { z } from "zod";
 import { defineOperation } from "../protocol/operation-definition.schema.js";
 
@@ -16,6 +17,10 @@ const emptyParamsSchema = z.object({}).optional();
 const agentIdSchema = z.string().startsWith("agent_");
 const queuedPromptIdSchema = z.string().startsWith("promptq_");
 const agentIdParamsSchema = z.object({ agentId: agentIdSchema });
+const subagentTranscriptParamsSchema = z.object({
+  parentAgentId: agentIdSchema,
+  childAgentId: agentIdSchema,
+});
 const agentConfigureParamsSchema = agentIdParamsSchema.merge(
   updateAgentRequestSchema,
 );
@@ -62,6 +67,15 @@ export const agentsOperationDefinitions = [
     "none",
     ["workbench_server"] as const,
     "operation.agent.get",
+  ),
+  defineOperation(
+    "agent.subagentTranscript.get",
+    subagentTranscriptParamsSchema,
+    z.object({ transcript: subagentTranscriptSnapshotSchema }),
+    "read",
+    "none",
+    ["workbench_server"] as const,
+    "operation.agent.subagentTranscript.get",
   ),
   defineOperation(
     "agent.configure",

--- a/packages/contracts/src/domains/agents/index.ts
+++ b/packages/contracts/src/domains/agents/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent.schema.js";
+export * from "./subagent-transcript.schema.js";
 export * from "./explore-policy.js";
 export * from "./agent.events.schema.js";
 export * from "./run.events.schema.js";

--- a/packages/contracts/src/domains/agents/subagent-transcript.schema.ts
+++ b/packages/contracts/src/domains/agents/subagent-transcript.schema.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import { thinkingLevelSchema } from "../models/index.js";
+import { conversationEntryUsageSchema } from "../conversations/tree.schema.js";
+import { toolCallTranscriptRecordSchema } from "../tools/records.schema.js";
+import { agentStatusSchema } from "./agent.schema.js";
+
+export const SUBAGENT_TRANSCRIPT_MAX_ENTRIES = 500;
+export const SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS = 500;
+export const SUBAGENT_TRANSCRIPT_MAX_TEXT_CHARS = 65_536;
+export const SUBAGENT_TRANSCRIPT_MAX_THINKING_BLOCKS = 32;
+
+const agentIdSchema = z.string().startsWith("agent_");
+
+const thinkingBlockSchema = z
+  .object({
+    text: z.string().max(SUBAGENT_TRANSCRIPT_MAX_TEXT_CHARS),
+    redacted: z.boolean().optional(),
+  })
+  .strict();
+
+const assistantDetailsSchema = z
+  .object({
+    thinkingBlocks: z
+      .array(thinkingBlockSchema)
+      .max(SUBAGENT_TRANSCRIPT_MAX_THINKING_BLOCKS)
+      .optional(),
+    stopReason: z.enum(["error", "aborted"]).optional(),
+    errorMessage: z.string().max(2_048).optional(),
+  })
+  .strict();
+
+const toolResultDetailsSchema = z
+  .object({
+    toolCallId: z.string().min(1).max(512).optional(),
+    toolRecordId: z.string().startsWith("tool_").optional(),
+    toolName: z.string().min(1).max(128).optional(),
+    status: z.enum(["completed", "error"]),
+    isError: z.boolean(),
+    outputOmitted: z.boolean().optional(),
+  })
+  .strict();
+
+export const subagentTranscriptEntrySchema = z
+  .object({
+    id: z.string().min(1).max(512),
+    conversationId: z.string().startsWith("conv_"),
+    agentId: agentIdSchema,
+    role: z.enum(["user", "assistant", "system"]),
+    kind: z.literal("message").default("message"),
+    text: z.string().max(SUBAGENT_TRANSCRIPT_MAX_TEXT_CHARS),
+    usage: conversationEntryUsageSchema.optional(),
+    details: z
+      .union([assistantDetailsSchema, toolResultDetailsSchema])
+      .optional(),
+    createdAt: z.string().datetime(),
+  })
+  .strict();
+export type SubagentTranscriptEntry = z.infer<
+  typeof subagentTranscriptEntrySchema
+>;
+
+export const subagentTranscriptSnapshotSchema = z
+  .object({
+    agentId: agentIdSchema,
+    parentAgentId: agentIdSchema,
+    status: agentStatusSchema,
+    model: z.string().max(256).optional(),
+    thinkingLevel: thinkingLevelSchema.optional(),
+    entries: z
+      .array(subagentTranscriptEntrySchema)
+      .max(SUBAGENT_TRANSCRIPT_MAX_ENTRIES),
+    toolCalls: z
+      .array(toolCallTranscriptRecordSchema)
+      .max(SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS),
+    totalEntryCount: z.number().int().nonnegative(),
+    totalToolCallCount: z.number().int().nonnegative(),
+    entriesTruncated: z.boolean(),
+    toolCallsTruncated: z.boolean(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+export type SubagentTranscriptSnapshot = z.infer<
+  typeof subagentTranscriptSnapshotSchema
+>;

--- a/packages/contracts/src/domains/agents/subagent-transcript.schema.ts
+++ b/packages/contracts/src/domains/agents/subagent-transcript.schema.ts
@@ -1,8 +1,15 @@
 import { z } from "zod";
-import { thinkingLevelSchema } from "../models/index.js";
+import { type ThinkingLevel, thinkingLevelSchema } from "../models/index.js";
+import {
+  type ConversationActiveRunSnapshot,
+  conversationActiveRunSnapshotSchema,
+} from "../conversations/conversation.schema.js";
 import { conversationEntryUsageSchema } from "../conversations/tree.schema.js";
-import { toolCallTranscriptRecordSchema } from "../tools/records.schema.js";
-import { agentStatusSchema } from "./agent.schema.js";
+import {
+  type ToolCallTranscriptRecord,
+  toolCallTranscriptRecordSchema,
+} from "../tools/records.schema.js";
+import { type AgentStatus, agentStatusSchema } from "./agent.schema.js";
 
 export const SUBAGENT_TRANSCRIPT_MAX_ENTRIES = 500;
 export const SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS = 500;
@@ -59,26 +66,47 @@ export type SubagentTranscriptEntry = z.infer<
   typeof subagentTranscriptEntrySchema
 >;
 
-export const subagentTranscriptSnapshotSchema = z
-  .object({
-    agentId: agentIdSchema,
-    parentAgentId: agentIdSchema,
-    status: agentStatusSchema,
-    model: z.string().max(256).optional(),
-    thinkingLevel: thinkingLevelSchema.optional(),
-    entries: z
-      .array(subagentTranscriptEntrySchema)
-      .max(SUBAGENT_TRANSCRIPT_MAX_ENTRIES),
-    toolCalls: z
-      .array(toolCallTranscriptRecordSchema)
-      .max(SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS),
-    totalEntryCount: z.number().int().nonnegative(),
-    totalToolCallCount: z.number().int().nonnegative(),
-    entriesTruncated: z.boolean(),
-    toolCallsTruncated: z.boolean(),
-    updatedAt: z.string().datetime(),
-  })
-  .strict();
-export type SubagentTranscriptSnapshot = z.infer<
-  typeof subagentTranscriptSnapshotSchema
->;
+export interface SubagentTranscriptSnapshot {
+  agentId: string;
+  parentAgentId: string;
+  conversationId: string;
+  projectId: string;
+  cursorSeq: number;
+  activeRun?: ConversationActiveRunSnapshot;
+  status: AgentStatus;
+  model?: string;
+  thinkingLevel?: ThinkingLevel;
+  entries: SubagentTranscriptEntry[];
+  toolCalls: ToolCallTranscriptRecord[];
+  totalEntryCount: number;
+  totalToolCallCount: number;
+  entriesTruncated: boolean;
+  toolCallsTruncated: boolean;
+  updatedAt: string;
+}
+
+export const subagentTranscriptSnapshotSchema: z.ZodType<SubagentTranscriptSnapshot> =
+  z
+    .object({
+      agentId: agentIdSchema,
+      parentAgentId: agentIdSchema,
+      conversationId: z.string().startsWith("conv_"),
+      projectId: z.string().startsWith("proj_"),
+      cursorSeq: z.number().int().nonnegative(),
+      activeRun: conversationActiveRunSnapshotSchema.optional(),
+      status: agentStatusSchema,
+      model: z.string().max(256).optional(),
+      thinkingLevel: thinkingLevelSchema.optional(),
+      entries: z
+        .array(subagentTranscriptEntrySchema)
+        .max(SUBAGENT_TRANSCRIPT_MAX_ENTRIES),
+      toolCalls: z
+        .array(toolCallTranscriptRecordSchema)
+        .max(SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS),
+      totalEntryCount: z.number().int().nonnegative(),
+      totalToolCallCount: z.number().int().nonnegative(),
+      entriesTruncated: z.boolean(),
+      toolCallsTruncated: z.boolean(),
+      updatedAt: z.string().datetime(),
+    })
+    .strict();

--- a/packages/contracts/test/subagent-transcript.test.ts
+++ b/packages/contracts/test/subagent-transcript.test.ts
@@ -4,6 +4,7 @@ import {
   SUBAGENT_TRANSCRIPT_MAX_ENTRIES,
   subagentTranscriptEntrySchema,
   subagentTranscriptSnapshotSchema,
+  validatePublicEvent,
 } from "../src/index.js";
 
 const entry = {
@@ -25,6 +26,9 @@ describe("subagent transcript contracts", () => {
     const snapshot = subagentTranscriptSnapshotSchema.parse({
       agentId: "agent_child_1",
       parentAgentId: "agent_parent_1",
+      conversationId: "conv_child_1",
+      projectId: "proj_child_1",
+      cursorSeq: 4,
       status: "idle",
       entries: [entry],
       toolCalls: [],
@@ -49,6 +53,9 @@ describe("subagent transcript contracts", () => {
       subagentTranscriptSnapshotSchema.safeParse({
         agentId: "agent_child_1",
         parentAgentId: "agent_parent_1",
+        conversationId: "conv_child_1",
+        projectId: "proj_child_1",
+        cursorSeq: 4,
         status: "idle",
         entries: Array.from(
           { length: SUBAGENT_TRANSCRIPT_MAX_ENTRIES + 1 },
@@ -62,6 +69,47 @@ describe("subagent transcript contracts", () => {
         updatedAt: "2026-08-02T00:00:00.000Z",
       }).success,
       false,
+    );
+  });
+
+  it("accepts bounded child live events and rejects raw or malformed content", () => {
+    const identity = {
+      conversationId: "conv_child_1",
+      projectId: "proj_child_1",
+      parentAgentId: "agent_parent_1",
+      childAgentId: "agent_child_1",
+      runId: "run_child_1",
+      turnId: "turn_child_1",
+      liveMessageId: "msg_child_1",
+      contentBlockId: "block_child_1",
+      contentIndex: 0,
+      kind: "text",
+      offset: 0,
+      delta: "Hello",
+    };
+    assert.equal(
+      (
+        validatePublicEvent(
+          "agent.subagent_transcript.content.delta",
+          identity,
+          "workbench_server",
+        ) as typeof identity
+      ).delta,
+      "Hello",
+    );
+    assert.throws(() =>
+      validatePublicEvent(
+        "agent.subagent_transcript.content.delta",
+        { ...identity, offset: -1 },
+        "workbench_server",
+      ),
+    );
+    assert.throws(() =>
+      validatePublicEvent(
+        "agent.subagent_transcript.content.delta",
+        { ...identity, args: { secret: true } },
+        "workbench_server",
+      ),
     );
   });
 });

--- a/packages/contracts/test/subagent-transcript.test.ts
+++ b/packages/contracts/test/subagent-transcript.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  SUBAGENT_TRANSCRIPT_MAX_ENTRIES,
+  subagentTranscriptEntrySchema,
+  subagentTranscriptSnapshotSchema,
+} from "../src/index.js";
+
+const entry = {
+  id: "entry_child_1",
+  conversationId: "conv_child_1",
+  agentId: "agent_child_1",
+  role: "assistant" as const,
+  kind: "message" as const,
+  text: "Done.",
+  details: {
+    thinkingBlocks: [{ text: "Checked the source.", redacted: false }],
+  },
+  createdAt: "2026-08-02T00:00:00.000Z",
+};
+
+describe("subagent transcript contracts", () => {
+  it("accepts bounded transport-neutral transcript entries", () => {
+    assert.equal(subagentTranscriptEntrySchema.parse(entry).text, "Done.");
+    const snapshot = subagentTranscriptSnapshotSchema.parse({
+      agentId: "agent_child_1",
+      parentAgentId: "agent_parent_1",
+      status: "idle",
+      entries: [entry],
+      toolCalls: [],
+      totalEntryCount: 1,
+      totalToolCallCount: 0,
+      entriesTruncated: false,
+      toolCallsTruncated: false,
+      updatedAt: "2026-08-02T00:00:00.000Z",
+    });
+    assert.equal(snapshot.entries.length, 1);
+  });
+
+  it("rejects arbitrary details and oversized entry collections", () => {
+    assert.equal(
+      subagentTranscriptEntrySchema.safeParse({
+        ...entry,
+        details: { providerPayload: { secret: "nope" } },
+      }).success,
+      false,
+    );
+    assert.equal(
+      subagentTranscriptSnapshotSchema.safeParse({
+        agentId: "agent_child_1",
+        parentAgentId: "agent_parent_1",
+        status: "idle",
+        entries: Array.from(
+          { length: SUBAGENT_TRANSCRIPT_MAX_ENTRIES + 1 },
+          (_, index) => ({ ...entry, id: `entry_child_${index}` }),
+        ),
+        toolCalls: [],
+        totalEntryCount: SUBAGENT_TRANSCRIPT_MAX_ENTRIES + 1,
+        totalToolCallCount: 0,
+        entriesTruncated: false,
+        toolCallsTruncated: false,
+        updatedAt: "2026-08-02T00:00:00.000Z",
+      }).success,
+      false,
+    );
+  });
+});

--- a/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
+++ b/packages/ui-kit/src/lib/components/ui/dialog-shell/dialog-shell.svelte
@@ -13,7 +13,7 @@ type Props = {
   description?: string;
   class?: string;
   closeLabel?: string;
-  size?: "sm" | "md" | "default" | "wide" | "viewport";
+  size?: "sm" | "md" | "default" | "wide" | "wide-viewport" | "viewport";
   /** Removes the default body padding for edge-to-edge list/graph content. */
   flush?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -48,6 +48,7 @@ function handleOpenChange(next: boolean) {
       size === "sm" && "dialog-content-sm",
       size === "md" && "dialog-content-md",
       size === "wide" && "dialog-content-wide",
+      size === "wide-viewport" && "dialog-content-wide-viewport",
       size === "viewport" && "dialog-content-viewport",
       className,
     )}

--- a/packages/ui-kit/src/styles/components/dialog.css
+++ b/packages/ui-kit/src/styles/components/dialog.css
@@ -57,6 +57,15 @@
   max-height: min(90dvh, calc(100dvh - 2rem));
 }
 
+.dialog-content-wide-viewport {
+  width: min(960px, calc(100vw - 2rem));
+  width: min(960px, calc(100dvw - 2rem));
+  height: min(760px, calc(100vh - 2rem));
+  height: min(760px, calc(100dvh - 2rem));
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
+}
+
 .dialog-content-viewport {
   width: min(1440px, calc(100vw - 3rem));
   width: min(1440px, calc(100dvw - 3rem));

--- a/packages/workbench-app/src/lib/api.ts
+++ b/packages/workbench-app/src/lib/api.ts
@@ -116,6 +116,7 @@ export type ToolCallDisplayRecord =
   | ToolCallTranscriptRecordType;
 export * from "@nervekit/ui-kit/core/api/client";
 export * from "./features/agents/api/agents.api";
+export * from "./features/agents/api/subagent-transcripts.api";
 export * from "./features/audio/api/transcription.api";
 export * from "./features/auth/api/auth.api";
 export * from "./features/auth/api/provider-catalog.api";

--- a/packages/workbench-app/src/lib/features/agents/api/subagent-transcripts.api.ts
+++ b/packages/workbench-app/src/lib/features/agents/api/subagent-transcripts.api.ts
@@ -1,0 +1,14 @@
+import type { SubagentTranscriptSnapshot } from "@nervekit/contracts";
+import { protocolRequest } from "@nervekit/protocol";
+
+export async function getSubagentTranscript(
+  parentAgentId: string,
+  childAgentId: string,
+): Promise<SubagentTranscriptSnapshot> {
+  return (
+    await protocolRequest("agent.subagentTranscript.get", {
+      parentAgentId,
+      childAgentId,
+    })
+  ).result.transcript;
+}

--- a/packages/workbench-app/src/lib/features/agents/subagent-transcript-watcher.test.ts
+++ b/packages/workbench-app/src/lib/features/agents/subagent-transcript-watcher.test.ts
@@ -1,0 +1,139 @@
+import type {
+  EventEnvelope,
+  SubagentTranscriptSnapshot,
+} from "@nervekit/contracts";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { WorkbenchEventHandler } from "$lib/core/events/event-bus";
+import { createSubagentTranscriptWatcher } from "./subagent-transcript-watcher.js";
+
+const ts = "2026-08-02T00:00:00.000Z";
+
+function snapshot(
+  cursorSeq: number,
+  status: "running" | "idle" = "running",
+): SubagentTranscriptSnapshot {
+  return {
+    agentId: "agent_child",
+    parentAgentId: "agent_parent",
+    conversationId: "conv_test",
+    projectId: "proj_test",
+    cursorSeq,
+    status,
+    entries: [],
+    toolCalls: [],
+    totalEntryCount: 0,
+    totalToolCallCount: 0,
+    entriesTruncated: false,
+    toolCallsTruncated: false,
+    updatedAt: ts,
+  };
+}
+
+function event(
+  seq: number,
+  type = "agent.subagent_transcript.turn.started",
+  childAgentId = "agent_child",
+): EventEnvelope<Record<string, unknown>> {
+  return {
+    seq,
+    id: `evt_${seq}`,
+    ts,
+    type,
+    data: {
+      conversationId: "conv_test",
+      projectId: "proj_test",
+      parentAgentId: "agent_parent",
+      childAgentId,
+      runId: "run_child",
+      turnId: "turn_child",
+      ordinal: 0,
+    },
+  };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("subagent transcript watcher", () => {
+  it("subscribes before fetch, replays newer matching events, final-reconciles, and disposes", async () => {
+    const order: string[] = [];
+    const snapshots = [snapshot(4), snapshot(9, "idle")];
+    let handler: WorkbenchEventHandler | undefined;
+    let fetchCount = 0;
+    let disposed = false;
+    const watch = createSubagentTranscriptWatcher({
+      subscribe: (next) => {
+        order.push("subscribe");
+        handler = next;
+        return () => {
+          disposed = true;
+        };
+      },
+      fetch: async () => {
+        order.push("fetch");
+        return snapshots[fetchCount++]!;
+      },
+    });
+    const received: number[] = [];
+    const reconciled: number[] = [];
+    const stop = watch("agent_parent", "agent_child", {
+      snapshot: (next) => reconciled.push(next.cursorSeq),
+      event: (next) => {
+        received.push(next.seq);
+      },
+      error: assert.fail,
+    });
+    assert.deepEqual(order, ["subscribe", "fetch"]);
+    await handler?.(event(3));
+    await handler?.(event(6, undefined, "agent_sibling"));
+    await handler?.(event(5));
+    await tick();
+    assert.deepEqual(reconciled, [4]);
+    assert.deepEqual(received, [5]);
+
+    await handler?.(event(9, "agent.subagent_transcript.run.completed"));
+    await tick();
+    assert.equal(fetchCount, 2);
+    assert.deepEqual(reconciled, [4, 9]);
+    stop();
+    assert.equal(disposed, true);
+    await handler?.(event(10));
+    assert.deepEqual(received, [5, 9]);
+  });
+
+  it("coalesces offset-gap recovery without removing the current observer state", async () => {
+    let handler: WorkbenchEventHandler | undefined;
+    let resolveRecovery:
+      | ((value: SubagentTranscriptSnapshot) => void)
+      | undefined;
+    let fetchCount = 0;
+    const watch = createSubagentTranscriptWatcher({
+      subscribe: (next) => {
+        handler = next;
+        return () => undefined;
+      },
+      fetch: () => {
+        fetchCount += 1;
+        if (fetchCount === 1) return Promise.resolve(snapshot(1));
+        return new Promise((resolve) => {
+          resolveRecovery = resolve;
+        });
+      },
+    });
+    const reconciled: number[] = [];
+    const stop = watch("agent_parent", "agent_child", {
+      snapshot: (next) => reconciled.push(next.cursorSeq),
+      event: () => false,
+      error: assert.fail,
+    });
+    await tick();
+    await handler?.(event(2));
+    await handler?.(event(3));
+    assert.equal(fetchCount, 2);
+    assert.deepEqual(reconciled, [1]);
+    resolveRecovery?.(snapshot(3));
+    await tick();
+    assert.deepEqual(reconciled, [1, 3]);
+    stop();
+  });
+});

--- a/packages/workbench-app/src/lib/features/agents/subagent-transcript-watcher.ts
+++ b/packages/workbench-app/src/lib/features/agents/subagent-transcript-watcher.ts
@@ -1,0 +1,158 @@
+import type { EventEnvelope } from "@nervekit/contracts";
+import { isSequencedEvent, onAnyEvent } from "$lib/core/events/event-bus";
+import type { SubagentTranscriptObserver } from "$lib/presentation/context.svelte";
+import { getSubagentTranscript } from "./api/subagent-transcripts.api";
+import type { WorkbenchEventHandler } from "$lib/core/events/event-bus";
+import type { SubagentTranscriptSnapshot } from "@nervekit/contracts";
+
+const TRANSCRIPT_PREFIX = "agent.subagent_transcript.";
+const TERMINAL_EVENT = "agent.subagent_transcript.run.completed";
+
+type BufferedEvent = EventEnvelope<Record<string, unknown>>;
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function matches(
+  event: BufferedEvent,
+  parentAgentId: string,
+  childAgentId: string,
+  expected?: { conversationId: string; projectId: string },
+): boolean {
+  const data = record(event.data);
+  if (!data) return false;
+  if (
+    expected &&
+    (data.conversationId !== expected.conversationId ||
+      data.projectId !== expected.projectId)
+  )
+    return false;
+  if (event.type.startsWith(TRANSCRIPT_PREFIX)) {
+    return (
+      data.parentAgentId === parentAgentId && data.childAgentId === childAgentId
+    );
+  }
+  return event.type === "toolCall.updated" && data.agentId === childAgentId;
+}
+
+type WatcherDependencies = {
+  fetch: (
+    parentAgentId: string,
+    childAgentId: string,
+  ) => Promise<SubagentTranscriptSnapshot>;
+  subscribe: (handler: WorkbenchEventHandler) => () => void;
+};
+
+export function createSubagentTranscriptWatcher(deps: WatcherDependencies) {
+  return function watchSubagentTranscriptSession(
+    parentAgentId: string,
+    childAgentId: string,
+    observer: SubagentTranscriptObserver,
+  ): () => void {
+    let disposed = false;
+    let hydrated = false;
+    let expectedIdentity:
+      | { conversationId: string; projectId: string }
+      | undefined;
+    let latestRelevantSeq = -1;
+    let buffer: BufferedEvent[] = [];
+    let refresh: Promise<void> | undefined;
+    let recoveryPending = false;
+    let terminalPending = false;
+    let terminalReconciled = false;
+
+    const deliver = (event: BufferedEvent) => {
+      if (event.seq <= latestRelevantSeq) return;
+      latestRelevantSeq = event.seq;
+      if (observer.event(event) === false) requestReconcile();
+      if (event.type === TERMINAL_EVENT && !terminalReconciled) {
+        terminalPending = true;
+        requestReconcile();
+      }
+    };
+
+    const requestReconcile = () => {
+      if (disposed) return;
+      if (refresh) {
+        recoveryPending = true;
+        return;
+      }
+      const finalizing = terminalPending;
+      refresh = deps
+        .fetch(parentAgentId, childAgentId)
+        .then((snapshot) => {
+          if (disposed) return;
+          if (
+            snapshot.parentAgentId !== parentAgentId ||
+            snapshot.agentId !== childAgentId
+          )
+            throw new Error("Subagent transcript ownership mismatch.");
+          expectedIdentity = {
+            conversationId: snapshot.conversationId,
+            projectId: snapshot.projectId,
+          };
+          observer.snapshot(snapshot);
+          const observedSeq = latestRelevantSeq;
+          latestRelevantSeq = Math.max(latestRelevantSeq, snapshot.cursorSeq);
+          if (snapshot.cursorSeq >= observedSeq) recoveryPending = false;
+          if (!hydrated) {
+            hydrated = true;
+            const replay = buffer
+              .filter(
+                (event) =>
+                  event.seq > snapshot.cursorSeq &&
+                  matches(event, parentAgentId, childAgentId, expectedIdentity),
+              )
+              .sort((a, b) => a.seq - b.seq);
+            buffer = [];
+            for (const event of replay) deliver(event);
+          }
+          if (finalizing) {
+            terminalPending = false;
+            terminalReconciled = true;
+          }
+        })
+        .catch((error: unknown) => {
+          if (!disposed) {
+            observer.error(
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        })
+        .finally(() => {
+          refresh = undefined;
+          if (recoveryPending && !disposed) {
+            recoveryPending = false;
+            requestReconcile();
+          }
+        });
+    };
+
+    const unsubscribe = deps.subscribe((candidate) => {
+      if (disposed || !isSequencedEvent(candidate)) return;
+      const event = candidate as BufferedEvent;
+      if (!matches(event, parentAgentId, childAgentId, expectedIdentity))
+        return;
+      if (!hydrated) {
+        buffer.push(event);
+        return;
+      }
+      deliver(event);
+    });
+
+    requestReconcile();
+    return () => {
+      disposed = true;
+      buffer = [];
+      unsubscribe();
+    };
+  };
+}
+
+export const watchSubagentTranscript = createSubagentTranscriptWatcher({
+  fetch: getSubagentTranscript,
+  subscribe: onAnyEvent,
+});

--- a/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
@@ -13,7 +13,7 @@ import {
   AudioInputAuthRequiredDialog,
   chatGptAudioAuth,
 } from "$lib/features/audio";
-import { getSubagentTranscript } from "$lib/features/agents/api/subagent-transcripts.api";
+import { watchSubagentTranscript } from "$lib/features/agents/subagent-transcript-watcher";
 import { getToolCall } from "$lib/features/tools/api/tools.api";
 import {
   confluenceSiteUrl,
@@ -28,8 +28,7 @@ import {
 export function workbenchConversationUiCapabilities(): ConversationUiCapabilities {
   return {
     fetchToolCall: (toolCallId) => getToolCall(toolCallId),
-    fetchSubagentTranscript: (parentAgentId, childAgentId) =>
-      getSubagentTranscript(parentAgentId, childAgentId),
+    watchSubagentTranscript,
     atlassian: { jiraSiteUrl, confluenceSiteUrl },
     voice: {
       session: voiceInputSession,

--- a/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
@@ -13,6 +13,7 @@ import {
   AudioInputAuthRequiredDialog,
   chatGptAudioAuth,
 } from "$lib/features/audio";
+import { getSubagentTranscript } from "$lib/features/agents/api/subagent-transcripts.api";
 import { getToolCall } from "$lib/features/tools/api/tools.api";
 import {
   confluenceSiteUrl,
@@ -27,6 +28,8 @@ import {
 export function workbenchConversationUiCapabilities(): ConversationUiCapabilities {
   return {
     fetchToolCall: (toolCallId) => getToolCall(toolCallId),
+    fetchSubagentTranscript: (parentAgentId, childAgentId) =>
+      getSubagentTranscript(parentAgentId, childAgentId),
     atlassian: { jiraSiteUrl, confluenceSiteUrl },
     voice: {
       session: voiceInputSession,

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-event-policy.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-event-policy.ts
@@ -41,7 +41,8 @@ export function shouldRefreshWorkspace(type: string): boolean {
     type === "conversation.navigated" ||
     type === "project.deleted" ||
     type === "agent.created" ||
-    type.startsWith("agent.subagent_") ||
+    type === "agent.subagent_started" ||
+    type === "agent.subagent_completed" ||
     type.startsWith("agent.explore_") ||
     type === "project.created" ||
     type === "plan.written" ||

--- a/packages/workbench-app/src/lib/presentation/context.svelte.ts
+++ b/packages/workbench-app/src/lib/presentation/context.svelte.ts
@@ -1,4 +1,7 @@
-import type { ToolCallRecord } from "@nervekit/contracts";
+import type {
+  SubagentTranscriptSnapshot,
+  ToolCallRecord,
+} from "@nervekit/contracts";
 import type { Component } from "svelte";
 import { getContext, setContext } from "svelte";
 
@@ -60,6 +63,11 @@ export interface AtlassianLinkCapability {
 export interface ConversationUiCapabilities {
   /** Fetch a full tool-call record for the details dialog. */
   fetchToolCall?: (toolCallId: string) => Promise<ToolCallRecord>;
+  /** Fetch a bounded, read-only child-agent transcript on explicit demand. */
+  fetchSubagentTranscript?: (
+    parentAgentId: string,
+    childAgentId: string,
+  ) => Promise<SubagentTranscriptSnapshot>;
   /** Voice input integration for the ask-user card. */
   voice?: VoiceInputCapability;
   /** Site URLs used to build external Jira/Confluence links. */

--- a/packages/workbench-app/src/lib/presentation/context.svelte.ts
+++ b/packages/workbench-app/src/lib/presentation/context.svelte.ts
@@ -1,4 +1,5 @@
 import type {
+  EventEnvelope,
   SubagentTranscriptSnapshot,
   ToolCallRecord,
 } from "@nervekit/contracts";
@@ -60,14 +61,22 @@ export interface AtlassianLinkCapability {
   confluenceSiteUrl: () => string | undefined;
 }
 
+export interface SubagentTranscriptObserver {
+  snapshot: (snapshot: SubagentTranscriptSnapshot) => void;
+  /** Return false when canonical offset validation requests reconciliation. */
+  event: (event: EventEnvelope<Record<string, unknown>>) => boolean | void;
+  error: (message: string) => void;
+}
+
 export interface ConversationUiCapabilities {
   /** Fetch a full tool-call record for the details dialog. */
   fetchToolCall?: (toolCallId: string) => Promise<ToolCallRecord>;
-  /** Fetch a bounded, read-only child-agent transcript on explicit demand. */
-  fetchSubagentTranscript?: (
+  /** Observe one bounded, read-only child transcript while its dialog is open. */
+  watchSubagentTranscript?: (
     parentAgentId: string,
     childAgentId: string,
-  ) => Promise<SubagentTranscriptSnapshot>;
+    observer: SubagentTranscriptObserver,
+  ) => () => void;
   /** Voice input integration for the ask-user card. */
   voice?: VoiceInputCapability;
   /** Site URLs used to build external Jira/Confluence links. */

--- a/packages/workbench-app/src/lib/presentation/state/adapters.ts
+++ b/packages/workbench-app/src/lib/presentation/state/adapters.ts
@@ -60,6 +60,8 @@ export type ApplyConversationEventOptions = {
   }) => void;
   /** Advance the stream cursor for catalog events with no render projection. */
   consumeUnhandled?: boolean;
+  /** Retain hidden bounded tool previews for isolated child transcripts. */
+  retainHiddenToolCalls?: boolean;
 };
 
 export function fromConversationSnapshot(
@@ -146,7 +148,11 @@ export function applyConversationEvent(
       applyPromptRemoved(next, event.data as ConversationPromptCancelledData);
       break;
     case "toolCall.updated":
-      applyToolCallUpdated(next, event.data as ConversationToolCallUpdatedData);
+      applyToolCallUpdated(
+        next,
+        event.data as ConversationToolCallUpdatedData,
+        options.retainHiddenToolCalls,
+      );
       break;
     case "run.resumed":
       applyRunResumed(next, event.data as ConversationRunResumedData);
@@ -456,6 +462,7 @@ function removePrompt(
 function applyToolCallUpdated(
   state: ConversationRenderState,
   data: ConversationToolCallUpdatedData,
+  retainHidden = false,
 ): void {
   const toolCall = data.toolCall;
   const existing = state.toolCalls.find(
@@ -469,7 +476,7 @@ function applyToolCallUpdated(
       `conversation reducer tool call ${toolCall.id}`,
     );
   }
-  if (toolCall.hidden) {
+  if (toolCall.hidden && !retainHidden) {
     state.toolCalls = state.toolCalls.filter(
       (candidate) => candidate.id !== toolCall.id,
     );

--- a/packages/workbench-app/src/lib/presentation/state/index.ts
+++ b/packages/workbench-app/src/lib/presentation/state/index.ts
@@ -2,6 +2,7 @@ export * from "./active-run.js";
 export * from "./adapters.js";
 export * from "./conversation-view.js";
 export * from "./render.js";
+export * from "./subagent-transcript-session.js";
 export * from "./thinking-levels.js";
 export * from "./timeline.js";
 export * from "./timeline-output.js";

--- a/packages/workbench-app/src/lib/presentation/state/render.ts
+++ b/packages/workbench-app/src/lib/presentation/state/render.ts
@@ -37,7 +37,9 @@ export function buildConversationRenderProjection(
   const transcript = entriesToTranscript(state.entries);
   const toolCalls = state.toolCalls ?? [];
   const committed = buildCommittedTimeline(transcript, toolCalls, {
-    includeUnanchoredTerminalToolCalls: !state.activeRun,
+    includeHiddenToolCalls: state.retainHiddenToolCalls,
+    includeUnanchoredTerminalToolCalls:
+      state.retainHiddenToolCalls || !state.activeRun,
   });
   const liveItems = buildActiveRunTimeline(
     state.activeRun,

--- a/packages/workbench-app/src/lib/presentation/state/subagent-transcript-session.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/subagent-transcript-session.test.ts
@@ -1,0 +1,191 @@
+import type {
+  EventEnvelope,
+  SubagentTranscriptSnapshot,
+  ToolCallTranscriptRecord,
+} from "@nervekit/contracts";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  applyConversationEvent,
+  applySubagentTranscriptEvent,
+  buildConversationRenderProjection,
+  emptyConversationRenderState,
+  fromSubagentTranscriptSnapshot,
+} from "./index.js";
+
+const ts = "2026-08-02T00:00:00.000Z";
+const identity = {
+  conversationId: "conv_test",
+  projectId: "proj_test",
+  parentAgentId: "agent_parent",
+  childAgentId: "agent_child",
+  runId: "run_child",
+};
+
+function event(
+  seq: number,
+  type: string,
+  data: Record<string, unknown>,
+): EventEnvelope<Record<string, unknown>> {
+  return { seq, type, data, id: `evt_${seq}`, ts };
+}
+
+function snapshot(): SubagentTranscriptSnapshot {
+  return {
+    agentId: "agent_child",
+    parentAgentId: "agent_parent",
+    conversationId: "conv_test",
+    projectId: "proj_test",
+    cursorSeq: 20,
+    status: "running",
+    entries: [],
+    toolCalls: [],
+    totalEntryCount: 0,
+    totalToolCallCount: 0,
+    entriesTruncated: false,
+    toolCallsTruncated: false,
+    updatedAt: ts,
+  };
+}
+
+function hiddenTool(): ToolCallTranscriptRecord {
+  return {
+    id: "tool_child",
+    sourceToolCallId: "call_child",
+    providerToolCallId: "call_child",
+    conversationId: "conv_test",
+    agentId: "agent_child",
+    projectId: "proj_test",
+    runId: "run_child",
+    toolName: "read",
+    risk: "read",
+    cwd: "/workspace",
+    status: "running",
+    hidden: true,
+    createdAt: ts,
+    updatedAt: ts,
+  };
+}
+
+describe("subagent transcript session", () => {
+  it("projects child text incrementally across unrelated stream sequences", () => {
+    let state = fromSubagentTranscriptSnapshot(snapshot());
+    state = applySubagentTranscriptEvent(
+      state,
+      event(24, "agent.subagent_transcript.run.started", {
+        ...identity,
+        startedAt: ts,
+      }),
+    );
+    state = applySubagentTranscriptEvent(
+      state,
+      event(31, "agent.subagent_transcript.turn.started", {
+        ...identity,
+        turnId: "turn_child",
+        ordinal: 0,
+      }),
+    );
+    state = applySubagentTranscriptEvent(
+      state,
+      event(33, "agent.subagent_transcript.message.started", {
+        ...identity,
+        turnId: "turn_child",
+        liveMessageId: "msg_child",
+        messageOrdinal: 0,
+        startedAt: ts,
+      }),
+    );
+    state = applySubagentTranscriptEvent(
+      state,
+      event(40, "agent.subagent_transcript.content.delta", {
+        ...identity,
+        turnId: "turn_child",
+        liveMessageId: "msg_child",
+        contentBlockId: "block_child",
+        contentIndex: 0,
+        kind: "text",
+        offset: 0,
+        delta: "Streaming now",
+      }),
+    );
+    const projection = buildConversationRenderProjection(state);
+    assert.equal(projection.streamingText, "Streaming now");
+    assert.equal(projection.hasActiveTurnOutput, true);
+  });
+
+  it("retains hidden child tools only with the explicit reducer option", () => {
+    const update = event(1, "toolCall.updated", {
+      conversationId: "conv_test",
+      agentId: "agent_child",
+      projectId: "proj_test",
+      runId: "run_child",
+      toolCall: hiddenTool(),
+    });
+    const parent = applyConversationEvent(
+      emptyConversationRenderState("conv_test"),
+      update,
+    );
+    assert.equal(parent.toolCalls.length, 0);
+
+    const runningChild = applySubagentTranscriptEvent(
+      fromSubagentTranscriptSnapshot(snapshot()),
+      event(1, "agent.subagent_transcript.run.started", {
+        ...identity,
+        startedAt: ts,
+      }),
+    );
+    const child = applySubagentTranscriptEvent(runningChild, {
+      ...update,
+      seq: 2,
+      id: "evt_2",
+    });
+    assert.equal(child.toolCalls.length, 1);
+    assert.equal(buildConversationRenderProjection(child).timeline.length, 1);
+  });
+
+  it("reports canonical content-offset gaps without clearing current state", () => {
+    let state = fromSubagentTranscriptSnapshot(snapshot());
+    for (const [seq, type, data] of [
+      [
+        1,
+        "agent.subagent_transcript.run.started",
+        { ...identity, startedAt: ts },
+      ],
+      [
+        2,
+        "agent.subagent_transcript.turn.started",
+        { ...identity, turnId: "turn_child", ordinal: 0 },
+      ],
+      [
+        3,
+        "agent.subagent_transcript.message.started",
+        {
+          ...identity,
+          turnId: "turn_child",
+          liveMessageId: "msg_child",
+          messageOrdinal: 0,
+          startedAt: ts,
+        },
+      ],
+    ] as const) {
+      state = applySubagentTranscriptEvent(state, event(seq, type, data));
+    }
+    let gap = false;
+    const next = applySubagentTranscriptEvent(
+      state,
+      event(4, "agent.subagent_transcript.content.delta", {
+        ...identity,
+        turnId: "turn_child",
+        liveMessageId: "msg_child",
+        contentBlockId: "block_child",
+        contentIndex: 0,
+        kind: "text",
+        offset: 5,
+        delta: "bad",
+      }),
+      () => (gap = true),
+    );
+    assert.equal(gap, true);
+    assert.equal(buildConversationRenderProjection(next).streamingText, "");
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/state/subagent-transcript-session.ts
+++ b/packages/workbench-app/src/lib/presentation/state/subagent-transcript-session.ts
@@ -1,0 +1,88 @@
+import type {
+  ConversationEntry,
+  EventEnvelope,
+  SubagentTranscriptSnapshot,
+} from "@nervekit/contracts";
+import { applyConversationEvent } from "./adapters.js";
+import type { ConversationRenderState } from "./types.js";
+
+const PREFIX = "agent.subagent_transcript.";
+
+export function fromSubagentTranscriptSnapshot(
+  snapshot: SubagentTranscriptSnapshot,
+): ConversationRenderState {
+  const entries = snapshot.entries as ConversationEntry[];
+  return {
+    conversationId: snapshot.conversationId,
+    entries,
+    activeEntryIds: entries.map((entry) => entry.id),
+    toolCalls: snapshot.toolCalls,
+    activeRun: snapshot.activeRun,
+    queuedPrompts: [],
+    cursorSeq: snapshot.cursorSeq,
+    sending: Boolean(snapshot.activeRun) || snapshot.status === "running",
+    generatedAt: snapshot.updatedAt,
+    readOnly: true,
+    retainHiddenToolCalls: true,
+  };
+}
+
+export function applySubagentTranscriptEvent(
+  state: ConversationRenderState,
+  event: EventEnvelope<Record<string, unknown>>,
+  onGap?: () => void,
+): ConversationRenderState {
+  const mapped = mapEvent(state, event);
+  return applyConversationEvent(state, mapped, {
+    consumeUnhandled: true,
+    retainHiddenToolCalls: true,
+    onGap,
+  });
+}
+
+function mapEvent(
+  state: ConversationRenderState,
+  event: EventEnvelope<Record<string, unknown>>,
+): EventEnvelope<Record<string, unknown>> {
+  // The child family shares the parent's dense conversation stream. Normalize
+  // matching child events to the session cursor so unrelated parent/sibling
+  // sequence numbers cannot create false render gaps; content offsets remain
+  // checked by the canonical reducer.
+  const base = { ...event, seq: state.cursorSeq + 1 };
+  if (!event.type.startsWith(PREFIX)) return base;
+  const data = event.data;
+  const canonical = {
+    ...data,
+    agentId: data.childAgentId,
+  };
+  switch (event.type) {
+    case "agent.subagent_transcript.run.started":
+      return { ...base, type: "run.started", data: canonical };
+    case "agent.subagent_transcript.turn.started":
+      return {
+        ...base,
+        type: "conversation.live.turn.started",
+        data: canonical,
+      };
+    case "agent.subagent_transcript.message.started":
+      return {
+        ...base,
+        type: "conversation.live.message.started",
+        data: canonical,
+      };
+    case "agent.subagent_transcript.content.delta":
+      return {
+        ...base,
+        type: "conversation.live.content.delta",
+        data: canonical,
+      };
+    case "agent.subagent_transcript.content.done":
+      return {
+        ...base,
+        type: "conversation.live.content.done",
+        data: canonical,
+      };
+    default:
+      return base;
+  }
+}

--- a/packages/workbench-app/src/lib/presentation/state/timeline.committed.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline.committed.test.ts
@@ -1,10 +1,28 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { buildConversationTimeline } from "./timeline";
+import { buildCommittedTimeline, buildConversationTimeline } from "./timeline";
 import { keys, toolCall } from "./timeline.fixtures";
 import type { TranscriptItem } from "./transcript-types";
 
 describe("buildConversationTimeline committed transcript", () => {
+  it("includes hidden tool previews only for an explicit child transcript", () => {
+    const hidden = toolCall(
+      "tool_hidden",
+      "2026-01-01T00:00:01.000Z",
+      "read",
+      undefined,
+      { hidden: true },
+    );
+
+    assert.equal(buildCommittedTimeline([], [hidden]).items.length, 0);
+    const child = buildCommittedTimeline([], [hidden], {
+      includeHiddenToolCalls: true,
+      includeUnanchoredTerminalToolCalls: true,
+    });
+    assert.equal(child.items.length, 1);
+    assert.equal(child.items[0]?.kind, "tool");
+  });
+
   it("anchors historical tool cards at matching tool-result entries", () => {
     const transcript: TranscriptItem[] = [
       {

--- a/packages/workbench-app/src/lib/presentation/state/timeline.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline.ts
@@ -88,6 +88,7 @@ export type CommittedTimeline = {
 
 type BuildCommittedTimelineOptions = {
   includeUnanchoredTerminalToolCalls?: boolean;
+  includeHiddenToolCalls?: boolean;
 };
 
 const TOOL_CALL_PLACEHOLDER = /^\[Tool call:[\s\S]*\]$/;
@@ -190,7 +191,7 @@ export function buildCommittedTimeline(
 ): CommittedTimeline {
   const items: TimelineItem[] = [];
   const orderedToolCalls = toolCalls
-    .filter((toolCall) => !toolCall.hidden)
+    .filter((toolCall) => options.includeHiddenToolCalls || !toolCall.hidden)
     .sort(byCreatedAtAscending);
   const toolCallsById = new Map(
     orderedToolCalls.map((toolCall) => [toolCall.id, toolCall]),

--- a/packages/workbench-app/src/lib/presentation/state/types.ts
+++ b/packages/workbench-app/src/lib/presentation/state/types.ts
@@ -24,6 +24,7 @@ export interface ConversationRenderState {
   generatedAt?: string;
   stale?: boolean;
   readOnly?: boolean;
+  retainHiddenToolCalls?: boolean;
   fallbackReason?: string;
   appMetadata?: Record<string, unknown>;
 }

--- a/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
@@ -40,6 +40,7 @@ import ToolExecutingSkeleton from "./tool-call/ToolExecutingSkeleton.svelte";
 import ToolArgumentBody from "./tool-call/ToolArgumentBody.svelte";
 import ToolCallDetailsDialog from "./tool-call/ToolCallDetailsDialog.svelte";
 import ApprovalPrompt from "./tool-call/ApprovalPrompt.svelte";
+import ExploreToolView from "./tool-call/ExploreToolView.svelte";
 
 type Props = {
   /** Retained live slot used before and during durable-record handoff. */
@@ -52,6 +53,7 @@ type Props = {
   pendingUserQuestion?: UserQuestionRecord;
   pendingPlanReview?: PlanReviewRecord;
   hydrateBody?: boolean;
+  detailsEnabled?: boolean;
   planReviewModels?: ModelInfo[];
   planReviewModelKey?: string;
   planReviewThinkingLevel?: AgentRecord["thinkingLevel"];
@@ -80,6 +82,7 @@ let {
   pendingUserQuestion,
   pendingPlanReview,
   hydrateBody = true,
+  detailsEnabled = true,
   planReviewModels = [],
   planReviewModelKey = "",
   planReviewThinkingLevel = "off",
@@ -215,6 +218,9 @@ const approvalPresentation = $derived.by(() => {
   if (!toolName) return undefined;
   return presentToolArguments(toolName, argumentInput, "approval", cwd);
 });
+const isExplore = $derived(
+  (toolCall?.toolName ?? draft?.block.toolName) === "explore",
+);
 const hilInteractive = $derived(
   view?.kind === "ask_user" ||
     (view?.kind === "plan_mode" && view.action === "present"),
@@ -258,7 +264,7 @@ const activitySections = $derived.by(() =>
     hasInteraction: hilInteractive,
     resultPlaceholder: lifecycleSpec.resultPlaceholder,
     footerItems: activityMeta,
-    hasDetailsAction: Boolean(toolCall),
+    hasDetailsAction: Boolean(toolCall && detailsEnabled),
   }),
 );
 const draftArg = $derived.by<PrimaryArg | undefined>(() => {
@@ -301,7 +307,7 @@ const dotTone = $derived(presentation?.dotTone ?? "running");
 const dotPulse = $derived(presentation?.dotPulse ?? true);
 const meta = $derived(activityMeta);
 const detailsAction = $derived(
-  toolCall
+  toolCall && detailsEnabled
     ? {
         label: presentation?.detailsAction?.label ?? "Details",
         onClick: openDetails,
@@ -373,14 +379,22 @@ async function openDetails() {
   error={activitySections.errorVisible ? errorPreview : undefined}
   {meta}
   footer={activitySections.footerVisible}
-  bodyVisible={activitySections.argumentVisible ||
+  bodyVisible={isExplore ||
+    activitySections.argumentVisible ||
     activitySections.interactionMode !== "none" ||
     activitySections.resultMode !== "none"}
   {layoutRevision}
   {detailsAction}
   {onOpenFile}
 >
-  {#if activitySections.argumentVisible && argumentBody}
+  {#if isExplore}
+    <ExploreToolView
+      {draft}
+      {toolCall}
+      view={view?.kind === "explore" ? view : undefined}
+      {onOpenFile}
+    />
+  {:else if activitySections.argumentVisible && argumentBody}
     <ToolArgumentBody
       body={argumentBody}
       highlight={Boolean(toolCall || draft?.block.done)}
@@ -400,12 +414,12 @@ async function openDetails() {
     />
   {/if}
 
-  {#if activitySections.resultMode === "placeholder" && lifecycleSpec.resultPlaceholder}
+  {#if !isExplore && activitySections.resultMode === "placeholder" && lifecycleSpec.resultPlaceholder}
     <ToolExecutingSkeleton
       variant={lifecycleSpec.resultPlaceholder.variant}
       rows={lifecycleSpec.resultPlaceholder.rows}
     />
-  {:else if activitySections.resultMode === "output" && toolCall && view && ToolView}
+  {:else if !isExplore && activitySections.resultMode === "output" && toolCall && view && ToolView}
     <ToolView
       {toolCall}
       {view}
@@ -426,7 +440,7 @@ async function openDetails() {
   {/if}
 </CardShell>
 
-{#if toolCall}
+{#if toolCall && detailsEnabled}
   <ToolCallDetailsDialog
     open={detailsOpen}
     previewToolCall={toolCall}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
@@ -262,7 +262,7 @@ const aggregateLabel = $derived.by(() => {
               <Button
                 size="xs"
                 variant="outline"
-                class="h-6 gap-1 px-1.5 text-xs shadow-none"
+                class="h-5 gap-1 rounded px-1.5 text-xs shadow-none"
                 onclick={() => openTranscript(task)}
                 aria-label={`View transcript for ${taskTitle(task)}`}
               >
@@ -274,7 +274,7 @@ const aggregateLabel = $derived.by(() => {
               <Button
                 size="xs"
                 variant="outline"
-                class="h-6 gap-1 px-1.5 text-xs shadow-none"
+                class="h-5 gap-1 rounded px-1.5 text-xs shadow-none"
                 onclick={() =>
                   task.report?.reportPath &&
                   onOpenFile?.(task.report.reportPath)}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
@@ -73,14 +73,37 @@ const tasks = $derived.by<DisplayTask[]>(
   () => aggregated?.tasks ?? draftTasks(),
 );
 const summary = $derived(aggregated?.summary);
-let selectedTaskKey = $state<string>();
-const selectedTask = $derived(
-  tasks.find(
-    (task): task is ExploreTaskState =>
-      task.key === selectedTaskKey && task.status !== "drafting",
-  ),
-);
+type SelectedTranscript = {
+  taskKey: string;
+  parentAgentId: string;
+  childAgentId: string;
+  label: string;
+  status: ExploreTaskState["status"];
+};
+let selectedTranscript = $state<SelectedTranscript>();
 let transcriptOpen = $state(false);
+
+$effect(() => {
+  if (!selectedTranscript) return;
+  const current = tasks.find(
+    (task): task is ExploreTaskState =>
+      task.key === selectedTranscript?.taskKey && task.status !== "drafting",
+  );
+  if (!current?.agentId) return;
+  const nextLabel = taskTitle(current);
+  if (
+    selectedTranscript.childAgentId === current.agentId &&
+    selectedTranscript.label === nextLabel &&
+    selectedTranscript.status === current.status
+  )
+    return;
+  selectedTranscript = {
+    ...selectedTranscript,
+    childAgentId: current.agentId,
+    label: nextLabel,
+    status: current.status,
+  };
+});
 
 function basename(path: string): string {
   return path.split(/[\\/]/).pop() || path;
@@ -159,7 +182,13 @@ function activityText(task: ExploreTaskState): string {
 
 function openTranscript(task: ExploreTaskState) {
   if (!task.agentId || !toolCall?.agentId) return;
-  selectedTaskKey = task.key;
+  selectedTranscript = {
+    taskKey: task.key,
+    parentAgentId: toolCall.agentId,
+    childAgentId: task.agentId,
+    label: taskTitle(task),
+    status: task.status,
+  };
   transcriptOpen = true;
 }
 
@@ -269,14 +298,12 @@ const aggregateLabel = $derived.by(() => {
   </ol>
 </div>
 
-{#if selectedTask && toolCall?.agentId}
+{#if selectedTranscript}
   <SubagentTranscriptDialog
     bind:open={transcriptOpen}
-    parentAgentId={toolCall.agentId}
-    childAgentId={selectedTask.agentId}
-    label={taskTitle(selectedTask)}
-    revision={selectedTask.revision}
-    running={selectedTask.status === "running"}
+    parentAgentId={selectedTranscript.parentAgentId}
+    childAgentId={selectedTranscript.childAgentId}
+    label={selectedTranscript.label}
     onOpenChange={(open) => (transcriptOpen = open)}
   />
 {/if}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
@@ -258,17 +258,11 @@ const aggregateLabel = $derived.by(() => {
           </div>
 
           <div class="flex min-w-0 flex-wrap items-center gap-1.5">
-            {#each usageChips(task) as chip (chip)}
-              <span
-                class="inline-flex min-h-5 items-center rounded border bg-muted/30 px-1.5 py-0.5 text-xs tabular-nums text-muted-foreground"
-                >{chip}</span
-              >
-            {/each}
             {#if task.agentId && toolCall?.agentId}
               <Button
                 size="xs"
-                variant="ghost"
-                class="h-6 gap-1 px-1.5 text-xs"
+                variant="outline"
+                class="h-6 gap-1 px-1.5 text-xs shadow-none"
                 onclick={() => openTranscript(task)}
                 aria-label={`View transcript for ${taskTitle(task)}`}
               >
@@ -279,8 +273,8 @@ const aggregateLabel = $derived.by(() => {
             {#if task.report?.reportPath}
               <Button
                 size="xs"
-                variant="ghost"
-                class="h-6 gap-1 px-1.5 text-xs"
+                variant="outline"
+                class="h-6 gap-1 px-1.5 text-xs shadow-none"
                 onclick={() =>
                   task.report?.reportPath &&
                   onOpenFile?.(task.report.reportPath)}
@@ -291,6 +285,12 @@ const aggregateLabel = $derived.by(() => {
                 Report
               </Button>
             {/if}
+            {#each usageChips(task) as chip (chip)}
+              <span
+                class="inline-flex min-h-5 items-center rounded border bg-muted/30 px-1.5 py-0.5 text-xs tabular-nums text-muted-foreground"
+                >{chip}</span
+              >
+            {/each}
           </div>
         {/if}
       </li>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
@@ -10,7 +10,6 @@ import {
   type ExploreTaskState,
   type ToolView,
 } from "../../views/tool-result-view";
-import ToolStatusIcon from "./ToolStatusIcon.svelte";
 import SubagentTranscriptDialog from "./SubagentTranscriptDialog.svelte";
 
 type Props = {
@@ -134,18 +133,18 @@ function statusLabel(task: DisplayTask): string {
   }
 }
 
-function statusTone(task: DisplayTask) {
+function statusTextClass(task: DisplayTask): string {
   switch (task.status) {
     case "running":
-      return "running" as const;
+      return "text-info";
     case "completed":
-      return "good" as const;
+      return "text-success";
     case "failed":
-      return "danger" as const;
+      return "text-destructive";
     case "aborted":
-      return "warn" as const;
+      return "text-warning";
     default:
-      return "neutral" as const;
+      return "text-muted-foreground";
   }
 }
 
@@ -185,11 +184,6 @@ const aggregateLabel = $derived.by(() => {
         data-status={task.status}
       >
         <div class="flex min-w-0 items-center gap-2">
-          <ToolStatusIcon
-            tone={statusTone(task)}
-            pulse={task.status === "running"}
-            label={statusLabel(task)}
-          />
           <div class="flex min-w-0 flex-1 items-center gap-2">
             {#if task.status === "drafting" && !task.label && !task.task}
               <Skeleton class="h-4 w-2/5" />
@@ -205,7 +199,7 @@ const aggregateLabel = $derived.by(() => {
               >
             {/if}
           </div>
-          <span class="shrink-0 text-xs font-medium text-muted-foreground"
+          <span class={`shrink-0 text-xs font-medium ${statusTextClass(task)}`}
             >{statusLabel(task)}</span
           >
           {#if (task.count ?? 0) > 1}
@@ -216,16 +210,14 @@ const aggregateLabel = $derived.by(() => {
         </div>
 
         {#if task.status === "drafting"}
-          <div class="grid gap-1 pl-6" aria-hidden="true">
+          <div class="grid gap-1" aria-hidden="true">
             <Skeleton class="h-3 w-full" />
             <Skeleton class="h-3 w-2/3" />
           </div>
         {:else}
-          <div class="flex min-w-0 items-center gap-2 pl-6">
+          <div class="flex min-w-0 items-center gap-2">
             <p
               class="m-0 min-w-0 flex-1 truncate text-xs text-muted-foreground"
-              class:font-mono={task.status === "running" &&
-                task.currentActionMono}
             >
               {activityText(task)}
             </p>
@@ -236,7 +228,7 @@ const aggregateLabel = $derived.by(() => {
             {/if}
           </div>
 
-          <div class="flex min-w-0 flex-wrap items-center gap-1.5 pl-6">
+          <div class="flex min-w-0 flex-wrap items-center gap-1.5">
             {#each usageChips(task) as chip (chip)}
               <span
                 class="inline-flex min-h-5 items-center rounded border bg-muted/30 px-1.5 py-0.5 text-xs tabular-nums text-muted-foreground"
@@ -283,7 +275,7 @@ const aggregateLabel = $derived.by(() => {
     parentAgentId={toolCall.agentId}
     childAgentId={selectedTask.agentId}
     label={taskTitle(selectedTask)}
-    revision={`${selectedTask.status}:${selectedTask.actionCount}:${selectedTask.report?.summaryPreview ?? ""}`}
+    revision={selectedTask.revision}
     running={selectedTask.status === "running"}
     onOpenChange={(open) => (transcriptOpen = open)}
   />

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
@@ -4,6 +4,10 @@ import MessagesSquare from "@lucide/svelte/icons/messages-square";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
 import type { ToolDraftViewModel } from "../../../state/active-run";
+import {
+  projectExploreDraftTasks,
+  type ExploreDraftTask,
+} from "../../views/explore-draft";
 import type { ToolCallDisplayRecord } from "../../views/tool-result-view";
 import {
   aggregateExploreTasks,
@@ -20,57 +24,16 @@ type Props = {
 };
 let { draft, toolCall, view, onOpenFile }: Props = $props();
 
-type DraftTask = {
-  key: string;
-  index: number;
-  count: number;
-  label?: string;
-  task?: string;
-  status: "drafting";
-};
-type DisplayTask = ExploreTaskState | DraftTask;
-
-function draftTasks(): DraftTask[] {
-  const args = draft?.block.args as Record<string, unknown> | undefined;
-  let rawTasks = Array.isArray(args?.tasks) ? args.tasks : [];
-  if (rawTasks.length === 0 && typeof args?.task === "string") {
-    rawTasks = [{ task: args.task, label: args.label }];
-  }
-  if (rawTasks.length === 0 && draft?.block.done && draft.block.argsText) {
-    try {
-      const parsed = JSON.parse(draft.block.argsText) as Record<
-        string,
-        unknown
-      >;
-      rawTasks = Array.isArray(parsed.tasks)
-        ? parsed.tasks
-        : typeof parsed.task === "string"
-          ? [{ task: parsed.task, label: parsed.label }]
-          : [];
-    } catch {
-      // Partial JSON is expected while the model drafts arguments.
-    }
-  }
-  const count = Math.max(1, rawTasks.length);
-  return (rawTasks.length > 0 ? rawTasks : [undefined]).map((value, index) => {
-    const record =
-      value && typeof value === "object"
-        ? (value as Record<string, unknown>)
-        : undefined;
-    return {
-      key: `task-${index}`,
-      index,
-      count,
-      label: typeof record?.label === "string" ? record.label : undefined,
-      task: typeof record?.task === "string" ? record.task : undefined,
-      status: "drafting" as const,
-    };
-  });
-}
+type DisplayTask = ExploreTaskState | ExploreDraftTask;
 
 const aggregated = $derived(view ? aggregateExploreTasks(view) : undefined);
 const tasks = $derived.by<DisplayTask[]>(
-  () => aggregated?.tasks ?? draftTasks(),
+  () =>
+    aggregated?.tasks ??
+    projectExploreDraftTasks({
+      args: draft?.block.args,
+      argsText: draft?.block.argsText,
+    }),
 );
 const summary = $derived(aggregated?.summary);
 type SelectedTranscript = {

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExploreToolView.svelte
@@ -1,160 +1,290 @@
 <script lang="ts">
 import FileText from "@lucide/svelte/icons/file-text";
+import MessagesSquare from "@lucide/svelte/icons/messages-square";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
+import type { ToolDraftViewModel } from "../../../state/active-run";
 import type { ToolCallDisplayRecord } from "../../views/tool-result-view";
 import {
   aggregateExploreTasks,
+  type ExploreTaskState,
   type ToolView,
 } from "../../views/tool-result-view";
+import ToolStatusIcon from "./ToolStatusIcon.svelte";
+import SubagentTranscriptDialog from "./SubagentTranscriptDialog.svelte";
 
 type Props = {
-  toolCall: ToolCallDisplayRecord;
-  view: Extract<ToolView, { kind: "explore" }>;
+  draft?: ToolDraftViewModel;
+  toolCall?: ToolCallDisplayRecord;
+  view?: Extract<ToolView, { kind: "explore" }>;
   onOpenFile?: (path: string, line?: number) => void;
 };
-let { toolCall, view, onOpenFile }: Props = $props();
+let { draft, toolCall, view, onOpenFile }: Props = $props();
 
-const aggregated = $derived(aggregateExploreTasks(view));
-const tasks = $derived(aggregated.tasks);
+type DraftTask = {
+  key: string;
+  index: number;
+  count: number;
+  label?: string;
+  task?: string;
+  status: "drafting";
+};
+type DisplayTask = ExploreTaskState | DraftTask;
+
+function draftTasks(): DraftTask[] {
+  const args = draft?.block.args as Record<string, unknown> | undefined;
+  let rawTasks = Array.isArray(args?.tasks) ? args.tasks : [];
+  if (rawTasks.length === 0 && typeof args?.task === "string") {
+    rawTasks = [{ task: args.task, label: args.label }];
+  }
+  if (rawTasks.length === 0 && draft?.block.done && draft.block.argsText) {
+    try {
+      const parsed = JSON.parse(draft.block.argsText) as Record<
+        string,
+        unknown
+      >;
+      rawTasks = Array.isArray(parsed.tasks)
+        ? parsed.tasks
+        : typeof parsed.task === "string"
+          ? [{ task: parsed.task, label: parsed.label }]
+          : [];
+    } catch {
+      // Partial JSON is expected while the model drafts arguments.
+    }
+  }
+  const count = Math.max(1, rawTasks.length);
+  return (rawTasks.length > 0 ? rawTasks : [undefined]).map((value, index) => {
+    const record =
+      value && typeof value === "object"
+        ? (value as Record<string, unknown>)
+        : undefined;
+    return {
+      key: `task-${index}`,
+      index,
+      count,
+      label: typeof record?.label === "string" ? record.label : undefined,
+      task: typeof record?.task === "string" ? record.task : undefined,
+      status: "drafting" as const,
+    };
+  });
+}
+
+const aggregated = $derived(view ? aggregateExploreTasks(view) : undefined);
+const tasks = $derived.by<DisplayTask[]>(
+  () => aggregated?.tasks ?? draftTasks(),
+);
+const summary = $derived(aggregated?.summary);
+let selectedTaskKey = $state<string>();
+const selectedTask = $derived(
+  tasks.find(
+    (task): task is ExploreTaskState =>
+      task.key === selectedTaskKey && task.status !== "drafting",
+  ),
+);
+let transcriptOpen = $state(false);
+
 function basename(path: string): string {
   return path.split(/[\\/]/).pop() || path;
 }
 
-/** Short, human display for a model id (drops provider + path prefixes). */
 function modelLabel(model: string): string {
   return model.split(/[/:]/).pop() ?? model;
 }
 
-function taskTitle(task: (typeof tasks)[number]): string {
-  return (
-    task.label ??
-    (task.index === undefined ? "Explore" : `Explore ${task.index + 1}`)
-  );
+function taskTitle(task: DisplayTask): string {
+  return task.label ?? task.task ?? `Explore ${(task.index ?? 0) + 1}`;
 }
 
-function modelThinkingLabel(task: (typeof tasks)[number]): string | undefined {
+function modelThinkingLabel(task: DisplayTask): string | undefined {
+  if (!("model" in task)) return undefined;
   const parts: string[] = [];
   if (task.model) parts.push(modelLabel(task.model));
   if (task.thinkingLevel) parts.push(task.thinkingLevel);
   return parts.length > 0 ? parts.join(" · ") : undefined;
 }
 
-function placeholderLine(task: (typeof tasks)[number]): string {
-  if (task.status === "queued") return "Queued…";
-  if (task.status === "running") return "Waiting for first tool…";
-  return "No recent activity.";
-}
-
-function recentDisplayLines(task: (typeof tasks)[number]) {
-  const lines = [...task.recentMessages].slice(-3);
-  return lines.length > 0
-    ? lines
-    : [{ text: placeholderLine(task), mono: false }];
-}
-
 function pluralCount(value: number, noun: string): string {
   return `${value.toLocaleString()} ${noun}${value === 1 ? "" : "s"}`;
 }
 
-function usageChips(
-  report: NonNullable<(typeof tasks)[number]["report"]>,
-): string[] {
+function usageChips(task: ExploreTaskState): string[] {
+  const usage = task.report?.usage;
+  if (!usage) return [];
   const chips: string[] = [];
-  if (report.usage?.turns) chips.push(pluralCount(report.usage.turns, "turn"));
-  const tokenCount = report.usage
-    ? report.usage.totalTokens > 0
-      ? report.usage.totalTokens
-      : report.usage.input + report.usage.output
-    : 0;
-  if (tokenCount > 0) chips.push(pluralCount(tokenCount, "token"));
+  if (usage.turns) chips.push(pluralCount(usage.turns, "turn"));
+  const tokens = usage.totalTokens || usage.input + usage.output;
+  if (tokens > 0) chips.push(pluralCount(tokens, "token"));
   return chips;
 }
+
+function statusLabel(task: DisplayTask): string {
+  switch (task.status) {
+    case "drafting":
+      return "Drafting";
+    case "queued":
+      return "Queued";
+    case "running":
+      return "Running";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "aborted":
+      return "Stopped";
+  }
+}
+
+function statusTone(task: DisplayTask) {
+  switch (task.status) {
+    case "running":
+      return "running" as const;
+    case "completed":
+      return "good" as const;
+    case "failed":
+      return "danger" as const;
+    case "aborted":
+      return "warn" as const;
+    default:
+      return "neutral" as const;
+  }
+}
+
+function activityText(task: ExploreTaskState): string {
+  if (task.status === "queued") return "Waiting for an active-agent slot…";
+  if (task.status === "running")
+    return task.currentAction ?? "Waiting for the first tool…";
+  if (task.status === "aborted") return task.error ?? "Agent run stopped.";
+  if (task.status === "failed") return task.error ?? "Agent run failed.";
+  return task.report?.summaryPreview ?? "Investigation complete.";
+}
+
+function openTranscript(task: ExploreTaskState) {
+  if (!task.agentId || !toolCall?.agentId) return;
+  selectedTaskKey = task.key;
+  transcriptOpen = true;
+}
+
+const aggregateLabel = $derived.by(() => {
+  if (!summary) return "Preparing explore agents";
+  const finished = summary.completed + summary.failed + summary.aborted;
+  const extras = [
+    summary.failed > 0 ? `${summary.failed} failed` : undefined,
+    summary.aborted > 0 ? `${summary.aborted} stopped` : undefined,
+  ].filter(Boolean);
+  return `${finished} of ${summary.total} finished${extras.length ? ` · ${extras.join(" · ")}` : ""}`;
+});
 </script>
 
-<div class="grid gap-1.5">
-  {#if tasks.length > 0}
-    <ol class="grid gap-1.5">
-      {#each tasks as task (task.key)}
-        {@const modelThinking = modelThinkingLabel(task)}
-        <li
-          class="grid min-w-0 gap-1 rounded-lg border border-border bg-card px-3 py-2.5"
-        >
-          <div class="flex min-w-0 items-center gap-2">
-            <div class="flex min-w-0 flex-1 items-center gap-2">
+<div class="grid gap-2">
+  <p class="sr-only" aria-live="polite">{aggregateLabel}</p>
+  <ol class="grid gap-2">
+    {#each tasks as task (task.key)}
+      {@const modelThinking = modelThinkingLabel(task)}
+      <li
+        class="grid min-w-0 gap-2 rounded-lg border bg-card px-3 py-2.5"
+        data-status={task.status}
+      >
+        <div class="flex min-w-0 items-center gap-2">
+          <ToolStatusIcon
+            tone={statusTone(task)}
+            pulse={task.status === "running"}
+            label={statusLabel(task)}
+          />
+          <div class="flex min-w-0 flex-1 items-center gap-2">
+            {#if task.status === "drafting" && !task.label && !task.task}
+              <Skeleton class="h-4 w-2/5" />
+            {:else}
               <strong class="min-w-0 truncate text-sm font-medium leading-tight"
                 >{taskTitle(task)}</strong
               >
-              {#if modelThinking}
-                <span
-                  class="shrink-0 rounded border border-border px-1.5 py-0.5 text-xs leading-none text-muted-foreground"
-                  title={[task.model, task.thinkingLevel]
-                    .filter(Boolean)
-                    .join(" · ")}>{modelThinking}</span
-                >
-              {/if}
-              {#if task.report?.reportPath}
-                <button
-                  type="button"
-                  class="inline-flex min-w-0 shrink items-center gap-1 rounded border border-border bg-muted/30 px-1.5 py-0.5 text-xs font-medium leading-none text-primary hover:bg-muted"
-                  onclick={() =>
-                    task.report?.reportPath &&
-                    onOpenFile?.(task.report.reportPath)}
-                  title={task.report.reportPath}
-                  aria-label={`Open report ${basename(task.report.reportPath)}`}
-                >
-                  <FileText size={12} strokeWidth={2.1} class="shrink-0" />
-                  <span class="min-w-0 truncate font-mono"
-                    >{basename(task.report.reportPath)}</span
-                  >
-                </button>
-              {/if}
-            </div>
-            {#if task.count && task.count > 1 && task.index !== undefined}
-              <span class="shrink-0 text-xs tabular-nums text-muted-foreground"
-                >{task.index + 1}/{task.count}</span
+            {/if}
+            {#if modelThinking}
+              <span
+                class="shrink-0 rounded border px-1.5 py-0.5 text-xs leading-none text-muted-foreground"
+                >{modelThinking}</span
               >
             {/if}
           </div>
-
-          <div
-            class="grid min-h-[1lh] min-w-0 gap-0.5 text-xs text-muted-foreground"
+          <span class="shrink-0 text-xs font-medium text-muted-foreground"
+            >{statusLabel(task)}</span
           >
-            {#each recentDisplayLines(task) as line, index (`${line.text}:${index}`)}
-              <p
-                class="m-0 {line.mono ? 'font-mono' : ''}"
-                class:line-clamp-3={task.status === "completed"}
-                class:truncate={task.status !== "completed"}
+          {#if (task.count ?? 0) > 1}
+            <span class="shrink-0 text-xs tabular-nums text-muted-foreground"
+              >{(task.index ?? 0) + 1}/{task.count}</span
+            >
+          {/if}
+        </div>
+
+        {#if task.status === "drafting"}
+          <div class="grid gap-1 pl-6" aria-hidden="true">
+            <Skeleton class="h-3 w-full" />
+            <Skeleton class="h-3 w-2/3" />
+          </div>
+        {:else}
+          <div class="flex min-w-0 items-center gap-2 pl-6">
+            <p
+              class="m-0 min-w-0 flex-1 truncate text-xs text-muted-foreground"
+              class:font-mono={task.status === "running" &&
+                task.currentActionMono}
+            >
+              {activityText(task)}
+            </p>
+            {#if task.status === "running" && task.actionCount > 0}
+              <span class="shrink-0 text-xs tabular-nums text-muted-foreground"
+                >{pluralCount(task.actionCount, "action")}</span
               >
-                {line.text}
-              </p>
-            {/each}
+            {/if}
           </div>
 
-          {#if task.report}
-            {@const chips = usageChips(task.report)}
-            {#if chips.length > 0}
-              <div class="flex min-w-0 flex-wrap gap-1 pt-0.5">
-                {#each chips as chip, index (`${chip}:${index}`)}
-                  <span
-                    class="inline-flex min-h-5 items-center rounded border border-border bg-sidebar px-1.5 py-0.5 text-xs font-medium leading-none tabular-nums text-muted-foreground"
-                    >{chip}</span
-                  >
-                {/each}
-              </div>
+          <div class="flex min-w-0 flex-wrap items-center gap-1.5 pl-6">
+            {#each usageChips(task) as chip (chip)}
+              <span
+                class="inline-flex min-h-5 items-center rounded border bg-muted/30 px-1.5 py-0.5 text-xs tabular-nums text-muted-foreground"
+                >{chip}</span
+              >
+            {/each}
+            {#if task.agentId && toolCall?.agentId}
+              <Button
+                size="xs"
+                variant="ghost"
+                class="h-6 gap-1 px-1.5 text-xs"
+                onclick={() => openTranscript(task)}
+                aria-label={`View transcript for ${taskTitle(task)}`}
+              >
+                <MessagesSquare class="size-3" aria-hidden="true" />
+                Transcript
+              </Button>
             {/if}
-          {/if}
-        </li>
-      {/each}
-    </ol>
-  {:else if view.liveLog}
-    <pre
-      class="overflow-auto rounded-md border border-border bg-muted/40 p-3 font-mono text-xs text-muted-foreground">{view.liveLog}</pre>
-  {:else if toolCall.status === "running" || toolCall.status === "requested"}
-    <p class="text-sm leading-relaxed text-muted-foreground">
-      Explore agents are working…
-    </p>
-  {:else}
-    <p class="text-sm leading-relaxed text-muted-foreground">
-      Explore completed without report files.
-    </p>
-  {/if}
+            {#if task.report?.reportPath}
+              <Button
+                size="xs"
+                variant="ghost"
+                class="h-6 gap-1 px-1.5 text-xs"
+                onclick={() =>
+                  task.report?.reportPath &&
+                  onOpenFile?.(task.report.reportPath)}
+                title={task.report.reportPath}
+                aria-label={`Open report ${basename(task.report.reportPath)}`}
+              >
+                <FileText class="size-3" aria-hidden="true" />
+                Report
+              </Button>
+            {/if}
+          </div>
+        {/if}
+      </li>
+    {/each}
+  </ol>
 </div>
+
+{#if selectedTask && toolCall?.agentId}
+  <SubagentTranscriptDialog
+    bind:open={transcriptOpen}
+    parentAgentId={toolCall.agentId}
+    childAgentId={selectedTask.agentId}
+    label={taskTitle(selectedTask)}
+    revision={`${selectedTask.status}:${selectedTask.actionCount}:${selectedTask.report?.summaryPreview ?? ""}`}
+    running={selectedTask.status === "running"}
+    onOpenChange={(open) => (transcriptOpen = open)}
+  />
+{/if}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type {
-  ConversationEntry,
   SubagentTranscriptSnapshot,
+  EventEnvelope,
 } from "@nervekit/contracts";
 import DialogShell from "@nervekit/ui-kit/components/ui/dialog-shell";
 import ArrowDown from "@lucide/svelte/icons/arrow-down";
@@ -11,8 +11,12 @@ import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
 import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
 import { notifyCopyResult } from "@nervekit/ui-kit/core/notify";
 import { getConversationUiCapabilities } from "../../../context.svelte";
-import { entriesToTranscript } from "../../../state/transcript";
-import { buildCommittedTimeline } from "../../../state/timeline";
+import {
+  applySubagentTranscriptEvent,
+  fromSubagentTranscriptSnapshot,
+} from "../../../state/subagent-transcript-session";
+import { buildConversationRenderProjection } from "../../../state/render";
+import type { ConversationRenderState } from "../../../state/types";
 import { createConversationScrollController } from "../../../components/transcript/conversation-scroll.svelte.js";
 import {
   groupConsecutiveThinking,
@@ -20,45 +24,44 @@ import {
 } from "../../../components/transcript/transcript-presentation";
 import ThinkingGroup from "../../../components/transcript/ThinkingGroup.svelte";
 import UserMessageContent from "../../../components/transcript/UserMessageContent.svelte";
+import WorkingIndicator from "../../../components/transcript/WorkingIndicator.svelte";
 import ToolCallCard from "../ToolCallCard.svelte";
 import ToolResultErrorCard from "./ToolResultErrorCard.svelte";
+
+type DialogRow =
+  | { kind: "timeline"; key: string; node: TranscriptDisplayNode }
+  | { kind: "waiting"; key: string };
 
 let {
   open = $bindable(false),
   parentAgentId,
   childAgentId,
   label,
-  revision,
-  running = false,
   onOpenChange,
 }: {
   open?: boolean;
   parentAgentId?: string;
   childAgentId?: string;
   label: string;
-  revision: string;
-  running?: boolean;
   onOpenChange?: (open: boolean) => void;
 } = $props();
 
 const capabilities = getConversationUiCapabilities();
 let snapshot = $state<SubagentTranscriptSnapshot>();
+let renderState = $state<ConversationRenderState>();
 let loading = $state(false);
 let error = $state<string>();
-let requestVersion = 0;
-let loadedKey: string | undefined;
+let retryKey = $state(0);
 
-const timeline = $derived.by(() => {
-  if (!snapshot) return [];
-  const transcript = entriesToTranscript(
-    snapshot.entries as ConversationEntry[],
+const projection = $derived(buildConversationRenderProjection(renderState));
+const rows = $derived.by(() => {
+  const timeline = groupConsecutiveThinking(projection.timeline).map(
+    (node): DialogRow => ({ kind: "timeline", key: node.key, node }),
   );
-  return groupConsecutiveThinking(
-    buildCommittedTimeline(transcript, snapshot.toolCalls, {
-      includeHiddenToolCalls: true,
-      includeUnanchoredTerminalToolCalls: true,
-    }).items,
-  );
+  if (renderState?.sending && !projection.hasActiveTurnOutput) {
+    timeline.push({ kind: "waiting", key: "__waiting__" });
+  }
+  return timeline;
 });
 
 const scroll = createConversationScrollController({
@@ -68,10 +71,12 @@ const scroll = createConversationScrollController({
     parentAgentId && childAgentId
       ? `subagent:${parentAgentId}:${childAgentId}`
       : undefined,
-  contentReady: () => timeline.length > 0,
+  contentReady: () => rows.length > 0,
 });
 
-function measurementVersion(node: TranscriptDisplayNode): string {
+function measurementVersion(row: DialogRow): string {
+  if (row.kind === "waiting") return "waiting";
+  const node = row.node;
   if (node.kind === "thinking_group") {
     return node.items
       .map(
@@ -96,51 +101,54 @@ function measurementVersion(node: TranscriptDisplayNode): string {
   return node.key;
 }
 
-async function load(force = false, revisionKey = revision) {
-  if (!parentAgentId || !childAgentId) return;
-  const key = `${parentAgentId}:${childAgentId}:${revisionKey}`;
-  if (!force && snapshot && loadedKey === key) return;
-  const fetchTranscript = capabilities.fetchSubagentTranscript;
-  if (!fetchTranscript) {
+$effect(() => {
+  const parent = parentAgentId;
+  const child = childAgentId;
+  const attempt = retryKey;
+  if (!open || !parent || !child) return;
+  const watch = capabilities.watchSubagentTranscript;
+  if (!watch) {
     error = "Subagent transcripts are unavailable here.";
     return;
   }
-  const version = ++requestVersion;
   loading = !snapshot;
   error = undefined;
-  try {
-    const next = await fetchTranscript(parentAgentId, childAgentId);
-    if (version !== requestVersion || !open) return;
-    snapshot = next;
-    loadedKey = key;
-  } catch (caught) {
-    if (version !== requestVersion || !open) return;
-    error = caught instanceof Error ? caught.message : String(caught);
-  } finally {
-    if (version === requestVersion) loading = false;
-  }
-}
-
-$effect(() => {
-  if (!open || !childAgentId || !parentAgentId) return;
-  const refreshRevision = revision;
-  const delay = snapshot && running ? 900 : 0;
-  const timer = setTimeout(() => void load(false, refreshRevision), delay);
-  return () => clearTimeout(timer);
+  const dispose = watch(parent, child, {
+    snapshot: (next) => {
+      if (next.parentAgentId !== parent || next.agentId !== child) return;
+      snapshot = next;
+      renderState = fromSubagentTranscriptSnapshot(next);
+      loading = false;
+      error = undefined;
+    },
+    event: (event: EventEnvelope<Record<string, unknown>>) => {
+      if (!renderState) return;
+      let gap = false;
+      renderState = applySubagentTranscriptEvent(renderState, event, () => {
+        gap = true;
+        error = "Live activity was interrupted; recovering the transcript.";
+      });
+      return !gap;
+    },
+    error: (message) => {
+      loading = false;
+      error = message;
+    },
+  });
+  void attempt;
+  return dispose;
 });
 
 $effect(() => {
   const activeChildId = childAgentId;
   if (!activeChildId) return;
-  requestVersion += 1;
   snapshot = undefined;
-  loadedKey = undefined;
+  renderState = undefined;
   error = undefined;
 });
 
 function handleOpenChange(next: boolean) {
   open = next;
-  if (!next) requestVersion += 1;
   onOpenChange?.(next);
 }
 </script>
@@ -148,7 +156,7 @@ function handleOpenChange(next: boolean) {
 <DialogShell
   flush
   bind:open
-  size="wide"
+  size="wide-viewport"
   title={`${label} transcript`}
   description={snapshot
     ? [snapshot.status, snapshot.model, snapshot.thinkingLevel]
@@ -166,7 +174,7 @@ function handleOpenChange(next: boolean) {
   {:else if error && !snapshot}
     <div class="grid place-items-center gap-3 p-8 text-center">
       <p class="m-0 text-sm text-destructive">{error}</p>
-      <Button size="sm" variant="outline" onclick={() => void load(true)}
+      <Button size="sm" variant="outline" onclick={() => (retryKey += 1)}
         >Retry</Button
       >
     </div>
@@ -180,11 +188,11 @@ function handleOpenChange(next: boolean) {
             Showing the assignment and most recent bounded activity.
           {/if}
           {#if error}
-            <span class="text-destructive"> Refresh failed: {error}</span>
+            <span class="text-destructive"> {error}</span>
           {/if}
         </div>
       {/if}
-      {#if timeline.length === 0}
+      {#if rows.length === 0}
         <div class="grid place-items-center p-8 text-sm text-muted-foreground">
           No transcript activity yet.
         </div>
@@ -193,8 +201,8 @@ function handleOpenChange(next: boolean) {
           <VirtualScroller
             bind:controller={scroll.controller}
             bind:atEnd={scroll.atEnd}
-            items={timeline}
-            getKey={(node) => node.key}
+            items={rows}
+            getKey={(row) => row.key}
             heightCacheKey={parentAgentId && childAgentId
               ? `subagent-transcript:${parentAgentId}:${childAgentId}`
               : undefined}
@@ -211,46 +219,55 @@ function handleOpenChange(next: boolean) {
             viewportAriaLabel={`${label} subagent transcript`}
             viewportClass="h-full px-3"
           >
-            {#snippet row({ item: node })}
-              {#if node.kind === "tool" && node.toolCall}
+            {#snippet row({ item: row })}
+              {#if row.kind === "waiting"}
+                <article
+                  class="transcript-entry assistant streaming waiting-entry"
+                >
+                  <WorkingIndicator />
+                </article>
+              {:else if row.node.kind === "tool" && row.node.toolCall}
                 <div class="min-w-0 px-3">
                   <ToolCallCard
-                    toolCall={node.toolCall}
+                    toolCall={row.node.toolCall}
                     detailsEnabled={false}
                   />
                 </div>
-              {:else if node.kind === "tool_result_error"}
+              {:else if row.node.kind === "tool_result_error"}
                 <div class="min-w-0 px-3">
                   <ToolResultErrorCard
-                    toolName={node.toolName}
-                    error={node.error}
+                    toolName={row.node.toolName}
+                    error={row.node.error}
                   />
                 </div>
-              {:else if node.kind === "thinking_group"}
+              {:else if row.node.kind === "thinking_group"}
                 <article class="min-w-0 p-3 text-sm">
                   <ThinkingGroup
-                    items={node.items.map((member) => member.item)}
+                    items={row.node.items.map((member) => member.item)}
                   />
                 </article>
-              {:else if node.kind === "message"}
+              {:else if row.node.kind === "message"}
                 <article
-                  class="min-w-0 p-3 text-sm {node.item.role === 'user'
+                  class="min-w-0 p-3 text-sm {row.node.item.role === 'user'
                     ? 'ml-auto w-fit max-w-[70%] rounded-lg rounded-br-sm border border-primary/20 bg-primary/10 px-3 py-2'
                     : 'w-full'}"
                 >
-                  {#if node.item.role === "user"}
-                    <UserMessageContent text={node.item.text} pending={false} />
+                  {#if row.node.item.role === "user"}
+                    <UserMessageContent
+                      text={row.node.item.text}
+                      pending={false}
+                    />
                   {:else}
                     <Markdown
-                      text={node.item.text}
-                      trimCodeBlocks={node.item.role !== "assistant"}
+                      text={row.node.item.text}
+                      trimCodeBlocks={row.node.item.role !== "assistant"}
                       onCopy={notifyCopyResult}
                     />
                   {/if}
-                  {#if node.item.stopReason === "error" && node.item.errorMessage}
+                  {#if row.node.item.stopReason === "error" && row.node.item.errorMessage}
                     <pre
-                      class="mt-2 whitespace-pre-wrap break-words rounded-md border border-destructive/40 bg-destructive/10 p-3 font-mono text-xs text-destructive">{node
-                        .item.errorMessage}</pre>
+                      class="mt-2 whitespace-pre-wrap break-words rounded-md border border-destructive/40 bg-destructive/10 p-3 font-mono text-xs text-destructive">{row
+                        .node.item.errorMessage}</pre>
                   {/if}
                 </article>
               {/if}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+import type {
+  ConversationEntry,
+  SubagentTranscriptSnapshot,
+} from "@nervekit/contracts";
+import DialogShell from "@nervekit/ui-kit/components/ui/dialog-shell";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
+import {
+  VirtualScroller,
+  type VirtualScrollerController,
+} from "@nervekit/ui-kit/components/ui/virtual-list";
+import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
+import { notifyCopyResult } from "@nervekit/ui-kit/core/notify";
+import { getConversationUiCapabilities } from "../../../context.svelte";
+import { entriesToTranscript } from "../../../state/transcript";
+import { buildCommittedTimeline } from "../../../state/timeline";
+import { groupConsecutiveThinking } from "../../../components/transcript/transcript-presentation";
+import ThinkingGroup from "../../../components/transcript/ThinkingGroup.svelte";
+import UserMessageContent from "../../../components/transcript/UserMessageContent.svelte";
+import ToolCallCard from "../ToolCallCard.svelte";
+import ToolResultErrorCard from "./ToolResultErrorCard.svelte";
+
+let {
+  open = $bindable(false),
+  parentAgentId,
+  childAgentId,
+  label,
+  revision,
+  running = false,
+  onOpenChange,
+}: {
+  open?: boolean;
+  parentAgentId?: string;
+  childAgentId?: string;
+  label: string;
+  revision: string;
+  running?: boolean;
+  onOpenChange?: (open: boolean) => void;
+} = $props();
+
+const capabilities = getConversationUiCapabilities();
+let snapshot = $state<SubagentTranscriptSnapshot>();
+let loading = $state(false);
+let error = $state<string>();
+let requestVersion = 0;
+let loadedKey: string | undefined;
+let controller = $state<VirtualScrollerController>();
+
+const timeline = $derived.by(() => {
+  if (!snapshot) return [];
+  const transcript = entriesToTranscript(
+    snapshot.entries as ConversationEntry[],
+  );
+  return groupConsecutiveThinking(
+    buildCommittedTimeline(transcript, snapshot.toolCalls, {
+      includeHiddenToolCalls: true,
+      includeUnanchoredTerminalToolCalls: true,
+    }).items,
+  );
+});
+
+async function load(force = false, revisionKey = revision) {
+  if (!parentAgentId || !childAgentId) return;
+  const key = `${parentAgentId}:${childAgentId}:${revisionKey}`;
+  if (!force && snapshot && loadedKey === key) return;
+  const fetchTranscript = capabilities.fetchSubagentTranscript;
+  if (!fetchTranscript) {
+    error = "Subagent transcripts are unavailable here.";
+    return;
+  }
+  const version = ++requestVersion;
+  loading = !snapshot;
+  error = undefined;
+  try {
+    const next = await fetchTranscript(parentAgentId, childAgentId);
+    if (version !== requestVersion || !open) return;
+    snapshot = next;
+    loadedKey = key;
+  } catch (caught) {
+    if (version !== requestVersion || !open) return;
+    error = caught instanceof Error ? caught.message : String(caught);
+  } finally {
+    if (version === requestVersion) loading = false;
+  }
+}
+
+$effect(() => {
+  if (!open || !childAgentId || !parentAgentId) return;
+  const refreshRevision = revision;
+  const delay = snapshot && running ? 900 : 0;
+  const timer = setTimeout(() => void load(false, refreshRevision), delay);
+  return () => clearTimeout(timer);
+});
+
+$effect(() => {
+  const activeChildId = childAgentId;
+  if (!activeChildId) return;
+  requestVersion += 1;
+  snapshot = undefined;
+  loadedKey = undefined;
+  error = undefined;
+});
+
+function handleOpenChange(next: boolean) {
+  open = next;
+  if (!next) requestVersion += 1;
+  onOpenChange?.(next);
+}
+</script>
+
+<DialogShell
+  flush
+  bind:open
+  size="viewport"
+  title={`${label} transcript`}
+  description={snapshot
+    ? [snapshot.status, snapshot.model, snapshot.thinkingLevel]
+        .filter(Boolean)
+        .join(" · ")
+    : "Read-only child-agent activity"}
+  onOpenChange={handleOpenChange}
+>
+  {#if loading && !snapshot}
+    <div class="grid gap-3 p-6" aria-label="Loading subagent transcript">
+      <Skeleton class="h-16 w-3/4" />
+      <Skeleton class="h-24 w-full" />
+      <Skeleton class="h-20 w-4/5" />
+    </div>
+  {:else if error && !snapshot}
+    <div class="grid place-items-center gap-3 p-8 text-center">
+      <p class="m-0 text-sm text-destructive">{error}</p>
+      <Button size="sm" variant="outline" onclick={() => void load(true)}
+        >Retry</Button
+      >
+    </div>
+  {:else if snapshot}
+    <div class="grid h-full min-h-0 grid-rows-[auto_1fr]">
+      {#if snapshot.entriesTruncated || snapshot.toolCallsTruncated || error}
+        <div
+          class="border-b bg-muted/30 px-4 py-2 text-xs text-muted-foreground"
+        >
+          {#if snapshot.entriesTruncated || snapshot.toolCallsTruncated}
+            Showing the assignment and most recent bounded activity.
+          {/if}
+          {#if error}
+            <span class="text-destructive"> Refresh failed: {error}</span>
+          {/if}
+        </div>
+      {/if}
+      {#if timeline.length === 0}
+        <div class="grid place-items-center p-8 text-sm text-muted-foreground">
+          No transcript activity yet.
+        </div>
+      {:else}
+        <VirtualScroller
+          bind:controller
+          items={timeline}
+          getKey={(node) => node.key}
+          estimateSize={() => 112}
+          overscan={8}
+          anchor="end"
+          followOutput={true}
+          paddingStart={12}
+          paddingEnd={12}
+          gap={2}
+          viewportTabIndex={0}
+          viewportAriaLabel={`${label} subagent transcript`}
+          viewportClass="h-full px-3"
+        >
+          {#snippet row({ item: node })}
+            {#if node.kind === "tool" && node.toolCall}
+              <div class="min-w-0 px-3">
+                <ToolCallCard toolCall={node.toolCall} detailsEnabled={false} />
+              </div>
+            {:else if node.kind === "tool_result_error"}
+              <div class="min-w-0 px-3">
+                <ToolResultErrorCard
+                  toolName={node.toolName}
+                  error={node.error}
+                />
+              </div>
+            {:else if node.kind === "thinking_group"}
+              <article class="min-w-0 p-3 text-sm">
+                <ThinkingGroup
+                  items={node.items.map((member) => member.item)}
+                />
+              </article>
+            {:else if node.kind === "message"}
+              <article
+                class="min-w-0 p-3 text-sm {node.item.role === 'user'
+                  ? 'ml-auto w-fit max-w-[70%] rounded-lg rounded-br-sm border border-primary/20 bg-primary/10 px-3 py-2'
+                  : 'w-full'}"
+              >
+                {#if node.item.role === "user"}
+                  <UserMessageContent text={node.item.text} pending={false} />
+                {:else}
+                  <Markdown
+                    text={node.item.text}
+                    trimCodeBlocks={node.item.role !== "assistant"}
+                    onCopy={notifyCopyResult}
+                  />
+                {/if}
+                {#if node.item.stopReason === "error" && node.item.errorMessage}
+                  <pre
+                    class="mt-2 whitespace-pre-wrap break-words rounded-md border border-destructive/40 bg-destructive/10 p-3 font-mono text-xs text-destructive">{node
+                      .item.errorMessage}</pre>
+                {/if}
+              </article>
+            {/if}
+          {/snippet}
+        </VirtualScroller>
+      {/if}
+    </div>
+  {/if}
+</DialogShell>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
@@ -4,18 +4,20 @@ import type {
   SubagentTranscriptSnapshot,
 } from "@nervekit/contracts";
 import DialogShell from "@nervekit/ui-kit/components/ui/dialog-shell";
+import ArrowDown from "@lucide/svelte/icons/arrow-down";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
-import {
-  VirtualScroller,
-  type VirtualScrollerController,
-} from "@nervekit/ui-kit/components/ui/virtual-list";
+import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
 import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
 import { notifyCopyResult } from "@nervekit/ui-kit/core/notify";
 import { getConversationUiCapabilities } from "../../../context.svelte";
 import { entriesToTranscript } from "../../../state/transcript";
 import { buildCommittedTimeline } from "../../../state/timeline";
-import { groupConsecutiveThinking } from "../../../components/transcript/transcript-presentation";
+import { createConversationScrollController } from "../../../components/transcript/conversation-scroll.svelte.js";
+import {
+  groupConsecutiveThinking,
+  type TranscriptDisplayNode,
+} from "../../../components/transcript/transcript-presentation";
 import ThinkingGroup from "../../../components/transcript/ThinkingGroup.svelte";
 import UserMessageContent from "../../../components/transcript/UserMessageContent.svelte";
 import ToolCallCard from "../ToolCallCard.svelte";
@@ -45,7 +47,6 @@ let loading = $state(false);
 let error = $state<string>();
 let requestVersion = 0;
 let loadedKey: string | undefined;
-let controller = $state<VirtualScrollerController>();
 
 const timeline = $derived.by(() => {
   if (!snapshot) return [];
@@ -59,6 +60,41 @@ const timeline = $derived.by(() => {
     }).items,
   );
 });
+
+const scroll = createConversationScrollController({
+  active: () => open,
+  conversationOpen: () => open,
+  conversationId: () =>
+    parentAgentId && childAgentId
+      ? `subagent:${parentAgentId}:${childAgentId}`
+      : undefined,
+  contentReady: () => timeline.length > 0,
+});
+
+function measurementVersion(node: TranscriptDisplayNode): string {
+  if (node.kind === "thinking_group") {
+    return node.items
+      .map(
+        (member) =>
+          `${member.item.text.length}:${member.item.done ? "done" : "open"}`,
+      )
+      .join("|");
+  }
+  if (node.kind === "message") {
+    return [
+      node.item.text.length,
+      node.item.done ? "done" : "open",
+      node.item.stopReason ?? "ok",
+      node.item.errorMessage?.length ?? 0,
+    ].join(":");
+  }
+  if (node.kind === "tool") {
+    return node.toolCall
+      ? `${node.toolCall.status}:${node.toolCall.updatedAt}`
+      : `draft:${node.draft?.block.argsText.length ?? 0}`;
+  }
+  return node.key;
+}
 
 async function load(force = false, revisionKey = revision) {
   if (!parentAgentId || !childAgentId) return;
@@ -112,7 +148,7 @@ function handleOpenChange(next: boolean) {
 <DialogShell
   flush
   bind:open
-  size="viewport"
+  size="wide"
   title={`${label} transcript`}
   description={snapshot
     ? [snapshot.status, snapshot.model, snapshot.thinkingLevel]
@@ -153,63 +189,86 @@ function handleOpenChange(next: boolean) {
           No transcript activity yet.
         </div>
       {:else}
-        <VirtualScroller
-          bind:controller
-          items={timeline}
-          getKey={(node) => node.key}
-          estimateSize={() => 112}
-          overscan={8}
-          anchor="end"
-          followOutput={true}
-          paddingStart={12}
-          paddingEnd={12}
-          gap={2}
-          viewportTabIndex={0}
-          viewportAriaLabel={`${label} subagent transcript`}
-          viewportClass="h-full px-3"
-        >
-          {#snippet row({ item: node })}
-            {#if node.kind === "tool" && node.toolCall}
-              <div class="min-w-0 px-3">
-                <ToolCallCard toolCall={node.toolCall} detailsEnabled={false} />
-              </div>
-            {:else if node.kind === "tool_result_error"}
-              <div class="min-w-0 px-3">
-                <ToolResultErrorCard
-                  toolName={node.toolName}
-                  error={node.error}
-                />
-              </div>
-            {:else if node.kind === "thinking_group"}
-              <article class="min-w-0 p-3 text-sm">
-                <ThinkingGroup
-                  items={node.items.map((member) => member.item)}
-                />
-              </article>
-            {:else if node.kind === "message"}
-              <article
-                class="min-w-0 p-3 text-sm {node.item.role === 'user'
-                  ? 'ml-auto w-fit max-w-[70%] rounded-lg rounded-br-sm border border-primary/20 bg-primary/10 px-3 py-2'
-                  : 'w-full'}"
-              >
-                {#if node.item.role === "user"}
-                  <UserMessageContent text={node.item.text} pending={false} />
-                {:else}
-                  <Markdown
-                    text={node.item.text}
-                    trimCodeBlocks={node.item.role !== "assistant"}
-                    onCopy={notifyCopyResult}
+        <div class="relative min-h-0">
+          <VirtualScroller
+            bind:controller={scroll.controller}
+            bind:atEnd={scroll.atEnd}
+            items={timeline}
+            getKey={(node) => node.key}
+            heightCacheKey={parentAgentId && childAgentId
+              ? `subagent-transcript:${parentAgentId}:${childAgentId}`
+              : undefined}
+            getMeasurementVersion={measurementVersion}
+            estimateSize={() => 112}
+            overscan={10}
+            anchor="end"
+            followOutput={scroll.followBottom}
+            scrollEndThreshold={32}
+            paddingStart={12}
+            paddingEnd={12}
+            gap={2}
+            viewportTabIndex={0}
+            viewportAriaLabel={`${label} subagent transcript`}
+            viewportClass="h-full px-3"
+          >
+            {#snippet row({ item: node })}
+              {#if node.kind === "tool" && node.toolCall}
+                <div class="min-w-0 px-3">
+                  <ToolCallCard
+                    toolCall={node.toolCall}
+                    detailsEnabled={false}
                   />
-                {/if}
-                {#if node.item.stopReason === "error" && node.item.errorMessage}
-                  <pre
-                    class="mt-2 whitespace-pre-wrap break-words rounded-md border border-destructive/40 bg-destructive/10 p-3 font-mono text-xs text-destructive">{node
-                      .item.errorMessage}</pre>
-                {/if}
-              </article>
-            {/if}
-          {/snippet}
-        </VirtualScroller>
+                </div>
+              {:else if node.kind === "tool_result_error"}
+                <div class="min-w-0 px-3">
+                  <ToolResultErrorCard
+                    toolName={node.toolName}
+                    error={node.error}
+                  />
+                </div>
+              {:else if node.kind === "thinking_group"}
+                <article class="min-w-0 p-3 text-sm">
+                  <ThinkingGroup
+                    items={node.items.map((member) => member.item)}
+                  />
+                </article>
+              {:else if node.kind === "message"}
+                <article
+                  class="min-w-0 p-3 text-sm {node.item.role === 'user'
+                    ? 'ml-auto w-fit max-w-[70%] rounded-lg rounded-br-sm border border-primary/20 bg-primary/10 px-3 py-2'
+                    : 'w-full'}"
+                >
+                  {#if node.item.role === "user"}
+                    <UserMessageContent text={node.item.text} pending={false} />
+                  {:else}
+                    <Markdown
+                      text={node.item.text}
+                      trimCodeBlocks={node.item.role !== "assistant"}
+                      onCopy={notifyCopyResult}
+                    />
+                  {/if}
+                  {#if node.item.stopReason === "error" && node.item.errorMessage}
+                    <pre
+                      class="mt-2 whitespace-pre-wrap break-words rounded-md border border-destructive/40 bg-destructive/10 p-3 font-mono text-xs text-destructive">{node
+                        .item.errorMessage}</pre>
+                  {/if}
+                </article>
+              {/if}
+            {/snippet}
+          </VirtualScroller>
+          {#if !scroll.atEnd}
+            <Button
+              size="icon-sm"
+              variant="secondary"
+              class="absolute right-5 bottom-4 rounded-full shadow-md"
+              onclick={() => scroll.jumpToBottom()}
+              aria-label="Jump to latest subagent activity"
+              title="Jump to latest"
+            >
+              <ArrowDown class="size-4" aria-hidden="true" />
+            </Button>
+          {/if}
+        </div>
       {/if}
     </div>
   {/if}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/SubagentTranscriptDialog.svelte
@@ -222,7 +222,7 @@ function handleOpenChange(next: boolean) {
             {#snippet row({ item: row })}
               {#if row.kind === "waiting"}
                 <article
-                  class="transcript-entry assistant streaming waiting-entry"
+                  class="transcript-entry assistant streaming waiting-entry min-w-0 p-3 text-sm"
                 >
                   <WorkingIndicator />
                 </article>

--- a/packages/workbench-app/src/lib/presentation/tools/lifecycle/argument-source.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/lifecycle/argument-source.test.ts
@@ -48,6 +48,42 @@ describe("ToolArgumentSource", () => {
     );
   });
 
+  it("projects object-array entries from incomplete streamed JSON", () => {
+    const sources = toolArgumentSource({
+      argsText:
+        '{"tasks":[{"task":"Inspect {server}","label":"Server"},{"task":"Review UI","label":"Cli',
+    }).objectArraySources("tasks");
+
+    assert.equal(sources.length, 2);
+    assert.equal(sources[0]?.string("task"), "Inspect {server}");
+    assert.equal(sources[0]?.string("label"), "Server");
+    assert.equal(sources[1]?.string("task"), "Review UI");
+    assert.equal(sources[1]?.string("label"), "Cli");
+  });
+
+  it("does not split partial objects on escaped quotes or nested braces", () => {
+    const sources = toolArgumentSource({
+      argsText:
+        '{"tasks":[{"task":"Inspect \\"quoted\\" {text}","context":{"note":"}"}},{"task":"Second',
+    }).objectArraySources("tasks");
+
+    assert.equal(sources.length, 2);
+    assert.equal(sources[0]?.string("task"), 'Inspect "quoted" {text}');
+    assert.equal(sources[1]?.string("task"), "Second");
+  });
+
+  it("prefers exact object arrays over streamed fragments", () => {
+    const sources = toolArgumentSource({
+      args: { tasks: [{ task: "Exact A" }, { task: "Exact B" }] },
+      argsText: '{"tasks":[{"task":"Partial',
+    }).objectArraySources("tasks");
+
+    assert.deepEqual(
+      sources.map((source) => source.string("task")),
+      ["Exact A", "Exact B"],
+    );
+  });
+
   it("exposes environment key names without values", () => {
     const source = toolArgumentSource({
       args: {

--- a/packages/workbench-app/src/lib/presentation/tools/lifecycle/argument-source.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/lifecycle/argument-source.ts
@@ -75,6 +75,96 @@ function partialStringValues(text: string, key: string): string[] {
   return values;
 }
 
+function objectArrayFragments(text: string, key: string): string[] {
+  let arrayStart = -1;
+  let inString = false;
+  let escaped = false;
+  let stringStart = -1;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') {
+        inString = false;
+        const property = decodeJsonString(text.slice(stringStart, index));
+        if (property !== key) continue;
+        let cursor = index + 1;
+        while (/\s/.test(text[cursor] ?? "")) cursor += 1;
+        if (text[cursor] !== ":") continue;
+        cursor += 1;
+        while (/\s/.test(text[cursor] ?? "")) cursor += 1;
+        if (text[cursor] === "[") {
+          arrayStart = cursor;
+          break;
+        }
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      stringStart = index + 1;
+    }
+  }
+  if (arrayStart < 0) return [];
+
+  const fragments: string[] = [];
+  let arrayDepth = 1;
+  let objectDepth = 0;
+  let objectStart = -1;
+  inString = false;
+  escaped = false;
+  for (let index = arrayStart + 1; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "[") {
+      arrayDepth += 1;
+      continue;
+    }
+    if (char === "]") {
+      arrayDepth -= 1;
+      if (arrayDepth === 0) break;
+      continue;
+    }
+    if (char === "{") {
+      if (objectDepth === 0 && arrayDepth === 1) objectStart = index;
+      if (objectStart >= 0) objectDepth += 1;
+      continue;
+    }
+    if (char === "}" && objectStart >= 0) {
+      objectDepth -= 1;
+      if (objectDepth === 0) {
+        fragments.push(
+          text.slice(
+            objectStart,
+            Math.min(index + 1, objectStart + MAX_PARTIAL_VALUE_CHARS),
+          ),
+        );
+        objectStart = -1;
+        if (fragments.length >= MAX_FALLBACK_ITEMS) break;
+      }
+    }
+  }
+  if (objectStart >= 0 && fragments.length < MAX_FALLBACK_ITEMS) {
+    fragments.push(
+      text.slice(
+        objectStart,
+        Math.min(text.length, objectStart + MAX_PARTIAL_VALUE_CHARS),
+      ),
+    );
+  }
+  return fragments;
+}
+
 function partialScalar(
   text: string,
   key: string,
@@ -190,6 +280,24 @@ export class ToolArgumentSource {
     return value
       .map(asRecord)
       .filter((record) => Object.keys(record).length > 0);
+  }
+
+  /** Object-array entries from exact arguments or an incomplete streamed array. */
+  objectArraySources(key: string): ToolArgumentSource[] {
+    for (const record of this.records) {
+      if (!Object.hasOwn(record, key)) continue;
+      const value = record[key];
+      if (!Array.isArray(value)) return [];
+      return value.slice(0, MAX_FALLBACK_ITEMS).map(
+        (entry) =>
+          new ToolArgumentSource({
+            args: asRecord(entry),
+          }),
+      );
+    }
+    return objectArrayFragments(this.argsText, key).map(
+      (fragment) => new ToolArgumentSource({ argsText: fragment }),
+    );
   }
 
   record(key: string): Record<string, unknown> | undefined {

--- a/packages/workbench-app/src/lib/presentation/tools/views/explore-draft.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/explore-draft.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { projectExploreDraftTasks } from "./explore-draft";
+
+describe("Explore draft task projection", () => {
+  it("starts with one anonymous placeholder", () => {
+    assert.deepEqual(projectExploreDraftTasks({ argsText: '{"tasks":[' }), [
+      {
+        key: "task-0",
+        index: 0,
+        count: 1,
+        label: undefined,
+        task: undefined,
+        status: "drafting",
+      },
+    ]);
+  });
+
+  it("adds stable cards as task objects begin and fills partial titles", () => {
+    const first = projectExploreDraftTasks({
+      argsText: '{"tasks":[{"task":"Inspect server","label":"Ser',
+    });
+    assert.equal(first.length, 1);
+    assert.equal(first[0]?.key, "task-0");
+    assert.equal(first[0]?.label, "Ser");
+    assert.equal(first[0]?.task, "Inspect server");
+
+    const second = projectExploreDraftTasks({
+      argsText:
+        '{"tasks":[{"task":"Inspect server","label":"Server"},{"task":"Review cl',
+    });
+    assert.equal(second.length, 2);
+    assert.deepEqual(
+      second.map((task) => task.key),
+      ["task-0", "task-1"],
+    );
+    assert.equal(second[0]?.label, "Server");
+    assert.equal(second[1]?.task, "Review cl");
+    assert.equal(second[0]?.count, 2);
+  });
+
+  it("prefers labels and supports final and legacy single-task arguments", () => {
+    const exact = projectExploreDraftTasks({
+      args: {
+        tasks: [
+          { task: "Long task A", label: "A" },
+          { task: "Long task B", label: "B" },
+        ],
+      },
+    });
+    assert.equal(exact[0]?.label, "A");
+    assert.equal(exact[1]?.label, "B");
+
+    assert.deepEqual(
+      projectExploreDraftTasks({
+        argsText: '{"task":"Inspect one thing","label":"Focused',
+      })[0],
+      {
+        key: "task-0",
+        index: 0,
+        count: 1,
+        label: "Focused",
+        task: "Inspect one thing",
+        status: "drafting",
+      },
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/tools/views/explore-draft.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/explore-draft.ts
@@ -1,0 +1,48 @@
+import { toolArgumentSource } from "../lifecycle/argument-source";
+
+export type ExploreDraftTask = {
+  key: string;
+  index: number;
+  count: number;
+  label?: string;
+  task?: string;
+  status: "drafting";
+};
+
+export function projectExploreDraftTasks(input: {
+  args?: unknown;
+  argsText?: string;
+}): ExploreDraftTask[] {
+  const source = toolArgumentSource(input);
+  const taskSources = source.objectArraySources("tasks");
+  if (taskSources.length === 0) {
+    const task = source.string("task");
+    const label = source.string("label");
+    return [draftTask(0, 1, label, task)];
+  }
+  const count = taskSources.length;
+  return taskSources.map((taskSource, index) =>
+    draftTask(
+      index,
+      count,
+      taskSource.string("label"),
+      taskSource.string("task"),
+    ),
+  );
+}
+
+function draftTask(
+  index: number,
+  count: number,
+  label: string | undefined,
+  task: string | undefined,
+): ExploreDraftTask {
+  return {
+    key: `task-${index}`,
+    index,
+    count,
+    label,
+    task,
+    status: "drafting",
+  };
+}

--- a/packages/workbench-app/src/lib/presentation/tools/views/explore-progress.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/explore-progress.ts
@@ -95,7 +95,10 @@ function recentTaskMessages(
     .filter((action): action is ExploreTaskAction => action !== undefined);
   if (liveMessages.length > 0) return liveMessages.slice(-3);
 
-  if (input.status === "failed" && input.error) {
+  if (
+    (input.status === "failed" || input.status === "aborted") &&
+    input.error
+  ) {
     return [{ text: input.error, mono: false }];
   }
   if (input.status === "completed" && input.report?.summaryPreview) {
@@ -169,7 +172,9 @@ function aggregateExploreTasksUncached(
     const failed = updates.find((u) => u.phase === "failed");
 
     let status: ExploreTaskStatus;
-    if (report?.status === "failed" || report?.status === "aborted") {
+    if (report?.status === "aborted") {
+      status = "aborted";
+    } else if (report?.status === "failed") {
       status = "failed";
     } else if (
       report?.status === "completed" ||
@@ -226,6 +231,7 @@ function aggregateExploreTasksUncached(
 
   const completed = tasks.filter((t) => t.status === "completed").length;
   const failedCount = tasks.filter((t) => t.status === "failed").length;
+  const aborted = tasks.filter((t) => t.status === "aborted").length;
   const running = tasks.filter(
     (t) => t.status === "running" || t.status === "queued",
   ).length;
@@ -236,8 +242,9 @@ function aggregateExploreTasksUncached(
       total,
       completed,
       failed: failedCount,
+      aborted,
       running,
-      done: total > 0 && completed + failedCount === total,
+      done: total > 0 && completed + failedCount + aborted === total,
     },
   };
 }

--- a/packages/workbench-app/src/lib/presentation/tools/views/explore-progress.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/explore-progress.ts
@@ -1,3 +1,4 @@
+import { exploreReportSummarySchema } from "@nervekit/contracts";
 import { asRecord, stringField } from "./tool-view-helpers";
 import type {
   ExploreProgressView,
@@ -40,6 +41,7 @@ export function parseExploreProgressLog(text: string | undefined): {
           thinkingLevel: stringField(record.thinkingLevel),
           phase: record.phase as ExploreProgressView["phase"],
           message: record.message,
+          report: exploreReportSummarySchema.safeParse(record.report).data,
         });
         continue;
       }
@@ -161,8 +163,9 @@ function aggregateExploreTasksUncached(
 
   const tasks: ExploreTaskState[] = [];
   for (let index = 0; index < total; index += 1) {
-    const report = reports[index];
     const updates = byIndex.get(index) ?? [];
+    const streamedReport = updates.findLast((update) => update.report)?.report;
+    const report = reports[index] ?? streamedReport;
     const latest = updates[updates.length - 1];
     const recentActions = updates
       .map(friendlyExploreAction)
@@ -236,6 +239,14 @@ function aggregateExploreTasksUncached(
   const running = tasks.filter(
     (t) => t.status === "running" || t.status === "queued",
   ).length;
+  const totalTurns = tasks.reduce(
+    (sum, task) => sum + (task.report?.usage?.turns ?? 0),
+    0,
+  );
+  const totalTokens = tasks.reduce((sum, task) => {
+    const usage = task.report?.usage;
+    return sum + (usage ? usage.totalTokens || usage.input + usage.output : 0);
+  }, 0);
 
   return {
     tasks,
@@ -245,6 +256,8 @@ function aggregateExploreTasksUncached(
       failed: failedCount,
       aborted,
       running,
+      totalTurns,
+      totalTokens,
       done: total > 0 && completed + failedCount + aborted === total,
     },
   };

--- a/packages/workbench-app/src/lib/presentation/tools/views/explore-progress.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/explore-progress.ts
@@ -68,7 +68,7 @@ function friendlyExploreAction(
   if (EXPLORE_NOISE_MESSAGES.has(update.message)) return undefined;
   switch (update.phase) {
     case "tool_call":
-      return { text: update.message, mono: true };
+      return { text: update.message, mono: false };
     case "tool_result":
       return isLowSignalToolResultMessage(update.message)
         ? undefined
@@ -214,6 +214,7 @@ function aggregateExploreTasksUncached(
       model,
       thinkingLevel,
       status,
+      revision: `${latest?.timestamp ?? "stored"}:${report?.status ?? "live"}`,
       currentAction: action?.text,
       currentActionMono: action?.mono ?? false,
       recentActions: status === "running" ? recentActions : [],

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation.ts
@@ -717,7 +717,9 @@ export function toolPresentation(
       // explore rows; keep the generic footer reserved for high-signal status.
       if (summary.failed > 0)
         meta.push({ text: `${summary.failed} failed`, tone: "error" });
-      const finished = summary.completed + summary.failed;
+      if (summary.aborted > 0)
+        meta.push({ text: `${summary.aborted} stopped`, tone: "warning" });
+      const finished = summary.completed + summary.failed + summary.aborted;
       const countLabel = `${finished}/${summary.total} ${
         summary.total === 1 ? "agent" : "agents"
       }`;

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation.ts
@@ -713,8 +713,14 @@ export function toolPresentation(
     case "explore": {
       const { summary } = aggregateExploreTasks(view);
       const meta: MetaItem[] = [];
-      // Per-agent report paths, model, turns, and token usage render inside the
-      // explore rows; keep the generic footer reserved for high-signal status.
+      if (summary.totalTurns > 0) {
+        meta.push({
+          text: `${summary.totalTurns.toLocaleString()} ${summary.totalTurns === 1 ? "turn" : "turns"}`,
+        });
+      }
+      if (summary.totalTokens > 0) {
+        meta.push({ text: `${summary.totalTokens.toLocaleString()} tokens` });
+      }
       if (summary.failed > 0)
         meta.push({ text: `${summary.failed} failed`, tone: "error" });
       if (summary.aborted > 0)

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.orchestration.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.orchestration.test.ts
@@ -220,9 +220,9 @@ describe("parseToolView ask_user/todos/task/explore", () => {
     // Task 0: keeps concrete tool activity and ignores generic completion noise.
     assert.equal(tasks[0]?.status, "running");
     assert.equal(tasks[0]?.currentAction, "read server.ts");
-    assert.equal(tasks[0]?.currentActionMono, true);
+    assert.equal(tasks[0]?.currentActionMono, false);
     assert.deepEqual(tasks[0]?.recentActions, [
-      { text: "read server.ts", mono: true },
+      { text: "read server.ts", mono: false },
     ]);
     assert.equal(tasks[0]?.actionCount, 1);
     assert.equal(tasks[0]?.label, "api");
@@ -230,7 +230,7 @@ describe("parseToolView ask_user/todos/task/explore", () => {
     assert.equal(tasks[0]?.model, "anthropic/claude-haiku");
     assert.equal(tasks[0]?.thinkingLevel, "medium");
     assert.deepEqual(tasks[0]?.recentMessages, [
-      { text: "read server.ts", mono: true },
+      { text: "read server.ts", mono: false },
     ]);
     // Task 1: started but no display-safe tool action yet.
     assert.equal(tasks[1]?.status, "running");

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.orchestration.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.orchestration.test.ts
@@ -238,6 +238,85 @@ describe("parseToolView ask_user/todos/task/explore", () => {
     assert.deepEqual(tasks[1]?.recentActions, []);
   });
 
+  it("surfaces a completed child report and aggregate usage before siblings finish", () => {
+    const streamedReport = {
+      agentId: "agent_02H00000000000000000000000",
+      task: "Inspect server",
+      label: "server",
+      status: "completed",
+      reportPath: "/home/me/.nerve/explore-reports/server.md",
+      summaryPreview: "Server inspection complete.",
+      usage: {
+        input: 1_200,
+        output: 300,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 1_500,
+        cost: 0.01,
+        turns: 3,
+      },
+      model: "openai/gpt-5.6-terra",
+      thinkingLevel: "medium",
+    };
+    const view = parseToolView(
+      toolCall("explore", {}, { reports: [] }, { status: "running" }),
+      {
+        toolCallId: "tool_live_output",
+        chunks: [],
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        text: [
+          exploreUpdate("completed", "Report written", {
+            taskIndex: 0,
+            taskCount: 2,
+            agentId: streamedReport.agentId,
+            report: streamedReport,
+          }),
+          exploreUpdate("started", "Explore 2/2 started", {
+            taskIndex: 1,
+            taskCount: 2,
+            agentId: "agent_03H00000000000000000000000",
+          }),
+        ].join("\n"),
+      },
+    );
+    assert.equal(view.kind, "explore");
+    if (view.kind !== "explore") return;
+    const { tasks, summary } = aggregateExploreTasks(view);
+    assert.equal(tasks[0]?.status, "completed");
+    assert.equal(tasks[0]?.report?.reportPath, streamedReport.reportPath);
+    assert.equal(tasks[0]?.report?.usage?.turns, 3);
+    assert.equal(tasks[1]?.status, "running");
+    assert.equal(summary.done, false);
+    assert.equal(summary.totalTurns, 3);
+    assert.equal(summary.totalTokens, 1_500);
+
+    const presentation = toolPresentation(view, toolCall("explore", {}, {}));
+    assert.deepEqual(
+      presentation.meta.map((item) => item.text),
+      ["3 turns", "1,500 tokens"],
+    );
+  });
+
+  it("ignores malformed streamed child reports", () => {
+    const view = parseToolView(
+      toolCall("explore", {}, { reports: [] }, { status: "running" }),
+      {
+        toolCallId: "tool_live_output",
+        chunks: [],
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        text: exploreUpdate("completed", "Report written", {
+          taskIndex: 0,
+          taskCount: 1,
+          report: { reportPath: "/tmp/unowned.md", raw: "not allowed" },
+        }),
+      },
+    );
+    assert.equal(view.kind, "explore");
+    if (view.kind !== "explore") return;
+    const { tasks } = aggregateExploreTasks(view);
+    assert.equal(tasks[0]?.report, undefined);
+  });
+
   it("aggregates explore tasks with mixed completed and failed results", () => {
     const view = parseToolView(
       toolCall(

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
@@ -75,6 +75,7 @@ export type ExploreProgressView = {
     | "completed"
     | "failed";
   message: string;
+  report?: ExploreReportSummaryPayload;
 };
 
 export type ExploreTaskStatus =
@@ -122,6 +123,8 @@ export type ExploreSummary = {
   failed: number;
   aborted: number;
   running: number;
+  totalTurns: number;
+  totalTokens: number;
   done: boolean;
 };
 

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
@@ -77,7 +77,12 @@ export type ExploreProgressView = {
   message: string;
 };
 
-export type ExploreTaskStatus = "queued" | "running" | "completed" | "failed";
+export type ExploreTaskStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "aborted";
 
 export type ExploreTaskAction = {
   text: string;
@@ -113,6 +118,7 @@ export type ExploreSummary = {
   total: number;
   completed: number;
   failed: number;
+  aborted: number;
   running: number;
   done: boolean;
 };

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
@@ -100,6 +100,8 @@ export type ExploreTaskState = {
   model?: string;
   thinkingLevel?: string;
   status: ExploreTaskStatus;
+  /** Latest progress/report revision used for open transcript refreshes. */
+  revision: string;
   /** De-noised latest activity while running. */
   currentAction?: string;
   /** Whether currentAction is a concrete tool action (render as mono). */

--- a/packages/workbench-server/src/domains/agents/run/explore-helpers.ts
+++ b/packages/workbench-server/src/domains/agents/run/explore-helpers.ts
@@ -11,6 +11,7 @@ import type {
 } from "@nervekit/contracts";
 import type { ExploreProgressUpdate } from "../../tools/tool-service.js";
 import { promptText } from "../prompting/prompt-text.js";
+import { summarizeExploreToolCall } from "./explore-tool-summary.js";
 import type {
   ExploreReport,
   ExploreRunPlan,
@@ -193,7 +194,7 @@ export function exploreProgressFromHarnessEvent(
     return {
       ...base,
       phase: "tool_call",
-      message: summarizeToolCall(toolName, asRecord(record.args) ?? {}),
+      message: summarizeExploreToolCall(toolName, asRecord(record.args) ?? {}),
     };
   }
   if (record.type === "tool_execution_end") {
@@ -216,28 +217,6 @@ export function exploreProgressFromHarnessEvent(
     return undefined;
   }
   return undefined;
-}
-
-function summarizeToolCall(
-  toolName: string,
-  args: Record<string, unknown>,
-): string {
-  switch (toolName) {
-    case "read":
-      return `read ${stringValue(args.path) ?? "file"}${rangeSuffix(args)}`;
-    case "grep":
-      return `grep ${quoteValue(args.pattern)}${pathSuffix(args)}`;
-    case "find":
-      return `find ${quoteValue(args.pattern)}${pathSuffix(args)}`;
-    case "ls":
-      return `ls ${stringValue(args.path) ?? "."}`;
-    case "task_status":
-      return `task_status ${taskStatusScopeLabel(args)}`;
-    case "task_logs":
-      return `task_logs ${taskScopeLabel(args)}${modeSuffix(args)}`;
-    default:
-      return `ran ${toolName}`;
-  }
 }
 
 function summarizeToolResult(
@@ -377,59 +356,6 @@ export function exploreAssistantMetadata(message: AssistantMessage): {
       (message as { errorMessage?: unknown }).errorMessage,
     ),
   };
-}
-
-function quoteValue(value: unknown): string {
-  const text = stringValue(value);
-  return text ? JSON.stringify(truncateInline(text, 80)) : "pattern";
-}
-
-function pathSuffix(args: Record<string, unknown>): string {
-  const path = stringValue(args.path);
-  const paths = Array.isArray(args.paths)
-    ? args.paths.filter((value) => typeof value === "string")
-    : [];
-  if (path) return ` in ${path}`;
-  if (paths.length > 0) return ` in ${paths.length} paths`;
-  return " in .";
-}
-
-function rangeSuffix(args: Record<string, unknown>): string {
-  const offset = typeof args.offset === "number" ? args.offset : undefined;
-  const limit = typeof args.limit === "number" ? args.limit : undefined;
-  if (offset === undefined && limit === undefined) return "";
-  return ` (${offset ?? 1}${limit ? `+${limit}` : ""})`;
-}
-
-function modeSuffix(args: Record<string, unknown>): string {
-  const mode = stringValue(args.mode);
-  return mode ? ` (${mode})` : "";
-}
-
-function taskScopeLabel(args: Record<string, unknown>): string {
-  const taskId = stringValue(args.taskId);
-  if (taskId) return taskId;
-  const taskIds = Array.isArray(args.taskIds)
-    ? args.taskIds.filter((value) => typeof value === "string")
-    : [];
-  if (taskIds.length > 0) {
-    return `${taskIds.length} task${taskIds.length === 1 ? "" : "s"}`;
-  }
-  const groupId = stringValue(args.groupId);
-  if (groupId) return `group ${groupId}`;
-  const name = stringValue(args.name);
-  if (name) return name;
-  return "current";
-}
-
-function taskStatusScopeLabel(args: Record<string, unknown>): string {
-  const scope = taskScopeLabel(args);
-  const hasSelector =
-    Boolean(stringValue(args.taskId)) ||
-    Array.isArray(args.taskIds) ||
-    Boolean(stringValue(args.groupId));
-  const status = stringValue(args.status) ?? (hasSelector ? "all" : "active");
-  return `${scope} · ${status}`;
 }
 
 export function messageRole(message: unknown): string | undefined {

--- a/packages/workbench-server/src/domains/agents/run/explore-tool-summary.ts
+++ b/packages/workbench-server/src/domains/agents/run/explore-tool-summary.ts
@@ -1,0 +1,246 @@
+export function summarizeExploreToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+): string {
+  switch (toolName) {
+    case "read":
+      return activity("Reading file", pathDetail(args) + rangeSuffix(args));
+    case "grep":
+      return activity(
+        "Searching codebase",
+        `${quoteValue(args.pattern)}${pathSuffix(args)}`,
+      );
+    case "find":
+      return activity(
+        "Finding files",
+        `${quoteValue(args.pattern)}${pathSuffix(args)}`,
+      );
+    case "ls":
+      return activity("Listing directory", pathDetail(args));
+    case "edit":
+      return activity("Editing file", pathDetail(args));
+    case "write":
+      return activity("Writing file", pathDetail(args));
+    case "bash":
+      return "Running shell command";
+    case "python_exec":
+      return stringValue(args.path)
+        ? activity("Running Python script", stringValue(args.path))
+        : "Running Python code";
+    case "web_search":
+      return activity("Searching the web", stringValue(args.query));
+    case "web_fetch":
+      return activity("Fetching web page", safeUrl(args.url));
+    case "ask_user":
+      return "Requesting user input";
+    case "todos_set":
+      return "Updating task list";
+    case "todos_get":
+      return "Reading task list";
+    case "task_start":
+      return activity("Starting background task", stringValue(args.name));
+    case "task_status":
+      return activity("Checking background tasks", taskStatusScopeLabel(args));
+    case "task_logs":
+      return activity(
+        "Reading task logs",
+        `${taskScopeLabel(args)}${modeSuffix(args)}`,
+      );
+    case "task_cancel":
+      return activity("Stopping background task", taskScopeLabel(args));
+    case "task_restart":
+      return activity("Restarting background task", taskScopeLabel(args));
+    case "jira_search_users":
+      return activity(
+        "Searching Jira users",
+        firstString(args, "query", "username", "displayName"),
+      );
+    case "jira_search_issues":
+      return activity("Searching Jira issues", stringValue(args.jql));
+    case "jira_get_issue":
+      return activity("Reading Jira issue", issueDetail(args));
+    case "jira_get_project":
+      return activity("Reading Jira project", projectDetail(args));
+    case "jira_create_issue":
+      return activity("Creating Jira issue", projectDetail(args));
+    case "jira_update_issue":
+      return activity("Updating Jira issue", issueDetail(args));
+    case "jira_add_comment":
+      return activity("Commenting on Jira issue", issueDetail(args));
+    case "jira_transition_issue":
+      return activity("Transitioning Jira issue", issueDetail(args));
+    case "confluence_search_spaces":
+      return activity(
+        "Searching Confluence spaces",
+        firstString(args, "query", "space_key", "spaceKey", "key"),
+      );
+    case "confluence_search_pages":
+      return activity(
+        "Searching Confluence pages",
+        firstString(args, "cql", "query", "title", "space_key"),
+      );
+    case "confluence_get_page":
+      return activity("Reading Confluence page", pageDetail(args));
+    case "confluence_download_pages":
+      return activity(
+        "Downloading Confluence pages",
+        firstString(args, "page_id", "space_key", "cql"),
+      );
+    case "confluence_create_page":
+      return activity(
+        "Creating Confluence page",
+        firstString(args, "title", "space_key"),
+      );
+    case "confluence_update_page":
+      return activity("Updating Confluence page", pageDetail(args));
+    case "confluence_publish_pages":
+      return activity(
+        "Publishing Confluence pages",
+        firstString(args, "input_path"),
+      );
+    case "confluence_upload_attachment":
+      return activity(
+        "Uploading Confluence attachment",
+        firstString(args, "file_path", "filename", "page_id"),
+      );
+    case "explore":
+      return "Exploring the codebase";
+    case "plan_mode_enter":
+      return "Entering plan mode";
+    case "plan_mode_present":
+      return "Presenting implementation plan";
+    case "plan_mode_force_exit":
+      return "Leaving plan mode";
+    default:
+      return `Running ${humanizeToolName(toolName)}`;
+  }
+}
+
+function activity(label: string, detail?: string): string {
+  const bounded = detail ? truncateInline(detail, 120) : undefined;
+  return bounded ? `${label} (${bounded})` : label;
+}
+
+function firstString(
+  args: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = stringValue(args[key]);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function pathDetail(args: Record<string, unknown>): string {
+  return truncateInline(stringValue(args.path) ?? ".", 100);
+}
+
+function issueDetail(args: Record<string, unknown>): string | undefined {
+  return firstString(
+    args,
+    "issue_key",
+    "issueIdOrKey",
+    "issueKey",
+    "key",
+    "id",
+  );
+}
+
+function projectDetail(args: Record<string, unknown>): string | undefined {
+  return firstString(
+    args,
+    "project_key",
+    "projectIdOrKey",
+    "projectKey",
+    "key",
+    "id",
+  );
+}
+
+function pageDetail(args: Record<string, unknown>): string | undefined {
+  return firstString(args, "page_id", "pageId", "id", "title");
+}
+
+function safeUrl(value: unknown): string | undefined {
+  const text = stringValue(value);
+  if (!text) return undefined;
+  try {
+    const url = new URL(text);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return text.split(/[?#]/, 1)[0];
+  }
+}
+
+function humanizeToolName(toolName: string): string {
+  const readable = toolName.replace(/[_-]+/g, " ").trim();
+  return truncateInline(readable || "tool", 80);
+}
+
+function quoteValue(value: unknown): string {
+  const text = stringValue(value);
+  return text ? JSON.stringify(truncateInline(text, 80)) : "pattern";
+}
+
+function pathSuffix(args: Record<string, unknown>): string {
+  const path = stringValue(args.path);
+  const paths = Array.isArray(args.paths)
+    ? args.paths.filter((value) => typeof value === "string")
+    : [];
+  if (path) return ` in ${truncateInline(path, 100)}`;
+  if (paths.length > 0) return ` in ${paths.length} paths`;
+  return " in .";
+}
+
+function rangeSuffix(args: Record<string, unknown>): string {
+  const offset = typeof args.offset === "number" ? args.offset : undefined;
+  const limit = typeof args.limit === "number" ? args.limit : undefined;
+  if (offset === undefined && limit === undefined) return "";
+  return ` · line ${offset ?? 1}${limit ? ` · ${limit} lines` : ""}`;
+}
+
+function modeSuffix(args: Record<string, unknown>): string {
+  const mode = stringValue(args.mode);
+  return mode ? ` · ${mode}` : "";
+}
+
+function taskScopeLabel(args: Record<string, unknown>): string {
+  const taskId = stringValue(args.taskId);
+  if (taskId) return taskId;
+  const taskIds = Array.isArray(args.taskIds)
+    ? args.taskIds.filter((value) => typeof value === "string")
+    : [];
+  if (taskIds.length > 0) {
+    return `${taskIds.length} task${taskIds.length === 1 ? "" : "s"}`;
+  }
+  const groupId = stringValue(args.groupId);
+  if (groupId) return `group ${groupId}`;
+  const name = stringValue(args.name);
+  if (name) return name;
+  return "current";
+}
+
+function taskStatusScopeLabel(args: Record<string, unknown>): string {
+  const scope = taskScopeLabel(args);
+  const hasSelector =
+    Boolean(stringValue(args.taskId)) ||
+    Array.isArray(args.taskIds) ||
+    Boolean(stringValue(args.groupId));
+  const status = stringValue(args.status) ?? (hasSelector ? "all" : "active");
+  return `${scope} · ${status}`;
+}
+
+function truncateInline(text: string, maxChars: number): string {
+  return text.length <= maxChars ? text : `${text.slice(0, maxChars - 1)}…`;
+}

--- a/packages/workbench-server/src/domains/agents/run/message-mirror.ts
+++ b/packages/workbench-server/src/domains/agents/run/message-mirror.ts
@@ -35,6 +35,34 @@ export interface AppendEntryInput {
   createdAt?: string;
 }
 
+export function projectHarnessMessageEntry(input: {
+  entry: Extract<ConversationTreeEntry, { type: "message" }>;
+  conversationId: string;
+  agentId: string;
+}): ConversationEntry | undefined {
+  const { entry, conversationId, agentId } = input;
+  if (
+    entry.message.role !== "user" &&
+    entry.message.role !== "assistant" &&
+    entry.message.role !== "toolResult"
+  ) {
+    return undefined;
+  }
+  const role: ConversationEntry["role"] =
+    entry.message.role === "toolResult" ? "system" : entry.message.role;
+  return {
+    id: entry.id,
+    conversationId,
+    agentId,
+    role,
+    kind: "message",
+    text: agentMessageText(entry.message as AgentMessage),
+    usage: extractEntryUsage(entry.message as AgentMessage),
+    details: entryDetails(entry.message as AgentMessage),
+    createdAt: entry.timestamp,
+  };
+}
+
 export type AppendEntryFn = (
   input: AppendEntryInput,
   options?: { mirrorToHarness?: boolean },

--- a/packages/workbench-server/src/domains/agents/run/subagent-runner.ts
+++ b/packages/workbench-server/src/domains/agents/run/subagent-runner.ts
@@ -258,20 +258,7 @@ export class SubagentRunner {
             plan,
             output,
           });
-          publishExploreProgress(options.onProgress, {
-            agentId: output.agent.id,
-            taskIndex: index,
-            taskCount: tasks.length,
-            label: task.label,
-            model: output.model,
-            thinkingLevel: output.thinkingLevel,
-            phase: output.status === "completed" ? "completed" : "failed",
-            message:
-              output.status === "completed"
-                ? `Report written: ${reportPath}`
-                : `Failure report written: ${reportPath}`,
-          });
-          return {
+          const report: ExploreReport = {
             agentId: output.agent.id,
             task: task.task,
             label: task.label,
@@ -286,6 +273,21 @@ export class SubagentRunner {
             errorMessage: output.errorMessage,
             steps: output.steps,
           };
+          publishExploreProgress(options.onProgress, {
+            agentId: output.agent.id,
+            taskIndex: index,
+            taskCount: tasks.length,
+            label: task.label,
+            model: output.model,
+            thinkingLevel: output.thinkingLevel,
+            phase: output.status === "completed" ? "completed" : "failed",
+            message:
+              output.status === "completed"
+                ? `Report written: ${reportPath}`
+                : `Failure report written: ${reportPath}`,
+            report: exploreReportEventSummary(report),
+          });
+          return report;
         }),
       );
     } finally {

--- a/packages/workbench-server/src/domains/agents/run/subagent-runner.ts
+++ b/packages/workbench-server/src/domains/agents/run/subagent-runner.ts
@@ -40,6 +40,7 @@ import type { SubscriptionUsageService } from "../../usage/subscription-usage-se
 import type { WorkbenchExploreAdmission } from "./workbench-explore-admission.js";
 import type { WorkbenchSubagentExecutions } from "./workbench-subagent-executions.js";
 import type { AgentBrowserSkillCatalog } from "../prompting/agent-browser-skills.js";
+import type { SubagentTranscriptLiveService } from "../subagent-transcript-live.service.js";
 import { loadHarnessResources } from "../prompting/resource-loader.js";
 
 export { exploreRunPlanArg, exploreSystemPrompt } from "./explore-helpers.js";
@@ -158,6 +159,7 @@ export interface SubagentRunnerDeps {
   executions: WorkbenchSubagentExecutions;
   exploreAdmission: WorkbenchExploreAdmission;
   agentBrowserSkills: AgentBrowserSkillCatalog;
+  transcriptLive: SubagentTranscriptLiveService;
 }
 
 export class SubagentRunner {
@@ -361,6 +363,11 @@ export class SubagentRunner {
     });
 
     const runId = createId("run");
+    await this.deps.transcriptLive.register({
+      parentAgentId: spec.parent.id,
+      child,
+      runId,
+    });
     const abortController = new AbortController();
     const abortFromParent = () => abortController.abort(spec.signal?.reason);
     if (spec.signal?.aborted) abortFromParent();
@@ -421,7 +428,8 @@ export class SubagentRunner {
           this.deps.auth.requestAuthForPiModel(requestModel),
         systemPrompt: () => spec.systemPrompt,
       });
-      harness.subscribe((event) => {
+      harness.subscribe(async (event) => {
+        await this.deps.transcriptLive.handleHarnessEvent(child.id, event);
         const update = exploreProgressFromHarnessEvent(event, child, spec);
         if (update) {
           publishExploreProgress(spec.onProgress, update);
@@ -477,6 +485,7 @@ export class SubagentRunner {
       }
       if (!report) throw new Error("Explore agent completed without a report.");
       await this.deps.setAgentStatus(child, "idle");
+      await this.deps.transcriptLive.complete(child.id, "completed");
       await this.deps.events.publish("agent.subagent_completed", {
         parentAgentId: spec.parent.id,
         childAgentId: child.id,
@@ -496,6 +505,11 @@ export class SubagentRunner {
       };
     } catch (error) {
       const aborted = abortRequested || signal.aborted;
+      const terminalMessage =
+        error instanceof Error ? error.message : String(error);
+      await this.deps.transcriptLive
+        .complete(child.id, aborted ? "aborted" : "failed", terminalMessage)
+        .catch(() => undefined);
       await this.deps
         .setAgentStatus(child, aborted ? "aborted" : "error")
         .catch(() => undefined);
@@ -521,7 +535,7 @@ export class SubagentRunner {
         error,
       });
       if (aborted) throw abortError();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = terminalMessage;
       return {
         agent: child,
         status: "failed",

--- a/packages/workbench-server/src/domains/agents/run/workbench-agent-mechanics.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-agent-mechanics.ts
@@ -41,6 +41,7 @@ import type {
 } from "../../tools/tool-service.js";
 import type { SubscriptionUsageService } from "../../usage/subscription-usage-service.js";
 import type { AgentBrowserSkillCatalog } from "../prompting/agent-browser-skills.js";
+import type { SubagentTranscriptLiveService } from "../subagent-transcript-live.service.js";
 import { executeWorkbenchHarness } from "./workbench-harness-execution.js";
 import { AutoCompactionRunner } from "./auto-compaction-runner.js";
 import { InlineCommandRunner } from "./inline-command-runner.js";
@@ -78,6 +79,7 @@ export interface WorkbenchAgentMechanicsDeps {
   subagentExecutions: WorkbenchSubagentExecutions;
   exploreAdmission: WorkbenchExploreAdmission;
   agentBrowserSkills: AgentBrowserSkillCatalog;
+  subagentTranscriptLive: SubagentTranscriptLiveService;
 }
 
 export class WorkbenchAgentMechanics {
@@ -99,6 +101,7 @@ export class WorkbenchAgentMechanics {
       executions: deps.subagentExecutions,
       exploreAdmission: deps.exploreAdmission,
       agentBrowserSkills: deps.agentBrowserSkills,
+      transcriptLive: deps.subagentTranscriptLive,
     });
     this.inlineCommands = new InlineCommandRunner(deps);
     this.autoCompaction = new AutoCompactionRunner(deps);

--- a/packages/workbench-server/src/domains/agents/subagent-transcript-live.service.ts
+++ b/packages/workbench-server/src/domains/agents/subagent-transcript-live.service.ts
@@ -1,0 +1,277 @@
+import type { AgentHarnessEvent } from "@nervekit/harness";
+import {
+  PUBLIC_EVENT_MAX_STRING_CHARS,
+  type AgentRecord,
+  type ConversationActiveRunSnapshot,
+} from "@nervekit/contracts";
+import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
+import { ConversationRuntime } from "../runs/runtime/conversation-runtime.js";
+import { assistantContentRedacted } from "./run/harness-execution-shared.js";
+
+type ChildLiveState = {
+  parentAgentId: string;
+  child: AgentRecord;
+  runId: string;
+  runtime: ConversationRuntime;
+  turnId?: string;
+  liveMessageId?: string;
+  tail: Promise<void>;
+  terminal: boolean;
+};
+
+export class SubagentTranscriptLiveService {
+  private readonly children = new Map<string, ChildLiveState>();
+
+  constructor(private readonly events: StreamLogRegistry) {}
+
+  async register(input: {
+    parentAgentId: string;
+    child: AgentRecord;
+    runId: string;
+  }): Promise<void> {
+    const runtime = new ConversationRuntime();
+    const run = runtime.startRun({
+      conversationId: input.child.conversationId,
+      agentId: input.child.id,
+      projectId: input.child.projectId,
+      runId: input.runId,
+    });
+    const state: ChildLiveState = {
+      ...input,
+      runtime,
+      tail: Promise.resolve(),
+      terminal: false,
+    };
+    this.children.set(input.child.id, state);
+    try {
+      await this.publish(state, "agent.subagent_transcript.run.started", {
+        startedAt: run.startedAt,
+      });
+    } catch (error) {
+      runtime.failRun(input.runId);
+      this.children.delete(input.child.id);
+      throw error;
+    }
+  }
+
+  handleHarnessEvent(
+    childAgentId: string,
+    event: AgentHarnessEvent,
+  ): Promise<void> {
+    const state = this.children.get(childAgentId);
+    if (!state || state.terminal) return Promise.resolve();
+    const work = state.tail.then(() => this.project(state, event));
+    state.tail = work.catch(() => undefined);
+    return work;
+  }
+
+  snapshot(childAgentId: string): ConversationActiveRunSnapshot | undefined {
+    const state = this.children.get(childAgentId);
+    return state?.runtime.snapshotForConversation(state.child.conversationId);
+  }
+
+  async complete(
+    childAgentId: string,
+    status: "completed" | "failed" | "aborted",
+    message?: string,
+  ): Promise<void> {
+    const state = this.children.get(childAgentId);
+    if (!state || state.terminal) return;
+    await state.tail;
+    state.terminal = true;
+    try {
+      await this.finishOpenLifecycle(
+        state,
+        status === "completed" ? "completed" : "failed",
+      );
+      await this.publish(state, "agent.subagent_transcript.run.completed", {
+        status,
+        completedAt: new Date().toISOString(),
+        message: message?.slice(0, PUBLIC_EVENT_MAX_STRING_CHARS),
+      });
+    } finally {
+      if (status === "completed") state.runtime.completeRun(state.runId);
+      else state.runtime.failRun(state.runId);
+      this.children.delete(childAgentId);
+    }
+  }
+
+  private async project(
+    state: ChildLiveState,
+    event: AgentHarnessEvent,
+  ): Promise<void> {
+    if (event.type === "turn_start") {
+      const turn = state.runtime.startTurn(state.runId);
+      state.turnId = turn.turnId;
+      state.liveMessageId = undefined;
+      await this.publish(state, "agent.subagent_transcript.turn.started", {
+        turnId: turn.turnId,
+        ordinal: turn.ordinal,
+      });
+      return;
+    }
+    if (event.type === "message_start" && event.message.role === "assistant") {
+      if (!state.turnId) {
+        const turn = state.runtime.startTurn(state.runId);
+        state.turnId = turn.turnId;
+        await this.publish(state, "agent.subagent_transcript.turn.started", {
+          turnId: turn.turnId,
+          ordinal: turn.ordinal,
+        });
+      }
+      const message = state.runtime.startAssistantMessage(
+        state.runId,
+        state.turnId,
+      );
+      state.liveMessageId = message.liveMessageId;
+      await this.publish(state, "agent.subagent_transcript.message.started", {
+        turnId: state.turnId,
+        liveMessageId: message.liveMessageId,
+        messageOrdinal: message.messageOrdinal,
+        startedAt: message.startedAt,
+      });
+      return;
+    }
+    if (
+      event.type === "message_update" &&
+      state.turnId &&
+      state.liveMessageId
+    ) {
+      const update = event.assistantMessageEvent;
+      if (update.type === "text_delta" || update.type === "thinking_delta") {
+        const data = state.runtime.applyContentDelta({
+          runId: state.runId,
+          turnId: state.turnId,
+          liveMessageId: state.liveMessageId,
+          contentIndex: update.contentIndex,
+          kind: update.type === "text_delta" ? "text" : "thinking",
+          delta: update.delta,
+        });
+        await this.publish(
+          state,
+          "agent.subagent_transcript.content.delta",
+          data,
+        );
+      } else if (update.type === "text_end" || update.type === "thinking_end") {
+        const kind = update.type === "text_end" ? "text" : "thinking";
+        const data = state.runtime.finishContent({
+          runId: state.runId,
+          turnId: state.turnId,
+          liveMessageId: state.liveMessageId,
+          contentIndex: update.contentIndex,
+          kind,
+          finalText: update.content,
+          redacted:
+            kind === "thinking"
+              ? assistantContentRedacted(update.partial, update.contentIndex)
+              : undefined,
+        });
+        await this.publish(state, "agent.subagent_transcript.content.done", {
+          ...data,
+          finalText:
+            data.finalText &&
+            data.finalText.length <= PUBLIC_EVENT_MAX_STRING_CHARS
+              ? data.finalText
+              : undefined,
+        });
+      }
+      return;
+    }
+    if (
+      event.type === "message_end" &&
+      event.message.role === "assistant" &&
+      state.turnId &&
+      state.liveMessageId
+    ) {
+      const failed =
+        event.message.stopReason === "error" ||
+        event.message.stopReason === "aborted";
+      if (failed)
+        state.runtime.failAssistantMessage(
+          state.runId,
+          state.turnId,
+          state.liveMessageId,
+        );
+      else
+        state.runtime.completeAssistantMessage(
+          state.runId,
+          state.turnId,
+          state.liveMessageId,
+        );
+      await this.publish(state, "agent.subagent_transcript.message.completed", {
+        turnId: state.turnId,
+        liveMessageId: state.liveMessageId,
+        status: failed ? "failed" : "completed",
+      });
+      state.liveMessageId = undefined;
+      return;
+    }
+    if (event.type === "turn_end" && state.turnId) {
+      const failed =
+        event.message.role === "assistant" &&
+        (event.message.stopReason === "error" ||
+          event.message.stopReason === "aborted");
+      const turnId = state.turnId;
+      if (failed) state.runtime.failTurn(state.runId, turnId);
+      else state.runtime.completeTurn(state.runId, turnId);
+      await this.publish(state, "agent.subagent_transcript.turn.completed", {
+        turnId,
+        status: failed ? "failed" : "completed",
+      });
+      state.turnId = undefined;
+    }
+  }
+
+  private async finishOpenLifecycle(
+    state: ChildLiveState,
+    status: "completed" | "failed",
+  ) {
+    if (state.turnId && state.liveMessageId) {
+      if (status === "completed")
+        state.runtime.completeAssistantMessage(
+          state.runId,
+          state.turnId,
+          state.liveMessageId,
+        );
+      else
+        state.runtime.failAssistantMessage(
+          state.runId,
+          state.turnId,
+          state.liveMessageId,
+        );
+      await this.publish(state, "agent.subagent_transcript.message.completed", {
+        turnId: state.turnId,
+        liveMessageId: state.liveMessageId,
+        status,
+      });
+      state.liveMessageId = undefined;
+    }
+    if (state.turnId) {
+      const turnId = state.turnId;
+      if (status === "completed")
+        state.runtime.completeTurn(state.runId, turnId);
+      else state.runtime.failTurn(state.runId, turnId);
+      await this.publish(state, "agent.subagent_transcript.turn.completed", {
+        turnId,
+        status,
+      });
+      state.turnId = undefined;
+    }
+  }
+
+  private publish(state: ChildLiveState, type: string, data: object) {
+    const payload = { ...(data as Record<string, unknown>) };
+    delete payload.conversationId;
+    delete payload.projectId;
+    delete payload.agentId;
+    delete payload.runId;
+    return this.events.publish(type, {
+      conversationId: state.child.conversationId,
+      projectId: state.child.projectId,
+      parentAgentId: state.parentAgentId,
+      childAgentId: state.child.id,
+      runId: state.runId,
+      ...payload,
+    });
+  }
+}

--- a/packages/workbench-server/src/domains/agents/subagent-transcript.service.ts
+++ b/packages/workbench-server/src/domains/agents/subagent-transcript.service.ts
@@ -5,6 +5,7 @@ import {
   type ConversationTreeEntry,
 } from "@nervekit/harness";
 import {
+  conversationStream,
   SUBAGENT_TRANSCRIPT_MAX_ENTRIES,
   SUBAGENT_TRANSCRIPT_MAX_TEXT_CHARS,
   SUBAGENT_TRANSCRIPT_MAX_THINKING_BLOCKS,
@@ -18,10 +19,12 @@ import {
   type InitializedStorage,
   pathExists,
 } from "../../infrastructure/storage/index.js";
+import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { ConversationHarnessStorage } from "../conversations/conversation-harness-storage.js";
 import type { ToolService } from "../tools/tool-service.js";
 import { toToolCallTranscriptRecord } from "../tools/tool-call-transcript-preview.js";
 import { projectHarnessMessageEntry } from "./run/message-mirror.js";
+import type { SubagentTranscriptLiveService } from "./subagent-transcript-live.service.js";
 
 const MAX_PROJECTED_TEXT_CHARS = 2 * 1024 * 1024;
 
@@ -30,6 +33,8 @@ export interface SubagentTranscriptServiceDeps {
   harnessStorage: ConversationHarnessStorage;
   tools: ToolService;
   getAgent: (agentId: string) => AgentRecord;
+  events: StreamLogRegistry;
+  live: SubagentTranscriptLiveService;
 }
 
 function modelLabel(agent: AgentRecord): string | undefined {
@@ -168,79 +173,96 @@ export class SubagentTranscriptService {
       );
     }
 
-    const childPath = join(
-      this.deps.storage.paths.home,
-      "agents",
-      child.id,
-      "conversation.jsonl",
-    );
-    let projected: SubagentTranscriptEntry[] = [];
-    if (await pathExists(childPath)) {
-      const env = new NodeExecutionEnv({
-        cwd: child.projectDir,
-        shellPath: this.deps.storage.settings.runtime.shellPath,
-      });
-      const childStorage = await JsonlConversationStorage.open(env, childPath);
-      const parentPath = this.deps.harnessStorage.conversationPath(
-        parent.conversationId,
-      );
-      const parentIds = new Set<string>();
-      if (await pathExists(parentPath)) {
-        const parentStorage = await JsonlConversationStorage.open(
-          env,
-          parentPath,
+    const captured = await this.deps.events.withCursor(
+      conversationStream(child.conversationId),
+      async () => {
+        const childPath = join(
+          this.deps.storage.paths.home,
+          "agents",
+          child.id,
+          "conversation.jsonl",
         );
-        for (const entry of await parentStorage.getEntries())
-          parentIds.add(entry.id);
-      }
-      projected = messageEntries(await childStorage.getEntries())
-        .filter((entry) => !parentIds.has(entry.id))
-        .map((entry) =>
-          boundedEntry(
-            projectHarnessMessageEntry({
-              entry,
-              conversationId: child.conversationId,
-              agentId: child.id,
-            }),
-          ),
-        )
-        .filter((entry): entry is SubagentTranscriptEntry => Boolean(entry));
-    }
+        let projected: SubagentTranscriptEntry[] = [];
+        if (await pathExists(childPath)) {
+          const env = new NodeExecutionEnv({
+            cwd: child.projectDir,
+            shellPath: this.deps.storage.settings.runtime.shellPath,
+          });
+          const childStorage = await JsonlConversationStorage.open(
+            env,
+            childPath,
+          );
+          const parentPath = this.deps.harnessStorage.conversationPath(
+            parent.conversationId,
+          );
+          const parentIds = new Set<string>();
+          if (await pathExists(parentPath)) {
+            const parentStorage = await JsonlConversationStorage.open(
+              env,
+              parentPath,
+            );
+            for (const entry of await parentStorage.getEntries())
+              parentIds.add(entry.id);
+          }
+          projected = messageEntries(await childStorage.getEntries())
+            .filter((entry) => !parentIds.has(entry.id))
+            .map((entry) =>
+              boundedEntry(
+                projectHarnessMessageEntry({
+                  entry,
+                  conversationId: child.conversationId,
+                  agentId: child.id,
+                }),
+              ),
+            )
+            .filter((entry): entry is SubagentTranscriptEntry =>
+              Boolean(entry),
+            );
+        }
 
-    const allToolCalls = this.deps.tools
-      .listToolCalls()
-      .filter((toolCall) => toolCall.agentId === child.id)
-      .sort((a, b) =>
-        a.createdAt === b.createdAt
-          ? a.id.localeCompare(b.id)
-          : a.createdAt.localeCompare(b.createdAt),
-      );
-    const toolCalls = allToolCalls
-      .slice(-SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS)
-      .map(toToolCallTranscriptRecord);
-    const entries = boundedTail(projected);
-    const updatedAt = [
-      child.updatedAt,
-      entries.at(-1)?.createdAt,
-      toolCalls.at(-1)?.updatedAt,
-    ]
-      .filter((value): value is string => Boolean(value))
-      .sort()
-      .at(-1)!;
+        const allToolCalls = this.deps.tools
+          .listToolCalls()
+          .filter((toolCall) => toolCall.agentId === child.id)
+          .sort((a, b) =>
+            a.createdAt === b.createdAt
+              ? a.id.localeCompare(b.id)
+              : a.createdAt.localeCompare(b.createdAt),
+          );
+        const toolCalls = allToolCalls
+          .slice(-SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS)
+          .map(toToolCallTranscriptRecord);
+        const entries = boundedTail(projected);
+        const updatedAt = [
+          child.updatedAt,
+          entries.at(-1)?.createdAt,
+          toolCalls.at(-1)?.updatedAt,
+        ]
+          .filter((value): value is string => Boolean(value))
+          .sort()
+          .at(-1)!;
 
+        return {
+          agentId: child.id,
+          parentAgentId: parent.id,
+          conversationId: child.conversationId,
+          projectId: child.projectId,
+          activeRun: this.deps.live.snapshot(child.id),
+          status: child.status,
+          model: modelLabel(child),
+          thinkingLevel: child.thinkingLevel,
+          entries,
+          toolCalls,
+          totalEntryCount: projected.length,
+          totalToolCallCount: allToolCalls.length,
+          entriesTruncated: entries.length < projected.length,
+          toolCallsTruncated: toolCalls.length < allToolCalls.length,
+          updatedAt,
+        };
+      },
+    );
     return {
-      agentId: child.id,
-      parentAgentId: parent.id,
-      status: child.status,
-      model: modelLabel(child),
-      thinkingLevel: child.thinkingLevel,
-      entries,
-      toolCalls,
-      totalEntryCount: projected.length,
-      totalToolCallCount: allToolCalls.length,
-      entriesTruncated: entries.length < projected.length,
-      toolCallsTruncated: toolCalls.length < allToolCalls.length,
-      updatedAt,
+      ...captured.value,
+      cursorSeq: captured.cursor.processedSeq,
     };
   }
 }

--- a/packages/workbench-server/src/domains/agents/subagent-transcript.service.ts
+++ b/packages/workbench-server/src/domains/agents/subagent-transcript.service.ts
@@ -1,0 +1,246 @@
+import { join } from "node:path";
+import {
+  JsonlConversationStorage,
+  NodeExecutionEnv,
+  type ConversationTreeEntry,
+} from "@nervekit/harness";
+import {
+  SUBAGENT_TRANSCRIPT_MAX_ENTRIES,
+  SUBAGENT_TRANSCRIPT_MAX_TEXT_CHARS,
+  SUBAGENT_TRANSCRIPT_MAX_THINKING_BLOCKS,
+  SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS,
+  type AgentRecord,
+  type SubagentTranscriptEntry,
+  type SubagentTranscriptSnapshot,
+} from "@nervekit/contracts";
+import { ApplicationError } from "../../core/application-error.js";
+import {
+  type InitializedStorage,
+  pathExists,
+} from "../../infrastructure/storage/index.js";
+import type { ConversationHarnessStorage } from "../conversations/conversation-harness-storage.js";
+import type { ToolService } from "../tools/tool-service.js";
+import { toToolCallTranscriptRecord } from "../tools/tool-call-transcript-preview.js";
+import { projectHarnessMessageEntry } from "./run/message-mirror.js";
+
+const MAX_PROJECTED_TEXT_CHARS = 2 * 1024 * 1024;
+
+export interface SubagentTranscriptServiceDeps {
+  storage: InitializedStorage;
+  harnessStorage: ConversationHarnessStorage;
+  tools: ToolService;
+  getAgent: (agentId: string) => AgentRecord;
+}
+
+function modelLabel(agent: AgentRecord): string | undefined {
+  if (!agent.model) return undefined;
+  return `${agent.model.provider}/${agent.model.modelId}`;
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function boundedEntry(
+  entry: ReturnType<typeof projectHarnessMessageEntry>,
+): SubagentTranscriptEntry | undefined {
+  if (!entry || !entry.agentId) return undefined;
+  const details = entry.details as Record<string, unknown> | undefined;
+  let boundedDetails: SubagentTranscriptEntry["details"];
+  if (details && Array.isArray(details.thinkingBlocks)) {
+    boundedDetails = {
+      thinkingBlocks: details.thinkingBlocks
+        .filter((block): block is { text: string; redacted?: boolean } =>
+          Boolean(
+            block &&
+            typeof block === "object" &&
+            typeof (block as { text?: unknown }).text === "string",
+          ),
+        )
+        .slice(0, SUBAGENT_TRANSCRIPT_MAX_THINKING_BLOCKS)
+        .map((block) => ({
+          text: truncate(block.text, SUBAGENT_TRANSCRIPT_MAX_TEXT_CHARS),
+          redacted: block.redacted,
+        })),
+      stopReason:
+        details.stopReason === "error" || details.stopReason === "aborted"
+          ? details.stopReason
+          : undefined,
+      errorMessage:
+        typeof details.errorMessage === "string"
+          ? truncate(details.errorMessage, 2_048)
+          : undefined,
+    };
+  } else if (details && typeof details.isError === "boolean") {
+    boundedDetails = {
+      toolCallId:
+        typeof details.toolCallId === "string"
+          ? truncate(details.toolCallId, 512)
+          : undefined,
+      toolRecordId:
+        typeof details.toolRecordId === "string" &&
+        details.toolRecordId.startsWith("tool_")
+          ? details.toolRecordId
+          : undefined,
+      toolName:
+        typeof details.toolName === "string"
+          ? truncate(details.toolName, 128)
+          : undefined,
+      status: details.isError ? "error" : "completed",
+      isError: details.isError,
+      outputOmitted: details.isError ? undefined : true,
+    };
+  }
+  return {
+    id: truncate(entry.id, 512),
+    conversationId: entry.conversationId,
+    agentId: entry.agentId,
+    role: entry.role,
+    kind: "message",
+    text: truncate(entry.text, SUBAGENT_TRANSCRIPT_MAX_TEXT_CHARS),
+    usage: entry.usage,
+    details: boundedDetails,
+    createdAt: entry.createdAt,
+  };
+}
+
+function textSize(entry: SubagentTranscriptEntry): number {
+  const thinking =
+    entry.details && "thinkingBlocks" in entry.details
+      ? (entry.details.thinkingBlocks ?? []).reduce(
+          (sum, block) => sum + block.text.length,
+          0,
+        )
+      : 0;
+  return entry.text.length + thinking;
+}
+
+function boundedTail(
+  entries: SubagentTranscriptEntry[],
+): SubagentTranscriptEntry[] {
+  if (entries.length === 0) return [];
+  const firstAssignment = entries.find((entry) => entry.role === "user");
+  const selected: SubagentTranscriptEntry[] = [];
+  const tailLimit = SUBAGENT_TRANSCRIPT_MAX_ENTRIES - (firstAssignment ? 1 : 0);
+  let size = firstAssignment ? textSize(firstAssignment) : 0;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!entry || entry === firstAssignment) continue;
+    const nextSize = textSize(entry);
+    if (selected.length >= tailLimit) break;
+    if (size + nextSize > MAX_PROJECTED_TEXT_CHARS) break;
+    selected.push(entry);
+    size += nextSize;
+  }
+  selected.reverse();
+  if (firstAssignment) selected.unshift(firstAssignment);
+  return selected.slice(-SUBAGENT_TRANSCRIPT_MAX_ENTRIES);
+}
+
+function messageEntries(
+  entries: ConversationTreeEntry[],
+): Array<Extract<ConversationTreeEntry, { type: "message" }>> {
+  return entries.filter(
+    (entry): entry is Extract<ConversationTreeEntry, { type: "message" }> =>
+      entry.type === "message",
+  );
+}
+
+export class SubagentTranscriptService {
+  constructor(private readonly deps: SubagentTranscriptServiceDeps) {}
+
+  async get(
+    parentAgentId: string,
+    childAgentId: string,
+  ): Promise<SubagentTranscriptSnapshot> {
+    const parent = this.deps.getAgent(parentAgentId);
+    const child = this.deps.getAgent(childAgentId);
+    if (
+      child.parentAgentId !== parent.id ||
+      child.conversationId !== parent.conversationId ||
+      child.projectId !== parent.projectId ||
+      child.rootAgentId !== parent.rootAgentId
+    ) {
+      throw new ApplicationError(
+        404,
+        "SUBAGENT_TRANSCRIPT_NOT_FOUND",
+        "Subagent transcript not found.",
+      );
+    }
+
+    const childPath = join(
+      this.deps.storage.paths.home,
+      "agents",
+      child.id,
+      "conversation.jsonl",
+    );
+    let projected: SubagentTranscriptEntry[] = [];
+    if (await pathExists(childPath)) {
+      const env = new NodeExecutionEnv({
+        cwd: child.projectDir,
+        shellPath: this.deps.storage.settings.runtime.shellPath,
+      });
+      const childStorage = await JsonlConversationStorage.open(env, childPath);
+      const parentPath = this.deps.harnessStorage.conversationPath(
+        parent.conversationId,
+      );
+      const parentIds = new Set<string>();
+      if (await pathExists(parentPath)) {
+        const parentStorage = await JsonlConversationStorage.open(
+          env,
+          parentPath,
+        );
+        for (const entry of await parentStorage.getEntries())
+          parentIds.add(entry.id);
+      }
+      projected = messageEntries(await childStorage.getEntries())
+        .filter((entry) => !parentIds.has(entry.id))
+        .map((entry) =>
+          boundedEntry(
+            projectHarnessMessageEntry({
+              entry,
+              conversationId: child.conversationId,
+              agentId: child.id,
+            }),
+          ),
+        )
+        .filter((entry): entry is SubagentTranscriptEntry => Boolean(entry));
+    }
+
+    const allToolCalls = this.deps.tools
+      .listToolCalls()
+      .filter((toolCall) => toolCall.agentId === child.id)
+      .sort((a, b) =>
+        a.createdAt === b.createdAt
+          ? a.id.localeCompare(b.id)
+          : a.createdAt.localeCompare(b.createdAt),
+      );
+    const toolCalls = allToolCalls
+      .slice(-SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS)
+      .map(toToolCallTranscriptRecord);
+    const entries = boundedTail(projected);
+    const updatedAt = [
+      child.updatedAt,
+      entries.at(-1)?.createdAt,
+      toolCalls.at(-1)?.updatedAt,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .sort()
+      .at(-1)!;
+
+    return {
+      agentId: child.id,
+      parentAgentId: parent.id,
+      status: child.status,
+      model: modelLabel(child),
+      thinkingLevel: child.thinkingLevel,
+      entries,
+      toolCalls,
+      totalEntryCount: projected.length,
+      totalToolCallCount: allToolCalls.length,
+      entriesTruncated: entries.length < projected.length,
+      toolCallsTruncated: toolCalls.length < allToolCalls.length,
+      updatedAt,
+    };
+  }
+}

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -5,6 +5,7 @@ import {
   type ApprovalRecord,
   assertTransition,
   createId,
+  type ExploreReportSummaryPayload,
   type Mode,
   type StartTaskRequest,
   type TaskRecord,
@@ -81,6 +82,8 @@ export type ExploreProgressUpdate = {
     | "completed"
     | "failed";
   message: string;
+  /** Bounded terminal projection for progressive per-child report rendering. */
+  report?: ExploreReportSummaryPayload;
 };
 
 export type ExploreRunResult = {

--- a/packages/workbench-server/src/protocol/method-handlers/conversation-agent-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/conversation-agent-method-handlers.ts
@@ -43,6 +43,12 @@ export const conversationAgentMethodHandlers = defineWorkbenchMethodHandlers({
   "agent.get": (state, params) => ({
     agent: state.registry.getAgent(params.agentId),
   }),
+  "agent.subagentTranscript.get": async (state, params) => ({
+    transcript: await state.registry.subagentTranscripts.get(
+      params.parentAgentId,
+      params.childAgentId,
+    ),
+  }),
   "agent.configure": async (state, params) => ({
     agent: await state.registry.configureAgent(params.agentId, params),
   }),

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -11,6 +11,7 @@ import {
 } from "../domains/agents/run/index.js";
 import type { AgentBrowserSkillCatalog } from "../domains/agents/prompting/agent-browser-skills.js";
 import { SubagentTranscriptService } from "../domains/agents/subagent-transcript.service.js";
+import { SubagentTranscriptLiveService } from "../domains/agents/subagent-transcript-live.service.js";
 import type { AuthManager } from "../domains/auth/index.js";
 import { WorkbenchExploreAdmission } from "../domains/agents/run/workbench-explore-admission.js";
 import { WorkbenchSubagentExecutions } from "../domains/agents/run/workbench-subagent-executions.js";
@@ -114,6 +115,7 @@ export interface RuntimeServices {
   conversationLifecycle: ConversationLifecycleService;
   conversationQuery: ConversationQueryService;
   agentLifecycle: AgentLifecycleService;
+  subagentTranscriptLive: SubagentTranscriptLiveService;
   subagentTranscripts: SubagentTranscriptService;
   humanInput: HumanInputResolutionService;
   pruneConversations: PruneProjectConversationsService;
@@ -430,11 +432,14 @@ export function composeRuntime(
     state.conversationRuntime,
     logger.child({ component: "tool" }),
   );
+  services.subagentTranscriptLive = new SubagentTranscriptLiveService(events);
   services.subagentTranscripts = new SubagentTranscriptService({
     storage,
     harnessStorage: services.harnessStorage,
     tools: services.tools,
     getAgent,
+    events,
+    live: services.subagentTranscriptLive,
   });
   services.agentMechanics = new WorkbenchAgentMechanics({
     storage,
@@ -457,6 +462,7 @@ export function composeRuntime(
     subscriptionUsage,
     logger: logger.child({ component: "workbench-agent-execution" }),
     agentBrowserSkills: deps.agentBrowserSkills,
+    subagentTranscriptLive: services.subagentTranscriptLive,
     exploreAdmission,
     subagentExecutions,
   });

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -10,6 +10,7 @@ import {
   MessageMirror,
 } from "../domains/agents/run/index.js";
 import type { AgentBrowserSkillCatalog } from "../domains/agents/prompting/agent-browser-skills.js";
+import { SubagentTranscriptService } from "../domains/agents/subagent-transcript.service.js";
 import type { AuthManager } from "../domains/auth/index.js";
 import { WorkbenchExploreAdmission } from "../domains/agents/run/workbench-explore-admission.js";
 import { WorkbenchSubagentExecutions } from "../domains/agents/run/workbench-subagent-executions.js";
@@ -113,6 +114,7 @@ export interface RuntimeServices {
   conversationLifecycle: ConversationLifecycleService;
   conversationQuery: ConversationQueryService;
   agentLifecycle: AgentLifecycleService;
+  subagentTranscripts: SubagentTranscriptService;
   humanInput: HumanInputResolutionService;
   pruneConversations: PruneProjectConversationsService;
 }
@@ -428,6 +430,12 @@ export function composeRuntime(
     state.conversationRuntime,
     logger.child({ component: "tool" }),
   );
+  services.subagentTranscripts = new SubagentTranscriptService({
+    storage,
+    harnessStorage: services.harnessStorage,
+    tools: services.tools,
+    getAgent,
+  });
   services.agentMechanics = new WorkbenchAgentMechanics({
     storage,
     events,

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -87,6 +87,10 @@ export class RuntimeRegistry {
     return this.services.tools;
   }
 
+  get subagentTranscripts() {
+    return this.services.subagentTranscripts;
+  }
+
   get git() {
     return this.services.git;
   }

--- a/packages/workbench-server/test/explore-progress-summary.test.ts
+++ b/packages/workbench-server/test/explore-progress-summary.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { allToolDescriptors } from "@nervekit/tools";
+import { summarizeExploreToolCall } from "../src/domains/agents/run/explore-tool-summary.js";
+
+describe("Explore progress tool summaries", () => {
+  it("summarizes representative tool families with bounded context", () => {
+    assert.equal(
+      summarizeExploreToolCall("read", { path: "src/server.ts", offset: 8 }),
+      "Reading file (src/server.ts · line 8)",
+    );
+    assert.equal(
+      summarizeExploreToolCall("grep", {
+        pattern: "createServer",
+        path: "packages/workbench-server",
+      }),
+      'Searching codebase ("createServer" in packages/workbench-server)',
+    );
+    assert.equal(
+      summarizeExploreToolCall("find", {
+        pattern: "**/*.test.ts",
+        path: "packages",
+      }),
+      'Finding files ("**/*.test.ts" in packages)',
+    );
+    assert.equal(
+      summarizeExploreToolCall("ls", { path: "packages/tools" }),
+      "Listing directory (packages/tools)",
+    );
+    assert.equal(
+      summarizeExploreToolCall("web_search", { query: "Svelte virtualizer" }),
+      "Searching the web (Svelte virtualizer)",
+    );
+    assert.equal(
+      summarizeExploreToolCall("task_logs", {
+        taskId: "dev-server",
+        mode: "errors",
+      }),
+      "Reading task logs (dev-server · errors)",
+    );
+    assert.equal(
+      summarizeExploreToolCall("jira_get_issue", { issue_key: "NER-42" }),
+      "Reading Jira issue (NER-42)",
+    );
+    assert.equal(
+      summarizeExploreToolCall("confluence_get_page", { page_id: "123" }),
+      "Reading Confluence page (123)",
+    );
+    assert.equal(
+      summarizeExploreToolCall("plan_mode_enter", {}),
+      "Entering plan mode",
+    );
+    assert.equal(
+      summarizeExploreToolCall("future_tool", {}),
+      "Running future tool",
+    );
+  });
+
+  it("has specialized wording for every current built-in tool", () => {
+    for (const descriptor of allToolDescriptors) {
+      const fallback = `Running ${descriptor.name.replace(/[_-]+/g, " ")}`;
+      assert.notEqual(
+        summarizeExploreToolCall(descriptor.name, {}),
+        fallback,
+        `missing Explore activity summary for ${descriptor.name}`,
+      );
+    }
+  });
+
+  it("does not expose commands, scripts, environment values, or URL secrets", () => {
+    const secret = "do-not-display-this-secret";
+    const summaries = [
+      summarizeExploreToolCall("bash", {
+        command: `curl https://user:${secret}@example.test`,
+      }),
+      summarizeExploreToolCall("python_exec", {
+        code: `print(${JSON.stringify(secret)})`,
+        env: { TOKEN: secret },
+      }),
+      summarizeExploreToolCall("edit", {
+        path: "src/config.ts",
+        patch: secret,
+      }),
+      summarizeExploreToolCall("web_fetch", {
+        url: `https://user:${secret}@example.test/docs?token=${secret}#private`,
+      }),
+    ];
+    for (const summary of summaries) assert.ok(!summary.includes(secret));
+    assert.equal(summaries[3], "Fetching web page (https://example.test/docs)");
+  });
+
+  it("truncates argument-derived detail", () => {
+    const summary = summarizeExploreToolCall("web_search", {
+      query: "x".repeat(1_000),
+    });
+    assert.ok(summary.length < 160);
+    assert.match(summary, /…\)$/);
+  });
+});

--- a/packages/workbench-server/test/explore-subagent-isolation.test.ts
+++ b/packages/workbench-server/test/explore-subagent-isolation.test.ts
@@ -120,6 +120,25 @@ describe("explore subagent transcript isolation", () => {
       assert.equal(childToolCalls[0]?.toolName, "ls");
       assert.equal(childToolCalls[0]?.status, "completed");
       assert.equal(childToolCalls[0]?.hidden, true);
+      const childTranscript =
+        await orchestrator.registry.subagentTranscripts.get(
+          parent.id,
+          child.id,
+        );
+      assert.equal(childTranscript.parentAgentId, parent.id);
+      assert.equal(childTranscript.agentId, child.id);
+      assert.match(
+        childTranscript.entries.map((entry) => entry.text).join("\n"),
+        /focused read-only verification|temporary project is isolated/i,
+      );
+      assert.equal(childTranscript.toolCalls.length, 1);
+      assert.equal(childTranscript.toolCalls[0]?.toolName, "ls");
+      assert.equal(childTranscript.toolCalls[0]?.hidden, true);
+      assert.equal(childTranscript.entriesTruncated, false);
+      await assert.rejects(
+        orchestrator.registry.subagentTranscripts.get(child.id, parent.id),
+        hasErrorCode("SUBAGENT_TRANSCRIPT_NOT_FOUND"),
+      );
       assert.equal(
         snapshot.toolCalls.some((toolCall) => toolCall.agentId === child.id),
         false,

--- a/packages/workbench-server/test/explore-subagent-isolation.test.ts
+++ b/packages/workbench-server/test/explore-subagent-isolation.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import { registerAgentScriptedProvider } from "@nervekit/harness";
+import { conversationStream } from "@nervekit/contracts";
 import {
   createOrchestratorState,
   shutdownOrchestratorState,
@@ -135,6 +136,35 @@ describe("explore subagent transcript isolation", () => {
       assert.equal(childTranscript.toolCalls[0]?.toolName, "ls");
       assert.equal(childTranscript.toolCalls[0]?.hidden, true);
       assert.equal(childTranscript.entriesTruncated, false);
+      assert.equal(childTranscript.conversationId, conversation.id);
+      assert.equal(childTranscript.projectId, project.id);
+      assert.equal(childTranscript.activeRun, undefined);
+      assert.ok(childTranscript.cursorSeq > 0);
+
+      const stream = await orchestrator.events.readStream(
+        conversationStream(conversation.id),
+        1,
+        1_000,
+      );
+      const dedicated = stream.events.filter((event) =>
+        event.type.startsWith("agent.subagent_transcript."),
+      );
+      assert.ok(dedicated.length > 0);
+      assert.equal(dedicated[0]?.type, "agent.subagent_transcript.run.started");
+      assert.equal(
+        dedicated.at(-1)?.type,
+        "agent.subagent_transcript.run.completed",
+      );
+      assert.equal(
+        stream.events.some(
+          (event) =>
+            event.type.startsWith("conversation.live.") &&
+            (event.data as { agentId?: string }).agentId === child.id,
+        ),
+        false,
+      );
+      const dedicatedJson = JSON.stringify(dedicated);
+      assert.doesNotMatch(dedicatedJson, /explore_ls_1|arguments|result|cwd/);
       await assert.rejects(
         orchestrator.registry.subagentTranscripts.get(child.id, parent.id),
         hasErrorCode("SUBAGENT_TRANSCRIPT_NOT_FOUND"),

--- a/packages/workbench-server/test/subagent-transcript-live.test.ts
+++ b/packages/workbench-server/test/subagent-transcript-live.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import type { AgentHarnessEvent } from "@nervekit/harness";
+import type { AgentRecord } from "@nervekit/contracts";
+import { conversationStream } from "@nervekit/contracts";
+import { SubagentTranscriptLiveService } from "../src/domains/agents/subagent-transcript-live.service.js";
+import { StreamLogRegistry } from "../src/infrastructure/events/index.js";
+
+const ts = "2026-08-02T00:00:00.000Z";
+
+function child(id: string): AgentRecord {
+  return {
+    id,
+    projectId: "proj_test",
+    conversationId: "conv_test",
+    rootAgentId: "agent_parent",
+    parentAgentId: "agent_parent",
+    projectDir: "/workspace",
+    mode: "coding",
+    permissionLevel: "read_only",
+    workspaceScope: { roots: ["/workspace"] },
+    status: "running",
+    thinkingLevel: "off",
+    budget: { depth: 1, maxDepth: 3 },
+    createdAt: ts,
+    updatedAt: ts,
+  } as AgentRecord;
+}
+
+function harnessEvent(value: unknown): AgentHarnessEvent {
+  return value as AgentHarnessEvent;
+}
+
+describe("subagent transcript live service", () => {
+  it("streams bounded canonical text with isolated sibling runtimes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-child-live-"));
+    try {
+      const events = new StreamLogRegistry(root);
+      await events.hydrate();
+      const live = new SubagentTranscriptLiveService(events);
+      const first = child("agent_child_one");
+      const second = child("agent_child_two");
+      await live.register({
+        parentAgentId: "agent_parent",
+        child: first,
+        runId: "run_child_one",
+      });
+      await live.register({
+        parentAgentId: "agent_parent",
+        child: second,
+        runId: "run_child_two",
+      });
+
+      await live.handleHarnessEvent(
+        first.id,
+        harnessEvent({ type: "turn_start" }),
+      );
+      await live.handleHarnessEvent(
+        first.id,
+        harnessEvent({
+          type: "message_start",
+          message: { role: "assistant" },
+        }),
+      );
+      await live.handleHarnessEvent(
+        first.id,
+        harnessEvent({
+          type: "message_update",
+          assistantMessageEvent: {
+            type: "text_delta",
+            contentIndex: 0,
+            delta: "partial",
+          },
+        }),
+      );
+
+      const firstSnapshot = live.snapshot(first.id);
+      const secondSnapshot = live.snapshot(second.id);
+      assert.equal(
+        firstSnapshot?.turns[0]?.messages[0]?.blocks[0]?.kind,
+        "text",
+      );
+      assert.equal(
+        firstSnapshot?.turns[0]?.messages[0]?.blocks[0]?.text,
+        "partial",
+      );
+      assert.deepEqual(secondSnapshot?.turns, []);
+
+      const stream = await events.readStream(
+        conversationStream("conv_test"),
+        1,
+        100,
+      );
+      const delta = stream.events.find(
+        (event) => event.type === "agent.subagent_transcript.content.delta",
+      );
+      assert.deepEqual(delta?.data, {
+        conversationId: "conv_test",
+        projectId: "proj_test",
+        parentAgentId: "agent_parent",
+        childAgentId: first.id,
+        runId: "run_child_one",
+        turnId: firstSnapshot?.turns[0]?.turnId,
+        liveMessageId: firstSnapshot?.turns[0]?.messages[0]?.liveMessageId,
+        contentBlockId:
+          firstSnapshot?.turns[0]?.messages[0]?.blocks[0]?.contentBlockId,
+        contentIndex: 0,
+        kind: "text",
+        offset: 0,
+        delta: "partial",
+      });
+
+      await live.complete(first.id, "aborted", "stopped");
+      assert.equal(live.snapshot(first.id), undefined);
+      assert.ok(live.snapshot(second.id));
+      await live.complete(second.id, "completed");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- unify Explore drafting, queued, running, and terminal states in a stable per-agent UI
- add compact progress summaries with immediate completed, failed, and stopped differentiation
- add a lazy, bounded, virtualized read-only subagent transcript dialog
- introduce an ownership-validated transcript protocol and server projection for child messages and hidden tool previews
- add contract, isolation, and timeline coverage

## Validation
- `pnpm fix && pnpm check && pnpm test`

## Notes
- browser-based visual validation was skipped at the user's request
