### PR TITLE
Stop status pulses from causing continuous idle repaints

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/status-dot/status-dot.svelte
+++ b/packages/ui-kit/src/lib/components/ui/status-dot/status-dot.svelte
@@ -5,12 +5,14 @@ export const statusDotVariants = tv({
   base: "inline-block flex-none rounded-full",
   variants: {
     tone: {
-      neutral: "bg-muted-foreground border-muted-foreground",
-      accent: "bg-foreground border-foreground",
-      running: "bg-info border-info",
-      good: "bg-success border-success",
-      warn: "bg-warning border-warning",
-      danger: "bg-destructive-solid border-destructive-solid",
+      neutral:
+        "bg-muted-foreground border-muted-foreground text-muted-foreground",
+      accent: "bg-foreground border-foreground text-foreground",
+      running: "bg-info border-info text-info",
+      good: "bg-success border-success text-success",
+      warn: "bg-warning border-warning text-warning",
+      danger:
+        "bg-destructive-solid border-destructive-solid text-destructive-solid",
     },
     size: {
       xs: "size-[0.42rem]",

--- a/packages/ui-kit/src/styles/animation.css
+++ b/packages/ui-kit/src/styles/animation.css
@@ -46,9 +46,10 @@
   }
 }
 
-/* Status dot pulse (status-dot.svelte). Applied via class="status-pulse". */
+/* Status dot pulse (status-dot.svelte). Keep this finite: an infinite paint
+ * animation makes an otherwise idle Electron window redraw continuously. */
 .status-pulse {
-  animation: status-pulse 1.5s ease-in-out infinite;
+  animation: status-pulse 1.5s ease-in-out 2;
 }
 
 @keyframes status-pulse {


### PR DESCRIPTION
## Summary
- limit status-dot pulse animations to two cycles instead of running indefinitely
- apply semantic text colors so pulse halos match each status tone
- prevent idle Electron windows from continuously repainting status indicators

## Validation
- `pnpm fix && pnpm check && pnpm test`
- profiled the Electron renderer and Intel GPU process before and after the animation completes