### PR TITLE
Add project file explorer pane

### DIFF
--- a/packages/contracts/src/domains/filesystem/filesystem.operations.schema.ts
+++ b/packages/contracts/src/domains/filesystem/filesystem.operations.schema.ts
@@ -1,6 +1,8 @@
 import {
   filesystemDirectoryQuerySchema,
   filesystemDirectoryResponseSchema,
+  filesystemProjectEntriesQuerySchema,
+  filesystemProjectEntriesResponseSchema,
 } from "./index.js";
 import { defineOperation } from "../protocol/operation-definition.schema.js";
 
@@ -13,5 +15,14 @@ export const filesystemOperationDefinitions = [
     "none",
     ["workbench_server"] as const,
     "operation.filesystem.directories.list",
+  ),
+  defineOperation(
+    "filesystem.project.entries.list",
+    filesystemProjectEntriesQuerySchema,
+    filesystemProjectEntriesResponseSchema,
+    "read",
+    "none",
+    ["workbench_server"] as const,
+    "operation.filesystem.project.entries.list",
   ),
 ] as const;

--- a/packages/contracts/src/domains/filesystem/filesystem.schema.ts
+++ b/packages/contracts/src/domains/filesystem/filesystem.schema.ts
@@ -37,6 +37,36 @@ export type FilesystemDirectoryQuery = z.infer<
   typeof filesystemDirectoryQuerySchema
 >;
 
+export const filesystemProjectEntrySchema = z.object({
+  name: z.string().min(1),
+  path: z.string().min(1),
+  kind: z.enum(["file", "directory", "other"]),
+  symlink: z.boolean(),
+});
+export type FilesystemProjectEntry = z.infer<
+  typeof filesystemProjectEntrySchema
+>;
+
+export const filesystemProjectEntriesQuerySchema = z.object({
+  projectId: z.string().min(1),
+  path: z.string().optional(),
+  cursor: z.string().min(1).optional(),
+  limit: z.coerce.number().int().positive().max(2_000).optional(),
+});
+export type FilesystemProjectEntriesQuery = z.infer<
+  typeof filesystemProjectEntriesQuerySchema
+>;
+
+export const filesystemProjectEntriesResponseSchema = z.object({
+  projectId: z.string().min(1),
+  path: z.string(),
+  entries: z.array(filesystemProjectEntrySchema),
+  nextCursor: z.string().min(1).optional(),
+});
+export type FilesystemProjectEntriesResponse = z.infer<
+  typeof filesystemProjectEntriesResponseSchema
+>;
+
 export const filesystemFileQuerySchema = z.object({
   projectId: z.string().min(1),
   path: z.string().min(1),

--- a/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
@@ -5,6 +5,7 @@ import {
   ContextPanelView,
   conversationSelectors,
 } from "$lib/features/conversations";
+import { FilesPanelView } from "$lib/features/filesystem";
 import {
   GitPanelView,
   GitPullRequestsPanelView,
@@ -69,7 +70,9 @@ function focusTasks() {
 }
 </script>
 
-{#if viewId === "conversations"}
+{#if viewId === "files"}
+  <FilesPanelView {activeProject} />
+{:else if viewId === "conversations"}
   <ConversationsPanelView />
 {:else if viewId === "git"}
   <GitPanelView model={gitModel} actions={gitActions} />

--- a/packages/workbench-app/src/lib/app/shell/panel-views.ts
+++ b/packages/workbench-app/src/lib/app/shell/panel-views.ts
@@ -14,23 +14,23 @@ import type { PanelViewDescriptor } from "$lib/presentation/shell";
  */
 export const panelViewDescriptors: PanelViewDescriptor[] = [
   {
-    id: "files",
-    title: "Files",
-    icon: FolderTree,
-    defaultDock: "left",
-    defaultOrder: 0,
-  },
-  {
     id: "conversations",
     title: "Conversations",
     icon: MessagesSquare,
     defaultDock: "left",
-    defaultOrder: 1,
+    defaultOrder: 0,
     hideable: false,
   },
   {
+    id: "files",
+    title: "Files",
+    icon: FolderTree,
+    defaultDock: "left",
+    defaultOrder: 1,
+  },
+  {
     id: "git",
-    title: "Git",
+    title: "Git Changes",
     icon: GitBranch,
     defaultDock: "right",
     defaultOrder: 0,
@@ -50,18 +50,18 @@ export const panelViewDescriptors: PanelViewDescriptor[] = [
     defaultOrder: 2,
   },
   {
-    id: "notes",
-    title: "Notes",
-    icon: NotebookPen,
-    defaultDock: "right",
-    defaultOrder: 3,
-  },
-  {
     id: "tasks",
     title: "Tasks",
     icon: Terminal,
     defaultDock: "left",
     defaultOrder: 2,
+  },
+  {
+    id: "notes",
+    title: "Scratch Notes",
+    icon: NotebookPen,
+    defaultDock: "left",
+    defaultOrder: 3,
   },
 ];
 

--- a/packages/workbench-app/src/lib/app/shell/panel-views.ts
+++ b/packages/workbench-app/src/lib/app/shell/panel-views.ts
@@ -1,4 +1,4 @@
-import Files from "@lucide/svelte/icons/files";
+import FolderTree from "@lucide/svelte/icons/folder-tree";
 import GitBranch from "@lucide/svelte/icons/git-branch";
 import GitPullRequest from "@lucide/svelte/icons/git-pull-request";
 import Info from "@lucide/svelte/icons/info";
@@ -16,7 +16,7 @@ export const panelViewDescriptors: PanelViewDescriptor[] = [
   {
     id: "files",
     title: "Files",
-    icon: Files,
+    icon: FolderTree,
     defaultDock: "left",
     defaultOrder: 0,
   },

--- a/packages/workbench-app/src/lib/app/shell/panel-views.ts
+++ b/packages/workbench-app/src/lib/app/shell/panel-views.ts
@@ -1,3 +1,4 @@
+import Files from "@lucide/svelte/icons/files";
 import GitBranch from "@lucide/svelte/icons/git-branch";
 import GitPullRequest from "@lucide/svelte/icons/git-pull-request";
 import Info from "@lucide/svelte/icons/info";
@@ -13,11 +14,18 @@ import type { PanelViewDescriptor } from "$lib/presentation/shell";
  */
 export const panelViewDescriptors: PanelViewDescriptor[] = [
   {
+    id: "files",
+    title: "Files",
+    icon: Files,
+    defaultDock: "left",
+    defaultOrder: 0,
+  },
+  {
     id: "conversations",
     title: "Conversations",
     icon: MessagesSquare,
     defaultDock: "left",
-    defaultOrder: 0,
+    defaultOrder: 1,
     hideable: false,
   },
   {
@@ -53,7 +61,7 @@ export const panelViewDescriptors: PanelViewDescriptor[] = [
     title: "Tasks",
     icon: Terminal,
     defaultDock: "left",
-    defaultOrder: 1,
+    defaultOrder: 2,
   },
 ];
 

--- a/packages/workbench-app/src/lib/features/filesystem/api/filesystem.api.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/api/filesystem.api.ts
@@ -2,6 +2,8 @@ import type {
   ClipboardImageUploadResponse,
   FilesystemDirectoryResponse,
   FilesystemFileResponse,
+  FilesystemProjectEntriesQuery,
+  FilesystemProjectEntriesResponse,
 } from "@nervekit/contracts";
 import {
   apiGet,
@@ -29,6 +31,13 @@ export async function listDirectories(
   return (
     await protocolRequest("filesystem.directories.list", { path, showHidden })
   ).result;
+}
+
+export async function listProjectEntries(
+  query: FilesystemProjectEntriesQuery,
+): Promise<FilesystemProjectEntriesResponse> {
+  return (await protocolRequest("filesystem.project.entries.list", query))
+    .result;
 }
 
 export async function getFileContent(

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+import File from "@lucide/svelte/icons/file";
+import Files from "@lucide/svelte/icons/files";
+import Folder from "@lucide/svelte/icons/folder";
+import Link from "@lucide/svelte/icons/link";
+import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
+import type { ProjectRecord } from "$lib/api";
+import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
+import { fileSelectors } from "$lib/features/filesystem/state/file-selectors.svelte";
+import { openFilePane } from "$lib/features/filesystem/state/file-tabs.svelte";
+import {
+  activateFileExplorerItem,
+  ensureFileExplorerRoot,
+  refreshFileExplorerProject,
+  setFileExplorerItemExpanded,
+} from "$lib/features/filesystem/state/file-explorer-actions.svelte";
+import { startFileExplorerRefreshScheduler } from "$lib/features/filesystem/state/file-explorer-refresh-scheduler";
+import { fileExplorerState } from "$lib/features/filesystem/state/file-explorer-state.svelte";
+import {
+  buildFileExplorerTree,
+  type FileExplorerTreeItem,
+} from "$lib/features/filesystem/state/file-explorer-tree";
+import {
+  PanelBanner,
+  PanelEmpty,
+  PanelHeader,
+  PanelToolbarButton,
+  PanelTree,
+  PanelView,
+} from "$lib/presentation/panel";
+import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+
+let { activeProject }: { activeProject?: ProjectRecord } = $props();
+
+const project = $derived(
+  activeProject ? fileExplorerState.projects[activeProject.id] : undefined,
+);
+const root = $derived(project?.directories[""]);
+const nodes = $derived(project ? buildFileExplorerTree(project) : []);
+const activeFile = $derived(fileSelectors.activeCenterFileView);
+const activeRelativePath = $derived.by(() => {
+  const file = activeFile;
+  if (!file || file.projectId !== activeProject?.id) return undefined;
+  return file.content?.relativePath ?? file.path;
+});
+const busy = $derived(
+  Object.values(project?.directories ?? {}).some(
+    (directory) => directory.loading || directory.refreshing,
+  ),
+);
+
+function itemPath(item: FileExplorerTreeItem): string | undefined {
+  return item.type === "entry" ? item.entry.path : undefined;
+}
+
+function activate(item: FileExplorerTreeItem): void {
+  if (!activeProject) return;
+  if (item.type === "entry" && item.entry.kind === "file") {
+    void openFilePane({ projectId: activeProject.id, path: item.entry.path });
+    return;
+  }
+  activateFileExplorerItem(activeProject.id, item);
+}
+
+$effect(() => {
+  const projectId = activeProject?.id;
+  if (!projectId || !workbenchStartupState.progressiveActive) return;
+  void ensureFileExplorerRoot(projectId);
+  return startFileExplorerRefreshScheduler({
+    refresh: () => refreshFileExplorerProject(projectId),
+  });
+});
+</script>
+
+{#snippet header()}
+  <PanelHeader title="Files" count={root?.entries.length}>
+    {#snippet trailing()}
+      <PanelToolbarButton
+        icon={RefreshCw}
+        label="Refresh files"
+        loading={busy}
+        disabled={!activeProject || !root || busy}
+        onclick={() => {
+          if (activeProject) void refreshFileExplorerProject(activeProject.id);
+        }}
+      />
+    {/snippet}
+  </PanelHeader>
+  {#if root?.error && root.entries.length === 0}
+    <PanelBanner tone="destructive" icon={TriangleAlert}>
+      <span>{root.error}</span>
+    </PanelBanner>
+  {/if}
+{/snippet}
+
+<PanelView scroll={false} padded={false} banner={header}>
+  {#if !activeProject}
+    <PanelEmpty
+      icon={Files}
+      title="No project selected"
+      description="Select a project to browse its files."
+    />
+  {:else if !root || (root.loading && root.entries.length === 0)}
+    <div class="flex min-h-24 items-center justify-center">
+      <Spinner class="size-4 text-muted-foreground" />
+    </div>
+  {:else if root.error && root.entries.length === 0}
+    <PanelEmpty
+      icon={TriangleAlert}
+      title="Could not load files"
+      description={root.error}
+    >
+      {#snippet action()}
+        <PanelToolbarButton
+          icon={RefreshCw}
+          label="Retry loading files"
+          title="Retry"
+          onclick={() => void ensureFileExplorerRoot(activeProject.id)}
+        />
+      {/snippet}
+    </PanelEmpty>
+  {:else if root.entries.length === 0}
+    <PanelEmpty icon={Folder} title="This project is empty" />
+  {:else if project}
+    <PanelTree
+      {nodes}
+      ariaLabel={`${activeProject.name} files`}
+      virtualized
+      expandedIds={project.expandedIds}
+      getItemTitle={(item) =>
+        item.type === "entry"
+          ? item.entry.path
+          : item.type === "error"
+            ? item.message
+            : "Load more files"}
+      getItemSelected={(item) => itemPath(item) === activeRelativePath}
+      onItemActivate={activate}
+      onItemExpansionChange={(item, expanded) =>
+        setFileExplorerItemExpanded(activeProject.id, item, expanded)}
+    >
+      {#snippet itemLeading(item)}
+        {#if item.type === "entry"}
+          {#if item.entry.symlink}
+            <Link class="size-3.5" aria-hidden="true" />
+          {:else if item.entry.kind === "directory"}
+            <Folder class="size-3.5" aria-hidden="true" />
+          {:else}
+            <File class="size-3.5" aria-hidden="true" />
+          {/if}
+          {#if item.entry.kind === "directory" && project.directories[item.entry.path]?.loading}
+            <Spinner class="ml-0.5 size-3" />
+          {/if}
+        {:else if item.type === "error"}
+          <TriangleAlert class="size-3.5 text-destructive" aria-hidden="true" />
+        {/if}
+      {/snippet}
+    </PanelTree>
+  {/if}
+</PanelView>

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -2,6 +2,7 @@
 import File from "@lucide/svelte/icons/file";
 import Files from "@lucide/svelte/icons/files";
 import Folder from "@lucide/svelte/icons/folder";
+import FolderOpen from "@lucide/svelte/icons/folder-open";
 import Link from "@lucide/svelte/icons/link";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
@@ -19,6 +20,7 @@ import { startFileExplorerRefreshScheduler } from "$lib/features/filesystem/stat
 import { fileExplorerState } from "$lib/features/filesystem/state/file-explorer-state.svelte";
 import {
   buildFileExplorerTree,
+  fileExplorerEntryNodeId,
   type FileExplorerTreeItem,
 } from "$lib/features/filesystem/state/file-explorer-tree";
 import {
@@ -144,7 +146,11 @@ $effect(() => {
           {#if item.entry.symlink}
             <Link class="size-3.5" aria-hidden="true" />
           {:else if item.entry.kind === "directory"}
-            <Folder class="size-3.5" aria-hidden="true" />
+            {#if project.expandedIds.has(fileExplorerEntryNodeId(activeProject.id, item.entry.path))}
+              <FolderOpen class="size-3.5" aria-hidden="true" />
+            {:else}
+              <Folder class="size-3.5" aria-hidden="true" />
+            {/if}
           {:else}
             <File class="size-3.5" aria-hidden="true" />
           {/if}

--- a/packages/workbench-app/src/lib/features/filesystem/index.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/index.ts
@@ -1,9 +1,11 @@
 export * from "./api/filesystem.api";
 export { default as FileShell } from "./components/FileShell.svelte";
+export { default as FilesPanelView } from "./components/FilesPanelView.svelte";
 export { fileSelectors } from "./state/file-selectors.svelte";
 export type { FileViewState } from "./state/file-state.svelte";
 export { fileState } from "./state/file-state.svelte";
 export {
+  openFilePane,
   refreshFilePane,
   toggleFileDisplayMode,
   toggleFileLineWrap,

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-actions.svelte.ts
@@ -1,0 +1,172 @@
+import { listProjectEntries } from "$lib/features/filesystem/api/filesystem.api";
+import {
+  ensureFileExplorerProject,
+  type FileExplorerDirectoryState,
+} from "./file-explorer-state.svelte";
+import { SvelteMap } from "svelte/reactivity";
+import {
+  fileExplorerEntryNodeId,
+  type FileExplorerTreeItem,
+} from "./file-explorer-tree";
+
+const PAGE_SIZE = 500;
+const REFRESH_CONCURRENCY = 4;
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function ensureDirectory(
+  projectId: string,
+  path: string,
+): FileExplorerDirectoryState {
+  const project = ensureFileExplorerProject(projectId);
+  return (project.directories[path] ??= {
+    path,
+    entries: [],
+    pagesLoaded: 0,
+    loading: false,
+    refreshing: false,
+    generation: 0,
+  });
+}
+
+async function requestPages(
+  projectId: string,
+  path: string,
+  pageCount: number,
+): Promise<{
+  entries: FileExplorerDirectoryState["entries"];
+  nextCursor?: string;
+  pagesLoaded: number;
+}> {
+  const entries: FileExplorerDirectoryState["entries"] = [];
+  let cursor: string | undefined;
+  let pagesLoaded = 0;
+  do {
+    const response = await listProjectEntries({
+      projectId,
+      path: path || undefined,
+      cursor,
+      limit: PAGE_SIZE,
+    });
+    entries.push(...response.entries);
+    cursor = response.nextCursor;
+    pagesLoaded += 1;
+  } while (cursor && pagesLoaded < pageCount);
+  return { entries, nextCursor: cursor, pagesLoaded };
+}
+
+export async function loadFileExplorerDirectory(
+  projectId: string,
+  path: string,
+  options: { append?: boolean; refresh?: boolean } = {},
+): Promise<void> {
+  const directory = ensureDirectory(projectId, path);
+  if (directory.loading || directory.refreshing) return;
+  const generation = ++directory.generation;
+  const refreshing = options.refresh === true;
+  if (refreshing) directory.refreshing = true;
+  else directory.loading = true;
+  directory.error = undefined;
+
+  try {
+    if (options.append && directory.nextCursor) {
+      const response = await listProjectEntries({
+        projectId,
+        path: path || undefined,
+        cursor: directory.nextCursor,
+        limit: PAGE_SIZE,
+      });
+      if (directory.generation !== generation) return;
+      const merged = new SvelteMap(
+        directory.entries.map((entry) => [entry.path, entry]),
+      );
+      for (const entry of response.entries) merged.set(entry.path, entry);
+      directory.entries = [...merged.values()];
+      directory.nextCursor = response.nextCursor;
+      directory.pagesLoaded += 1;
+    } else {
+      const result = await requestPages(
+        projectId,
+        path,
+        refreshing ? Math.max(1, directory.pagesLoaded) : 1,
+      );
+      if (directory.generation !== generation) return;
+      directory.entries = result.entries;
+      directory.nextCursor = result.nextCursor;
+      directory.pagesLoaded = result.pagesLoaded;
+    }
+  } catch (error) {
+    if (directory.generation === generation) directory.error = messageOf(error);
+  } finally {
+    if (directory.generation === generation) {
+      directory.loading = false;
+      directory.refreshing = false;
+    }
+  }
+}
+
+export async function ensureFileExplorerRoot(projectId: string): Promise<void> {
+  const project = ensureFileExplorerProject(projectId);
+  const root = project.directories[""];
+  if (root && !root.error) return;
+  await loadFileExplorerDirectory(projectId, "");
+}
+
+export function setFileExplorerItemExpanded(
+  projectId: string,
+  item: FileExplorerTreeItem,
+  expanded: boolean,
+): void {
+  if (item.type !== "entry" || item.entry.kind !== "directory") return;
+  const project = ensureFileExplorerProject(projectId);
+  const id = fileExplorerEntryNodeId(projectId, item.entry.path);
+  if (expanded) {
+    project.expandedIds.add(id);
+    if (!project.directories[item.entry.path] && !item.entry.symlink)
+      void loadFileExplorerDirectory(projectId, item.entry.path);
+  } else {
+    project.expandedIds.delete(id);
+  }
+}
+
+export function activateFileExplorerItem(
+  projectId: string,
+  item: FileExplorerTreeItem,
+): void {
+  if (item.type === "load-more") {
+    void loadFileExplorerDirectory(projectId, item.directoryPath, {
+      append: true,
+    });
+  } else if (item.type === "error") {
+    void loadFileExplorerDirectory(projectId, item.directoryPath, {
+      refresh: true,
+    });
+  }
+}
+
+async function runBounded(tasks: Array<() => Promise<void>>): Promise<void> {
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < tasks.length) {
+      const task = tasks[cursor++];
+      if (task) await task();
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(REFRESH_CONCURRENCY, tasks.length) }, worker),
+  );
+}
+
+export async function refreshFileExplorerProject(
+  projectId: string,
+): Promise<void> {
+  const project = ensureFileExplorerProject(projectId);
+  await runBounded(
+    Object.keys(project.directories).map(
+      (path) => () =>
+        loadFileExplorerDirectory(projectId, path, { refresh: true }),
+    ),
+  );
+}

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-actions.svelte.ts
@@ -21,14 +21,15 @@ function ensureDirectory(
   path: string,
 ): FileExplorerDirectoryState {
   const project = ensureFileExplorerProject(projectId);
-  return (project.directories[path] ??= {
+  project.directories[path] ??= {
     path,
     entries: [],
     pagesLoaded: 0,
     loading: false,
     refreshing: false,
     generation: 0,
-  });
+  };
+  return project.directories[path];
 }
 
 async function requestPages(

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { startFileExplorerRefreshScheduler } from "./file-explorer-refresh-scheduler";
+
+test("refreshes only while visible and cleans up listeners", () => {
+  const windowTarget = new EventTarget();
+  const documentTarget = new EventTarget();
+  let interval: (() => void) | undefined;
+  let visible = true;
+  let refreshes = 0;
+  const stop = startFileExplorerRefreshScheduler({
+    refresh: () => {
+      refreshes += 1;
+    },
+    window: {
+      addEventListener: windowTarget.addEventListener.bind(windowTarget),
+      removeEventListener: windowTarget.removeEventListener.bind(windowTarget),
+      setInterval: ((callback: TimerHandler) => {
+        interval = callback as () => void;
+        return 1;
+      }) as Window["setInterval"],
+      clearInterval: (() => undefined) as Window["clearInterval"],
+    },
+    document: {
+      addEventListener: documentTarget.addEventListener.bind(documentTarget),
+      removeEventListener:
+        documentTarget.removeEventListener.bind(documentTarget),
+      get visibilityState() {
+        return visible ? "visible" : "hidden";
+      },
+    },
+  });
+
+  interval?.();
+  windowTarget.dispatchEvent(new Event("focus"));
+  assert.equal(refreshes, 2);
+  visible = false;
+  interval?.();
+  documentTarget.dispatchEvent(new Event("visibilitychange"));
+  assert.equal(refreshes, 2);
+  stop();
+  visible = true;
+  windowTarget.dispatchEvent(new Event("focus"));
+  assert.equal(refreshes, 2);
+});

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.test.ts
@@ -6,6 +6,7 @@ test("refreshes only while visible and cleans up listeners", () => {
   const windowTarget = new EventTarget();
   const documentTarget = new EventTarget();
   let interval: (() => void) | undefined;
+  let intervalMs: number | undefined;
   let visible = true;
   let refreshes = 0;
   const stop = startFileExplorerRefreshScheduler({
@@ -15,8 +16,9 @@ test("refreshes only while visible and cleans up listeners", () => {
     window: {
       addEventListener: windowTarget.addEventListener.bind(windowTarget),
       removeEventListener: windowTarget.removeEventListener.bind(windowTarget),
-      setInterval: ((callback: TimerHandler) => {
+      setInterval: ((callback: TimerHandler, delay?: number) => {
         interval = callback as () => void;
+        intervalMs = delay;
         return 1;
       }) as Window["setInterval"],
       clearInterval: (() => undefined) as Window["clearInterval"],
@@ -31,6 +33,7 @@ test("refreshes only while visible and cleans up listeners", () => {
     },
   });
 
+  assert.equal(intervalMs, 20_000);
   interval?.();
   windowTarget.dispatchEvent(new Event("focus"));
   assert.equal(refreshes, 2);

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.ts
@@ -1,0 +1,29 @@
+type RefreshWindow = Pick<
+  Window,
+  "addEventListener" | "removeEventListener" | "setInterval" | "clearInterval"
+>;
+type RefreshDocument = Pick<
+  Document,
+  "addEventListener" | "removeEventListener" | "visibilityState"
+>;
+
+export function startFileExplorerRefreshScheduler(options: {
+  refresh: () => void | Promise<void>;
+  intervalMs?: number;
+  window?: RefreshWindow;
+  document?: RefreshDocument;
+}): () => void {
+  const targetWindow = options.window ?? window;
+  const targetDocument = options.document ?? document;
+  const refresh = (): void => {
+    if (targetDocument.visibilityState === "visible") void options.refresh();
+  };
+  const timer = targetWindow.setInterval(refresh, options.intervalMs ?? 5_000);
+  targetWindow.addEventListener("focus", refresh);
+  targetDocument.addEventListener("visibilitychange", refresh);
+  return () => {
+    targetWindow.clearInterval(timer);
+    targetWindow.removeEventListener("focus", refresh);
+    targetDocument.removeEventListener("visibilitychange", refresh);
+  };
+}

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.ts
@@ -18,7 +18,7 @@ export function startFileExplorerRefreshScheduler(options: {
   const refresh = (): void => {
     if (targetDocument.visibilityState === "visible") void options.refresh();
   };
-  const timer = targetWindow.setInterval(refresh, options.intervalMs ?? 5_000);
+  const timer = targetWindow.setInterval(refresh, options.intervalMs ?? 20_000);
   targetWindow.addEventListener("focus", refresh);
   targetDocument.addEventListener("visibilitychange", refresh);
   return () => {

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-state.svelte.ts
@@ -25,9 +25,12 @@ export const fileExplorerState = $state({
 export function ensureFileExplorerProject(
   projectId: string,
 ): FileExplorerProjectState {
-  return (fileExplorerState.projects[projectId] ??= {
+  fileExplorerState.projects[projectId] ??= {
     projectId,
     directories: {},
     expandedIds: new SvelteSet<string>(),
-  });
+  };
+  // Read the assigned value back through the deep state proxy. Returning the
+  // raw right-hand side of `??=` would make later async mutations non-reactive.
+  return fileExplorerState.projects[projectId];
 }

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-state.svelte.ts
@@ -1,0 +1,33 @@
+import type { FilesystemProjectEntry } from "@nervekit/contracts";
+import { SvelteSet } from "svelte/reactivity";
+
+export type FileExplorerDirectoryState = {
+  path: string;
+  entries: FilesystemProjectEntry[];
+  nextCursor?: string;
+  pagesLoaded: number;
+  loading: boolean;
+  refreshing: boolean;
+  error?: string;
+  generation: number;
+};
+
+export type FileExplorerProjectState = {
+  projectId: string;
+  directories: Record<string, FileExplorerDirectoryState>;
+  expandedIds: SvelteSet<string>;
+};
+
+export const fileExplorerState = $state({
+  projects: {} as Record<string, FileExplorerProjectState>,
+});
+
+export function ensureFileExplorerProject(
+  projectId: string,
+): FileExplorerProjectState {
+  return (fileExplorerState.projects[projectId] ??= {
+    projectId,
+    directories: {},
+    expandedIds: new SvelteSet<string>(),
+  });
+}

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-tree.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-tree.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { SvelteSet } from "svelte/reactivity";
+import type { FileExplorerProjectState } from "./file-explorer-state.svelte";
+import {
+  buildFileExplorerTree,
+  fileExplorerEntryNodeId,
+} from "./file-explorer-tree";
+
+function project(): FileExplorerProjectState {
+  return {
+    projectId: "project",
+    expandedIds: new SvelteSet<string>(),
+    directories: {
+      "": {
+        path: "",
+        entries: [
+          { name: ".git", path: ".git", kind: "directory", symlink: false },
+          {
+            name: "README.md",
+            path: "README.md",
+            kind: "file",
+            symlink: false,
+          },
+        ],
+        pagesLoaded: 1,
+        loading: false,
+        refreshing: false,
+        generation: 0,
+      },
+    },
+  };
+}
+
+test("projects unloaded directories as expandable tree items", () => {
+  const state = project();
+  const nodes = buildFileExplorerTree(state);
+  assert.equal(nodes[0]?.id, fileExplorerEntryNodeId("project", ".git"));
+  assert.equal(nodes[0]?.kind, "item");
+  assert.equal(nodes[0]?.expandable, true);
+  assert.deepEqual(nodes[0]?.children, []);
+});
+
+test("projects loaded descendants and pagination rows", () => {
+  const state = project();
+  state.directories[".git"] = {
+    path: ".git",
+    entries: [
+      { name: "config", path: ".git/config", kind: "file", symlink: false },
+    ],
+    nextCursor: "next",
+    pagesLoaded: 1,
+    loading: false,
+    refreshing: false,
+    generation: 0,
+  };
+  const folder = buildFileExplorerTree(state)[0];
+  assert.deepEqual(
+    folder?.children.map((node) => node.label),
+    ["config", "Load more…"],
+  );
+});
+
+test("keeps symlink directories visible but non-expandable", () => {
+  const state = project();
+  state.directories[""].entries.unshift({
+    name: "linked",
+    path: "linked",
+    kind: "directory",
+    symlink: true,
+  });
+  const linked = buildFileExplorerTree(state)[0];
+  assert.equal(linked?.label, "linked");
+  assert.equal(linked?.kind, "item");
+  if (linked?.kind === "item") assert.equal(linked.expandable, false);
+});

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-tree.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-tree.ts
@@ -1,0 +1,94 @@
+import type { FilesystemProjectEntry } from "@nervekit/contracts";
+import type { PanelTreeNode } from "$lib/presentation/panel";
+import type { FileExplorerProjectState } from "./file-explorer-state.svelte";
+
+export type FileExplorerEntryItem = {
+  type: "entry";
+  entry: FilesystemProjectEntry;
+};
+
+export type FileExplorerLoadMoreItem = {
+  type: "load-more";
+  directoryPath: string;
+  cursor: string;
+};
+
+export type FileExplorerErrorItem = {
+  type: "error";
+  directoryPath: string;
+  message: string;
+};
+
+export type FileExplorerTreeItem =
+  | FileExplorerEntryItem
+  | FileExplorerLoadMoreItem
+  | FileExplorerErrorItem;
+
+export function fileExplorerEntryNodeId(
+  projectId: string,
+  path: string,
+): string {
+  return `file:${projectId}:${path}`;
+}
+
+function directoryChildren(
+  project: FileExplorerProjectState,
+  directoryPath: string,
+  ancestorPaths: ReadonlySet<string>,
+): PanelTreeNode<FileExplorerTreeItem>[] {
+  const directory = project.directories[directoryPath];
+  if (!directory) return [];
+
+  const nodes = directory.entries.map<PanelTreeNode<FileExplorerTreeItem>>(
+    (entry) => {
+      const id = fileExplorerEntryNodeId(project.projectId, entry.path);
+      const mayExpand = entry.kind === "directory" && !entry.symlink;
+      const cyclic = mayExpand && ancestorPaths.has(entry.path);
+      const nextAncestors = new Set(ancestorPaths).add(entry.path);
+      return {
+        kind: "item",
+        id,
+        label: entry.name,
+        path: entry.path.split("/"),
+        value: { type: "entry", entry },
+        children:
+          mayExpand && !cyclic
+            ? directoryChildren(project, entry.path, nextAncestors)
+            : [],
+        expandable: mayExpand && !cyclic,
+      };
+    },
+  );
+
+  if (directory.error) {
+    nodes.push({
+      kind: "item",
+      id: `file-error:${project.projectId}:${directoryPath}`,
+      label: "Could not refresh directory",
+      path: [directoryPath, "error"],
+      value: { type: "error", directoryPath, message: directory.error },
+      children: [],
+    });
+  }
+  if (directory.nextCursor) {
+    nodes.push({
+      kind: "item",
+      id: `file-more:${project.projectId}:${directoryPath}:${directory.nextCursor}`,
+      label: directory.loading ? "Loading…" : "Load more…",
+      path: [directoryPath, "more"],
+      value: {
+        type: "load-more",
+        directoryPath,
+        cursor: directory.nextCursor,
+      },
+      children: [],
+    });
+  }
+  return nodes;
+}
+
+export function buildFileExplorerTree(
+  project: FileExplorerProjectState,
+): PanelTreeNode<FileExplorerTreeItem>[] {
+  return directoryChildren(project, "", new Set([""]));
+}

--- a/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
@@ -3,6 +3,10 @@ import ChevronDown from "@lucide/svelte/icons/chevron-down";
 import ChevronRight from "@lucide/svelte/icons/chevron-right";
 import Folder from "@lucide/svelte/icons/folder";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
+import {
+  VirtualScroller,
+  type VirtualScrollerController,
+} from "@nervekit/ui-kit/components/ui/virtual-list";
 import { cn } from "@nervekit/ui-kit/core/utils";
 import { tick, type Snippet } from "svelte";
 import { SvelteSet } from "svelte/reactivity";
@@ -15,6 +19,7 @@ import {
   parentPanelTreeRowId,
   visiblePanelTreeRows,
   type PanelTreeNode,
+  type PanelTreeRow,
 } from "./panel-tree.js";
 
 type Props = {
@@ -41,6 +46,13 @@ type Props = {
    */
   indentItems?: boolean;
   getItemSelected?: (item: T) => boolean;
+  /** Controlled expansion state. Node ids are the ids produced by the builders. */
+  expandedIds?: ReadonlySet<string>;
+  /** Uncontrolled initial expansion policy. Existing callers default to all. */
+  defaultExpanded?: "all" | "none";
+  onItemExpansionChange?: (item: T, expanded: boolean) => void;
+  /** Opt into a single fixed-height virtualized viewport for large trees. */
+  virtualized?: boolean;
   itemMono?: boolean;
   /** Renders item descriptions on a second line instead of inline. */
   itemStacked?: boolean;
@@ -69,6 +81,10 @@ let {
   itemClass,
   indentItems = true,
   getItemSelected,
+  expandedIds,
+  defaultExpanded = "all",
+  onItemExpansionChange,
+  virtualized = false,
   itemMono = false,
   itemStacked = false,
   onItemActivate,
@@ -80,15 +96,23 @@ let {
 }: Props = $props();
 
 let root: HTMLElement | undefined = $state();
+let virtualController = $state<VirtualScrollerController>();
 const collapsed = new SvelteSet<string>();
+const locallyExpanded = new SvelteSet<string>();
 let focusedId = $state<string>();
 
 const expandableIds = $derived(panelTreeExpandableIds(nodes));
-const expanded = $derived(expandedPanelTreeIds(expandableIds, collapsed));
+const expanded = $derived.by(() => {
+  if (expandedIds)
+    return new Set([...expandedIds].filter((id) => expandableIds.has(id)));
+  if (defaultExpanded === "all")
+    return expandedPanelTreeIds(expandableIds, collapsed);
+  return new Set([...locallyExpanded].filter((id) => expandableIds.has(id)));
+});
 const rows = $derived(visiblePanelTreeRows(nodes, expanded));
 /** Reserve the chevron column so leaf rows align with expandable siblings. */
 const hasExpandableItems = $derived(
-  rows.some((row) => row.node.kind === "item" && row.node.children.length > 0),
+  rows.some((row) => row.node.kind === "item" && isExpandable(row.node)),
 );
 
 /** Card grouping: a root row opens a surface that its descendants continue. */
@@ -114,17 +138,28 @@ $effect(() => {
   if (!focusedId || !visibleIds.has(focusedId)) focusedId = rows[0]?.node.id;
 });
 
-function setExpanded(id: string, open: boolean): void {
-  if (open) collapsed.delete(id);
-  else collapsed.add(id);
+function setExpanded(node: PanelTreeNode<T>, open: boolean): void {
+  if (expandedIds) {
+    if (node.kind === "item") onItemExpansionChange?.(node.value, open);
+    return;
+  }
+  if (defaultExpanded === "all") {
+    if (open) collapsed.delete(node.id);
+    else collapsed.add(node.id);
+  } else if (open) locallyExpanded.add(node.id);
+  else locallyExpanded.delete(node.id);
+  if (node.kind === "item") onItemExpansionChange?.(node.value, open);
 }
 
 function isExpandable(node: PanelTreeNode<T>): boolean {
-  return node.children.length > 0;
+  return (
+    node.children.length > 0 ||
+    (node.kind === "item" && node.expandable === true)
+  );
 }
 
 function toggle(node: PanelTreeNode<T>): void {
-  if (isExpandable(node)) setExpanded(node.id, !expanded.has(node.id));
+  if (isExpandable(node)) setExpanded(node, !expanded.has(node.id));
 }
 
 function activate(node: PanelTreeNode<T>): void {
@@ -135,7 +170,12 @@ function activate(node: PanelTreeNode<T>): void {
 async function focusRow(id: string | undefined): Promise<void> {
   if (!id) return;
   focusedId = id;
+  if (virtualized) {
+    const index = rows.findIndex((row) => row.node.id === id);
+    if (index >= 0) virtualController?.scrollToIndex(index, { align: "auto" });
+  }
   await tick();
+  if (virtualized) await tick();
   const element = [
     ...(root?.querySelectorAll<HTMLElement>("[data-panel-row-id]") ?? []),
   ].find((candidate) => candidate.dataset.panelRowId === id);
@@ -170,7 +210,7 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       break;
     case "ArrowRight":
       if (isExpandable(node) && !expanded.has(node.id)) {
-        setExpanded(node.id, true);
+        setExpanded(node, true);
         destination = node.id;
       } else if (isExpandable(node)) {
         destination = firstPanelTreeChildId(rows, node.id) ?? node.id;
@@ -178,7 +218,7 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       break;
     case "ArrowLeft":
       if (isExpandable(node) && expanded.has(node.id)) {
-        setExpanded(node.id, false);
+        setExpanded(node, false);
         destination = node.id;
       } else {
         destination = parentPanelTreeRowId(rows, node.id) ?? node.id;
@@ -199,97 +239,119 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
 }
 </script>
 
+{#snippet renderRow(row: PanelTreeRow<T>, rowIndex: number)}
+  {@const node = row.node}
+  {@const expandable = isExpandable(node)}
+  {@const open = expandable && expanded.has(node.id)}
+  {#if node.kind === "group"}
+    {#snippet groupLeading()}
+      {#if open}
+        <ChevronDown class="size-3" aria-hidden="true" />
+        <FolderOpen class="size-3.5" aria-hidden="true" />
+      {:else}
+        <ChevronRight class="size-3" aria-hidden="true" />
+        <Folder class="size-3.5" aria-hidden="true" />
+      {/if}
+    {/snippet}
+    <PanelRow
+      label={node.label}
+      title={node.path.join("/")}
+      leading={groupLeading}
+      dense
+      indent={baseIndent + row.depth}
+      role="treeitem"
+      tabindex={focusedId === node.id ? 0 : -1}
+      contentTabindex={-1}
+      ariaExpanded={open}
+      ariaLevel={row.depth + 1}
+      ariaPosInSet={row.posInSet}
+      ariaSetSize={row.setSize}
+      dataId={node.id}
+      onfocus={() => (focusedId = node.id)}
+      onkeydown={(event) => handleKeydown(event, node)}
+      onclick={(event) => activateFromPointer(event, node)}
+    />
+  {:else}
+    {#snippet leafLeading()}
+      {#if expandable}
+        {#if open}
+          <ChevronDown class="size-3" aria-hidden="true" />
+        {:else}
+          <ChevronRight class="size-3" aria-hidden="true" />
+        {/if}
+      {:else if hasExpandableItems}
+        <span class="size-3" aria-hidden="true"></span>
+      {/if}
+      {#if itemLeading}{@render itemLeading(node.value)}{/if}
+    {/snippet}
+    {#snippet leafLabelTrailing()}
+      {#if itemLabelTrailing}{@render itemLabelTrailing(node.value)}{/if}
+    {/snippet}
+    {#snippet leafBadges()}
+      {#if itemBadges}{@render itemBadges(node.value)}{/if}
+    {/snippet}
+    {#snippet leafActions()}
+      {#if itemActions}{@render itemActions(node.value)}{/if}
+    {/snippet}
+    <PanelRow
+      label={node.label}
+      description={getItemDescription?.(node.value)}
+      meta={getItemMeta?.(node.value)}
+      metaMono={itemMetaMono}
+      title={getItemTitle?.(node.value)}
+      selected={getItemSelected?.(node.value) ?? false}
+      mono={itemMono}
+      stacked={itemStacked}
+      leading={itemLeading || expandable || hasExpandableItems
+        ? leafLeading
+        : undefined}
+      labelTrailing={itemLabelTrailing ? leafLabelTrailing : undefined}
+      badges={itemBadges ? leafBadges : undefined}
+      actions={itemActions ? leafActions : undefined}
+      dense
+      alwaysShowActions
+      class={cn(cardClass(rowIndex), itemClass)}
+      indent={baseIndent + (indentItems ? row.depth : 0)}
+      role="treeitem"
+      tabindex={focusedId === node.id ? 0 : -1}
+      contentTabindex={-1}
+      ariaExpanded={expandable ? open : undefined}
+      ariaLevel={row.depth + 1}
+      ariaPosInSet={row.posInSet}
+      ariaSetSize={row.setSize}
+      dataId={node.id}
+      onfocus={() => (focusedId = node.id)}
+      onkeydown={(event) => handleKeydown(event, node)}
+      onclick={(event) => activateFromPointer(event, node)}
+    />
+  {/if}
+{/snippet}
+
 <div
   bind:this={root}
   role="tree"
   aria-label={ariaLabel}
-  class={cn("flex min-w-0 flex-col", className)}
+  class={cn(
+    "flex min-w-0 flex-col",
+    virtualized && "min-h-0 flex-1",
+    className,
+  )}
 >
-  {#each rows as row, rowIndex (row.node.id)}
-    {@const node = row.node}
-    {@const expandable = node.children.length > 0}
-    {@const open = expandable && expanded.has(node.id)}
-    {#if node.kind === "group"}
-      {#snippet groupLeading()}
-        {#if open}
-          <ChevronDown class="size-3" aria-hidden="true" />
-          <FolderOpen class="size-3.5" aria-hidden="true" />
-        {:else}
-          <ChevronRight class="size-3" aria-hidden="true" />
-          <Folder class="size-3.5" aria-hidden="true" />
-        {/if}
+  {#if virtualized}
+    <VirtualScroller
+      items={rows}
+      getKey={(row) => row.node.id}
+      estimateSize={() => 20}
+      bind:controller={virtualController}
+      viewportClass="h-full"
+    >
+      {#snippet row({ item, index })}
+        {@render renderRow(item, index)}
       {/snippet}
-      <PanelRow
-        label={node.label}
-        title={node.path.join("/")}
-        leading={groupLeading}
-        dense
-        indent={baseIndent + row.depth}
-        role="treeitem"
-        tabindex={focusedId === node.id ? 0 : -1}
-        contentTabindex={-1}
-        ariaExpanded={open}
-        ariaLevel={row.depth + 1}
-        ariaPosInSet={row.posInSet}
-        ariaSetSize={row.setSize}
-        dataId={node.id}
-        onfocus={() => (focusedId = node.id)}
-        onkeydown={(event) => handleKeydown(event, node)}
-        onclick={(event) => activateFromPointer(event, node)}
-      />
-    {:else}
-      {#snippet leafLeading()}
-        {#if expandable}
-          {#if open}
-            <ChevronDown class="size-3" aria-hidden="true" />
-          {:else}
-            <ChevronRight class="size-3" aria-hidden="true" />
-          {/if}
-        {:else if hasExpandableItems}
-          <span class="size-3" aria-hidden="true"></span>
-        {/if}
-        {#if itemLeading}{@render itemLeading(node.value)}{/if}
-      {/snippet}
-      {#snippet leafLabelTrailing()}
-        {#if itemLabelTrailing}{@render itemLabelTrailing(node.value)}{/if}
-      {/snippet}
-      {#snippet leafBadges()}
-        {#if itemBadges}{@render itemBadges(node.value)}{/if}
-      {/snippet}
-      {#snippet leafActions()}
-        {#if itemActions}{@render itemActions(node.value)}{/if}
-      {/snippet}
-      <PanelRow
-        label={node.label}
-        description={getItemDescription?.(node.value)}
-        meta={getItemMeta?.(node.value)}
-        metaMono={itemMetaMono}
-        title={getItemTitle?.(node.value)}
-        selected={getItemSelected?.(node.value) ?? false}
-        mono={itemMono}
-        stacked={itemStacked}
-        leading={itemLeading || expandable || hasExpandableItems
-          ? leafLeading
-          : undefined}
-        labelTrailing={itemLabelTrailing ? leafLabelTrailing : undefined}
-        badges={itemBadges ? leafBadges : undefined}
-        actions={itemActions ? leafActions : undefined}
-        dense
-        alwaysShowActions
-        class={cn(cardClass(rowIndex), itemClass)}
-        indent={baseIndent + (indentItems ? row.depth : 0)}
-        role="treeitem"
-        tabindex={focusedId === node.id ? 0 : -1}
-        contentTabindex={-1}
-        ariaExpanded={expandable ? open : undefined}
-        ariaLevel={row.depth + 1}
-        ariaPosInSet={row.posInSet}
-        ariaSetSize={row.setSize}
-        dataId={node.id}
-        onfocus={() => (focusedId = node.id)}
-        onkeydown={(event) => handleKeydown(event, node)}
-        onclick={(event) => activateFromPointer(event, node)}
-      />
-    {/if}
-  {/each}
+    </VirtualScroller>
+  {:else}
+    {#each rows as row, rowIndex (row.node.id)}
+      {@render renderRow(row, rowIndex)}
+    {/each}
+  {/if}
 </div>

--- a/packages/workbench-app/src/lib/presentation/panel/panel-tree.test.ts
+++ b/packages/workbench-app/src/lib/presentation/panel/panel-tree.test.ts
@@ -153,6 +153,22 @@ const itemTree = (items: Node[]) =>
     getLabel: (item) => item.id,
   });
 
+test("marks unloaded item nodes expandable before children arrive", () => {
+  const nodes = buildPanelItemTree<Node>([{ id: "folder" }], {
+    getKey: (item) => item.id,
+    getParentKey: (item) => item.parent,
+    getLabel: (item) => item.id,
+    isExpandable: () => true,
+  });
+  assert.deepEqual([...panelTreeExpandableIds(nodes)], ["item:folder"]);
+  assert.deepEqual(
+    visiblePanelTreeRows(nodes, new Set(["item:folder"])).map(
+      (row) => row.node.label,
+    ),
+    ["folder"],
+  );
+});
+
 test("nests parent-keyed items in input order", () => {
   const nodes = itemTree([
     { id: "main" },

--- a/packages/workbench-app/src/lib/presentation/panel/panel-tree.ts
+++ b/packages/workbench-app/src/lib/presentation/panel/panel-tree.ts
@@ -4,8 +4,10 @@ export type PanelTreeItemNode<T> = {
   label: string;
   path: readonly string[];
   value: T;
-  /** Nested items; empty for leaves. Item parents expand like group nodes. */
+  /** Nested items; empty for leaves or not-yet-loaded parents. */
   children: readonly PanelTreeNode<T>[];
+  /** Marks an item expandable before lazy children have been loaded. */
+  expandable?: boolean;
 };
 
 export type PanelTreeGroupNode<T> = {
@@ -36,6 +38,7 @@ export type BuildPanelItemTreeOptions<T> = {
   getKey: (item: T) => string;
   getParentKey: (item: T) => string | undefined;
   getLabel: (item: T) => string;
+  isExpandable?: (item: T) => boolean;
 };
 
 type TrieItem<T> = {
@@ -233,6 +236,7 @@ export function buildPanelItemTree<T>(
         path,
         value: item,
         children: buildNodes(childrenByKey.get(key) ?? [], path),
+        expandable: options.isExpandable?.(item),
       };
     });
 
@@ -244,12 +248,14 @@ export function panelTreeExpandableIds<T>(
   nodes: readonly PanelTreeNode<T>[],
 ): Set<string> {
   const ids = new Set<string>();
-  const visit = (node: PanelTreeNode<T>): void => {
-    if (node.children.length === 0) return;
-    ids.add(node.id);
-    node.children.forEach(visit);
-  };
-  nodes.forEach(visit);
+  const stack = [...nodes];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    if (node.children.length > 0 || (node.kind === "item" && node.expandable))
+      ids.add(node.id);
+    stack.push(...node.children);
+  }
   return ids;
 }
 
@@ -265,26 +271,39 @@ export function visiblePanelTreeRows<T>(
   expanded: ReadonlySet<string>,
 ): PanelTreeRow<T>[] {
   const rows: PanelTreeRow<T>[] = [];
+  const stack: Array<{
+    siblings: readonly PanelTreeNode<T>[];
+    index: number;
+    depth: number;
+    parentId?: string;
+  }> = [{ siblings: nodes, index: 0, depth: 0 }];
 
-  const visit = (
-    siblings: readonly PanelTreeNode<T>[],
-    depth: number,
-    parentId?: string,
-  ): void => {
-    siblings.forEach((node, index) => {
-      rows.push({
-        node,
-        depth,
-        parentId,
-        posInSet: index + 1,
-        setSize: siblings.length,
-      });
-      if (node.children.length > 0 && expanded.has(node.id))
-        visit(node.children, depth + 1, node.id);
+  while (stack.length > 0) {
+    const frame = stack.at(-1);
+    if (!frame) break;
+    if (frame.index >= frame.siblings.length) {
+      stack.pop();
+      continue;
+    }
+    const index = frame.index++;
+    const node = frame.siblings[index];
+    if (!node) continue;
+    rows.push({
+      node,
+      depth: frame.depth,
+      parentId: frame.parentId,
+      posInSet: index + 1,
+      setSize: frame.siblings.length,
     });
-  };
-
-  visit(nodes, 0);
+    if (node.children.length > 0 && expanded.has(node.id)) {
+      stack.push({
+        siblings: node.children,
+        index: 0,
+        depth: frame.depth + 1,
+        parentId: node.id,
+      });
+    }
+  }
   return rows;
 }
 

--- a/packages/workbench-app/src/lib/presentation/shell/shell-layout.test.ts
+++ b/packages/workbench-app/src/lib/presentation/shell/shell-layout.test.ts
@@ -98,6 +98,37 @@ describe("normalizeShellLayout", () => {
     assert.deepEqual(layout.hidden, []);
   });
 
+  it("adds a newly registered files view to its default left dock", () => {
+    const files: PanelViewDescriptor = {
+      id: "files",
+      title: "Files",
+      icon,
+      defaultDock: "left",
+      defaultOrder: -1,
+    };
+    const fresh = defaultShellLayout([...descriptors, files]);
+    assert.deepEqual(fresh.docks.left.views, ["files", "conversations"]);
+
+    const persisted = normalizeShellLayout(
+      {
+        version: 1,
+        docks: {
+          left: {
+            views: ["conversations"],
+            activeViewId: "conversations",
+            size: 20,
+          },
+          right: { views: ["git", "context", "notes"], size: 22 },
+          bottom: { views: ["tasks"], size: 30 },
+        },
+        hidden: [],
+      },
+      [...descriptors, files],
+    );
+    assert.deepEqual(persisted.docks.left.views, ["conversations", "files"]);
+    assert.equal(persisted.docks.left.activeViewId, "conversations");
+  });
+
   it("clamps out-of-range sizes", () => {
     const layout = normalizeShellLayout(
       {

--- a/packages/workbench-server/src/domains/filesystem/filesystem.service.ts
+++ b/packages/workbench-server/src/domains/filesystem/filesystem.service.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   open,
   readdir,
+  realpath,
   stat,
   writeFile,
 } from "node:fs/promises";
@@ -22,8 +23,10 @@ import {
 import { createInterface } from "node:readline";
 import {
   clipboardImageUploadRequestSchema,
+  type FilesystemProjectEntry,
   type FilesystemSignal,
   filesystemFileQuerySchema,
+  filesystemProjectEntriesQuerySchema,
 } from "@nervekit/contracts";
 
 async function pathExists(path: string): Promise<boolean> {
@@ -167,6 +170,176 @@ export async function directoryListing(
         signals: await detectDirectorySignals(entryPath),
       };
     }),
+  };
+}
+
+const defaultProjectEntryLimit = 500;
+
+type ProjectEntrySortKey = [number, string, string, string];
+
+function normalizeProjectRelativeDirectory(
+  rawPath: string | undefined,
+): string {
+  const path = rawPath?.trim().replaceAll("\\", "/") ?? "";
+  if (!path) return "";
+  if (path.includes("\0") || path.startsWith("/") || /^[A-Za-z]:\//.test(path))
+    throw new Error("Project directory path must be relative.");
+  const segments = path.split("/");
+  if (
+    segments.some((segment) => !segment || segment === "." || segment === "..")
+  )
+    throw new Error("Project directory path contains an invalid segment.");
+  return segments.join("/");
+}
+
+function projectEntrySortKey(
+  entry: FilesystemProjectEntry,
+): ProjectEntrySortKey {
+  return [
+    entry.kind === "directory" ? 0 : entry.kind === "file" ? 1 : 2,
+    entry.name.toLocaleLowerCase(),
+    entry.name,
+    entry.path,
+  ];
+}
+
+function compareProjectEntryKeys(
+  left: ProjectEntrySortKey,
+  right: ProjectEntrySortKey,
+): number {
+  return (
+    left[0] - right[0] ||
+    left[1].localeCompare(right[1], undefined, { numeric: true }) ||
+    left[2].localeCompare(right[2], undefined, { numeric: true }) ||
+    left[3].localeCompare(right[3])
+  );
+}
+
+function encodeProjectEntryCursor(
+  path: string,
+  key: ProjectEntrySortKey,
+): string {
+  return Buffer.from(JSON.stringify({ path, key })).toString("base64url");
+}
+
+function decodeProjectEntryCursor(
+  cursor: string,
+  path: string,
+): ProjectEntrySortKey {
+  try {
+    const decoded = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf8"),
+    ) as {
+      path?: unknown;
+      key?: unknown;
+    };
+    if (
+      decoded.path !== path ||
+      !Array.isArray(decoded.key) ||
+      decoded.key.length !== 4 ||
+      typeof decoded.key[0] !== "number" ||
+      decoded.key.slice(1).some((value) => typeof value !== "string")
+    )
+      throw new Error("invalid");
+    return decoded.key as ProjectEntrySortKey;
+  } catch {
+    throw new Error("Invalid or stale project directory cursor.");
+  }
+}
+
+async function classifyProjectEntry(
+  root: string,
+  directory: string,
+  relativeDirectory: string,
+  entry: import("node:fs").Dirent,
+): Promise<FilesystemProjectEntry> {
+  const path = relativeDirectory
+    ? `${relativeDirectory}/${entry.name}`
+    : entry.name;
+  if (!entry.isSymbolicLink()) {
+    return {
+      name: entry.name,
+      path,
+      kind: entry.isDirectory()
+        ? "directory"
+        : entry.isFile()
+          ? "file"
+          : "other",
+      symlink: false,
+    };
+  }
+
+  let kind: FilesystemProjectEntry["kind"] = "other";
+  try {
+    const target = await realpath(join(directory, entry.name));
+    if (isInside(root, target)) {
+      const info = await stat(target);
+      kind = info.isDirectory()
+        ? "directory"
+        : info.isFile()
+          ? "file"
+          : "other";
+    }
+  } catch {
+    // Broken and inaccessible links stay visible as non-browsable entries.
+  }
+  return { name: entry.name, path, kind, symlink: true };
+}
+
+export async function projectDirectoryEntries(
+  input: unknown,
+  getProjectDirectory: (projectId: string) => string,
+) {
+  const query = filesystemProjectEntriesQuerySchema.parse(input);
+  const relativeDirectory = normalizeProjectRelativeDirectory(query.path);
+  const root = await realpath(resolve(getProjectDirectory(query.projectId)));
+  const directory = resolve(root, relativeDirectory);
+  if (!isInside(root, directory))
+    throw new Error("Project directory path escapes the project root.");
+
+  const resolvedDirectory = await realpath(directory);
+  if (!isInside(root, resolvedDirectory))
+    throw new Error("Project directory path escapes the project root.");
+  const info = await stat(resolvedDirectory);
+  if (!info.isDirectory())
+    throw new Error(`${relativeDirectory || "."} is not a directory.`);
+
+  const entries = await mapBatched(
+    await readdir(resolvedDirectory, { withFileTypes: true }),
+    32,
+    (entry) =>
+      classifyProjectEntry(root, resolvedDirectory, relativeDirectory, entry),
+  );
+  entries.sort((left, right) =>
+    compareProjectEntryKeys(
+      projectEntrySortKey(left),
+      projectEntrySortKey(right),
+    ),
+  );
+
+  let start = 0;
+  if (query.cursor) {
+    const cursorKey = decodeProjectEntryCursor(query.cursor, relativeDirectory);
+    const cursorIndex = entries.findIndex(
+      (entry) =>
+        compareProjectEntryKeys(projectEntrySortKey(entry), cursorKey) === 0,
+    );
+    if (cursorIndex < 0)
+      throw new Error("Invalid or stale project directory cursor.");
+    start = cursorIndex + 1;
+  }
+
+  const limit = query.limit ?? defaultProjectEntryLimit;
+  const page = entries.slice(start, start + limit);
+  const last = page.at(-1);
+  return {
+    projectId: query.projectId,
+    path: relativeDirectory,
+    entries: page,
+    nextCursor:
+      last && start + page.length < entries.length
+        ? encodeProjectEntryCursor(relativeDirectory, projectEntrySortKey(last))
+        : undefined,
   };
 }
 

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -5,7 +5,10 @@ import {
   providerOAuthSecretName,
 } from "../../domains/auth/index.js";
 import { listAvailableSkills } from "../../domains/agents/prompting/resource-loader.js";
-import { directoryListing } from "../../domains/filesystem/filesystem.service.js";
+import {
+  directoryListing,
+  projectDirectoryEntries,
+} from "../../domains/filesystem/filesystem.service.js";
 import { writeSettings } from "../../infrastructure/storage/index.js";
 import {
   getConversationSnapshotResponse,
@@ -125,6 +128,11 @@ export const platformMethodHandlers = defineWorkbenchMethodHandlers({
   }),
   "filesystem.directories.list": (_state, params) =>
     directoryListing(params?.path, params?.showHidden as boolean | undefined),
+  "filesystem.project.entries.list": (state, params) =>
+    projectDirectoryEntries(
+      params,
+      (projectId) => state.registry.getProject(projectId).dir,
+    ),
   "applicationLog.prune": (state, params) => state.logger.prune(params),
 });
 

--- a/packages/workbench-server/test/filesystem.service.test.ts
+++ b/packages/workbench-server/test/filesystem.service.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -7,6 +7,7 @@ import {
   directoryListing,
   fileContent,
   normalizeIncomingFilePath,
+  projectDirectoryEntries,
 } from "../src/domains/filesystem/filesystem.service.js";
 
 describe("filesystem application service", () => {
@@ -44,6 +45,115 @@ describe("filesystem application service", () => {
       all.entries.map((entry) => entry.name),
       [".git", ".hidden", "visible"],
     );
+  });
+
+  it("lists all project entries lazily with stable pagination", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-project-entries-"));
+    try {
+      await Promise.all([
+        mkdir(join(root, "node_modules")),
+        mkdir(join(root, ".git")),
+        mkdir(join(root, "src")),
+        writeFile(join(root, ".env"), "secret"),
+        writeFile(join(root, "file10.ts"), ""),
+        writeFile(join(root, "file2.ts"), ""),
+        writeFile(join(root, "src", "nested.ts"), ""),
+      ]);
+
+      const lookup = () => root;
+      const first = await projectDirectoryEntries(
+        { projectId: "project", limit: 3 },
+        lookup,
+      );
+      assert.deepEqual(
+        first.entries.map((entry) => entry.name),
+        [".git", "node_modules", "src"],
+      );
+      assert.ok(first.nextCursor);
+      const second = await projectDirectoryEntries(
+        { projectId: "project", limit: 3, cursor: first.nextCursor },
+        lookup,
+      );
+      assert.deepEqual(
+        [...first.entries, ...second.entries].map((entry) => entry.name),
+        [".git", "node_modules", "src", ".env", "file2.ts", "file10.ts"],
+      );
+      assert.equal(second.nextCursor, undefined);
+
+      const nested = await projectDirectoryEntries(
+        { projectId: "project", path: "src" },
+        lookup,
+      );
+      assert.deepEqual(
+        nested.entries.map((entry) => entry.path),
+        ["src/nested.ts"],
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unsafe project paths and stale cursors", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-project-paths-"));
+    const lookup = () => root;
+    try {
+      await assert.rejects(
+        projectDirectoryEntries(
+          { projectId: "project", path: "../other" },
+          lookup,
+        ),
+        /invalid segment|escapes/i,
+      );
+      await assert.rejects(
+        projectDirectoryEntries({ projectId: "project", path: root }, lookup),
+        /relative/i,
+      );
+      await assert.rejects(
+        projectDirectoryEntries(
+          { projectId: "project", cursor: "not-a-cursor" },
+          lookup,
+        ),
+        /cursor/i,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("shows links but does not classify links that escape the project", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-project-links-"));
+    const outside = await mkdtemp(join(tmpdir(), "nerve-project-outside-"));
+    try {
+      await Promise.all([
+        writeFile(join(root, "target.txt"), "target"),
+        writeFile(join(outside, "outside.txt"), "outside"),
+      ]);
+      await Promise.all([
+        symlink(join(root, "target.txt"), join(root, "inside-link")),
+        symlink(join(outside, "outside.txt"), join(root, "outside-link")),
+        symlink(join(root, "missing"), join(root, "broken-link")),
+      ]);
+      const result = await projectDirectoryEntries(
+        { projectId: "project" },
+        () => root,
+      );
+      const entries = Object.fromEntries(
+        result.entries.map((entry) => [entry.name, entry]),
+      );
+      assert.deepEqual(entries["inside-link"], {
+        name: "inside-link",
+        path: "inside-link",
+        kind: "file",
+        symlink: true,
+      });
+      assert.equal(entries["outside-link"]?.kind, "other");
+      assert.equal(entries["broken-link"]?.kind, "other");
+    } finally {
+      await Promise.all([
+        rm(root, { recursive: true, force: true }),
+        rm(outside, { recursive: true, force: true }),
+      ]);
+    }
   });
 
   it("reads project files through an injected project-directory lookup", async () => {


### PR DESCRIPTION
## Summary
- add a Files panel to the default left dock with lazy directory loading and existing file previews
- add a project-scoped, paginated filesystem listing protocol with path and symlink safeguards
- upgrade the shared panel tree with controlled lazy expansion and optional virtualization
- preserve explorer state per project and refresh loaded directories while the panel is visible

## Validation
- `pnpm fix && pnpm check && pnpm test`
