### PR TITLE
Handle installed PWA updates reliably

### DIFF
--- a/packages/workbench-app/src/lib/core/pwa/pwa-update-scheduler.test.ts
+++ b/packages/workbench-app/src/lib/core/pwa/pwa-update-scheduler.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { startPwaUpdateScheduler } from "./pwa-update-scheduler";
+
+function schedulerHarness(
+  checkForUpdate: () => void | Promise<void> = () => undefined,
+) {
+  const windowTarget = new EventTarget();
+  const documentTarget = new EventTarget();
+  let interval: (() => void) | undefined;
+  let intervalMs: number | undefined;
+  let intervalCleared = false;
+  let visible = true;
+  let now = 0;
+
+  const stop = startPwaUpdateScheduler({
+    checkForUpdate,
+    now: () => now,
+    window: {
+      addEventListener: windowTarget.addEventListener.bind(windowTarget),
+      removeEventListener: windowTarget.removeEventListener.bind(windowTarget),
+      setInterval: ((callback: TimerHandler, delay?: number) => {
+        interval = callback as () => void;
+        intervalMs = delay;
+        return 1;
+      }) as Window["setInterval"],
+      clearInterval: (() => {
+        intervalCleared = true;
+      }) as Window["clearInterval"],
+    },
+    document: {
+      addEventListener: documentTarget.addEventListener.bind(documentTarget),
+      removeEventListener:
+        documentTarget.removeEventListener.bind(documentTarget),
+      get visibilityState() {
+        return visible ? "visible" : "hidden";
+      },
+    },
+  });
+
+  return {
+    stop,
+    windowTarget,
+    documentTarget,
+    runInterval: () => interval?.(),
+    intervalMs: () => intervalMs,
+    intervalCleared: () => intervalCleared,
+    setVisible: (value: boolean) => {
+      visible = value;
+    },
+    advance: (milliseconds: number) => {
+      now += milliseconds;
+    },
+  };
+}
+
+async function flushChecks(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+test("checks for updates from visible lifecycle and interval events", async () => {
+  let checks = 0;
+  const harness = schedulerHarness(() => {
+    checks += 1;
+  });
+
+  assert.equal(harness.intervalMs(), 60 * 60_000);
+
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  await flushChecks();
+  assert.equal(checks, 1);
+
+  harness.advance(60_000);
+  harness.documentTarget.dispatchEvent(new Event("visibilitychange"));
+  await flushChecks();
+  assert.equal(checks, 2);
+
+  harness.advance(60_000);
+  harness.windowTarget.dispatchEvent(new Event("online"));
+  await flushChecks();
+  assert.equal(checks, 3);
+
+  harness.advance(60_000);
+  harness.runInterval();
+  await flushChecks();
+  assert.equal(checks, 4);
+});
+
+test("skips hidden and throttled update checks", async () => {
+  let checks = 0;
+  const harness = schedulerHarness(() => {
+    checks += 1;
+  });
+
+  harness.setVisible(false);
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  harness.windowTarget.dispatchEvent(new Event("online"));
+  harness.runInterval();
+  await flushChecks();
+  assert.equal(checks, 0);
+
+  harness.setVisible(true);
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  harness.documentTarget.dispatchEvent(new Event("visibilitychange"));
+  await flushChecks();
+  assert.equal(checks, 1);
+
+  harness.advance(59_999);
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  await flushChecks();
+  assert.equal(checks, 1);
+
+  harness.advance(1);
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  await flushChecks();
+  assert.equal(checks, 2);
+});
+
+test("contains rejected checks and cleans up all event sources", async () => {
+  let checks = 0;
+  const harness = schedulerHarness(() => {
+    checks += 1;
+    return Promise.reject(new Error("offline"));
+  });
+
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  await flushChecks();
+  assert.equal(checks, 1);
+
+  harness.stop();
+  assert.equal(harness.intervalCleared(), true);
+
+  harness.advance(60_000);
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  harness.windowTarget.dispatchEvent(new Event("online"));
+  harness.documentTarget.dispatchEvent(new Event("visibilitychange"));
+  assert.equal(checks, 1);
+});

--- a/packages/workbench-app/src/lib/core/pwa/pwa-update-scheduler.ts
+++ b/packages/workbench-app/src/lib/core/pwa/pwa-update-scheduler.ts
@@ -1,0 +1,56 @@
+type UpdateWindow = Pick<
+  Window,
+  "addEventListener" | "removeEventListener" | "setInterval" | "clearInterval"
+>;
+
+type UpdateDocument = Pick<
+  Document,
+  "addEventListener" | "removeEventListener" | "visibilityState"
+>;
+
+export function startPwaUpdateScheduler(options: {
+  checkForUpdate: () => void | Promise<void>;
+  intervalMs?: number;
+  minimumCheckIntervalMs?: number;
+  now?: () => number;
+  window?: UpdateWindow;
+  document?: UpdateDocument;
+}): () => void {
+  const targetWindow = options.window ?? window;
+  const targetDocument = options.document ?? document;
+  const now = options.now ?? Date.now;
+  const minimumCheckIntervalMs = options.minimumCheckIntervalMs ?? 60_000;
+  let lastCheckAt = Number.NEGATIVE_INFINITY;
+  let checkInFlight = false;
+
+  const checkWhileVisible = (): void => {
+    if (targetDocument.visibilityState !== "visible" || checkInFlight) return;
+
+    const checkedAt = now();
+    if (checkedAt - lastCheckAt < minimumCheckIntervalMs) return;
+
+    lastCheckAt = checkedAt;
+    checkInFlight = true;
+    void Promise.resolve()
+      .then(options.checkForUpdate)
+      .catch(() => undefined)
+      .finally(() => {
+        checkInFlight = false;
+      });
+  };
+
+  const timer = targetWindow.setInterval(
+    checkWhileVisible,
+    options.intervalMs ?? 60 * 60_000,
+  );
+  targetWindow.addEventListener("focus", checkWhileVisible);
+  targetWindow.addEventListener("online", checkWhileVisible);
+  targetDocument.addEventListener("visibilitychange", checkWhileVisible);
+
+  return () => {
+    targetWindow.clearInterval(timer);
+    targetWindow.removeEventListener("focus", checkWhileVisible);
+    targetWindow.removeEventListener("online", checkWhileVisible);
+    targetDocument.removeEventListener("visibilitychange", checkWhileVisible);
+  };
+}

--- a/packages/workbench-app/src/lib/core/pwa/register-pwa.ts
+++ b/packages/workbench-app/src/lib/core/pwa/register-pwa.ts
@@ -1,0 +1,51 @@
+/// <reference types="vite-plugin-pwa/client" />
+
+import { registerSW } from "virtual:pwa-register";
+import { toast } from "svelte-sonner";
+import { startPwaUpdateScheduler } from "./pwa-update-scheduler";
+
+const UPDATE_TOAST_ID = "nerve-pwa-update";
+
+export function registerPwaServiceWorker(): void {
+  if (!shouldRegisterServiceWorker()) return;
+
+  let stopUpdateScheduler: (() => void) | undefined;
+  const updateServiceWorker = registerSW({
+    immediate: true,
+    onNeedRefresh: () => {
+      toast.message("Update available", {
+        id: UPDATE_TOAST_ID,
+        description: "A new version of Nerve is ready.",
+        duration: Infinity,
+        dismissible: false,
+        action: {
+          label: "Reload",
+          onClick: () => {
+            void updateServiceWorker().catch((error: unknown) => {
+              console.error("Failed to activate the Nerve update.", error);
+            });
+          },
+        },
+      });
+    },
+    onRegisteredSW: (_workerUrl, registration) => {
+      stopUpdateScheduler?.();
+      stopUpdateScheduler = registration
+        ? startPwaUpdateScheduler({
+            checkForUpdate: async () => {
+              await registration.update();
+            },
+          })
+        : undefined;
+    },
+    onRegisterError: (error: unknown) => {
+      console.error("Failed to register the Nerve service worker.", error);
+    },
+  });
+}
+
+function shouldRegisterServiceWorker(): boolean {
+  return (
+    "serviceWorker" in navigator && window.nerveDesktop?.kind !== "electron"
+  );
+}

--- a/packages/workbench-app/src/main.ts
+++ b/packages/workbench-app/src/main.ts
@@ -1,9 +1,9 @@
 /// <reference types="vite-plugin-pwa/client" />
 
-import { registerSW } from "virtual:pwa-register";
 import { mount } from "svelte";
 import Root from "./Root.svelte";
 import { applyZoomLevel } from "./lib/app/shell/appearance.svelte";
+import { registerPwaServiceWorker } from "./lib/core/pwa/register-pwa";
 import "./styles/app.css";
 
 let initialZoomLevel: string | null = null;
@@ -18,20 +18,12 @@ if (initialZoomLevel !== null) applyZoomLevel(Number(initialZoomLevel));
 const target = document.getElementById("app");
 if (!target) throw new Error("Missing #app mount target.");
 
-if (shouldRegisterServiceWorker()) {
-  registerSW({ immediate: true });
-}
+registerPwaServiceWorker();
 
 const startupBootstrap = document.getElementById("startup-bootstrap");
 const app = mount(Root, {
   target,
 });
 startupBootstrap?.remove();
-
-function shouldRegisterServiceWorker(): boolean {
-  return (
-    "serviceWorker" in navigator && window.nerveDesktop?.kind !== "electron"
-  );
-}
 
 export default app;

--- a/packages/workbench-app/vite.config.ts
+++ b/packages/workbench-app/vite.config.ts
@@ -63,7 +63,7 @@ export default defineConfig(({ mode }) => {
       svelte(),
       tailwindcss(),
       VitePWA({
-        registerType: "autoUpdate",
+        registerType: "prompt",
         injectRegister: false,
         // Keep the service worker out of `pnpm dev` so it cannot shadow the
         // Vite `/api` + `/ws` proxy below.


### PR DESCRIPTION
## Summary
- check for service-worker updates when the PWA resumes, reconnects, or remains open
- prompt users to reload before activating a waiting frontend update
- throttle update checks and cover scheduler behavior with tests

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `pnpm --filter @nervekit/workbench-app build`