### PR TITLE
docs: credit @earendil-works/pi-ai in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ If Nerve is useful to you, you can [support its continued development on Patreon
 Contributions are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a change, and report vulnerabilities through the private channels in [`SECURITY.md`](SECURITY.md).
 
 Nerve is licensed under Apache-2.0. See [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE).
+
+## Acknowledgements
+
+Nerve's model routing, provider integrations, and streaming are built on
+[@earendil-works/pi-ai](https://github.com/earendil-works/pi), a unified LLM API
+client by Mario Zechner (MIT license).


### PR DESCRIPTION
## Summary

Add a short **Acknowledgements** section to `README.md` crediting [@earendil-works/pi-ai](https://github.com/earendil-works/pi) (by Mario Zechner, MIT license), which Nerve uses as its LLM API client for model routing, provider integrations, and streaming in `packages/harness` and `packages/workbench-server`.

This is a courtesy credit only — pi is used as a third-party dependency (MIT), so no legal notice or `NOTICE` changes are needed.

## Validation

- `pnpm fix && pnpm check && pnpm test` passed.