### PR TITLE
Add curated application themes

### DIFF
--- a/packages/contracts/src/domains/settings/settings.schema.ts
+++ b/packages/contracts/src/domains/settings/settings.schema.ts
@@ -6,6 +6,12 @@ import { userConfigurableToolNameSchema } from "../tools/index.js";
 export const modeSchema = z.enum(["planning", "coding"]);
 export type Mode = z.infer<typeof modeSchema>;
 
+export const colorThemeSchema = z.enum(["nerve", "ocean", "forest"]);
+export type ColorTheme = z.infer<typeof colorThemeSchema>;
+
+export const colorModeSchema = z.enum(["system", "light", "dark"]);
+export type ColorMode = z.infer<typeof colorModeSchema>;
+
 export const permissionLevelSchema = z.enum([
   "autonomous",
   "supervised",
@@ -157,7 +163,8 @@ export const settingsSchema = z.object({
     allowRemote: z.boolean().default(false),
   }),
   ui: z.object({
-    theme: z.enum(["system", "light", "dark"]),
+    theme: colorThemeSchema.default("nerve"),
+    colorMode: colorModeSchema.default("system"),
     zoomLevel: z.number().int().min(-8).max(8).default(0),
   }),
   desktop: z.object({
@@ -230,7 +237,8 @@ export const defaultSettings: Settings = {
     allowRemote: false,
   },
   ui: {
-    theme: "system",
+    theme: "nerve",
+    colorMode: "system",
     zoomLevel: 0,
   },
   desktop: {
@@ -299,7 +307,8 @@ export const updateSettingsRequestSchema = z.object({
     .optional(),
   ui: z
     .object({
-      theme: z.enum(["system", "light", "dark"]).optional(),
+      theme: colorThemeSchema.optional(),
+      colorMode: colorModeSchema.optional(),
       zoomLevel: z.number().int().min(-8).max(8).optional(),
     })
     .optional(),

--- a/packages/contracts/test/settings.test.ts
+++ b/packages/contracts/test/settings.test.ts
@@ -15,6 +15,7 @@ describe("settings schema", () => {
       rememberLastAgentSelection: undefined,
       lastAgentSelection: undefined,
       notifications: undefined,
+      ui: { theme: undefined, colorMode: undefined, zoomLevel: undefined },
       tools: undefined,
       skills: undefined,
     });
@@ -32,6 +33,11 @@ describe("settings schema", () => {
     );
     assert.equal(settings.lastAgentSelection.thinkingLevel, "off");
     assert.deepEqual(settings.runtime, {});
+    assert.deepEqual(settings.ui, {
+      theme: "nerve",
+      colorMode: "system",
+      zoomLevel: 0,
+    });
     assert.deepEqual(settings.notifications, {
       systemEnabled: true,
       soundsEnabled: true,
@@ -116,6 +122,7 @@ describe("settings schema", () => {
         pythonExecutablePath: "/usr/bin/python3",
         shellPath: "C:\\Program Files\\Git\\bin\\bash.exe",
       },
+      ui: { theme: "ocean", colorMode: "dark" },
       defaultApprovalPolicy: { autoApproveReadOnly: false },
       lastAgentSelection: {
         approvalPolicy: { autoApproveReadOnly: false },
@@ -157,6 +164,13 @@ describe("settings schema", () => {
         updateSettingsRequestSchema.safeParse({
           notifications: { events: { approval: invalidTone } },
         }).success,
+        false,
+      );
+    }
+    assert.deepEqual(parsed.ui, { theme: "ocean", colorMode: "dark" });
+    for (const ui of [{ theme: "unknown" }, { colorMode: "sepia" }]) {
+      assert.equal(
+        updateSettingsRequestSchema.safeParse({ ui }).success,
         false,
       );
     }

--- a/packages/ui-kit/src/styles/theme-contrast.test.ts
+++ b/packages/ui-kit/src/styles/theme-contrast.test.ts
@@ -17,7 +17,9 @@ const badgeSource = readFileSync(
 
 type Oklch = readonly [lightness: number, chroma: number, hue: number];
 type LinearRgb = readonly [red: number, green: number, blue: number];
-type ThemeName = "light" | "dark";
+type ColorTheme = "nerve" | "ocean" | "forest";
+type ColorMode = "light" | "dark";
+type ThemeName = `${ColorTheme}-${ColorMode}`;
 
 const tokenNames = [
   "background",
@@ -43,17 +45,21 @@ const tokenNames = [
 ] as const;
 type TokenName = (typeof tokenNames)[number];
 
-function themeBlock(selector: ":root" | ".dark"): string {
-  const escapedSelector = selector.replace(".", "\\.");
+function themeBlock(theme: ColorTheme, mode: ColorMode): string {
+  const selector = `[data-theme-preview="${theme}"][data-color-mode="${mode}"]`;
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = themeCss.match(
     new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\n\\}`),
   );
-  assert.ok(match, `Missing ${selector} theme block`);
+  assert.ok(match, `Missing ${theme} ${mode} theme block`);
   return match[1];
 }
 
-function parseTokens(selector: ":root" | ".dark"): Record<TokenName, Oklch> {
-  const block = themeBlock(selector);
+function parseTokens(
+  theme: ColorTheme,
+  mode: ColorMode,
+): Record<TokenName, Oklch> {
+  const block = themeBlock(theme, mode);
   return Object.fromEntries(
     tokenNames.map((name) => {
       const match = block.match(
@@ -61,7 +67,7 @@ function parseTokens(selector: ":root" | ".dark"): Record<TokenName, Oklch> {
           `--${name}:\\s*oklch\\(\\s*([\\d.]+)\\s+([\\d.]+)\\s+([\\d.]+)\\s*\\)`,
         ),
       );
-      assert.ok(match, `Missing OKLCH token --${name} in ${selector}`);
+      assert.ok(match, `Missing OKLCH token --${name} in ${theme} ${mode}`);
       return [name, match.slice(1, 4).map(Number) as unknown as Oklch];
     }),
   ) as Record<TokenName, Oklch>;
@@ -117,10 +123,14 @@ function assertContrast(
   );
 }
 
-const themes = {
-  light: parseTokens(":root"),
-  dark: parseTokens(".dark"),
-} satisfies Record<ThemeName, Record<TokenName, Oklch>>;
+const themes = Object.fromEntries(
+  (["nerve", "ocean", "forest"] as const).flatMap((theme) =>
+    (["light", "dark"] as const).map((mode) => [
+      `${theme}-${mode}`,
+      parseTokens(theme, mode),
+    ]),
+  ),
+) as Record<ThemeName, Record<TokenName, Oklch>>;
 
 const filledPairs = [
   ["primary", "primary-foreground"],

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -4,6 +4,32 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  --radius: 0.625rem;
+
+  /* Motion: adaptive one-shot timing for live transcript content. */
+  --motion-enter-duration: 180ms;
+  --motion-enter-compact-duration: 120ms;
+  --motion-enter-minimal-duration: 90ms;
+  --motion-enter-easing: cubic-bezier(0.2, 0.8, 0.2, 1);
+
+  --tracking-normal: 0em;
+  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm:
+    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow-md:
+    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+  --shadow-lg:
+    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+  --shadow-xl:
+    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
+  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+}
+
+:root,
+:root[data-theme="nerve"],
+[data-theme-preview="nerve"][data-color-mode="light"] {
   --background: oklch(0.9818 0.0054 95.0986);
   --foreground: oklch(0.3438 0.0269 95.7226);
   --card: oklch(0.9665 0.0067 97.3521);
@@ -36,14 +62,6 @@
   --chart-3: oklch(0.8816 0.0276 93.128);
   --chart-4: oklch(0.8822 0.0403 298.1792);
   --chart-5: oklch(0.5608 0.1348 42.0584);
-  --radius: 0.625rem;
-
-  /* Motion: adaptive one-shot timing for live transcript content. */
-  --motion-enter-duration: 180ms;
-  --motion-enter-compact-duration: 120ms;
-  --motion-enter-minimal-duration: 90ms;
-  --motion-enter-easing: cubic-bezier(0.2, 0.8, 0.2, 1);
-
   --sidebar: oklch(0.9663 0.008 98.8792);
   --sidebar-foreground: oklch(0.359 0.0051 106.6524);
   --sidebar-primary: oklch(0.6171 0.1375 39.0427);
@@ -52,23 +70,11 @@
   --sidebar-accent-foreground: oklch(0.325 0 0);
   --sidebar-border: oklch(0.9401 0 0);
   --sidebar-ring: oklch(0.7731 0 0);
-
-  --tracking-normal: 0em;
-  --shadow-2xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-xs: 0 1px 3px 0px hsl(0 0% 0% / 0.05);
-  --shadow-sm:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow: 0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 1px 2px -1px hsl(0 0% 0% / 0.1);
-  --shadow-md:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
-  --shadow-lg:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
-  --shadow-xl:
-    0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
-  --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
 }
 
-.dark {
+:root.dark,
+:root[data-theme="nerve"].dark,
+[data-theme-preview="nerve"][data-color-mode="dark"] {
   --background: oklch(0.2679 0.0036 106.6427);
   --foreground: oklch(0.9576 0.0027 106.4494);
   --card: oklch(0.2928 0.0018 106.5092);
@@ -107,6 +113,182 @@
   --sidebar-primary-foreground: oklch(0.9881 0 0);
   --sidebar-accent: oklch(0.168 0.002 106.6177);
   --sidebar-accent-foreground: oklch(0.8074 0.0142 93.0137);
+  --sidebar-border: oklch(0.9401 0 0);
+  --sidebar-ring: oklch(0.7731 0 0);
+}
+
+:root[data-theme="ocean"],
+[data-theme-preview="ocean"][data-color-mode="light"] {
+  --background: oklch(0.9818 0.0054 250);
+  --foreground: oklch(0.3438 0.025 250);
+  --card: oklch(0.9665 0.0067 250);
+  --card-foreground: oklch(0.1908 0.002 250);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.2671 0.0196 250);
+  --primary: oklch(0.56 0.1375 250);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.9245 0.0138 250);
+  --secondary-foreground: oklch(0.4334 0.0177 250);
+  --muted: oklch(0.9341 0.0153 250);
+  --muted-foreground: oklch(0.5341 0.0078 250);
+  --accent: oklch(0.9245 0.0138 250);
+  --accent-foreground: oklch(0.2671 0.0196 250);
+  --destructive: oklch(0.5 0.19 27);
+  --destructive-foreground: oklch(1 0 0);
+  --destructive-solid: oklch(0.55 0.21 27.5);
+  --destructive-solid-foreground: oklch(1 0 0);
+  --success: oklch(0.47 0.17 149.2);
+  --success-foreground: oklch(0.986 0.002 67.8);
+  --warning: oklch(0.5 0.16 70.1);
+  --warning-foreground: oklch(0.986 0.002 67.8);
+  --info: oklch(0.49 0.158 254.1);
+  --info-foreground: oklch(0.986 0.002 67.8);
+  --border: oklch(0.8847 0.0069 250);
+  --input: oklch(0.7621 0.0156 250);
+  --ring: oklch(0.6171 0.1375 250);
+  --chart-1: oklch(0.5583 0.1276 250);
+  --chart-2: oklch(0.6898 0.1581 305);
+  --chart-3: oklch(0.8816 0.0276 5);
+  --chart-4: oklch(0.8822 0.0403 70);
+  --chart-5: oklch(0.5608 0.1348 190);
+  --sidebar: oklch(0.9663 0.008 250);
+  --sidebar-foreground: oklch(0.359 0.0051 250);
+  --sidebar-primary: oklch(0.6171 0.1375 250);
+  --sidebar-primary-foreground: oklch(0.9881 0 0);
+  --sidebar-accent: oklch(0.9245 0.0138 250);
+  --sidebar-accent-foreground: oklch(0.325 0 0);
+  --sidebar-border: oklch(0.9401 0 0);
+  --sidebar-ring: oklch(0.7731 0 0);
+}
+
+:root[data-theme="ocean"].dark,
+[data-theme-preview="ocean"][data-color-mode="dark"] {
+  --background: oklch(0.2679 0.0036 250);
+  --foreground: oklch(0.9576 0.0027 250);
+  --card: oklch(0.2928 0.0018 250);
+  --card-foreground: oklch(0.9818 0.0054 250);
+  --popover: oklch(0.3085 0.0035 250);
+  --popover-foreground: oklch(0.9211 0.004 250);
+  --primary: oklch(0.6724 0.1308 250);
+  --primary-foreground: oklch(0.1908 0.002 250);
+  --secondary: oklch(0.9818 0.0054 250);
+  --secondary-foreground: oklch(0.3085 0.0035 250);
+  --muted: oklch(0.2213 0.0038 250);
+  --muted-foreground: oklch(0.7713 0.0169 250);
+  --accent: oklch(0.213 0.0078 250);
+  --accent-foreground: oklch(0.9663 0.008 250);
+  --destructive: oklch(0.8 0.114 25.5);
+  --destructive-foreground: oklch(0.147 0.004 49.3);
+  --destructive-solid: oklch(0.58 0.21 27.5);
+  --destructive-solid-foreground: oklch(1 0 0);
+  --success: oklch(0.78 0.176 149.2);
+  --success-foreground: oklch(0.147 0.004 49.3);
+  --warning: oklch(0.828 0.16 70.1);
+  --warning-foreground: oklch(0.147 0.004 49.3);
+  --info: oklch(0.8 0.134 254.1);
+  --info-foreground: oklch(0.147 0.004 49.3);
+  --border: oklch(0.3618 0.0101 250);
+  --input: oklch(0.4336 0.0113 250);
+  --ring: oklch(0.6724 0.1308 250);
+  --chart-1: oklch(0.5583 0.1276 250);
+  --chart-2: oklch(0.6898 0.1581 305);
+  --chart-3: oklch(0.213 0.0078 5);
+  --chart-4: oklch(0.3074 0.0516 70);
+  --chart-5: oklch(0.5608 0.1348 190);
+  --sidebar: oklch(0.2357 0.0024 250);
+  --sidebar-foreground: oklch(0.8074 0.0142 250);
+  --sidebar-primary: oklch(0.325 0.08 250);
+  --sidebar-primary-foreground: oklch(0.9881 0 0);
+  --sidebar-accent: oklch(0.168 0.002 250);
+  --sidebar-accent-foreground: oklch(0.8074 0.0142 250);
+  --sidebar-border: oklch(0.9401 0 0);
+  --sidebar-ring: oklch(0.7731 0 0);
+}
+
+:root[data-theme="forest"],
+[data-theme-preview="forest"][data-color-mode="light"] {
+  --background: oklch(0.9818 0.0054 105);
+  --foreground: oklch(0.3438 0.025 105);
+  --card: oklch(0.9665 0.0067 105);
+  --card-foreground: oklch(0.1908 0.002 105);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.2671 0.0196 105);
+  --primary: oklch(0.55 0.1375 145);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.9245 0.0138 105);
+  --secondary-foreground: oklch(0.4334 0.0177 105);
+  --muted: oklch(0.9341 0.0153 105);
+  --muted-foreground: oklch(0.5341 0.0078 105);
+  --accent: oklch(0.9245 0.0138 105);
+  --accent-foreground: oklch(0.2671 0.0196 105);
+  --destructive: oklch(0.5 0.19 27);
+  --destructive-foreground: oklch(1 0 0);
+  --destructive-solid: oklch(0.55 0.21 27.5);
+  --destructive-solid-foreground: oklch(1 0 0);
+  --success: oklch(0.47 0.17 149.2);
+  --success-foreground: oklch(0.986 0.002 67.8);
+  --warning: oklch(0.5 0.16 70.1);
+  --warning-foreground: oklch(0.986 0.002 67.8);
+  --info: oklch(0.49 0.158 254.1);
+  --info-foreground: oklch(0.986 0.002 67.8);
+  --border: oklch(0.8847 0.0069 105);
+  --input: oklch(0.7621 0.0156 105);
+  --ring: oklch(0.6171 0.1375 145);
+  --chart-1: oklch(0.5583 0.1276 145);
+  --chart-2: oklch(0.6898 0.1581 200);
+  --chart-3: oklch(0.8816 0.0276 260);
+  --chart-4: oklch(0.8822 0.0403 325);
+  --chart-5: oklch(0.5608 0.1348 85);
+  --sidebar: oklch(0.9663 0.008 115);
+  --sidebar-foreground: oklch(0.359 0.0051 115);
+  --sidebar-primary: oklch(0.6171 0.1375 145);
+  --sidebar-primary-foreground: oklch(0.9881 0 0);
+  --sidebar-accent: oklch(0.9245 0.0138 115);
+  --sidebar-accent-foreground: oklch(0.325 0 0);
+  --sidebar-border: oklch(0.9401 0 0);
+  --sidebar-ring: oklch(0.7731 0 0);
+}
+
+:root[data-theme="forest"].dark,
+[data-theme-preview="forest"][data-color-mode="dark"] {
+  --background: oklch(0.2679 0.0036 105);
+  --foreground: oklch(0.9576 0.0027 105);
+  --card: oklch(0.2928 0.0018 105);
+  --card-foreground: oklch(0.9818 0.0054 105);
+  --popover: oklch(0.3085 0.0035 105);
+  --popover-foreground: oklch(0.9211 0.004 105);
+  --primary: oklch(0.6724 0.1308 145);
+  --primary-foreground: oklch(0.1908 0.002 105);
+  --secondary: oklch(0.9818 0.0054 105);
+  --secondary-foreground: oklch(0.3085 0.0035 105);
+  --muted: oklch(0.2213 0.0038 105);
+  --muted-foreground: oklch(0.7713 0.0169 105);
+  --accent: oklch(0.213 0.0078 105);
+  --accent-foreground: oklch(0.9663 0.008 105);
+  --destructive: oklch(0.8 0.114 25.5);
+  --destructive-foreground: oklch(0.147 0.004 49.3);
+  --destructive-solid: oklch(0.58 0.21 27.5);
+  --destructive-solid-foreground: oklch(1 0 0);
+  --success: oklch(0.78 0.176 149.2);
+  --success-foreground: oklch(0.147 0.004 49.3);
+  --warning: oklch(0.828 0.16 70.1);
+  --warning-foreground: oklch(0.147 0.004 49.3);
+  --info: oklch(0.8 0.134 254.1);
+  --info-foreground: oklch(0.147 0.004 49.3);
+  --border: oklch(0.3618 0.0101 105);
+  --input: oklch(0.4336 0.0113 105);
+  --ring: oklch(0.6724 0.1308 145);
+  --chart-1: oklch(0.5583 0.1276 145);
+  --chart-2: oklch(0.6898 0.1581 200);
+  --chart-3: oklch(0.213 0.0078 260);
+  --chart-4: oklch(0.3074 0.0516 325);
+  --chart-5: oklch(0.5608 0.1348 85);
+  --sidebar: oklch(0.2357 0.0024 115);
+  --sidebar-foreground: oklch(0.8074 0.0142 115);
+  --sidebar-primary: oklch(0.325 0.08 145);
+  --sidebar-primary-foreground: oklch(0.9881 0 0);
+  --sidebar-accent: oklch(0.168 0.002 115);
+  --sidebar-accent-foreground: oklch(0.8074 0.0142 115);
   --sidebar-border: oklch(0.9401 0 0);
   --sidebar-ring: oklch(0.7731 0 0);
 }

--- a/packages/workbench-app/src/lib/api.ts
+++ b/packages/workbench-app/src/lib/api.ts
@@ -10,6 +10,8 @@ export type {
   AvailableSkill,
   AvailableSkillsResponse,
   ClipboardImageUploadResponse,
+  ColorMode,
+  ColorTheme,
   CompletionItem,
   ContextUsage,
   ConversationActiveRunSnapshot,

--- a/packages/workbench-app/src/lib/app/shell/appearance.svelte.ts
+++ b/packages/workbench-app/src/lib/app/shell/appearance.svelte.ts
@@ -1,24 +1,59 @@
+import {
+  colorThemeSchema,
+  type ColorMode,
+  type ColorTheme,
+} from "@nervekit/contracts";
 import { setMode, userPrefersMode } from "mode-watcher";
 
-export type ThemePreference = "system" | "light" | "dark";
+const COLOR_THEME_STORAGE_KEY = "nerve-color-theme";
 
 export const MIN_ZOOM_LEVEL = -8;
 export const MAX_ZOOM_LEVEL = 8;
 export const ZOOM_BASE = 1.1;
 
-export const themeState = $state({
-  preference: "system" as ThemePreference,
+export const appearanceState = $state({
+  theme: "nerve" as ColorTheme,
+  colorMode: "system" as ColorMode,
 });
 
 export const zoomState = $state({
   level: 0,
 });
 
-// Theme switching is delegated to mode-watcher, which toggles the `.dark` class
-// on <html>, follows the system preference, and persists the choice.
-export function applyTheme(preference = themeState.preference) {
-  themeState.preference = preference;
-  setMode(preference);
+function storeColorTheme(theme: ColorTheme): void {
+  try {
+    localStorage.setItem(COLOR_THEME_STORAGE_KEY, theme);
+  } catch {
+    // The live theme still applies when storage is unavailable.
+  }
+}
+
+function storedColorTheme(): unknown {
+  try {
+    return localStorage.getItem(COLOR_THEME_STORAGE_KEY);
+  } catch {
+    return undefined;
+  }
+}
+
+export function applyColorTheme(theme = appearanceState.theme): void {
+  appearanceState.theme = theme;
+  if (typeof document !== "undefined") {
+    document.documentElement.dataset.theme = theme;
+  }
+  if (typeof localStorage !== "undefined") storeColorTheme(theme);
+}
+
+// Color-mode switching remains delegated to mode-watcher, which toggles the
+// `.dark` class, follows the system preference, and persists the choice.
+export function applyColorMode(colorMode = appearanceState.colorMode): void {
+  appearanceState.colorMode = colorMode;
+  setMode(colorMode);
+}
+
+export function applyAppearance(theme: ColorTheme, colorMode: ColorMode): void {
+  applyColorTheme(theme);
+  applyColorMode(colorMode);
 }
 
 export function clampZoomLevel(level: number): number {
@@ -49,7 +84,16 @@ export function applyZoomLevel(level: number) {
   );
 }
 
-export function loadThemePreference(): ThemePreference {
-  // mode-watcher restores the persisted mode on mount; mirror it into state.
-  return userPrefersMode.current ?? "system";
+export function loadAppearancePreference(): {
+  theme: ColorTheme;
+  colorMode: ColorMode;
+} {
+  const storedTheme =
+    typeof localStorage === "undefined" ? undefined : storedColorTheme();
+  const parsedTheme = colorThemeSchema.safeParse(storedTheme);
+  return {
+    theme: parsedTheme.success ? parsedTheme.data : "nerve",
+    // mode-watcher restores the persisted mode on mount; mirror it into state.
+    colorMode: userPrefersMode.current ?? "system",
+  };
 }

--- a/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
+++ b/packages/workbench-app/src/lib/core/events/websocket-client.svelte.ts
@@ -15,8 +15,8 @@ import {
 } from "@nervekit/contracts";
 import { getClientConfig } from "$lib/api";
 import {
-  applyTheme,
-  loadThemePreference,
+  applyAppearance,
+  loadAppearancePreference,
 } from "$lib/app/shell/appearance.svelte";
 import {
   applyEventAndFlush,
@@ -88,7 +88,8 @@ export async function initializeWorkbench(): Promise<boolean> {
   intentionallyDisconnected = false;
   workspaceSnapshotLoaded = false;
   const generation = beginWorkbenchStartup();
-  applyTheme(loadThemePreference());
+  const appearance = loadAppearancePreference();
+  applyAppearance(appearance.theme, appearance.colorMode);
   try {
     const diagnostics = await runWorkbenchStartupSequence({
       loadClientConfig: () =>

--- a/packages/workbench-app/src/lib/features/settings/components/SettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/SettingsPage.svelte
@@ -2,13 +2,14 @@
 import type {
   AuthProviderMetadata,
   AvailableSkill,
+  ColorMode,
+  ColorTheme,
   ModelInfo,
   ProjectRecord,
   Settings,
   StatusResponse,
   UpdateSettingsRequest,
 } from "$lib/api";
-import type { ThemePreference } from "$lib/app/shell/appearance.svelte";
 import {
   SettingsShell,
   SettingsSidebarStatus,
@@ -56,7 +57,8 @@ type Props = {
   settingsSaveStatus?: SettingsSaveStatus;
   settingsMessage?: string;
   onSettingsChange?: SettingsChange;
-  onThemeChange?: (theme: ThemePreference) => void;
+  onColorThemeChange?: (theme: ColorTheme) => void;
+  onColorModeChange?: (colorMode: ColorMode) => void;
   onSkillsRetry?: () => void;
 };
 
@@ -74,7 +76,8 @@ let {
   settingsSaveStatus = "idle",
   settingsMessage,
   onSettingsChange,
-  onThemeChange,
+  onColorThemeChange,
+  onColorModeChange,
   onSkillsRetry,
 }: Props = $props();
 
@@ -149,7 +152,8 @@ function statusText(): string {
       {#if page.id === "workbench"}
         <WorkbenchSettingsPage
           {settingsDraft}
-          {onThemeChange}
+          {onColorThemeChange}
+          {onColorModeChange}
           {onSettingsChange}
         />
       {:else if page.id === "notifications"}

--- a/packages/workbench-app/src/lib/features/settings/components/SettingsShell.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/SettingsShell.svelte
@@ -7,7 +7,8 @@ import { workspaceSelectors } from "$lib/features/workspace/state/workspace-sele
 import {
   loadSettingsSkills,
   queueSettingsSave,
-  setTheme,
+  setColorMode,
+  setColorTheme,
 } from "$lib/features/settings/state/settings-actions.svelte";
 
 const status = $derived(workspaceSelectors.status);
@@ -37,5 +38,6 @@ $effect(() => {
   {settingsSaveStatus}
   {settingsMessage}
   onSettingsChange={queueSettingsSave}
-  onThemeChange={setTheme}
+  onColorThemeChange={setColorTheme}
+  onColorModeChange={setColorMode}
 />

--- a/packages/workbench-app/src/lib/features/settings/components/pages/workbench/ColorModePicker.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/workbench/ColorModePicker.svelte
@@ -1,26 +1,35 @@
 <script lang="ts">
 import type { Component } from "svelte";
-import Palette from "@lucide/svelte/icons/palette";
-import TreePine from "@lucide/svelte/icons/tree-pine";
-import Waves from "@lucide/svelte/icons/waves";
+import Monitor from "@lucide/svelte/icons/monitor";
+import Moon from "@lucide/svelte/icons/moon";
+import Sun from "@lucide/svelte/icons/sun";
+import type { ColorTheme } from "$lib/api";
 import { Label } from "@nervekit/ui-kit/components/ui/label";
 import * as RadioGroup from "@nervekit/ui-kit/components/ui/radio-group";
 import { cn } from "@nervekit/ui-kit/core/utils";
 
-type ThemeOption = {
+type ModePreview = "light" | "dark";
+type ModeOption = {
   value: string;
   label: string;
   icon: Component<{ class?: string; "aria-hidden"?: "true" }>;
+  previews: ModePreview[];
 };
 
-const options: ThemeOption[] = [
-  { value: "nerve", label: "Nerve", icon: Palette },
-  { value: "ocean", label: "Ocean", icon: Waves },
-  { value: "forest", label: "Forest", icon: TreePine },
+const options: ModeOption[] = [
+  {
+    value: "system",
+    label: "System",
+    icon: Monitor,
+    previews: ["light", "dark"],
+  },
+  { value: "light", label: "Light", icon: Sun, previews: ["light"] },
+  { value: "dark", label: "Dark", icon: Moon, previews: ["dark"] },
 ];
 
 type Props = {
   value?: string;
+  theme: ColorTheme;
   ariaLabel?: string;
   class?: string;
   onValueChange?: (value: string) => void;
@@ -28,7 +37,8 @@ type Props = {
 
 let {
   value = $bindable(""),
-  ariaLabel = "Theme",
+  theme,
+  ariaLabel = "Color mode",
   class: className,
   onValueChange,
 }: Props = $props();
@@ -43,15 +53,15 @@ let {
   {#each options as option (option.value)}
     {@const Icon = option.icon}
     <Label
-      class="group/theme grid w-30 cursor-pointer gap-1.5 rounded-md border border-border/60 p-1.5 transition-colors hover:bg-accent/40 has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/10"
+      class="group/mode grid w-30 cursor-pointer gap-1.5 rounded-md border border-border/60 p-1.5 transition-colors hover:bg-accent/40 has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/10"
     >
       <span
         class="flex h-12 overflow-hidden rounded-sm border border-border/60"
         aria-hidden="true"
       >
-        {#each ["light", "dark"] as mode, index (mode)}
+        {#each option.previews as mode, index (mode)}
           <span
-            data-theme-preview={option.value}
+            data-theme-preview={theme}
             data-color-mode={mode}
             class={cn(
               "flex min-w-0 flex-1 gap-1 bg-background p-1",
@@ -60,7 +70,7 @@ let {
           >
             <span class="w-1.5 flex-none rounded-xs bg-sidebar"></span>
             <span class="grid min-w-0 flex-1 content-start gap-1">
-              <span class="h-1 w-full rounded-full bg-primary"></span>
+              <span class="h-1 w-full rounded-full bg-foreground/30"></span>
               <span class="h-1 w-2/3 rounded-full bg-foreground/30"></span>
             </span>
           </span>
@@ -70,7 +80,7 @@ let {
       <span class="flex min-w-0 items-center gap-1.5">
         <RadioGroup.Item value={option.value} class="size-3.5" />
         <Icon
-          class="size-3.5 flex-none text-muted-foreground group-has-data-[state=checked]/theme:text-primary"
+          class="size-3.5 flex-none text-muted-foreground group-has-data-[state=checked]/mode:text-primary"
           aria-hidden="true"
         />
         <span class="truncate text-xs font-medium">{option.label}</span>

--- a/packages/workbench-app/src/lib/features/settings/components/pages/workbench/WorkbenchSettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/workbench/WorkbenchSettingsPage.svelte
@@ -1,27 +1,40 @@
 <script lang="ts">
-import type { Settings } from "$lib/api";
-import type { ThemePreference } from "$lib/app/shell/appearance.svelte";
+import type { ColorMode, ColorTheme, Settings } from "$lib/api";
 import {
   SettingsRow,
   SettingsSection,
   SettingsToggleRow,
 } from "$lib/presentation/components/settings";
 import type { SettingsChange } from "../settings-change";
+import ColorModePicker from "./ColorModePicker.svelte";
 import ThemePreviewPicker from "./ThemePreviewPicker.svelte";
 
 type Props = {
   settingsDraft: Settings;
-  onThemeChange?: (theme: ThemePreference) => void;
+  onColorThemeChange?: (theme: ColorTheme) => void;
+  onColorModeChange?: (colorMode: ColorMode) => void;
   onSettingsChange?: SettingsChange;
 };
 
-let { settingsDraft, onThemeChange, onSettingsChange }: Props = $props();
+let {
+  settingsDraft,
+  onColorThemeChange,
+  onColorModeChange,
+  onSettingsChange,
+}: Props = $props();
 
-function setThemePreference(value: string): void {
-  const preference = value as ThemePreference;
-  settingsDraft.ui.theme = preference;
-  onThemeChange?.(preference);
-  onSettingsChange?.({ ui: { theme: preference } }, { immediate: true });
+function setColorTheme(value: string): void {
+  const theme = value as ColorTheme;
+  settingsDraft.ui.theme = theme;
+  onColorThemeChange?.(theme);
+  onSettingsChange?.({ ui: { theme } }, { immediate: true });
+}
+
+function setColorMode(value: string): void {
+  const colorMode = value as ColorMode;
+  settingsDraft.ui.colorMode = colorMode;
+  onColorModeChange?.(colorMode);
+  onSettingsChange?.({ ui: { colorMode } }, { immediate: true });
 }
 
 function setCloseToTray(checked: boolean): void {
@@ -34,10 +47,17 @@ function setCloseToTray(checked: boolean): void {
 </script>
 
 <SettingsSection id="appearance" title="Appearance">
-  <SettingsRow label="Color theme" layout="stacked">
+  <SettingsRow label="Theme" layout="stacked">
     <ThemePreviewPicker
       value={settingsDraft.ui.theme}
-      onValueChange={setThemePreference}
+      onValueChange={setColorTheme}
+    />
+  </SettingsRow>
+  <SettingsRow label="Color mode" layout="stacked">
+    <ColorModePicker
+      value={settingsDraft.ui.colorMode}
+      theme={settingsDraft.ui.theme}
+      onValueChange={setColorMode}
     />
   </SettingsRow>
 </SettingsSection>

--- a/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
@@ -2,7 +2,7 @@ import {
   modelKey,
   scopedUsableModelOptions,
 } from "$lib/presentation/utils/model";
-import type { AgentRecord, ModelInfo } from "$lib/api";
+import type { AgentRecord, ColorMode, ColorTheme, ModelInfo } from "$lib/api";
 import {
   getAuthProviders,
   getClientConfig,
@@ -13,9 +13,10 @@ import {
   type UpdateSettingsRequest,
   updateSettings,
 } from "$lib/api";
-import type { ThemePreference } from "$lib/app/shell/appearance.svelte";
 import {
-  applyTheme,
+  applyAppearance,
+  applyColorMode,
+  applyColorTheme,
   applyZoomLevel,
   clampZoomLevel,
 } from "$lib/app/shell/appearance.svelte";
@@ -115,6 +116,7 @@ async function performCoreSettingsLoad(): Promise<void> {
     getAuthProviders(),
   ]);
   settingsState.settingsDraft = settings;
+  applyAppearance(settings.ui.theme, settings.ui.colorMode);
   applyZoomLevel(settings.ui.zoomLevel);
   settingsState.models = modelList;
   settingsState.authProviders = auth;
@@ -427,8 +429,12 @@ export async function flushSettingsSave() {
   }
 }
 
-export function setTheme(preference: ThemePreference) {
-  applyTheme(preference);
+export function setColorTheme(theme: ColorTheme): void {
+  applyColorTheme(theme);
+}
+
+export function setColorMode(colorMode: ColorMode): void {
+  applyColorMode(colorMode);
 }
 
 export function setUiZoomLevel(level: number) {

--- a/packages/workbench-server/src/infrastructure/storage/initialize.ts
+++ b/packages/workbench-server/src/infrastructure/storage/initialize.ts
@@ -16,6 +16,7 @@ import {
 } from "./json.js";
 import { resolveDataDir, type StoragePaths, storagePaths } from "./paths.js";
 import { ensureStateLayout } from "./state-layout.js";
+import { migrateLegacyAppearanceSettings } from "./settings-migrations.js";
 
 const dataSubdirs = [
   "auth",
@@ -147,7 +148,8 @@ export async function initializeStorage(
   }
 
   const rawSettings = await readJsonFile<unknown>(paths.configPath);
-  const normalizedTools = migrateLegacyToolNames(rawSettings);
+  const normalizedAppearance = migrateLegacyAppearanceSettings(rawSettings);
+  const normalizedTools = migrateLegacyToolNames(normalizedAppearance.value);
   const normalizedTones = migrateRemovedNotificationTones(
     normalizedTools.value,
   );
@@ -155,7 +157,11 @@ export async function initializeStorage(
     ...defaultSettings,
     ...(normalizedTones.value as object),
   });
-  if (normalizedTools.changed || normalizedTones.changed) {
+  if (
+    normalizedAppearance.changed ||
+    normalizedTools.changed ||
+    normalizedTones.changed
+  ) {
     await atomicWriteJson(paths.configPath, settings, 0o600);
   }
 

--- a/packages/workbench-server/src/infrastructure/storage/legacy-portable-state.ts
+++ b/packages/workbench-server/src/infrastructure/storage/legacy-portable-state.ts
@@ -8,6 +8,7 @@ import {
 } from "@nervekit/contracts";
 import { EncryptedFileSecretProvider } from "../secrets/index.js";
 import { pathExists, readJsonFile } from "./json.js";
+import { migrateLegacyAppearanceSettings } from "./settings-migrations.js";
 
 /** Secret names carrying provider/tool credentials (model, web, Jira, Confluence). */
 const providerCredentialName = /^provider:.+:(?:apiKey|oauth)$/;
@@ -82,7 +83,11 @@ async function readLegacySettings(home: string): Promise<Settings | undefined> {
       "settings",
     );
   }
-  const parsed = settingsSchema.safeParse({ ...defaultSettings, ...raw });
+  const normalized = migrateLegacyAppearanceSettings(raw);
+  const parsed = settingsSchema.safeParse({
+    ...defaultSettings,
+    ...(normalized.value as object),
+  });
   if (!parsed.success) {
     throw new LegacyPortableStateError(
       "The legacy config.json does not match the settings schema.",

--- a/packages/workbench-server/src/infrastructure/storage/settings-migrations.ts
+++ b/packages/workbench-server/src/infrastructure/storage/settings-migrations.ts
@@ -1,0 +1,33 @@
+const legacyColorModes = new Set(["system", "light", "dark"]);
+
+export function migrateLegacyAppearanceSettings(value: unknown): {
+  value: unknown;
+  changed: boolean;
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { value, changed: false };
+  }
+
+  const settings = value as Record<string, unknown>;
+  const ui = settings.ui;
+  if (!ui || typeof ui !== "object" || Array.isArray(ui)) {
+    return { value, changed: false };
+  }
+
+  const legacyUi = ui as Record<string, unknown>;
+  if (!legacyColorModes.has(String(legacyUi.theme))) {
+    return { value, changed: false };
+  }
+
+  return {
+    value: {
+      ...settings,
+      ui: {
+        ...legacyUi,
+        theme: "nerve",
+        colorMode: legacyUi.theme,
+      },
+    },
+    changed: true,
+  };
+}

--- a/packages/workbench-server/test/storage-settings-migration.test.ts
+++ b/packages/workbench-server/test/storage-settings-migration.test.ts
@@ -18,6 +18,39 @@ afterEach(async () => {
 });
 
 describe("settings migrations", () => {
+  for (const colorMode of ["system", "light", "dark"] as const) {
+    it(`migrates the legacy ${colorMode} appearance setting`, async () => {
+      const root = await mkdtemp(join(tmpdir(), "nerve-settings-migration-"));
+      roots.push(root);
+      const configPath = join(root, "config.json");
+      await initializeStorage(root);
+      await writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            ...defaultSettings,
+            ui: { theme: colorMode, zoomLevel: 3 },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const storage = await initializeStorage(root);
+
+      assert.deepEqual(storage.settings.ui, {
+        theme: "nerve",
+        colorMode,
+        zoomLevel: 3,
+      });
+      const persisted = JSON.parse(await readFile(configPath, "utf8")) as {
+        ui: { theme: string; colorMode: string; zoomLevel: number };
+      };
+      assert.deepEqual(persisted.ui, storage.settings.ui);
+    });
+  }
+
   it("backfills notification preferences for older settings files", async () => {
     const root = await mkdtemp(join(tmpdir(), "nerve-settings-migration-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- add Nerve, Ocean, and Forest palettes with light and dark variants
- separate theme selection from System/Light/Dark color mode in settings
- migrate legacy appearance settings and restore themes during startup
- validate semantic token contrast across all six variants

## Validation
- `pnpm fix && pnpm check && pnpm test`
- visually smoke-tested all theme and mode combinations