### PR TITLE
Simplify task log previews and link URLs

### DIFF
--- a/packages/ui-kit/src/lib/core/terminal/ansi.test.ts
+++ b/packages/ui-kit/src/lib/core/terminal/ansi.test.ts
@@ -10,6 +10,54 @@ describe("ansiToHtml", () => {
     );
   });
 
+  it("linkifies only HTTP(S) URLs when enabled", () => {
+    const html = ansiToHtml(
+      "Open http://127.0.0.1:5173/docs, https://example.test/a_(b). or file:///tmp/log",
+      { linkifyUrls: true },
+    );
+
+    assert.equal(
+      html,
+      'Open <a href="http://127.0.0.1:5173/docs" target="_blank" rel="noopener noreferrer">http://127.0.0.1:5173/docs</a>, <a href="https://example.test/a_(b)" target="_blank" rel="noopener noreferrer">https://example.test/a_(b)</a>. or file:///tmp/log',
+    );
+    assert.equal(ansiToHtml("https://example.test"), "https://example.test");
+  });
+
+  it("escapes link text and attributes", () => {
+    const html = ansiToHtml(
+      "https://example.test/search?a=1&b=2 <script>alert(1)</script>",
+      { linkifyUrls: true },
+    );
+
+    assert.equal(
+      html,
+      '<a href="https://example.test/search?a=1&amp;b=2" target="_blank" rel="noopener noreferrer">https://example.test/search?a=1&amp;b=2</a> &lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+  });
+
+  it("preserves ANSI styling around linked URLs", () => {
+    const html = ansiToHtml("\x1b[36mhttps://example.test\x1b[39m", {
+      linkifyUrls: true,
+    });
+
+    assert.equal(
+      html,
+      '<a href="https://example.test" target="_blank" rel="noopener noreferrer"><span class="ansi-fg-cyan">https://example.test</span></a>',
+    );
+  });
+
+  it("keeps one complete URL target across ANSI style changes", () => {
+    const html = ansiToHtml(
+      "\x1b[36mhttp://127.0.0.1:\x1b[1m5173\x1b[22m/\x1b[39m",
+      { linkifyUrls: true },
+    );
+
+    assert.equal(
+      html,
+      '<a href="http://127.0.0.1:5173/" target="_blank" rel="noopener noreferrer"><span class="ansi-fg-cyan">http://127.0.0.1:</span><span class="ansi-bold ansi-fg-cyan">5173</span><span class="ansi-fg-cyan">/</span></a>',
+    );
+  });
+
   it("renders common SGR colors and styles without raw escapes", () => {
     const html = ansiToHtml("\x1b[2m10:49 AM\x1b[22m \x1b[32mready\x1b[39m");
 

--- a/packages/ui-kit/src/lib/core/terminal/ansi.ts
+++ b/packages/ui-kit/src/lib/core/terminal/ansi.ts
@@ -24,6 +24,17 @@ const ANSI_COLOR_NAMES = [
 ] as const;
 
 const CSI_FINAL_BYTE = /[\x40-\x7e]/;
+const URL_PATTERN = /https?:\/\/[^\s<>"']+/giu;
+const TRAILING_URL_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?"]);
+const URL_CLOSING_PAIRS: Record<string, string> = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+};
+
+export type AnsiToHtmlOptions = {
+  linkifyUrls?: boolean;
+};
 
 function initialState(): AnsiStyleState {
   return {
@@ -241,15 +252,136 @@ function stateStyle(state: AnsiStyleState): string | undefined {
   return declarations.length > 0 ? declarations.join("; ") : undefined;
 }
 
-function renderText(text: string, state: AnsiStyleState): string {
-  if (text.length === 0) return "";
-  const escaped = escapeHtml(text);
-  const classes = stateClasses(state);
-  const style = stateStyle(state);
-  if (classes.length === 0 && style === undefined) return escaped;
+function countCharacter(text: string, character: string): number {
+  let count = 0;
+  for (const value of text) {
+    if (value === character) count += 1;
+  }
+  return count;
+}
+
+function trimUrlPunctuation(value: string): { url: string; trailing: string } {
+  let end = value.length;
+  while (end > 0) {
+    const last = value[end - 1];
+    if (TRAILING_URL_PUNCTUATION.has(last)) {
+      end -= 1;
+      continue;
+    }
+    const opening = URL_CLOSING_PAIRS[last];
+    const candidate = value.slice(0, end);
+    if (
+      opening &&
+      countCharacter(candidate, last) > countCharacter(candidate, opening)
+    ) {
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+  return { url: value.slice(0, end), trailing: value.slice(end) };
+}
+
+function isSafeWebUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+type UrlRange = {
+  start: number;
+  end: number;
+  url: string;
+};
+
+type AnsiTextRun = {
+  text: string;
+  state: AnsiStyleState;
+};
+
+function findUrlRanges(text: string): UrlRange[] {
+  const ranges: UrlRange[] = [];
+  URL_PATTERN.lastIndex = 0;
+
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const raw = match[0];
+    const { url } = trimUrlPunctuation(raw);
+    if (url && isSafeWebUrl(url)) {
+      ranges.push({ start: match.index, end: match.index + url.length, url });
+    }
+  }
+  return ranges;
+}
+
+type AnsiTextFragment = AnsiTextRun & {
+  url?: string;
+};
+
+function splitRunAtUrls(
+  run: AnsiTextRun,
+  start: number,
+  ranges: readonly UrlRange[],
+): AnsiTextFragment[] {
+  const end = start + run.text.length;
+  const fragments: AnsiTextFragment[] = [];
+  let offset = 0;
+
+  for (const range of ranges) {
+    if (range.end <= start) continue;
+    if (range.start >= end) break;
+    const linkStart = Math.max(range.start, start) - start;
+    const linkEnd = Math.min(range.end, end) - start;
+    if (linkStart > offset) {
+      fragments.push({
+        text: run.text.slice(offset, linkStart),
+        state: run.state,
+      });
+    }
+    fragments.push({
+      text: run.text.slice(linkStart, linkEnd),
+      state: run.state,
+      url: range.url,
+    });
+    offset = linkEnd;
+  }
+
+  if (offset < run.text.length) {
+    fragments.push({ text: run.text.slice(offset), state: run.state });
+  }
+  return fragments;
+}
+
+function renderStyledText(fragment: AnsiTextFragment): string {
+  const rendered = escapeHtml(fragment.text);
+  const classes = stateClasses(fragment.state);
+  const style = stateStyle(fragment.state);
+  if (classes.length === 0 && style === undefined) return rendered;
   const classAttr = classes.length > 0 ? ` class="${classes.join(" ")}"` : "";
   const styleAttr = style ? ` style="${style}"` : "";
-  return `<span${classAttr}${styleAttr}>${escaped}</span>`;
+  return `<span${classAttr}${styleAttr}>${rendered}</span>`;
+}
+
+function renderFragments(fragments: readonly AnsiTextFragment[]): string {
+  let output = "";
+  let activeUrl: string | undefined;
+
+  for (const fragment of fragments) {
+    if (fragment.url !== activeUrl) {
+      if (activeUrl) output += "</a>";
+      if (fragment.url) {
+        const escapedUrl = escapeHtml(fragment.url);
+        output += `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">`;
+      }
+      activeUrl = fragment.url;
+    }
+    output += renderStyledText(fragment);
+  }
+
+  if (activeUrl) output += "</a>";
+  return output;
 }
 
 function csiEndIndex(text: string, start: number): number {
@@ -267,11 +399,16 @@ function oscEndIndex(text: string, start: number): number {
   return Math.min(bel, st + 1);
 }
 
-export function ansiToHtml(text: string): string {
-  let output = "";
+function parseAnsiTextRuns(text: string): AnsiTextRun[] {
+  const runs: AnsiTextRun[] = [];
   let state = initialState();
   let plainStart = 0;
   let index = 0;
+
+  const appendRun = (end: number) => {
+    const value = text.slice(plainStart, end);
+    if (value) runs.push({ text: value, state });
+  };
 
   while (index < text.length) {
     if (text.charCodeAt(index) !== 0x1b) {
@@ -279,12 +416,15 @@ export function ansiToHtml(text: string): string {
       continue;
     }
 
-    output += renderText(text.slice(plainStart, index), state);
+    appendRun(index);
     const next = text[index + 1];
 
     if (next === "[") {
       const end = csiEndIndex(text, index + 2);
-      if (end === -1) break;
+      if (end === -1) {
+        plainStart = text.length;
+        break;
+      }
       const sequence = text.slice(index + 2, end + 1);
       if (sequence.endsWith("m")) state = applySgr(state, sequence);
       index = end + 1;
@@ -294,7 +434,10 @@ export function ansiToHtml(text: string): string {
 
     if (next === "]") {
       const end = oscEndIndex(text, index + 2);
-      if (end === -1) break;
+      if (end === -1) {
+        plainStart = text.length;
+        break;
+      }
       index = end + 1;
       plainStart = index;
       continue;
@@ -304,6 +447,22 @@ export function ansiToHtml(text: string): string {
     plainStart = index;
   }
 
-  output += renderText(text.slice(plainStart), state);
-  return output;
+  appendRun(text.length);
+  return runs;
+}
+
+export function ansiToHtml(
+  text: string,
+  options: AnsiToHtmlOptions = {},
+): string {
+  const runs = parseAnsiTextRuns(text);
+  const visibleText = runs.map((run) => run.text).join("");
+  const ranges = options.linkifyUrls ? findUrlRanges(visibleText) : [];
+  let offset = 0;
+  const fragments: AnsiTextFragment[] = [];
+  for (const run of runs) {
+    fragments.push(...splitRunAtUrls(run, offset, ranges));
+    offset += run.text.length;
+  }
+  return renderFragments(fragments);
 }

--- a/packages/ui-kit/src/styles/components/terminal-output.css
+++ b/packages/ui-kit/src/styles/components/terminal-output.css
@@ -75,6 +75,23 @@
   );
 }
 
+.terminal-output a {
+  color: inherit;
+  text-decoration-line: none;
+  text-underline-offset: 0.15em;
+}
+
+.terminal-output a:hover,
+.terminal-output a:focus-visible {
+  text-decoration-line: underline;
+}
+
+.terminal-output a:focus-visible {
+  border-radius: var(--radius-sm);
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
 .terminal-output .ansi-bold {
   font-weight: 700;
 }

--- a/packages/workbench-app/src/lib/features/tasks/components/TaskShell.svelte
+++ b/packages/workbench-app/src/lib/features/tasks/components/TaskShell.svelte
@@ -1,24 +1,9 @@
 <script lang="ts">
 import { TaskOutputPane } from "$lib/presentation/tasks";
-import {
-  loadEarlierTaskLogs,
-  loadTaskLogWindow,
-} from "$lib/features/tasks/state/task-logs.svelte";
-import {
-  setTaskEntryRun,
-  taskEntryKey,
-} from "$lib/features/tasks/state/task-tabs.svelte";
-import { taskState } from "$lib/features/tasks/state/task-state.svelte";
+import { loadEarlierTaskLogs } from "$lib/features/tasks/state/task-logs.svelte";
 import { taskSelectors } from "$lib/features/tasks/state/task-selectors.svelte";
 
 const activeCenterTask = $derived(taskSelectors.activeCenterTask);
-const runs = $derived(
-  activeCenterTask
-    ? taskState.tasks.filter(
-        (task) => taskEntryKey(task.id) === taskEntryKey(activeCenterTask.id),
-      )
-    : [],
-);
 const taskLogs = $derived(
   taskSelectors.taskLogs?.task.id === activeCenterTask?.id
     ? taskSelectors.taskLogs
@@ -29,13 +14,6 @@ const taskLogs = $derived(
 <TaskOutputPane
   task={activeCenterTask}
   {taskLogs}
-  {runs}
-  onSelectRun={(taskId) => {
-    if (!activeCenterTask) return;
-    setTaskEntryRun(taskEntryKey(activeCenterTask.id), taskId);
-    taskState.selectedTaskId = taskId;
-    void loadTaskLogWindow(taskId);
-  }}
   onLoadEarlier={() =>
     activeCenterTask
       ? loadEarlierTaskLogs(activeCenterTask.id)

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskOutputPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskOutputPane.svelte
@@ -1,43 +1,19 @@
 <script lang="ts">
 import Terminal from "@lucide/svelte/icons/terminal";
 import type { TaskLogQueryResponse, TaskRecord } from "@nervekit/contracts";
-import SelectField from "@nervekit/ui-kit/components/ui/select-field";
 import TaskLogTerminal from "./TaskLogTerminal.svelte";
-import { formatTaskRunTime } from "./task-panel-controller.js";
 
 type Props = {
   task?: Pick<TaskRecord, "id" | "command" | "status" | "error" | "runtime">;
   taskLogs?: TaskLogQueryResponse;
-  runs?: readonly TaskRecord[];
-  onSelectRun?: (taskId: string) => void;
   onLoadEarlier?: () => void | Promise<void>;
 };
 
-let { task, taskLogs, runs = [], onSelectRun, onLoadEarlier }: Props = $props();
-
-const runItems = $derived(
-  [...runs]
-    .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
-    .map((run) => ({
-      value: run.id,
-      label: `${run.status} · ${formatTaskRunTime(run.startedAt)}`,
-    })),
-);
+let { task, taskLogs, onLoadEarlier }: Props = $props();
 </script>
 
 <section class="flex h-full min-h-0 flex-col bg-background">
   {#if task}
-    {#if runItems.length > 1}
-      <div class="flex items-center border-b border-border px-2 py-1">
-        <SelectField
-          items={runItems}
-          value={task.id}
-          ariaLabel="Selected task run"
-          triggerClass="w-64 max-w-full"
-          onValueChange={(value: string) => onSelectRun?.(value)}
-        />
-      </div>
-    {/if}
     {#if task.status === "recovered" || task.status === "recovery_unknown" || task.status === "orphaned"}
       <div
         class="border-b border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning"

--- a/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
@@ -31,7 +31,7 @@ import TaskDefinitionRow from "./TaskDefinitionRow.svelte";
 import TaskOutputPane from "./TaskOutputPane.svelte";
 import TaskRunRow from "./TaskRunRow.svelte";
 import TaskRunsDialog from "./TaskRunsDialog.svelte";
-import { projectTaskPanel, taskLineageRuns } from "./task-panel-controller.js";
+import { projectTaskPanel } from "./task-panel-controller.js";
 import type {
   TaskEntryCapabilities,
   TaskPanelActions,
@@ -68,7 +68,6 @@ function toggleDefinition(id: string): void {
 // The wide bottom dock can host the run output next to the list.
 const SPLIT_MIN_WIDTH = 720;
 const splitLayout = $derived(panelWidth >= SPLIT_MIN_WIDTH);
-const selectedRuns = $derived(taskLineageRuns(model.tasks, model.selectedTask));
 const prunableRuns = $derived(
   projected.runs.filter((entry) => entry.isRemovable).length,
 );
@@ -282,8 +281,6 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
             <TaskOutputPane
               task={model.selectedTask}
               taskLogs={model.selectedLogs}
-              runs={selectedRuns}
-              onSelectRun={(taskId) => void panelActions.selectTask(taskId)}
             />
           </Pane>
         </PaneGroup>

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
@@ -4,7 +4,6 @@ import type { TaskRecord } from "@nervekit/contracts";
 import {
   projectTaskPanel,
   taskDefinitionLabel,
-  taskLineageRuns,
   taskRunLabel,
 } from "./task-panel-controller.js";
 import type { TaskPanelDefinition } from "./task-panel-types.js";
@@ -161,31 +160,4 @@ test("labels definitions by their label and runs by display name, then command",
     text: "pnpm dev",
     isCommand: true,
   });
-});
-
-test("groups lineage runs by definition, then restart root, then id", () => {
-  const tasks = [
-    run("task_def_1", { definitionId: "taskdef_a" }),
-    run("task_def_2", { definitionId: "taskdef_a" }),
-    run("task_root", { restartRootTaskId: "task_root" }),
-    run("task_restart", { restartRootTaskId: "task_root" }),
-    run("task_solo"),
-  ];
-  assert.deepEqual(
-    taskLineageRuns(tasks, tasks[0])
-      .map((task) => task.id)
-      .sort(),
-    ["task_def_1", "task_def_2"],
-  );
-  assert.deepEqual(
-    taskLineageRuns(tasks, tasks[3])
-      .map((task) => task.id)
-      .sort(),
-    ["task_restart", "task_root"],
-  );
-  assert.deepEqual(
-    taskLineageRuns(tasks, tasks[4]).map((task) => task.id),
-    ["task_solo"],
-  );
-  assert.deepEqual(taskLineageRuns(tasks, undefined), []);
 });

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
@@ -98,24 +98,7 @@ export function taskRunLabel(entry: TaskRunEntry): TaskEntryLabel {
   return { text: command || "Task", isCommand: command.length > 0 };
 }
 
-/** Lineage key shared by a definition's runs and by restart chains. */
-function lineageKey(task: TaskRecord): string {
-  return task.definitionId ?? task.restartRootTaskId ?? task.id;
-}
-
-/** All runs that belong to the same lineage as `task`, newest first. */
-export function taskLineageRuns(
-  tasks: readonly TaskRecord[],
-  task: TaskRecord | undefined,
-): TaskRecord[] {
-  if (!task) return [];
-  const key = lineageKey(task);
-  return tasks
-    .filter((candidate) => lineageKey(candidate) === key)
-    .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
-}
-
-/** Formats a run start time for compact single-line row and selector labels. */
+/** Formats a run start time for compact single-line row labels. */
 export function formatTaskRunTime(startedAt: string): string {
   const started = new Date(startedAt);
   const sameDay = started.toDateString() === new Date().toDateString();

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/TerminalText.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/TerminalText.svelte
@@ -9,7 +9,7 @@ type Props = {
 };
 
 let { text, stream, level }: Props = $props();
-const html = $derived(ansiToHtml(text));
+const html = $derived(ansiToHtml(text, { linkifyUrls: true }));
 </script>
 
 <span
@@ -17,7 +17,7 @@ const html = $derived(ansiToHtml(text));
   data-stream={stream}
   data-level={level}
 >
-  <!-- eslint-disable-next-line svelte/no-at-html-tags -- ansiToHtml escapes terminal text and emits only controlled ANSI spans. -->
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- ansiToHtml escapes terminal text and emits only controlled ANSI spans and HTTP(S) links. -->
   {@html html}
 </span>
 


### PR DESCRIPTION
## Summary
- remove the redundant run switcher from task log preview panes
- linkify HTTP(S) URLs in shared terminal log output while preserving ANSI styles
- open links externally and show URL underlines on hover or keyboard focus
- add coverage for safe URL rendering, punctuation, and ANSI-split URLs

## Validation
- `pnpm fix && pnpm check && pnpm test`