### PR TITLE
Improve transcript rendering and tab switching performance

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller.svelte
+++ b/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T">
 import { createVirtualizer } from "@tanstack/svelte-virtual";
+import { tick } from "svelte";
 import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import { get } from "svelte/store";
 import { cn } from "@nervekit/ui-kit/core/utils";
@@ -112,6 +113,7 @@ const renderedVirtualRows = $derived.by(() => {
 const FOLLOW_SETTLE_FRAMES = 8;
 let followFrame: number | undefined;
 let followSettleFrames = 0;
+let postMeasurementFollowPending = false;
 
 function shouldFollowEnd(): boolean {
   return anchor === "end" && Boolean(followOutput);
@@ -125,6 +127,28 @@ function cancelFollowFrame() {
   if (followFrame === undefined) return;
   cancelAnimationFrame(followFrame);
   followFrame = undefined;
+}
+
+function schedulePostMeasurementFollow() {
+  if (!shouldFollowEnd() || postMeasurementFollowPending) return;
+  postMeasurementFollowPending = true;
+  cancelFollowFrame();
+  followSettleFrames = 0;
+
+  // `resizeItem` updates the virtual total synchronously, while Svelte applies
+  // the spacer's new DOM height at the end of the current microtask. Waiting
+  // for that commit lets the browser accept the new maximum scrollTop before
+  // paint instead of exposing one frame at the previous estimated bottom.
+  void tick().then(() => {
+    postMeasurementFollowPending = false;
+    if (!viewportEl?.isConnected || !shouldFollowEnd()) return;
+
+    instance.scrollToEnd({ behavior: "auto" });
+    syncFromVirtualizer();
+    if (!instance.isAtEnd(scrollEndThreshold)) {
+      scheduleFollowToEnd(3);
+    }
+  });
 }
 
 function scheduleFollowToEnd(settleFrames = FOLLOW_SETTLE_FRAMES) {
@@ -298,7 +322,10 @@ function flushMeasurements() {
     committedMeasurementHeights.set(key, height);
     committedCount += 1;
   }
-  if (committedCount > 0) scheduleFollowToEnd(3);
+  if (committedCount > 0) {
+    syncFromVirtualizer();
+    schedulePostMeasurementFollow();
+  }
 }
 
 function queueMeasure(node: HTMLElement) {
@@ -344,6 +371,7 @@ $effect(() => {
   return () => {
     cancelFollowFrame();
     cancelMeasureFrame();
+    postMeasurementFollowPending = false;
     resizeObserver?.disconnect();
     resizeObserver = undefined;
     registeredMeasureNodes.clear();

--- a/packages/workbench-app/src/lib/features/conversations/state/conversation-activity.test.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/conversation-activity.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type {
+  AgentRecord,
+  ApprovalWithToolCall,
+  ConversationRecord,
+  PlanReviewRecord,
+  UserQuestionRecord,
+} from "$lib/api";
+import { conversationViewKey } from "$lib/core/state/state-keys";
+import type { ConversationViewState } from "$lib/core/types/state-types";
+import {
+  buildConversationActivityById,
+  conversationActivityForRecord,
+} from "./conversation-activity";
+
+function conversation(id: string, activeAgentId?: string): ConversationRecord {
+  return { id, activeAgentId, mode: "coding" } as ConversationRecord;
+}
+
+function agent(
+  id: string,
+  conversationId: string,
+  status: AgentRecord["status"],
+): AgentRecord {
+  return { id, conversationId, status, mode: "coding" } as AgentRecord;
+}
+
+function view(
+  conversationId: string,
+  state: Partial<ConversationViewState>,
+): ConversationViewState {
+  return { conversationId, ...state } as ConversationViewState;
+}
+
+describe("conversation activity", () => {
+  it("preserves active-agent precedence over the conversation fallback", () => {
+    const result = buildConversationActivityById({
+      conversations: [conversation("conversation-1", "active-agent")],
+      agents: [
+        agent("fallback-agent", "conversation-1", "running"),
+        agent("active-agent", "other-conversation", "error"),
+      ],
+      views: {},
+      approvals: [],
+      userQuestions: [],
+      planReviews: [],
+    });
+
+    assert.equal(result["conversation-1"]?.tone, "danger");
+    assert.equal(result["conversation-1"]?.source, "agent");
+  });
+
+  it("detects pending human input from every input collection", () => {
+    const inputs = [
+      {
+        approvals: [
+          { conversationId: "conversation-1", status: "pending" },
+        ] as ApprovalWithToolCall[],
+        userQuestions: [],
+        planReviews: [],
+      },
+      {
+        approvals: [],
+        userQuestions: [
+          { conversationId: "conversation-1", status: "pending" },
+        ] as UserQuestionRecord[],
+        planReviews: [],
+      },
+      {
+        approvals: [],
+        userQuestions: [],
+        planReviews: [
+          { conversationId: "conversation-1", status: "pending" },
+        ] as PlanReviewRecord[],
+      },
+    ];
+
+    for (const input of inputs) {
+      const result = buildConversationActivityById({
+        conversations: [conversation("conversation-1")],
+        agents: [],
+        views: {},
+        ...input,
+      });
+      assert.equal(result["conversation-1"]?.needsUser, true);
+      assert.equal(result["conversation-1"]?.source, "pending-input");
+    }
+  });
+
+  it("keeps activity priority stable", () => {
+    const needsUser = conversationActivityForRecord({
+      conversationId: "conversation-1",
+      agent: agent("agent-1", "conversation-1", "running"),
+      view: view("conversation-1", {
+        transient: { compaction: { id: "compaction-1", state: "running" } },
+      }),
+      hasPendingHumanInput: true,
+    });
+    assert.equal(needsUser.needsUser, true);
+
+    const compacting = conversationActivityForRecord({
+      conversationId: "conversation-1",
+      agent: agent("agent-1", "conversation-1", "running"),
+      view: view("conversation-1", {
+        transient: { compaction: { id: "compaction-1", state: "running" } },
+      }),
+    });
+    assert.equal(compacting.label, "Compacting context");
+
+    const running = conversationActivityForRecord({
+      conversationId: "conversation-1",
+      agent: agent("agent-1", "conversation-1", "running"),
+    });
+    assert.equal(running.busy, true);
+
+    const failed = conversationActivityForRecord({
+      conversationId: "conversation-1",
+      agent: agent("agent-1", "conversation-1", "error"),
+    });
+    assert.equal(failed.tone, "danger");
+
+    const idle = conversationActivityForRecord({
+      conversationId: "conversation-1",
+    });
+    assert.equal(idle.source, "none");
+  });
+
+  it("projects a larger conversation collection correctly", () => {
+    const conversations = Array.from({ length: 200 }, (_, index) =>
+      conversation(`conversation-${index}`),
+    );
+    const views = {
+      [conversationViewKey("conversation-199")]: view("conversation-199", {
+        sending: true,
+      }),
+    };
+    const result = buildConversationActivityById({
+      conversations,
+      agents: [],
+      views,
+      approvals: [],
+      userQuestions: [],
+      planReviews: [],
+    });
+
+    assert.equal(Object.keys(result).length, 200);
+    assert.equal(result["conversation-0"]?.source, "none");
+    assert.equal(result["conversation-199"]?.busy, true);
+  });
+});

--- a/packages/workbench-app/src/lib/features/conversations/state/conversation-activity.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/conversation-activity.ts
@@ -45,30 +45,6 @@ export function agentForConversation(
   );
 }
 
-function hasPendingHumanInput(
-  conversationId: string,
-  approvals: ApprovalWithToolCall[],
-  userQuestions: UserQuestionRecord[],
-  planReviews: PlanReviewRecord[],
-): boolean {
-  return (
-    approvals.some(
-      (approval) =>
-        approval.conversationId === conversationId &&
-        approval.status === "pending",
-    ) ||
-    userQuestions.some(
-      (question) =>
-        question.conversationId === conversationId &&
-        question.status === "pending",
-    ) ||
-    planReviews.some(
-      (review) =>
-        review.conversationId === conversationId && review.status === "pending",
-    )
-  );
-}
-
 export function conversationActivityForRecord(input: {
   conversationId: string;
   agent?: AgentRecord;
@@ -137,20 +113,47 @@ export function buildConversationActivityById(input: {
   userQuestions: UserQuestionRecord[];
   planReviews: PlanReviewRecord[];
 }): Record<string, ConversationActivityState> {
+  const agentsById = new Map<string, AgentRecord>();
+  const agentsByConversationId = new Map<string, AgentRecord>();
+  for (const agent of input.agents) {
+    agentsById.set(agent.id, agent);
+    if (
+      agent.conversationId &&
+      !agentsByConversationId.has(agent.conversationId)
+    ) {
+      agentsByConversationId.set(agent.conversationId, agent);
+    }
+  }
+
+  const pendingConversationIds = new Set<string>();
+  for (const approval of input.approvals) {
+    if (approval.status === "pending") {
+      pendingConversationIds.add(approval.conversationId);
+    }
+  }
+  for (const question of input.userQuestions) {
+    if (question.status === "pending") {
+      pendingConversationIds.add(question.conversationId);
+    }
+  }
+  for (const review of input.planReviews) {
+    if (review.status === "pending") {
+      pendingConversationIds.add(review.conversationId);
+    }
+  }
+
   const result: Record<string, ConversationActivityState> = Object.create(null);
   for (const conversation of input.conversations) {
-    const agent = agentForConversation(conversation, input.agents);
+    const agent =
+      (conversation.activeAgentId
+        ? agentsById.get(conversation.activeAgentId)
+        : undefined) ?? agentsByConversationId.get(conversation.id);
     result[conversation.id] = conversationActivityForRecord({
       conversationId: conversation.id,
       agent,
       mode: agent?.mode ?? conversation.mode,
       view: input.views[conversationViewKey(conversation.id)],
-      hasPendingHumanInput: hasPendingHumanInput(
-        conversation.id,
-        input.approvals,
-        input.userQuestions,
-        input.planReviews,
-      ),
+      hasPendingHumanInput: pendingConversationIds.has(conversation.id),
     });
   }
   return result;

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-selectors.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-selectors.svelte.ts
@@ -1,4 +1,5 @@
 import { SvelteSet } from "svelte/reactivity";
+import type { AgentRecord } from "$lib/api";
 import { projectKey } from "$lib/core/utils/project-tree";
 import { buildProjectSwitcherItems } from "$lib/features/projects/state/project-switcher";
 import { agentRunningTone } from "@nervekit/ui-kit/core/utils/status";
@@ -76,6 +77,21 @@ function activePendingConversation() {
 
 function isActiveTaskStatus(status: string): boolean {
   return ["starting", "running", "ready", "stopping"].includes(status);
+}
+
+const conversationActivityById = $derived.by(() =>
+  buildConversationActivityById({
+    conversations: workspaceState.conversations,
+    agents: workspaceState.agents,
+    views: conversationState.conversationViews,
+    approvals: workspaceState.approvals,
+    userQuestions: workspaceState.userQuestions,
+    planReviews: workspaceState.planReviews,
+  }),
+);
+
+function centerTabKey(tab: CenterTabIdentity): string {
+  return `${tab.kind}\0${tab.id}`;
 }
 
 export const workspaceSelectors = {
@@ -157,37 +173,48 @@ export const workspaceSelectors = {
     );
   },
   get conversationActivityById() {
-    return buildConversationActivityById({
-      conversations: workspaceState.conversations,
-      agents: workspaceState.agents,
-      views: conversationState.conversationViews,
-      approvals: workspaceState.approvals,
-      userQuestions: workspaceState.userQuestions,
-      planReviews: workspaceState.planReviews,
-    });
+    return conversationActivityById;
   },
   get openConversationTabs(): ConversationTabModel[] {
     const tabs: ConversationTabModel[] = [];
+    const conversationsById = Object.fromEntries(
+      workspaceState.conversations.map((conversation) => [
+        conversation.id,
+        conversation,
+      ]),
+    );
+    const projectsById = Object.fromEntries(
+      workspaceState.projects.map((project) => [project.id, project]),
+    );
+    const agentsById = Object.fromEntries(
+      workspaceState.agents.map((agent) => [agent.id, agent]),
+    );
+    const agentsByConversationId: Record<string, AgentRecord> =
+      Object.create(null);
+    for (const agent of workspaceState.agents) {
+      if (
+        agent.conversationId &&
+        !agentsByConversationId[agent.conversationId]
+      ) {
+        agentsByConversationId[agent.conversationId] = agent;
+      }
+    }
+    const activityById = conversationActivityById;
+
     for (const conversationId of conversationState.openConversationTabIds) {
-      const conversation = workspaceState.conversations.find(
-        (candidate) => candidate.id === conversationId,
-      );
+      const conversation = conversationsById[conversationId];
       if (!conversation) continue;
-      const project = workspaceState.projects.find(
-        (candidate) => candidate.id === conversation.projectId,
-      );
-      const agent = workspaceState.agents.find(
-        (candidate) =>
-          candidate.id === conversation.activeAgentId ||
-          candidate.conversationId === conversation.id,
-      );
+      const project = projectsById[conversation.projectId];
+      const agent =
+        (conversation.activeAgentId
+          ? agentsById[conversation.activeAgentId]
+          : undefined) ?? agentsByConversationId[conversation.id];
       const view =
         conversationState.conversationViews[
           conversationViewKey(conversation.id)
         ];
       const activity =
-        this.conversationActivityById[conversation.id] ??
-        idleConversationActivity;
+        activityById[conversation.id] ?? idleConversationActivity;
       tabs.push({
         kind: "conversation",
         id: conversation.id,
@@ -366,47 +393,28 @@ export const workspaceSelectors = {
     return ids;
   },
   get centerTabs(): CenterTabModel[] {
-    const models: CenterTabModel[] = [];
-    for (const tab of workspaceState.openCenterTabs) {
-      if (tab.kind === "conversation") {
-        const model = this.openConversationTabs.find(
-          (candidate) => candidate.id === tab.id,
-        );
-        if (model) models.push(model);
-      } else if (tab.kind === "pending-conversation") {
-        const model = this.openPendingConversationTabs.find(
-          (candidate) => candidate.id === tab.id,
-        );
-        if (model) models.push(model);
-      } else if (tab.kind === "task") {
-        const model = this.openTaskTabs.find(
-          (candidate) => candidate.id === tab.id,
-        );
-        if (model) models.push(model);
-      } else if (tab.kind === "file") {
-        const model = this.openFileTabs.find(
-          (candidate) => candidate.id === tab.id,
-        );
-        if (model) models.push(model);
-      } else if (tab.kind === "pr") {
-        const model = this.openPrTabs.find(
-          (candidate) => candidate.id === tab.id,
-        );
-        if (model) models.push(model);
-      } else if (tab.kind === "diff") {
-        const model = this.openDiffTabs.find(
-          (candidate) => candidate.id === tab.id,
-        );
-        if (model) models.push(model);
-      } else if (tab.kind === "settings") {
-        models.push(...this.openSettingsTabs);
-      } else if (tab.kind === "auth") {
-        models.push(...this.openAuthTabs);
-      } else if (tab.kind === "logs") {
-        models.push(...this.openLogsTabs);
+    const modelByKey: Record<string, CenterTabModel> = Object.create(null);
+    const collections: CenterTabModel[][] = [
+      this.openConversationTabs,
+      this.openPendingConversationTabs,
+      this.openTaskTabs,
+      this.openFileTabs,
+      this.openPrTabs,
+      this.openDiffTabs,
+      this.openSettingsTabs,
+      this.openAuthTabs,
+      this.openLogsTabs,
+    ];
+    for (const collection of collections) {
+      for (const model of collection) {
+        modelByKey[centerTabKey(model)] = model;
       }
     }
-    return models;
+
+    return workspaceState.openCenterTabs.flatMap((tab) => {
+      const model = modelByKey[centerTabKey(tab)];
+      return model ? [model] : [];
+    });
   },
   get activeCenterTab() {
     return workspaceState.activeCenterTab;

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ResultCodeBlock.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ResultCodeBlock.svelte
@@ -7,6 +7,7 @@ import {
   contentWidthFromBorderBox,
   nextFixedVisibleRows,
   parseCssPixels,
+  shouldMeasureInlineSize,
   visualRowsFromScrollHeight,
 } from "./result-code-block-sizing";
 
@@ -107,19 +108,18 @@ function measureVisualRows(): void {
   measureFrame = undefined;
   if (!hasFixedRows || !blockEl || !viewportEl || !contentEl) return;
 
-  const blockRect = blockEl.getBoundingClientRect();
-  const viewportRect = viewportEl.getBoundingClientRect();
-  const blockStyle = getComputedStyle(blockEl);
-  const contentWidth =
-    viewportRect.width > 0
-      ? viewportRect.width
-      : contentWidthFromBorderBox({
-          borderBoxWidth: blockRect.width,
-          paddingLeft: parseCssPixels(blockStyle.paddingLeft),
-          paddingRight: parseCssPixels(blockStyle.paddingRight),
-          borderLeftWidth: parseCssPixels(blockStyle.borderLeftWidth),
-          borderRightWidth: parseCssPixels(blockStyle.borderRightWidth),
-        });
+  let contentWidth = viewportEl.clientWidth;
+  if (contentWidth <= 0) {
+    const blockRect = blockEl.getBoundingClientRect();
+    const blockStyle = getComputedStyle(blockEl);
+    contentWidth = contentWidthFromBorderBox({
+      borderBoxWidth: blockRect.width,
+      paddingLeft: parseCssPixels(blockStyle.paddingLeft),
+      paddingRight: parseCssPixels(blockStyle.paddingRight),
+      borderLeftWidth: parseCssPixels(blockStyle.borderLeftWidth),
+      borderRightWidth: parseCssPixels(blockStyle.borderRightWidth),
+    });
+  }
 
   if (contentWidth <= 0) return;
 
@@ -170,10 +170,17 @@ $effect(() => {
   ) {
     return;
   }
-  const observer = new ResizeObserver(() => scheduleMeasure());
-  observer.observe(blockEl);
+  let observedInlineSize: number | undefined;
+  const observer = new ResizeObserver((entries) => {
+    const entry = entries.at(-1);
+    if (!entry) return;
+    const nextInlineSize =
+      entry.contentBoxSize[0]?.inlineSize ?? entry.contentRect.width;
+    if (!shouldMeasureInlineSize(observedInlineSize, nextInlineSize)) return;
+    observedInlineSize = nextInlineSize;
+    scheduleMeasure();
+  });
   observer.observe(viewportEl);
-  observer.observe(contentEl);
   scheduleMeasure();
   return () => observer.disconnect();
 });
@@ -392,7 +399,6 @@ $effect(() => {
     (var(--code-block-fixed-rows) * 1lh) + (var(--code-block-padding-y) * 2) +
       var(--code-block-border-y)
   );
-  transition: height 140ms ease-out;
 }
 
 .code-block[data-fixed-rows="true"] .code-block__viewport {

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/result-code-block-sizing.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/result-code-block-sizing.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { shouldMeasureInlineSize } from "./result-code-block-sizing";
+
+describe("result code block sizing", () => {
+  it("measures the first usable inline size and later width changes", () => {
+    assert.equal(shouldMeasureInlineSize(undefined, 640), true);
+    assert.equal(shouldMeasureInlineSize(640, 520), true);
+  });
+
+  it("ignores unchanged, subpixel, and unusable inline sizes", () => {
+    assert.equal(shouldMeasureInlineSize(640, 640), false);
+    assert.equal(shouldMeasureInlineSize(640, 640.5), false);
+    assert.equal(shouldMeasureInlineSize(undefined, 0), false);
+    assert.equal(shouldMeasureInlineSize(undefined, Number.NaN), false);
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/result-code-block-sizing.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/result-code-block-sizing.ts
@@ -39,6 +39,17 @@ export function contentWidthFromBorderBox(metrics: BoxChromeMetrics): number {
   return Math.max(0, width);
 }
 
+export function shouldMeasureInlineSize(
+  previousInlineSize: number | undefined,
+  nextInlineSize: number,
+): boolean {
+  if (!Number.isFinite(nextInlineSize) || nextInlineSize <= 0) return false;
+  return (
+    previousInlineSize === undefined ||
+    Math.abs(previousInlineSize - nextInlineSize) > 0.5
+  );
+}
+
 export function visualRowsFromScrollHeight(
   scrollHeight: number,
   lineHeightPixels: number,


### PR DESCRIPTION
## Summary
- stop fixed-row result blocks from remeasuring on height-only ResizeObserver updates and remove their layout-coupled height transition
- cache conversation activity reactively and replace repeated agent and pending-input scans with indexed projections
- build center-tab models once per collection instead of recomputing conversation tabs multiplicatively
- add regression coverage for code-block sizing and conversation activity behavior

## Profiling
- reduced `ResultCodeBlock.scheduleMeasure` inclusive time from about 609 ms to 2 ms in an 8-second live transcript trace
- reduced conversation activity projection from about 31.7 s in the blocked tab-switch trace to about 15 ms in the post-change cycle
- repeated switching across four open conversation tabs now completes without CDP timeouts

## Validation
- `pnpm fix && pnpm check && pnpm test`
- verified long transcript scrolling, responsive width changes, light/dark rendering, and virtual-row geometry