### PR TITLE
Improve landing page platform and local-first messaging

### DIFF
--- a/packages/website/src/components/marketing/DeviceFrame.astro
+++ b/packages/website/src/components/marketing/DeviceFrame.astro
@@ -1,7 +1,7 @@
 ---
 /* The desktop application frame.
  *
- * Deliberately not a macOS window: Nerve ships on Linux, Windows, and macOS, so
+ * Deliberately not a macOS window: Nerve ships on Linux, macOS, and Windows, so
  * traffic lights would be both inaccurate and pure noise. The bezel gutter
  * carries a real label instead, and the radius matches what an application
  * window corner looks like at this render scale.

--- a/packages/website/src/components/marketing/Hero.astro
+++ b/packages/website/src/components/marketing/Hero.astro
@@ -66,7 +66,7 @@ const staticRows: StaticRow[] = [
       <Reveal>
         <span class="badge">
           <span class="badge-dot animate-pulse-ring" aria-hidden="true"></span>
-          Open source · Beta
+          Free &amp; open source · Beta
         </span>
       </Reveal>
 
@@ -91,8 +91,31 @@ const staticRows: StaticRow[] = [
           <a class="btn btn-primary" href="/start/install/">
             Get started <span aria-hidden="true">→</span>
           </a>
-          <a class="btn btn-ghost" href="https://github.com/ThilinaTLM/nerve">
-            View on GitHub
+          <a
+            class="btn btn-ghost"
+            href="https://github.com/ThilinaTLM/nerve"
+            aria-label="Nerve on GitHub"
+            data-github-star-link
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.35-1.3-1.7-1.3-1.7-1.05-.72.08-.71.08-.71 1.16.08 1.78 1.2 1.78 1.2 1.03 1.78 2.7 1.27 3.36.97.1-.75.4-1.27.73-1.56-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.7 5.4-5.27 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.2.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"
+              ></path>
+            </svg>
+            <span>GitHub</span>
+            <span class="hero-star-separator" aria-hidden="true"></span>
+            <span
+              class="hero-star-count"
+              data-github-star-count
+              aria-hidden="true"
+              >00</span
+            >
           </a>
         </div>
       </Reveal>
@@ -100,9 +123,8 @@ const staticRows: StaticRow[] = [
       <Reveal delay={320} class="hero-install">
         <InstallCommand />
         <p class="meta-text">
-          No account. Loopback by default on <code class="code-chip"
-            >127.0.0.1:3747</code
-          >.
+          Runs locally. Bring your own API key or supported provider
+          subscription.
         </p>
       </Reveal>
     </div>
@@ -129,6 +151,9 @@ const staticRows: StaticRow[] = [
     <span class="cue-track"></span>
     <span class="cue-label">Follow the signal</span>
   </div>
+<script>
+  import "../../scripts/github-stars";
+</script>
 </section>
 
 <style>
@@ -211,6 +236,21 @@ const staticRows: StaticRow[] = [
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
+  }
+
+  .hero-star-separator {
+    width: 1px;
+    height: 1rem;
+    background-color: var(--hairline);
+  }
+
+  .hero-star-count {
+    min-width: 1.6em;
+    color: var(--muted-foreground);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
   }
 
   .hero-install {

--- a/packages/website/src/components/marketing/SignalStrip.astro
+++ b/packages/website/src/components/marketing/SignalStrip.astro
@@ -6,10 +6,10 @@
  * static, complete list of facts. */
 
 const facts = [
-  { value: "Apache-2.0", label: "Open source" },
-  { value: "npx @nervekit/desktop@latest", label: "Node.js 24+" },
-  { value: "Linux · Windows 11 · macOS", label: "Desktop shell" },
-  { value: "127.0.0.1:3747", label: "Loopback by default" },
+  { value: "Apache-2.0", label: "Free & open source" },
+  { value: "Linux · macOS · Windows 11", label: "Cross-platform" },
+  { value: "127.0.0.1:3747", label: "Local daemon by default" },
+  { value: "API key · subscription", label: "Bring your own provider" },
   { value: "~/.nerve", label: "Your state, your disk" },
 ];
 ---

--- a/packages/website/src/components/marketing/SiteHeader.astro
+++ b/packages/website/src/components/marketing/SiteHeader.astro
@@ -34,6 +34,7 @@ const links = [
       <a
         class="btn btn-ghost btn-sm hidden sm:inline-flex"
         href="https://github.com/ThilinaTLM/nerve"
+        aria-label="Nerve on GitHub"
       >
         <svg
           width="16"
@@ -82,13 +83,19 @@ const links = [
               </a>
             ))
           }
-          <a href="https://github.com/ThilinaTLM/nerve">GitHub</a>
+          <a
+            href="https://github.com/ThilinaTLM/nerve"
+            aria-label="Nerve on GitHub"
+          >
+            GitHub
+          </a>
           <a class="mobile-cta sm:hidden" href="/start/install/">Get started</a>
         </div>
       </details>
     </div>
   </div>
 </header>
+
 
 <style>
   .site-header {

--- a/packages/website/src/layouts/MarketingLayout.astro
+++ b/packages/website/src/layouts/MarketingLayout.astro
@@ -29,7 +29,7 @@ const softwareApplication = {
   name: "Nerve",
   description,
   applicationCategory: "DeveloperApplication",
-  operatingSystem: "Linux, Windows 11, macOS",
+  operatingSystem: "Linux, macOS, Windows 11",
   license: "https://www.apache.org/licenses/LICENSE-2.0",
   url: "https://nerve.tlmtech.dev/",
   codeRepository: "https://github.com/ThilinaTLM/nerve",

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -16,7 +16,7 @@ import WorkbenchTour from "../components/marketing/WorkbenchTour.astro";
 
 const title = "Nerve — see everything, steer it live";
 const description =
-  "An open-source, local-first coding harness where every agent event is inspectable and a running agent can be retuned mid-run — model, mode, and authority included.";
+  "A free, open-source, local-first coding harness with inspectable agent events, live controls, and support for your own provider API key or subscription.";
 const ogImage = new URL(socialPreview.src, Astro.site).href;
 ---
 

--- a/packages/website/src/scripts/github-stars.ts
+++ b/packages/website/src/scripts/github-stars.ts
@@ -1,0 +1,160 @@
+const repositoryEndpoint = "https://api.github.com/repos/ThilinaTLM/nerve";
+const cacheKey = "nerve:github-stars:v1";
+const cacheLifetime = 60 * 60 * 1000;
+const starCountFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const reducedMotion = matchMedia("(prefers-reduced-motion: reduce)").matches;
+const scrambleStartedAt = performance.now();
+const minimumScrambleTime = 500;
+let activeStarAnimation = 0;
+let scrambleInterval = 0;
+let scrambleTimeout = 0;
+let settleTimeout = 0;
+
+function starCountElement() {
+  return document.querySelector<HTMLElement>("[data-github-star-count]");
+}
+
+function setVisibleStarCount(count: number) {
+  const starCount = starCountElement();
+  if (starCount) {
+    starCount.textContent =
+      count === 0 ? "00" : starCountFormatter.format(count);
+  }
+}
+
+function stopScramble() {
+  window.clearInterval(scrambleInterval);
+  window.clearTimeout(scrambleTimeout);
+}
+
+function startScramble() {
+  if (reducedMotion) return;
+  scrambleInterval = window.setInterval(() => {
+    const randomCount = Math.floor(Math.random() * 100);
+    const starCount = starCountElement();
+    if (starCount) starCount.textContent = String(randomCount).padStart(2, "0");
+  }, 70);
+  scrambleTimeout = window.setTimeout(() => {
+    stopScramble();
+    setVisibleStarCount(0);
+  }, 8000);
+}
+
+function renderStarCount(count: number) {
+  const link = document.querySelector<HTMLAnchorElement>(
+    "[data-github-star-link]",
+  );
+  if (link) {
+    const exactCount = count.toLocaleString("en-US");
+    link.ariaLabel = `Nerve on GitHub · ${exactCount} stars`;
+    link.title = `${exactCount} GitHub stars`;
+  }
+
+  window.clearTimeout(settleTimeout);
+  const settleDelay = reducedMotion
+    ? 0
+    : Math.max(
+        0,
+        minimumScrambleTime - (performance.now() - scrambleStartedAt),
+      );
+  settleTimeout = window.setTimeout(() => {
+    stopScramble();
+    if (reducedMotion) {
+      setVisibleStarCount(count);
+      return;
+    }
+
+    cancelAnimationFrame(activeStarAnimation);
+    const visibleCount = Number.parseInt(
+      starCountElement()?.textContent ?? "0",
+      10,
+    );
+    const startingCount = Number.isFinite(visibleCount) ? visibleCount : 0;
+    const startedAt = performance.now();
+    const duration = 650;
+
+    const animate = (now: number) => {
+      const progress = Math.min((now - startedAt) / duration, 1);
+      const easedProgress = 1 - Math.pow(1 - progress, 3);
+      const displayedCount = Math.round(
+        startingCount + (count - startingCount) * easedProgress,
+      );
+      setVisibleStarCount(displayedCount);
+      if (progress < 1) activeStarAnimation = requestAnimationFrame(animate);
+    };
+
+    activeStarAnimation = requestAnimationFrame(animate);
+  }, settleDelay);
+}
+
+function readCachedStars() {
+  try {
+    const cached: unknown = JSON.parse(
+      localStorage.getItem(cacheKey) ?? "null",
+    );
+    if (
+      typeof cached === "object" &&
+      cached !== null &&
+      "count" in cached &&
+      "updatedAt" in cached &&
+      typeof cached.count === "number" &&
+      Number.isFinite(cached.count) &&
+      cached.count >= 0 &&
+      typeof cached.updatedAt === "number" &&
+      Number.isFinite(cached.updatedAt)
+    ) {
+      return { count: cached.count, updatedAt: cached.updatedAt };
+    }
+  } catch {
+    // Storage can be unavailable; the GitHub link still works without it.
+  }
+  return null;
+}
+
+function cacheStars(count: number) {
+  try {
+    localStorage.setItem(
+      cacheKey,
+      JSON.stringify({ count, updatedAt: Date.now() }),
+    );
+  } catch {
+    // A star count is optional progressive enhancement.
+  }
+}
+
+startScramble();
+const cachedStars = readCachedStars();
+if (cachedStars) renderStarCount(cachedStars.count);
+
+if (!cachedStars || Date.now() - cachedStars.updatedAt >= cacheLifetime) {
+  fetch(repositoryEndpoint, {
+    headers: { Accept: "application/vnd.github+json" },
+  })
+    .then((response) => {
+      if (!response.ok) throw new Error("GitHub star count unavailable");
+      return response.json();
+    })
+    .then((repository: unknown) => {
+      if (
+        typeof repository !== "object" ||
+        repository === null ||
+        !("stargazers_count" in repository) ||
+        typeof repository.stargazers_count !== "number" ||
+        !Number.isFinite(repository.stargazers_count) ||
+        repository.stargazers_count < 0
+      ) {
+        throw new Error("Invalid GitHub star count");
+      }
+      renderStarCount(repository.stargazers_count);
+      cacheStars(repository.stargazers_count);
+    })
+    .catch(() => {
+      if (!cachedStars) {
+        stopScramble();
+        setVisibleStarCount(0);
+      }
+    });
+}


### PR DESCRIPTION
## Summary
- highlight free/open-source, local-first, and bring-your-own-provider usage on the landing page
- present desktop support consistently as Linux, macOS, and Windows
- add a polished GitHub CTA with a cached, animated repository star count while keeping the header compact
- align social metadata and structured application data with the updated messaging

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `pnpm --filter @nervekit/website build`
- browser-checked desktop and mobile layouts, star-count animation, and overflow