### PR TITLE
Optimize live transcript rendering

### DIFF
--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -18,6 +18,7 @@
     "./core/components/Markdown.svelte": "./src/lib/core/components/Markdown.svelte",
     "./core/components/PlainText.svelte": "./src/lib/core/components/PlainText.svelte",
     "./core/components/markdown-render": "./src/lib/core/components/markdown-render.ts",
+    "./core/components/streaming-markdown": "./src/lib/core/components/streaming-markdown.ts",
     "./core/highlight/highlight": "./src/lib/core/highlight/highlight.ts",
     "./core/terminal/ansi": "./src/lib/core/terminal/ansi.ts",
     "./core/notify": "./src/lib/core/notify.ts",

--- a/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller-types.ts
+++ b/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller-types.ts
@@ -32,6 +32,11 @@ export type VirtualScrollerProps<T> = {
    * Keep this independent of mutable content and status fields.
    */
   getKey: (item: T, index: number) => string | number;
+  /**
+   * Optional caller-owned revision for the item key sequence. When supplied,
+   * full key capture/reconciliation is skipped until this value changes.
+   */
+  structureVersion?: unknown;
   /** Estimated row height in px before measurement. Defaults to 64. */
   estimateSize?: (index: number) => number;
   /**

--- a/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller.svelte
+++ b/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller.svelte
@@ -23,6 +23,7 @@ import { shouldCommitVirtualMeasurement } from "./virtual-measurement";
 let {
   items,
   getKey,
+  structureVersion,
   estimateSize,
   heightCacheKey,
   getMeasurementVersion,
@@ -67,6 +68,8 @@ $effect(() => {
 });
 
 let itemKeySnapshot: readonly VirtualScrollerItemKey[] = Object.freeze([]);
+let keySnapshotInitialized = false;
+let reconciledStructureVersion: unknown;
 
 function resolveEstimate(index: number): number {
   const key = itemKeySnapshot[index];
@@ -165,11 +168,16 @@ $effect(() => {
 // scroll element binds so `_willUpdate` can attach scroll listeners.
 $effect(() => {
   void viewportEl;
-  const nextKeySnapshot = captureItemKeySnapshot(items, getKey);
-  const structuralKeysChanged = !itemKeySnapshotsEqual(
-    itemKeySnapshot,
-    nextKeySnapshot,
-  );
+  const shouldCaptureKeys =
+    !keySnapshotInitialized ||
+    structureVersion === undefined ||
+    !Object.is(structureVersion, reconciledStructureVersion);
+  const nextKeySnapshot = shouldCaptureKeys
+    ? captureItemKeySnapshot(items, getKey)
+    : itemKeySnapshot;
+  const structuralKeysChanged =
+    shouldCaptureKeys &&
+    !itemKeySnapshotsEqual(itemKeySnapshot, nextKeySnapshot);
   // End-follow is deliberately independent of full structural detection: an
   // interior draft-to-tool replacement must refresh identity without pulling
   // a manually scrolled viewport back to the tail.
@@ -177,6 +185,8 @@ $effect(() => {
     nextKeySnapshot.length !== itemKeySnapshot.length ||
     !Object.is(nextKeySnapshot.at(-1), itemKeySnapshot.at(-1));
   itemKeySnapshot = nextKeySnapshot;
+  keySnapshotInitialized = true;
+  reconciledStructureVersion = structureVersion;
 
   instance.setOptions({
     count: items.length,

--- a/packages/ui-kit/src/lib/core/components/Markdown.svelte
+++ b/packages/ui-kit/src/lib/core/components/Markdown.svelte
@@ -10,6 +10,11 @@ import {
   renderMarkdown,
 } from "@nervekit/ui-kit/core/components/markdown-render";
 import {
+  appendedNewline,
+  splitStreamingMarkdown,
+} from "@nervekit/ui-kit/core/components/streaming-markdown";
+import { LatestPresentationScheduler } from "@nervekit/ui-kit/core/utils/latest-presentation-scheduler";
+import {
   parseLocalFileHref,
   resolveDisplayPath,
   splitPathLineSuffix,
@@ -18,16 +23,14 @@ import {
 type Props = {
   text: string;
   trimCodeBlocks?: boolean;
-  /**
-   * When true, coalesce re-renders to one frame and defer syntax highlighting
-   * (shiki) until streaming stops. Avoids per-token unified parse + async
-   * highlight cost for the actively streaming message.
-   */
+  /** Bound streaming work while deferring Shiki until completion. */
   streaming?: boolean;
   linkBasePath?: string;
   onOpenFile?: (path: string, line?: number) => void;
   onCopy?: (ok: boolean) => void;
 };
+
+type StreamingValue = { source: string; trim: boolean };
 
 let {
   text,
@@ -38,17 +41,34 @@ let {
   onCopy,
 }: Props = $props();
 
-const initialRender = untrack(() => ({
-  html: streaming
-    ? decorateMarkdownHtml(
-        renderMarkdown(text, { cache: false }),
-        trimCodeBlocks,
-      )
-    : renderBestAvailableMarkdown(text, trimCodeBlocks),
-  source: signatureFor(text, trimCodeBlocks),
-}));
+function renderStreamingPrefix(source: string, trim: boolean): string {
+  if (!source) return "";
+  return decorateMarkdownHtml(renderMarkdown(source, { cache: false }), trim);
+}
+
+const initialRender = untrack(() => {
+  const parts = streaming ? splitStreamingMarkdown(text) : undefined;
+  return {
+    html: streaming ? "" : renderBestAvailableMarkdown(text, trimCodeBlocks),
+    prefixHtml: parts
+      ? renderStreamingPrefix(parts.prefix, trimCodeBlocks)
+      : "",
+    prefixSource: parts?.prefix ?? "",
+    tail: parts?.tail ?? "",
+    streaming,
+    source: text,
+    trim: trimCodeBlocks,
+  };
+});
 let html = $state(initialRender.html);
-let htmlSource: string | undefined = initialRender.source;
+let streamingPrefixHtml = $state(initialRender.prefixHtml);
+let streamingPrefixSource = initialRender.prefixSource;
+let streamingPrefixTrim = initialRender.trim;
+let streamingTail = $state(initialRender.tail);
+let showingStreaming = $state(initialRender.streaming);
+let lastEnqueuedSource = initialRender.source;
+let lastEnqueuedTrim = initialRender.trim;
+let highlightToken = 0;
 
 async function handleClick(event: MouseEvent) {
   const target = event.target;
@@ -91,57 +111,44 @@ function copyButtonHandler(node: HTMLDivElement) {
   };
 }
 
-let frame: number | undefined;
-let highlightToken = 0;
-
-function signatureFor(source: string, trim: boolean): string {
-  return `${trim ? "trim" : "full"}\0${source}`;
-}
-
-function cancelFrame() {
-  if (frame === undefined) return;
-  cancelAnimationFrame(frame);
-  frame = undefined;
-}
-
-/** Decorate-only render (no shiki). Used per-frame while streaming. */
-function renderDecorateOnly(source: string, trim: boolean) {
-  const signature = signatureFor(source, trim);
-  if (htmlSource === signature) return;
-  // Streaming text is unique per frame; bypass the parse cache to avoid
-  // churning the shared LRU with transient prefixes.
-  html = decorateMarkdownHtml(renderMarkdown(source, { cache: false }), trim);
-  htmlSource = signature;
-  // Invalidate any in-flight highlight from a previous non-streaming pass.
+function commitStreaming(value: StreamingValue) {
+  const parts = splitStreamingMarkdown(value.source);
+  if (
+    parts.prefix !== streamingPrefixSource ||
+    value.trim !== streamingPrefixTrim
+  ) {
+    streamingPrefixHtml = renderStreamingPrefix(parts.prefix, value.trim);
+    streamingPrefixSource = parts.prefix;
+    streamingPrefixTrim = value.trim;
+  }
+  streamingTail = parts.tail;
+  showingStreaming = true;
   highlightToken += 1;
 }
 
-/** Full render + async shiki highlight. Used when not streaming. */
+const streamingScheduler = new LatestPresentationScheduler<StreamingValue>(
+  commitStreaming,
+);
+
+/** Full render + async Shiki highlight. Used only for finalized content. */
 function renderWithHighlight(source: string, trim: boolean) {
-  const signature = signatureFor(source, trim);
-  // Fast path: a finalized message re-mounted (tab switch / scroll) whose
-  // highlighted HTML is already cached — skip parse, decorate, and async work.
   const cachedHighlighted = getHighlightedMarkdownSync(source, trim);
   if (cachedHighlighted !== undefined) {
     html = cachedHighlighted;
-    htmlSource = signature;
     highlightToken += 1;
     return;
   }
   html = renderDecoratedMarkdown(source, trim);
-  htmlSource = signature;
   const token = (highlightToken += 1);
   renderHighlightedMarkdown(source, trim)
     .then((highlighted) => {
       if (token === highlightToken) {
         html = highlighted;
-        htmlSource = signature;
       }
     })
     .catch(() => {
       if (token === highlightToken) {
         html = renderDecoratedMarkdown(source, trim);
-        htmlSource = signature;
       }
     });
 }
@@ -150,27 +157,38 @@ $effect(() => {
   const source = text;
   const trim = trimCodeBlocks;
   if (!streaming) {
-    cancelFrame();
+    if (showingStreaming) streamingScheduler.flushNow({ source, trim });
+    showingStreaming = false;
     renderWithHighlight(source, trim);
+    lastEnqueuedSource = source;
+    lastEnqueuedTrim = trim;
     return;
   }
-  // Streaming: coalesce bursts of token deltas into one decorate-only render
-  // per animation frame; the final highlight happens once streaming stops.
-  if (frame !== undefined) return;
-  frame = requestAnimationFrame(() => {
-    frame = undefined;
-    renderDecorateOnly(text, trimCodeBlocks);
-  });
+
+  const priority =
+    !showingStreaming ||
+    trim !== lastEnqueuedTrim ||
+    appendedNewline(lastEnqueuedSource, source);
+  lastEnqueuedSource = source;
+  lastEnqueuedTrim = trim;
+  streamingScheduler.enqueue({ source, trim }, { priority });
 });
 
-$effect(() => {
-  return () => cancelFrame();
-});
+$effect(() => () => streamingScheduler.destroy());
 </script>
 
-<!-- eslint-disable-next-line svelte/no-at-html-tags -- renderMarkdown applies rehype-sanitize before producing markup. -->
-<div class="markdown" use:copyButtonHandler>{@html html}</div>
-
+{#if showingStreaming}
+  <div class="markdown" use:copyButtonHandler>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags -- the prefix uses the sanitized Markdown pipeline. -->
+    {@html streamingPrefixHtml}
+    {#if streamingTail}
+      <span class="whitespace-pre-wrap break-words">{streamingTail}</span>
+    {/if}
+  </div>
+{:else}
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- renderMarkdown applies rehype-sanitize before producing markup. -->
+  <div class="markdown" use:copyButtonHandler>{@html html}</div>
+{/if}
 <style>
 .markdown {
   min-width: 0;

--- a/packages/ui-kit/src/lib/core/components/streaming-markdown.test.ts
+++ b/packages/ui-kit/src/lib/core/components/streaming-markdown.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  appendedNewline,
+  splitStreamingMarkdown,
+} from "./streaming-markdown.js";
+
+describe("splitStreamingMarkdown", () => {
+  it("keeps the unresolved paragraph in the escaped tail", () => {
+    assert.deepEqual(splitStreamingMarkdown("First **done**\n\nPartial *"), {
+      prefix: "First **done**\n\n",
+      tail: "Partial *",
+    });
+  });
+
+  it("does not split at blank lines inside backtick or tilde fences", () => {
+    for (const marker of ["```", "~~~"]) {
+      const source = `Before\n\n${marker}ts\nline\n\nmore`;
+      assert.deepEqual(splitStreamingMarkdown(source), {
+        prefix: "Before\n\n",
+        tail: `${marker}ts\nline\n\nmore`,
+      });
+    }
+  });
+
+  it("advances again after a fence closes and a blank line arrives", () => {
+    const source = "```ts\nconst x = 1\n```\n\nNext";
+    assert.deepEqual(splitStreamingMarkdown(source), {
+      prefix: "```ts\nconst x = 1\n```\n\n",
+      tail: "Next",
+    });
+  });
+});
+
+describe("appendedNewline", () => {
+  it("detects only newly appended newline content", () => {
+    assert.equal(appendedNewline("a", "a\n"), true);
+    assert.equal(appendedNewline("a\n", "a\nb"), false);
+    assert.equal(appendedNewline("long", "short"), false);
+  });
+});

--- a/packages/ui-kit/src/lib/core/components/streaming-markdown.ts
+++ b/packages/ui-kit/src/lib/core/components/streaming-markdown.ts
@@ -12,10 +12,12 @@ export function splitStreamingMarkdown(source: string): StreamingMarkdownParts {
   let offset = 0;
   let fence: { marker: "`" | "~"; length: number } | undefined;
 
-  for (const lineWithBreak of source.matchAll(/.*(?:\n|$)/g)) {
-    const raw = lineWithBreak[0];
-    if (!raw) continue;
-    const line = raw.endsWith("\n") ? raw.slice(0, -1) : raw;
+  while (offset < source.length) {
+    const newline = source.indexOf("\n", offset);
+    const hasLineBreak = newline !== -1;
+    const lineEnd = hasLineBreak ? newline : source.length;
+    const nextOffset = hasLineBreak ? lineEnd + 1 : lineEnd;
+    const line = source.slice(offset, lineEnd);
     const marker = line.match(/^\s{0,3}(`{3,}|~{3,})/u)?.[1];
     if (marker) {
       const markerType = marker[0] as "`" | "~";
@@ -30,10 +32,8 @@ export function splitStreamingMarkdown(source: string): StreamingMarkdownParts {
       }
     }
 
-    offset += raw.length;
-    if (!fence && raw.endsWith("\n") && line.trim() === "") {
-      boundary = offset;
-    }
+    offset = nextOffset;
+    if (!fence && hasLineBreak && line.trim() === "") boundary = offset;
   }
 
   return {

--- a/packages/ui-kit/src/lib/core/components/streaming-markdown.ts
+++ b/packages/ui-kit/src/lib/core/components/streaming-markdown.ts
@@ -1,0 +1,49 @@
+export type StreamingMarkdownParts = {
+  prefix: string;
+  tail: string;
+};
+
+/**
+ * Select a conservative streaming boundary. Only blank lines outside fenced
+ * code advance the parsed prefix; the unresolved suffix remains escaped text.
+ */
+export function splitStreamingMarkdown(source: string): StreamingMarkdownParts {
+  let boundary = 0;
+  let offset = 0;
+  let fence: { marker: "`" | "~"; length: number } | undefined;
+
+  for (const lineWithBreak of source.matchAll(/.*(?:\n|$)/g)) {
+    const raw = lineWithBreak[0];
+    if (!raw) continue;
+    const line = raw.endsWith("\n") ? raw.slice(0, -1) : raw;
+    const marker = line.match(/^\s{0,3}(`{3,}|~{3,})/u)?.[1];
+    if (marker) {
+      const markerType = marker[0] as "`" | "~";
+      if (!fence) {
+        fence = { marker: markerType, length: marker.length };
+      } else if (
+        fence.marker === markerType &&
+        marker.length >= fence.length &&
+        line.slice(line.indexOf(marker) + marker.length).trim() === ""
+      ) {
+        fence = undefined;
+      }
+    }
+
+    offset += raw.length;
+    if (!fence && raw.endsWith("\n") && line.trim() === "") {
+      boundary = offset;
+    }
+  }
+
+  return {
+    prefix: source.slice(0, boundary),
+    tail: source.slice(boundary),
+  };
+}
+
+export function appendedNewline(previous: string, next: string): boolean {
+  return (
+    next.length > previous.length && next.slice(previous.length).includes("\n")
+  );
+}

--- a/packages/ui-kit/src/lib/core/utils/latest-presentation-scheduler.test.ts
+++ b/packages/ui-kit/src/lib/core/utils/latest-presentation-scheduler.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  LatestPresentationScheduler,
+  type PresentationClock,
+} from "./latest-presentation-scheduler.js";
+
+function fakeClock() {
+  let now = 0;
+  let nextHandle = 0;
+  const timers = new Map<number, { at: number; callback: () => void }>();
+  const clock: PresentationClock<number> = {
+    now: () => now,
+    schedule: (callback, delayMs) => {
+      const handle = ++nextHandle;
+      timers.set(handle, { at: now + delayMs, callback });
+      return handle;
+    },
+    cancel: (handle) => timers.delete(handle),
+  };
+  return {
+    clock,
+    advance(ms: number) {
+      now += ms;
+      for (const [handle, timer] of [...timers]) {
+        if (timer.at > now) continue;
+        timers.delete(handle);
+        timer.callback();
+      }
+    },
+    timers,
+  };
+}
+
+describe("LatestPresentationScheduler", () => {
+  it("commits first and priority values immediately and coalesces the rest", () => {
+    const time = fakeClock();
+    const values: string[] = [];
+    const scheduler = new LatestPresentationScheduler(
+      (value: string) => values.push(value),
+      75,
+      time.clock,
+    );
+
+    scheduler.enqueue("first");
+    scheduler.enqueue("second");
+    scheduler.enqueue("latest");
+    assert.deepEqual(values, ["first"]);
+    time.advance(74);
+    assert.deepEqual(values, ["first"]);
+    time.advance(1);
+    assert.deepEqual(values, ["first", "latest"]);
+
+    scheduler.enqueue("newline", { priority: true });
+    assert.deepEqual(values, ["first", "latest", "newline"]);
+  });
+
+  it("flushes the latest value and cancels pending work on destroy", () => {
+    const time = fakeClock();
+    const values: number[] = [];
+    const scheduler = new LatestPresentationScheduler(
+      (value: number) => values.push(value),
+      75,
+      time.clock,
+    );
+    scheduler.enqueue(1);
+    scheduler.enqueue(2);
+    scheduler.flushNow();
+    scheduler.enqueue(3);
+    scheduler.destroy();
+    time.advance(100);
+
+    assert.deepEqual(values, [1, 2]);
+    assert.equal(time.timers.size, 0);
+  });
+});

--- a/packages/ui-kit/src/lib/core/utils/latest-presentation-scheduler.ts
+++ b/packages/ui-kit/src/lib/core/utils/latest-presentation-scheduler.ts
@@ -1,0 +1,84 @@
+export type PresentationClock<Handle = ReturnType<typeof setTimeout>> = {
+  now: () => number;
+  schedule: (callback: () => void, delayMs: number) => Handle;
+  cancel: (handle: Handle) => void;
+};
+
+const defaultClock: PresentationClock = {
+  now: () => Date.now(),
+  schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+  cancel: (handle) => clearTimeout(handle),
+};
+
+/**
+ * Commits the latest presentation value at a bounded cadence.
+ * Canonical state remains immediate; superseded values are visual snapshots.
+ */
+export class LatestPresentationScheduler<
+  T,
+  Handle = ReturnType<typeof setTimeout>,
+> {
+  private pending: T | undefined;
+  private hasPending = false;
+  private timer: Handle | undefined;
+  private lastCommitAt: number | undefined;
+  private destroyed = false;
+
+  constructor(
+    private readonly commit: (value: T) => void,
+    private readonly intervalMs = 75,
+    private readonly clock: PresentationClock<Handle> = defaultClock as unknown as PresentationClock<Handle>,
+  ) {}
+
+  enqueue(value: T, options: { priority?: boolean } = {}): void {
+    if (this.destroyed) return;
+    this.pending = value;
+    this.hasPending = true;
+    if (options.priority || this.lastCommitAt === undefined) {
+      this.flushNow();
+      return;
+    }
+    if (this.timer !== undefined) return;
+    const elapsed = this.clock.now() - this.lastCommitAt;
+    this.timer = this.clock.schedule(
+      () => {
+        this.timer = undefined;
+        this.commitPending();
+      },
+      Math.max(0, this.intervalMs - elapsed),
+    );
+  }
+
+  flushNow(value?: T): void {
+    if (this.destroyed) return;
+    if (arguments.length > 0) {
+      this.pending = value as T;
+      this.hasPending = true;
+    }
+    this.cancelTimer();
+    this.commitPending();
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.cancelTimer();
+    this.pending = undefined;
+    this.hasPending = false;
+  }
+
+  private cancelTimer(): void {
+    if (this.timer === undefined) return;
+    this.clock.cancel(this.timer);
+    this.timer = undefined;
+  }
+
+  private commitPending(): void {
+    if (!this.hasPending) return;
+    const value = this.pending as T;
+    this.pending = undefined;
+    this.hasPending = false;
+    this.lastCommitAt = this.clock.now();
+    this.commit(value);
+  }
+}

--- a/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
@@ -8,9 +8,8 @@ import { shortProjectLabel } from "$lib/core/utils/project-tree";
 import {
   activeRunStreamingText,
   buildActiveRunTimeline,
-  buildCommittedTimeline,
+  CommittedTimelineProjection,
   currentTodosForAgent,
-  entriesToTranscript,
   hasActiveTurnTimelineOutput,
   selectVisibleCommitted,
 } from "$lib/presentation/state";
@@ -141,15 +140,15 @@ $effect(() => {
 $effect(() => () => renderProjection.destroy());
 const rendered = $derived(renderProjection.current);
 
-// Incremental projection: `committed` only recomputes when entries/optimistic
-// rows/toolCalls identity changes (i.e. not during pure text streaming), so
-// streaming tokens only re-run the small active-run tail.
-const transcript = $derived.by(() => [
-  ...entriesToTranscript(rendered.entries),
-  ...rendered.optimisticMessages,
-]);
+// Keep the durable projection outside the reactive derivation. `rendered` is
+// replaced for each visual commit, while these source arrays retain identity
+// during pure live streaming.
+const committedProjection = new CommittedTimelineProjection();
 const committed = $derived.by(() =>
-  buildCommittedTimeline(transcript, rendered.toolCalls, {
+  committedProjection.project({
+    entries: rendered.entries,
+    optimisticMessages: rendered.optimisticMessages,
+    toolCalls: rendered.toolCalls,
     includeUnanchoredTerminalToolCalls: !rendered.activeRun,
   }),
 );
@@ -168,7 +167,8 @@ const visibleCommitted = $derived(
     committed.context,
   ),
 );
-const timeline = $derived([...visibleCommitted, ...liveItems]);
+const timeline = $derived({ prefix: visibleCommitted, tail: liveItems });
+const combinedTimeline = $derived([...visibleCommitted, ...liveItems]);
 const compacting = $derived(transient?.compaction?.state === "running");
 const stopping = $derived(
   stoppingRequested || activeRun?.status === "aborting",
@@ -180,7 +180,7 @@ const treeEntriesById = $derived(
 // Latest-turn output remains true when a live row materializes into its durable
 // entry, while a newly started empty turn re-enables the waiting indicator.
 const hasActiveTurnOutput = $derived(
-  hasActiveTurnTimelineOutput(timeline, rendered.activeRun),
+  hasActiveTurnTimelineOutput(combinedTimeline, rendered.activeRun),
 );
 
 async function copyText(text: string, label = "message") {

--- a/packages/workbench-app/src/lib/presentation/components/conversation/conversation-pane.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/conversation-pane.svelte
@@ -29,7 +29,9 @@ let {
 } = $props();
 
 const active = $derived(model.active ?? true);
-const lastTimelineKey = $derived(model.timeline.at(-1)?.key);
+const lastTimelineKey = $derived(
+  model.timeline.tail.at(-1)?.key ?? model.timeline.prefix.at(-1)?.key,
+);
 const pendingApprovals = $derived(
   model.approvals?.filter((approval) => approval.status === "pending") ?? [],
 );
@@ -47,7 +49,7 @@ const pendingPlanReviewIds = $derived(
 );
 const transcriptHasContent = $derived(
   hasTranscriptContent({
-    timelineLength: model.timeline.length,
+    timelineLength: model.timeline.prefix.length + model.timeline.tail.length,
     streamingText: model.streamingText,
     sending: model.sending,
     queuedPromptCount: model.queuedPrompts.length,
@@ -91,7 +93,8 @@ const scroll = createConversationScrollController({
           heightCacheKey={model.transcriptHeightCacheKey ??
             model.conversationId}
           transcriptLabel={model.transcriptLabel}
-          timeline={model.timeline}
+          timelinePrefix={model.timeline.prefix}
+          timelineTail={model.timeline.tail}
           streamingText={model.streamingText}
           sending={model.sending}
           hasActiveTurnOutput={model.hasActiveTurnOutput}

--- a/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
@@ -82,11 +82,16 @@ export type ConversationComposerModel = {
   capabilities?: ConversationComposerCapabilities;
 };
 
+export type ConversationTimelineSections = {
+  prefix: TimelineItem[];
+  tail: TimelineItem[];
+};
+
 export type ConversationPaneModel = {
   conversationId?: string;
   open: boolean;
   active?: boolean;
-  timeline: TimelineItem[];
+  timeline: ConversationTimelineSections;
   streamingText: string;
   sending: boolean;
   hasActiveTurnOutput: boolean;

--- a/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Folder from "@lucide/svelte/icons/folder";
+import { SvelteMap } from "svelte/reactivity";
 import type {
   AgentRecord,
   ApprovalWithToolCall,
@@ -33,13 +34,15 @@ import { provideConversationMotionBudget } from "./conversation-motion-context.s
 import { toolLifecycleSpec } from "../../tools/lifecycle/registry";
 import { hasTranscriptContent } from "./transcript-content";
 
+type TimelineRowItem = {
+  kind: "timeline";
+  key: string;
+  node: TranscriptDisplayNode;
+  entranceMotion?: TranscriptEntranceMotion;
+};
+
 type TranscriptRowItem =
-  | {
-      kind: "timeline";
-      key: string;
-      node: TranscriptDisplayNode;
-      entranceMotion?: TranscriptEntranceMotion;
-    }
+  | TimelineRowItem
   | { kind: "waiting"; key: string }
   | { kind: "queued"; key: string; prompt: QueuedPromptRecord };
 
@@ -50,7 +53,8 @@ type Props = {
   heightCacheKey?: string;
   contentVisibility?: boolean;
   transcriptLabel?: string;
-  timeline: TimelineItem[];
+  timelinePrefix: TimelineItem[];
+  timelineTail: TimelineItem[];
   streamingText: string;
   sending: boolean;
   hasActiveTurnOutput: boolean;
@@ -108,7 +112,8 @@ let {
   // height while its newly rendered body paints over the following row.
   contentVisibility = false,
   transcriptLabel = "Conversation transcript",
-  timeline,
+  timelinePrefix,
+  timelineTail,
   streamingText,
   sending,
   hasActiveTurnOutput,
@@ -153,38 +158,98 @@ function entranceEligible(node: TranscriptDisplayNode): boolean {
   return node.kind === "tool" && Boolean(node.draft);
 }
 
-// The running CompactionCard is the sole activity indicator for that phase;
-// the generic per-turn waiting row must not double up beneath it.
-const compactionRunning = $derived(
-  timeline.some(
-    (item) => item.kind === "compaction" && item.notice.state === "running",
-  ),
-);
+type PrefixRows = {
+  revision: number;
+  rows: TimelineRowItem[];
+  seenKeys: Map<string, number>;
+};
 
-const rows = $derived.by<TranscriptRowItem[]>(() => {
+let prefixRevision = 0;
+const prefixRows = $derived.by<PrefixRows>(() => {
   const seenKeys = new Map<string, number>();
-  const displayNodes = groupConsecutiveThinking(timeline);
-  const timelineRows = displayNodes.map((node) => ({
+  const rows = groupConsecutiveThinking(timelinePrefix).map((node) => ({
     kind: "timeline" as const,
     key: uniqueRowKey(node.key, seenKeys),
     node,
   }));
+  prefixRevision += 1;
+  return { revision: prefixRevision, rows, seenKeys };
+});
+const tailDisplayNodes = $derived(groupConsecutiveThinking(timelineTail));
+const prefixCompactionRunning = $derived(
+  timelinePrefix.some(
+    (item) => item.kind === "compaction" && item.notice.state === "running",
+  ),
+);
+const tailCompactionRunning = $derived(
+  timelineTail.some(
+    (item) => item.kind === "compaction" && item.notice.state === "running",
+  ),
+);
+const compactionRunning = $derived(
+  prefixCompactionRunning || tailCompactionRunning,
+);
+
+let motionProjectionKey: string | undefined;
+let projectedEntranceMotions: ReadonlyMap<string, TranscriptEntranceMotion> =
+  new SvelteMap();
+const rows = $derived.by<TranscriptRowItem[]>(() => {
+  const seenKeys = new SvelteMap(prefixRows.seenKeys);
+  const stableRows = [...prefixRows.rows];
+  const liveNodes = [...tailDisplayNodes];
+
+  // Thinking can materialize into the durable prefix while the next reasoning
+  // block is still live. Preserve the original flat grouping at this one seam.
+  const lastPrefix = stableRows.at(-1);
+  const firstTail = liveNodes[0];
+  if (
+    lastPrefix?.node.kind === "thinking_group" &&
+    firstTail?.kind === "thinking_group"
+  ) {
+    stableRows.pop();
+    liveNodes.shift();
+    const count = seenKeys.get(lastPrefix.node.key) ?? 0;
+    if (count <= 1) seenKeys.delete(lastPrefix.node.key);
+    else seenKeys.set(lastPrefix.node.key, count - 1);
+    liveNodes.unshift({
+      kind: "thinking_group",
+      key: lastPrefix.node.key,
+      items: [...lastPrefix.node.items, ...firstTail.items],
+    });
+  }
+
+  const liveRows: TimelineRowItem[] = liveNodes.map((node) => ({
+    kind: "timeline",
+    key: uniqueRowKey(node.key, seenKeys),
+    node,
+  }));
+  const timelineRows = [...stableRows, ...liveRows];
   const scope = heightCacheKey ?? "__default-transcript__";
   if (scope !== motionScope) {
     motionScope = scope;
     motionBudget.reset();
   }
-  const entranceMotions = entranceLedger.project(
-    scope,
-    timelineRows.map((row) => ({
-      key: row.key,
-      eligible: entranceEligible(row.node),
+  const liveStructure = liveRows
+    .map((row) => `${row.key}:${entranceEligible(row.node) ? 1 : 0}`)
+    .join("|");
+  const nextMotionKey = `${scope}\0${prefixRows.revision}\0${liveStructure}`;
+  if (nextMotionKey !== motionProjectionKey) {
+    motionProjectionKey = nextMotionKey;
+    projectedEntranceMotions = entranceLedger.project(
+      scope,
+      timelineRows.map((row) => ({
+        key: row.key,
+        eligible: entranceEligible(row.node),
+      })),
+    );
+  }
+  const result: TranscriptRowItem[] = [
+    ...stableRows,
+    ...liveRows.map((row) => ({
+      ...row,
+      entranceMotion: projectedEntranceMotions.get(row.key),
     })),
-  );
-  const result: TranscriptRowItem[] = timelineRows.map((row) => ({
-    ...row,
-    entranceMotion: entranceMotions.get(row.key),
-  }));
+  ];
   // This is a per-turn pre-output row. Turn-scoped output stays true across
   // the live-to-durable handoff, so it cannot reappear after the final message.
   if (sending && !hasActiveTurnOutput && !compactionRunning) {
@@ -195,6 +260,24 @@ const rows = $derived.by<TranscriptRowItem[]>(() => {
   }
   return result;
 });
+const approvalsByToolCallId = $derived(
+  new Map(approvals.map((item) => [item.toolCallId, item])),
+);
+const questionsByToolCallId = $derived(
+  new Map(pendingUserQuestions.map((item) => [item.toolCallId, item])),
+);
+const reviewsByToolCallId = $derived(
+  new Map(pendingPlanReviews.map((item) => [item.toolCallId, item])),
+);
+const structureVersion = $derived(
+  `${prefixRows.revision}\0${tailDisplayNodes
+    .map((node) => node.key)
+    .join(
+      "|",
+    )}\0${sending && !hasActiveTurnOutput && !compactionRunning ? "waiting" : ""}\0${queuedPrompts
+    .map((prompt) => prompt.id)
+    .join("|")}`,
+);
 
 function claimEntrance(key: string, token: string): boolean {
   return entranceLedger.claim(key, token);
@@ -254,15 +337,9 @@ function measurementVersionForRow(row: TranscriptRowItem): string {
     }
     const toolCallId = node.toolCall.id;
     const lifecycle = toolLifecycleSpec(node.toolCall.toolName);
-    const approval = approvals.find(
-      (candidate) => candidate.toolCallId === toolCallId,
-    );
-    const question = pendingUserQuestions.find(
-      (candidate) => candidate.toolCallId === toolCallId,
-    );
-    const plan = pendingPlanReviews.find(
-      (candidate) => candidate.toolCallId === toolCallId,
-    );
+    const approval = approvalsByToolCallId.get(toolCallId);
+    const question = questionsByToolCallId.get(toolCallId);
+    const plan = reviewsByToolCallId.get(toolCallId);
     return [
       "tool",
       `arg:${lifecycle.argumentRegion}`,
@@ -294,7 +371,7 @@ function measurementVersionForRow(row: TranscriptRowItem): string {
 
 const showEmptyRun = $derived(
   !hasTranscriptContent({
-    timelineLength: timeline.length,
+    timelineLength: timelinePrefix.length + timelineTail.length,
     streamingText,
     sending,
     queuedPromptCount: queuedPrompts.length,
@@ -333,6 +410,7 @@ const showEmptyRun = $derived(
     bind:atEnd
     items={rows}
     getKey={(row) => row.key}
+    {structureVersion}
     {heightCacheKey}
     getMeasurementVersion={measurementVersionForRow}
     {contentVisibility}
@@ -357,9 +435,9 @@ const showEmptyRun = $derived(
           {sending}
           hydrateToolBodies={active}
           {activeProject}
-          {approvals}
-          {pendingUserQuestions}
-          {pendingPlanReviews}
+          {approvalsByToolCallId}
+          {questionsByToolCallId}
+          {reviewsByToolCallId}
           {lastTimelineKey}
           {planReviewModels}
           {planReviewModelKey}

--- a/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptRow.svelte
@@ -26,9 +26,9 @@ type Props = {
   node: TranscriptDisplayNode;
   sending: boolean;
   activeProject?: ProjectRecord;
-  approvals?: ApprovalWithToolCall[];
-  pendingUserQuestions?: UserQuestionRecord[];
-  pendingPlanReviews?: PlanReviewRecord[];
+  approvalsByToolCallId?: ReadonlyMap<string, ApprovalWithToolCall>;
+  questionsByToolCallId?: ReadonlyMap<string, UserQuestionRecord>;
+  reviewsByToolCallId?: ReadonlyMap<string, PlanReviewRecord>;
   hydrateToolBodies?: boolean;
   entranceMotion?: TranscriptEntranceMotion;
   onClaimEntrance?: (token: string) => boolean;
@@ -58,9 +58,9 @@ let {
   node,
   sending,
   activeProject,
-  approvals = [],
-  pendingUserQuestions = [],
-  pendingPlanReviews = [],
+  approvalsByToolCallId = new Map(),
+  questionsByToolCallId = new Map(),
+  reviewsByToolCallId = new Map(),
   hydrateToolBodies = true,
   entranceMotion,
   onClaimEntrance,
@@ -159,23 +159,16 @@ $effect(() => {
           toolCall={node.toolCall}
           liveOutput={node.liveOutput}
           cwd={activeProject?.dir}
-          pendingApproval={node.toolCall
-            ? approvals.find(
-                (approval) =>
-                  approval.toolCallId === node.toolCall?.id &&
-                  approval.status === "pending",
-              )
+          pendingApproval={node.toolCall &&
+          approvalsByToolCallId.get(node.toolCall.id)?.status === "pending"
+            ? approvalsByToolCallId.get(node.toolCall.id)
             : undefined}
           pendingUserQuestion={node.toolCall
-            ? pendingUserQuestions.find(
-                (question) => question.toolCallId === node.toolCall?.id,
-              )
+            ? questionsByToolCallId.get(node.toolCall.id)
             : undefined}
           hydrateBody={hydrateToolBodies}
           pendingPlanReview={node.toolCall
-            ? pendingPlanReviews.find(
-                (review) => review.toolCallId === node.toolCall?.id,
-              )
+            ? reviewsByToolCallId.get(node.toolCall.id)
             : undefined}
           {onOpenFile}
           {planReviewModels}

--- a/packages/workbench-app/src/lib/presentation/state/adapters.ts
+++ b/packages/workbench-app/src/lib/presentation/state/adapters.ts
@@ -49,6 +49,7 @@ import type {
   ConversationTransientState,
 } from "./transcript-types.js";
 import type { ConversationRenderState } from "./types.js";
+import { ConversationCowDraft } from "./conversation-cow-draft.js";
 
 const conversationEventTypeSet = new Set<string>(conversationEventTypes);
 
@@ -121,30 +122,36 @@ export function applyConversationEvent(
     return state;
   }
 
-  const next = cloneRenderState(state);
-  next.cursorSeq = event.seq;
+  const next: ConversationRenderState = { ...state, cursorSeq: event.seq };
   if (!handled) return next;
 
+  const draft = new ConversationCowDraft(next);
   const type = event.type as ConversationEventType;
   switch (type) {
     case "run.started":
       applyRunStarted(next, event.data as ConversationRunStartedData);
       break;
-    case "conversation.entry.appended":
-      applyEntryAppended(next, event.data as ConversationEntryAppendedData);
+    case "conversation.entry.appended": {
+      const data = event.data as ConversationEntryAppendedData;
+      if (data.entry.role === "assistant") draft.ownAllRunMessages();
+      applyEntryAppended(next, data);
       break;
+    }
     case "conversation.context.updated":
       next.contextUsage = (
         event.data as { contextUsage: typeof next.contextUsage }
       ).contextUsage;
       break;
     case "conversation.prompt.queued":
+      draft.ownRun();
       applyPromptQueued(next, event.data as ConversationPromptQueuedData);
       break;
     case "conversation.prompt.dequeued":
+      draft.ownRun();
       applyPromptRemoved(next, event.data as ConversationPromptDequeuedData);
       break;
     case "conversation.prompt.cancelled":
+      draft.ownRun();
       applyPromptRemoved(next, event.data as ConversationPromptCancelledData);
       break;
     case "toolCall.updated":
@@ -155,9 +162,11 @@ export function applyConversationEvent(
       );
       break;
     case "run.resumed":
+      draft.ownRun();
       applyRunResumed(next, event.data as ConversationRunResumedData);
       break;
     case "run.retrying":
+      draft.ownRun();
       applyRunRetrying(next, event.data as ConversationRunRetryingData);
       break;
     case "run.suspended":
@@ -170,9 +179,11 @@ export function applyConversationEvent(
       applyRunCancelled(next, event.data as ConversationRunCancelledData);
       break;
     case "run.failed":
+      draft.ownRun();
       applyRunFailed(next, event.data as ConversationRunFailedData);
       break;
     case "conversation.compaction.started":
+      draft.ownTransient();
       applyCompactionStarted(
         next,
         event.data as ConversationCompactionStartedData,
@@ -180,6 +191,7 @@ export function applyConversationEvent(
       );
       break;
     case "conversation.compaction.progress":
+      draft.ownTransient();
       applyCompactionProgress(
         next,
         event.data as ConversationCompactionProgressData,
@@ -187,6 +199,7 @@ export function applyConversationEvent(
       );
       break;
     case "conversation.compaction.failed":
+      draft.ownTransient();
       applyCompactionFailed(
         next,
         event.data as ConversationCompactionFailedData,
@@ -194,6 +207,7 @@ export function applyConversationEvent(
       );
       break;
     case "conversation.compaction.cancelled":
+      draft.ownTransient();
       applyCompactionCancelled(
         next,
         event.data as ConversationCompactionCancelledData,
@@ -203,25 +217,25 @@ export function applyConversationEvent(
     case "conversation.compacted":
       applyCompacted(next);
       break;
-    case "conversation.live.turn.started":
-      applyLiveTurnStarted(
-        next,
-        event.data as ConversationLiveTurnStartedData,
-        event.ts,
-      );
+    case "conversation.live.turn.started": {
+      const data = event.data as ConversationLiveTurnStartedData;
+      draft.ownTurn(data.turnId);
+      applyLiveTurnStarted(next, data, event.ts);
       break;
-    case "conversation.live.message.started":
-      applyLiveMessageStarted(
-        next,
-        event.data as ConversationLiveMessageStartedData,
-      );
+    }
+    case "conversation.live.message.started": {
+      const data = event.data as ConversationLiveMessageStartedData;
+      draft.ownMessage(data.turnId, data.liveMessageId);
+      applyLiveMessageStarted(next, data);
       break;
+    }
     case "conversation.live.content.delta":
       applyLiveContentDelta(
         next,
         event.data as ConversationLiveContentDeltaData,
         event.ts,
         options,
+        draft,
       );
       break;
     case "conversation.live.content.done":
@@ -229,6 +243,7 @@ export function applyConversationEvent(
         next,
         event.data as ConversationLiveContentDoneData,
         event.ts,
+        draft,
       );
       break;
     case "conversation.live.tool_draft.started":
@@ -236,6 +251,7 @@ export function applyConversationEvent(
         next,
         event.data as ConversationLiveToolDraftStartedData,
         event.ts,
+        draft,
       );
       break;
     case "conversation.live.tool_draft.delta":
@@ -244,6 +260,7 @@ export function applyConversationEvent(
         event.data as ConversationLiveToolDraftDeltaData,
         event.ts,
         options,
+        draft,
       );
       break;
     case "conversation.live.tool_draft.done":
@@ -251,6 +268,7 @@ export function applyConversationEvent(
         next,
         event.data as ConversationLiveToolDraftDoneData,
         event.ts,
+        draft,
       );
       break;
     case "conversation.live.tool_draft.progress":
@@ -258,40 +276,26 @@ export function applyConversationEvent(
         next,
         event.data as ConversationLiveToolDraftProgressData,
         event.ts,
+        draft,
       );
       break;
-    case "conversation.live.tool_draft.discarded":
-      applyToolDraftDiscarded(
-        next,
-        event.data as ConversationLiveToolDraftDiscardedData,
-      );
+    case "conversation.live.tool_draft.discarded": {
+      const data = event.data as ConversationLiveToolDraftDiscardedData;
+      draft.ownMessage(data.turnId, data.liveMessageId);
+      applyToolDraftDiscarded(next, data);
       break;
+    }
     case "conversation.live.tool_output.delta":
       applyToolOutputDelta(
         next,
         event.data as ConversationLiveToolOutputDeltaData,
         event.ts,
         options,
+        draft,
       );
       break;
   }
   return next;
-}
-
-/**
- * Shallow clone plus a deep clone of the mutable active-run tail. Handlers
- * replace `entries`/`toolCalls`/`activeEntryIds`/`queuedPrompts` immutably, so
- * those arrays keep their identity across unrelated events — the committed
- * timeline memoization depends on that.
- */
-function cloneRenderState(
-  state: ConversationRenderState,
-): ConversationRenderState {
-  return {
-    ...state,
-    activeRun: cloneActiveRun(state.activeRun),
-    transient: cloneTransient(state.transient),
-  };
 }
 
 function cloneActiveRun(
@@ -324,15 +328,6 @@ function cloneActiveRun(
         cloneLiveOutput(output),
       ]),
     ),
-  };
-}
-
-function cloneTransient(
-  transient: ConversationTransientState | undefined,
-): ConversationTransientState | undefined {
-  if (!transient) return undefined;
-  return {
-    compaction: transient.compaction ? { ...transient.compaction } : undefined,
   };
 }
 
@@ -791,6 +786,7 @@ function applyLiveContentDelta(
   data: ConversationLiveContentDeltaData,
   ts: string,
   options: ApplyConversationEventOptions,
+  draft: ConversationCowDraft,
 ): void {
   if (!data.delta) return;
   const current = findActiveBlock(state, data);
@@ -801,6 +797,7 @@ function applyLiveContentDelta(
     reportGap(options, data, "conversation.live.content.delta");
     return;
   }
+  draft.ownBlock(data.turnId, data.liveMessageId, data.contentBlockId);
   const block = ensureActiveTextBlock(state, data, ts);
   if (block) block.text = `${block.text}${data.delta}`;
   state.sending = true;
@@ -810,7 +807,9 @@ function applyLiveContentDone(
   state: ConversationRenderState,
   data: ConversationLiveContentDoneData,
   ts: string,
+  draft: ConversationCowDraft,
 ): void {
+  draft.ownBlock(data.turnId, data.liveMessageId, data.contentBlockId);
   const block = ensureActiveTextBlock(state, data, ts);
   if (!block) return;
   block.text = data.finalText ?? block.text;
@@ -822,7 +821,9 @@ function applyToolDraftStarted(
   state: ConversationRenderState,
   data: ConversationLiveToolDraftStartedData,
   ts: string,
+  draft: ConversationCowDraft,
 ): void {
+  draft.ownBlock(data.turnId, data.liveMessageId, data.contentBlockId);
   ensureActiveToolDraftBlock(state, data, ts);
   state.sending = true;
 }
@@ -832,6 +833,7 @@ function applyToolDraftDelta(
   data: ConversationLiveToolDraftDeltaData,
   ts: string,
   options: ApplyConversationEventOptions,
+  draft: ConversationCowDraft,
 ): void {
   const current = findActiveBlock(state, data);
   const currentLength =
@@ -841,6 +843,7 @@ function applyToolDraftDelta(
     reportGap(options, data, "conversation.live.tool_draft.delta");
     return;
   }
+  draft.ownBlock(data.turnId, data.liveMessageId, data.contentBlockId);
   const block = ensureActiveToolDraftBlock(state, data, ts);
   if (block) block.argsText = `${block.argsText}${data.delta}`;
 }
@@ -849,7 +852,9 @@ function applyToolDraftDone(
   state: ConversationRenderState,
   data: ConversationLiveToolDraftDoneData,
   ts: string,
+  draft: ConversationCowDraft,
 ): void {
+  draft.ownBlock(data.turnId, data.liveMessageId, data.contentBlockId);
   const block = ensureActiveToolDraftBlock(state, data, ts);
   if (!block) return;
   block.argsText = "";
@@ -863,7 +868,9 @@ function applyToolDraftProgress(
   state: ConversationRenderState,
   data: ConversationLiveToolDraftProgressData,
   ts: string,
+  draft: ConversationCowDraft,
 ): void {
+  draft.ownBlock(data.turnId, data.liveMessageId, data.contentBlockId);
   const block = ensureActiveToolDraftBlock(state, data, ts);
   if (block) block.progress = data.progress;
 }
@@ -891,6 +898,7 @@ function applyToolOutputDelta(
   data: ConversationLiveToolOutputDeltaData,
   ts: string,
   options: ApplyConversationEventOptions,
+  draft: ConversationCowDraft,
 ): void {
   if (!data.delta) return;
   const activeRun =
@@ -913,8 +921,11 @@ function applyToolOutputDelta(
     reportGap(options, data, "conversation.live.tool_output.delta");
     return;
   }
-  activeRun.toolOutputsByToolCallId = {
-    ...activeRun.toolOutputsByToolCallId,
+  draft.ownOutputMap();
+  const writableRun = state.activeRun;
+  if (!writableRun) return;
+  writableRun.toolOutputsByToolCallId = {
+    ...writableRun.toolOutputsByToolCallId,
     [data.toolCallId]: capLiveOutput({
       toolCallId: data.toolCallId,
       chunks: [

--- a/packages/workbench-app/src/lib/presentation/state/conversation-cow-draft.ts
+++ b/packages/workbench-app/src/lib/presentation/state/conversation-cow-draft.ts
@@ -1,0 +1,136 @@
+import type {
+  ConversationActiveRunSnapshot,
+  ConversationLiveMessageSnapshot,
+  ConversationLiveTurnSnapshot,
+} from "@nervekit/contracts";
+import type { ConversationRenderState } from "./types.js";
+
+/**
+ * Dispatch-local ownership helper for the conversation reducer.
+ *
+ * The reducer intentionally keeps imperative handlers, but every nested value
+ * they write must first be owned here. This preserves immutable render
+ * snapshots without cloning the complete active run for every live delta.
+ */
+export class ConversationCowDraft {
+  private runOwned = false;
+  private turnsOwned = false;
+  private outputMapOwned = false;
+  private transientOwned = false;
+  private readonly ownedTurns = new Set<string>();
+  private readonly ownedMessages = new Set<string>();
+  private readonly ownedBlocks = new Set<string>();
+
+  constructor(readonly state: ConversationRenderState) {}
+
+  ownRun(): ConversationActiveRunSnapshot | undefined {
+    const run = this.state.activeRun;
+    if (!run || this.runOwned) return run;
+    this.state.activeRun = { ...run };
+    this.runOwned = true;
+    return this.state.activeRun;
+  }
+
+  ownTurns(): ConversationActiveRunSnapshot | undefined {
+    const run = this.ownRun();
+    if (!run || this.turnsOwned) return run;
+    run.turns = [...run.turns];
+    this.turnsOwned = true;
+    return run;
+  }
+
+  ownTurn(turnId: string): ConversationLiveTurnSnapshot | undefined {
+    const run = this.ownTurns();
+    if (!run) return undefined;
+    const index = run.turns.findIndex((turn) => turn.turnId === turnId);
+    if (index < 0) return undefined;
+    if (!this.ownedTurns.has(turnId)) {
+      run.turns[index] = { ...run.turns[index] };
+      this.ownedTurns.add(turnId);
+    }
+    return run.turns[index];
+  }
+
+  ownMessage(
+    turnId: string,
+    liveMessageId: string,
+  ): ConversationLiveMessageSnapshot | undefined {
+    const turn = this.ownTurn(turnId);
+    if (!turn) return undefined;
+    if (!this.ownedMessages.has(turnId)) {
+      turn.messages = [...turn.messages];
+      this.ownedMessages.add(turnId);
+    }
+    const index = turn.messages.findIndex(
+      (message) => message.liveMessageId === liveMessageId,
+    );
+    if (index < 0) return undefined;
+    const key = `${turnId}\0${liveMessageId}`;
+    if (!this.ownedMessages.has(key)) {
+      turn.messages[index] = { ...turn.messages[index] };
+      this.ownedMessages.add(key);
+    }
+    return turn.messages[index];
+  }
+
+  ownBlock(
+    turnId: string,
+    liveMessageId: string,
+    contentBlockId: string,
+  ): void {
+    const message = this.ownMessage(turnId, liveMessageId);
+    if (!message) return;
+    const messageKey = `${turnId}\0${liveMessageId}`;
+    if (!this.ownedBlocks.has(messageKey)) {
+      message.blocks = [...message.blocks];
+      this.ownedBlocks.add(messageKey);
+    }
+    const index = message.blocks.findIndex(
+      (block) => block.contentBlockId === contentBlockId,
+    );
+    if (index < 0) return;
+    const blockKey = `${messageKey}\0${contentBlockId}`;
+    if (!this.ownedBlocks.has(blockKey)) {
+      const block = message.blocks[index];
+      message.blocks[index] =
+        block.kind === "tool_call_draft"
+          ? {
+              ...block,
+              args: block.args ? { ...block.args } : undefined,
+              progress: block.progress ? { ...block.progress } : undefined,
+            }
+          : { ...block };
+      this.ownedBlocks.add(blockKey);
+    }
+  }
+
+  ownOutputMap(): void {
+    const run = this.ownRun();
+    if (!run || this.outputMapOwned) return;
+    run.toolOutputsByToolCallId = { ...run.toolOutputsByToolCallId };
+    this.outputMapOwned = true;
+  }
+
+  ownTransient(): void {
+    if (this.transientOwned) return;
+    this.state.transient = this.state.transient
+      ? { ...this.state.transient }
+      : {};
+    this.transientOwned = true;
+  }
+
+  /** Own turn/message containers before materialization drain reassigns them. */
+  ownAllRunMessages(): void {
+    const run = this.ownTurns();
+    if (!run) return;
+    run.turns = run.turns.map((turn) => ({
+      ...turn,
+      messages: [...turn.messages],
+    }));
+    this.turnsOwned = true;
+    for (const turn of run.turns) {
+      this.ownedTurns.add(turn.turnId);
+      this.ownedMessages.add(turn.turnId);
+    }
+  }
+}

--- a/packages/workbench-app/src/lib/presentation/state/conversation-events.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/conversation-events.test.ts
@@ -12,6 +12,16 @@ import {
 
 const ts = "2026-07-07T00:00:00.000Z";
 
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== "object" || Object.isFrozen(value))
+    return value;
+  Object.freeze(value);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child);
+  }
+  return value;
+}
+
 function evt(seq: number, type: string, data: unknown): EventEnvelope {
   return {
     id: `evt_${seq}`,
@@ -65,6 +75,93 @@ function toolCall(
   };
 }
 describe("conversation event reducer", () => {
+  it("copy-on-write replaces only the live content ancestry", () => {
+    let state = applyConversationEvent(
+      applyConversationEvent(
+        emptyConversationRenderState("conv_test"),
+        startRun(),
+      ),
+      startMessage(),
+    );
+    state = applyConversationEvent(
+      state,
+      evt(3, "conversation.live.content.delta", {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        projectId: "proj_test",
+        runId: "run_test",
+        turnId: "turn_test",
+        liveMessageId: "msg_test",
+        contentBlockId: "block_text",
+        contentIndex: 0,
+        kind: "text",
+        offset: 0,
+        delta: "hello",
+      }),
+    );
+    const previous = deepFreeze(state);
+    const previousRun = previous.activeRun!;
+    const previousTurn = previousRun.turns[0]!;
+    const previousMessage = previousTurn.messages[0]!;
+    const previousBlock = previousMessage.blocks[0]!;
+    const previousOutputs = previousRun.toolOutputsByToolCallId;
+
+    const next = applyConversationEvent(
+      previous,
+      evt(4, "conversation.live.content.delta", {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        projectId: "proj_test",
+        runId: "run_test",
+        turnId: "turn_test",
+        liveMessageId: "msg_test",
+        contentBlockId: "block_text",
+        contentIndex: 0,
+        kind: "text",
+        offset: 5,
+        delta: " world",
+      }),
+    );
+
+    assert.notEqual(next, previous);
+    assert.notEqual(next.activeRun, previousRun);
+    assert.notEqual(next.activeRun?.turns, previousRun.turns);
+    assert.notEqual(next.activeRun?.turns[0], previousTurn);
+    assert.notEqual(next.activeRun?.turns[0]?.messages[0], previousMessage);
+    assert.notEqual(
+      next.activeRun?.turns[0]?.messages[0]?.blocks[0],
+      previousBlock,
+    );
+    assert.equal(next.activeRun?.toolOutputsByToolCallId, previousOutputs);
+    assert.equal(
+      next.activeRun?.turns[0]?.messages[0]?.blocks[0]?.kind === "text"
+        ? next.activeRun.turns[0].messages[0].blocks[0].text
+        : undefined,
+      "hello world",
+    );
+    assert.equal(
+      previousBlock.kind === "text" ? previousBlock.text : undefined,
+      "hello",
+    );
+  });
+
+  it("consumed render-neutral events retain every nested reference", () => {
+    const state = applyConversationEvent(
+      emptyConversationRenderState("conv_test"),
+      startRun(),
+    );
+    const next = applyConversationEvent(
+      state,
+      evt(2, "run.checkpointed", { conversationId: "conv_test" }),
+      { consumeUnhandled: true },
+    );
+    assert.notEqual(next, state);
+    assert.equal(next.cursorSeq, 2);
+    assert.equal(next.activeRun, state.activeRun);
+    assert.equal(next.entries, state.entries);
+    assert.equal(next.toolCalls, state.toolCalls);
+  });
+
   it("keeps the draft block and joins it with the durable tool call", () => {
     let state = emptyConversationRenderState("conv_test");
     state = applyConversationEvent(state, startRun());

--- a/packages/workbench-app/src/lib/presentation/state/index.ts
+++ b/packages/workbench-app/src/lib/presentation/state/index.ts
@@ -6,6 +6,7 @@ export * from "./subagent-transcript-session.js";
 export * from "./thinking-levels.js";
 export * from "./timeline.js";
 export * from "./timeline-output.js";
+export * from "./timeline-projection.js";
 export * from "./tool-types.js";
 export * from "./transcript.js";
 export * from "./transcript-types.js";

--- a/packages/workbench-app/src/lib/presentation/state/timeline-projection.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline-projection.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CommittedTimelineProjection } from "./timeline-projection.js";
+
+const emptyInput = {
+  entries: [],
+  optimisticMessages: [],
+  toolCalls: [],
+  includeUnanchoredTerminalToolCalls: false,
+};
+
+describe("CommittedTimelineProjection", () => {
+  it("reuses the durable projection while source identities stay stable", () => {
+    const projection = new CommittedTimelineProjection();
+    const first = projection.project(emptyInput);
+    const second = projection.project({ ...emptyInput });
+
+    assert.equal(second, first);
+    assert.equal(second.items, first.items);
+    assert.equal(second.context, first.context);
+  });
+
+  it("invalidates when a durable source identity changes", () => {
+    const projection = new CommittedTimelineProjection();
+    const first = projection.project(emptyInput);
+    const second = projection.project({ ...emptyInput, entries: [] });
+
+    assert.notEqual(second, first);
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/state/timeline-projection.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline-projection.ts
@@ -1,0 +1,57 @@
+import type {
+  ConversationEntry,
+  ToolCallTranscriptRecord,
+} from "@nervekit/contracts";
+import type { TranscriptItem } from "./transcript-types.js";
+import { buildCommittedTimeline, type CommittedTimeline } from "./timeline.js";
+import { entriesToTranscript } from "./transcript.js";
+
+export type CommittedTimelineProjectionInput = {
+  entries: ConversationEntry[];
+  optimisticMessages: TranscriptItem[];
+  toolCalls: ToolCallTranscriptRecord[];
+  includeUnanchoredTerminalToolCalls: boolean;
+};
+
+/**
+ * Identity-keyed durable timeline projection.
+ *
+ * Live active-run snapshots change on every visual commit. The durable source
+ * arrays do not, so retaining this memo outside a Svelte derived prevents a
+ * growing conversation history from being rebuilt for each streamed token.
+ */
+export class CommittedTimelineProjection {
+  private entries?: ConversationEntry[];
+  private optimisticMessages?: TranscriptItem[];
+  private toolCalls?: ToolCallTranscriptRecord[];
+  private includeUnanchoredTerminalToolCalls?: boolean;
+  private committed?: CommittedTimeline;
+
+  project(input: CommittedTimelineProjectionInput): CommittedTimeline {
+    if (
+      this.committed &&
+      this.entries === input.entries &&
+      this.optimisticMessages === input.optimisticMessages &&
+      this.toolCalls === input.toolCalls &&
+      this.includeUnanchoredTerminalToolCalls ===
+        input.includeUnanchoredTerminalToolCalls
+    ) {
+      return this.committed;
+    }
+
+    this.entries = input.entries;
+    this.optimisticMessages = input.optimisticMessages;
+    this.toolCalls = input.toolCalls;
+    this.includeUnanchoredTerminalToolCalls =
+      input.includeUnanchoredTerminalToolCalls;
+    this.committed = buildCommittedTimeline(
+      [...entriesToTranscript(input.entries), ...input.optimisticMessages],
+      input.toolCalls,
+      {
+        includeUnanchoredTerminalToolCalls:
+          input.includeUnanchoredTerminalToolCalls,
+      },
+    );
+    return this.committed;
+  }
+}

--- a/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { untrack } from "svelte";
 import type {
   AgentRecord,
   ApprovalWithToolCall,
@@ -34,6 +35,7 @@ import {
 } from "../views/tool-activity-state";
 import { getConversationUiCapabilities } from "../../context.svelte";
 import { trimTextPreview } from "@nervekit/ui-kit/core/utils/text-preview";
+import { LatestPresentationScheduler } from "@nervekit/ui-kit/core/utils/latest-presentation-scheduler";
 import { toolCardLayoutRevision } from "../views/tool-card-layout";
 import CardShell from "./tool-call/CardShell.svelte";
 import ToolExecutingSkeleton from "./tool-call/ToolExecutingSkeleton.svelte";
@@ -109,8 +111,31 @@ let bodyHydrated = $state(false);
 const shouldHydrateBody = $derived(hydrateBody || bodyHydrated);
 
 const capabilities = getConversationUiCapabilities();
+const initialLiveOutput = untrack(() => liveOutput);
+let displayedLiveOutput = $state(initialLiveOutput);
+let lastEnqueuedOutputText = initialLiveOutput?.text ?? "";
+const liveOutputScheduler = new LatestPresentationScheduler<
+  ConversationLiveToolOutputSnapshot | undefined
+>((value) => {
+  displayedLiveOutput = value;
+});
+$effect(() => {
+  const output = liveOutput;
+  const nextText = output?.text ?? "";
+  const appended = nextText.slice(lastEnqueuedOutputText.length);
+  const terminal = Boolean(
+    toolCall &&
+    !["requested", "pending_approval", "running"].includes(toolCall.status),
+  );
+  lastEnqueuedOutputText = nextText;
+  liveOutputScheduler.enqueue(output, {
+    priority: terminal || appended.includes("\n"),
+  });
+});
+$effect(() => () => liveOutputScheduler.destroy());
+
 const view = $derived.by(() =>
-  toolCall ? parseToolViewCached(toolCall, liveOutput) : undefined,
+  toolCall ? parseToolViewCached(toolCall, displayedLiveOutput) : undefined,
 );
 const presentation = $derived.by(() =>
   toolCall && view ? toolPresentationCached(view, toolCall) : undefined,

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolOutputBlock.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolOutputBlock.svelte
@@ -2,7 +2,7 @@
 import {
   COLLAPSED_LINES,
   splitLogicalLines,
-  tail,
+  tailLogicalText,
 } from "../../views/tool-result-view";
 import ResultCodeBlock from "./ResultCodeBlock.svelte";
 
@@ -34,11 +34,10 @@ let {
 
 const visible = $derived.by(() => {
   if (expanded) return text;
+  if (direction === "tail") return tailLogicalText(text, collapsedLines);
   const lines = splitLogicalLines(text);
   if (lines.length <= collapsedLines) return text;
-  return direction === "tail"
-    ? tail(lines, collapsedLines).join("\n")
-    : lines.slice(0, collapsedLines).join("\n");
+  return lines.slice(0, collapsedLines).join("\n");
 });
 </script>
 

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-parser.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-parser.ts
@@ -62,6 +62,7 @@ export {
   relativePath,
   splitLogicalLines,
   tail,
+  tailLogicalText,
 } from "./tool-view-helpers";
 export type {
   ExploreProgressView,

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-helpers.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-helpers.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { splitLogicalLines, tailLogicalText } from "./tool-view-helpers.js";
+
+describe("tailLogicalText", () => {
+  it("matches the existing split-and-tail semantics", () => {
+    const samples = [
+      "",
+      "one",
+      "one\n",
+      "one\ntwo\nthree",
+      "one\r\ntwo\r\nthree\r\n",
+      "one\n\nthree\n",
+    ];
+    for (const sample of samples) {
+      for (const count of [1, 2, 6]) {
+        const lines = splitLogicalLines(sample);
+        const expected =
+          lines.length <= count
+            ? sample
+            : lines.slice(lines.length - count).join("\n");
+        assert.equal(tailLogicalText(sample, count), expected);
+      }
+    }
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-helpers.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-helpers.ts
@@ -33,6 +33,19 @@ export function countLogicalLines(text: string | undefined): number {
   return text === undefined ? 0 : splitLogicalLines(text).length;
 }
 
+/** Extract the final logical lines without allocating every preceding line. */
+export function tailLogicalText(text: string, count: number): string {
+  if (text.length === 0 || count <= 0) return count <= 0 ? "" : text;
+  const contentEnd = text.endsWith("\n") ? text.length - 1 : text.length;
+  let remaining = count;
+  for (let index = contentEnd - 1; index >= 0; index -= 1) {
+    if (text.charCodeAt(index) !== 10) continue;
+    remaining -= 1;
+    if (remaining === 0) return text.slice(index + 1, contentEnd);
+  }
+  return text;
+}
+
 export function asRecord(value: unknown): Record<string, unknown> {
   if (value && typeof value === "object" && !Array.isArray(value)) {
     return value as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- replace eager active-run cloning with path-local copy-on-write updates
- memoize durable timeline projection and preserve stable transcript/virtual-row structure during live deltas
- coalesce streaming Markdown and tool-output presentation while keeping immediate first, newline, and completion updates
- render completed Markdown prefixes separately from escaped live tails and retain canonical final highlighting
- add focused regression tests for reducer identity, projection caching, scheduling, Markdown boundaries, and output tails

## Validation
- `pnpm fix && pnpm check && pnpm test`
- manually verified a long tool-heavy transcript in light and dark themes, including historical output expansion and virtualized scrolling
