### PR TITLE
feat(files): enrich file explorer with icons, git status, and entry actions

### DIFF
--- a/packages/contracts/src/domains/filesystem/filesystem.operations.schema.ts
+++ b/packages/contracts/src/domains/filesystem/filesystem.operations.schema.ts
@@ -3,6 +3,8 @@ import {
   filesystemDirectoryResponseSchema,
   filesystemProjectEntriesQuerySchema,
   filesystemProjectEntriesResponseSchema,
+  filesystemProjectEntryCreateRequestSchema,
+  filesystemProjectEntryCreateResponseSchema,
 } from "./index.js";
 import { defineOperation } from "../protocol/operation-definition.schema.js";
 
@@ -24,5 +26,14 @@ export const filesystemOperationDefinitions = [
     "none",
     ["workbench_server"] as const,
     "operation.filesystem.project.entries.list",
+  ),
+  defineOperation(
+    "filesystem.project.entries.create",
+    filesystemProjectEntryCreateRequestSchema,
+    filesystemProjectEntryCreateResponseSchema,
+    "mutation",
+    "recommended",
+    ["workbench_server"] as const,
+    "operation.filesystem.project.entries.create",
   ),
 ] as const;

--- a/packages/contracts/src/domains/filesystem/filesystem.schema.ts
+++ b/packages/contracts/src/domains/filesystem/filesystem.schema.ts
@@ -67,6 +67,23 @@ export type FilesystemProjectEntriesResponse = z.infer<
   typeof filesystemProjectEntriesResponseSchema
 >;
 
+export const filesystemProjectEntryCreateRequestSchema = z.object({
+  projectId: z.string().min(1),
+  parentPath: z.string().optional(),
+  name: z.string().min(1),
+  kind: z.enum(["file", "directory"]),
+});
+export type FilesystemProjectEntryCreateRequest = z.infer<
+  typeof filesystemProjectEntryCreateRequestSchema
+>;
+
+export const filesystemProjectEntryCreateResponseSchema = z.object({
+  entry: filesystemProjectEntrySchema,
+});
+export type FilesystemProjectEntryCreateResponse = z.infer<
+  typeof filesystemProjectEntryCreateResponseSchema
+>;
+
 export const filesystemFileQuerySchema = z.object({
   projectId: z.string().min(1),
   path: z.string().min(1),

--- a/packages/contracts/src/domains/git/git.operations.schema.ts
+++ b/packages/contracts/src/domains/git/git.operations.schema.ts
@@ -7,6 +7,7 @@ import {
   gitFileDiffResponseSchema,
   gitMutationResponseSchema,
   gitOverviewResponseSchema,
+  gitProjectFileStatusResponseSchema,
   gitRemoteOpRequestSchema,
   githubPrCheckoutResponseSchema,
   githubPrChecksResponseSchema,
@@ -79,6 +80,15 @@ export const gitOperationDefinitions = [
     "none",
     ["workbench_server"] as const,
     "operation.git.overview.get",
+  ),
+  defineOperation(
+    "git.project.files.status.get",
+    projectIdParamsSchema,
+    gitProjectFileStatusResponseSchema,
+    "read",
+    "none",
+    ["workbench_server"] as const,
+    "operation.git.project.files.status.get",
   ),
   defineOperation(
     "git.branches.list",

--- a/packages/contracts/src/domains/git/git.schema.ts
+++ b/packages/contracts/src/domains/git/git.schema.ts
@@ -69,6 +69,23 @@ export const gitFileChangeSchema = z.object({
 });
 export type GitFileChange = z.infer<typeof gitFileChangeSchema>;
 
+export const gitProjectFileStatusSchema = gitFileChangeSchema.extend({
+  /** Repository path relative to the project; `.` for a root repository. */
+  repo: z.string(),
+  /** File path relative to the project root. */
+  path: z.string(),
+  /** Previous path relative to the project root for renames. */
+  renamedFrom: z.string().optional(),
+});
+export type GitProjectFileStatus = z.infer<typeof gitProjectFileStatusSchema>;
+
+export const gitProjectFileStatusResponseSchema = z.object({
+  files: z.array(gitProjectFileStatusSchema),
+});
+export type GitProjectFileStatusResponse = z.infer<
+  typeof gitProjectFileStatusResponseSchema
+>;
+
 export const gitRecentCommitSchema = z.object({
   hash: z.string(),
   subject: z.string(),

--- a/packages/desktop-shell/src/ipc/project-entry-path.ts
+++ b/packages/desktop-shell/src/ipc/project-entry-path.ts
@@ -1,0 +1,47 @@
+import path, { win32 } from "node:path";
+
+export type DesktopProjectEntryTarget = {
+  root: string;
+  relativePath: string;
+};
+
+export function resolveProjectEntryPath(
+  input: unknown,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (!input || typeof input !== "object")
+    throw new Error("Project entry target is required.");
+  const { root, relativePath } = input as Record<string, unknown>;
+  if (typeof root !== "string" || typeof relativePath !== "string")
+    throw new Error("Project entry root and relative path must be strings.");
+
+  const pathApi = platform === "win32" ? win32 : path;
+  const normalizedRoot = root.trim();
+  const normalizedRelative = relativePath.trim().replaceAll("\\", "/");
+  if (!normalizedRoot || !pathApi.isAbsolute(normalizedRoot))
+    throw new Error("Project entry root must be absolute.");
+  if (
+    !normalizedRelative ||
+    normalizedRelative.includes("\0") ||
+    normalizedRelative.startsWith("/") ||
+    /^[A-Za-z]:\//.test(normalizedRelative)
+  )
+    throw new Error("Project entry path must be relative.");
+  const segments = normalizedRelative.split("/");
+  if (
+    segments.some((segment) => !segment || segment === "." || segment === "..")
+  )
+    throw new Error("Project entry path contains an invalid segment.");
+
+  const resolvedRoot = pathApi.resolve(normalizedRoot);
+  const target = pathApi.resolve(resolvedRoot, ...segments);
+  const fromRoot = pathApi.relative(resolvedRoot, target);
+  if (
+    !fromRoot ||
+    fromRoot === ".." ||
+    fromRoot.startsWith(`..${pathApi.sep}`) ||
+    pathApi.isAbsolute(fromRoot)
+  )
+    throw new Error("Project entry path escapes the project root.");
+  return target;
+}

--- a/packages/desktop-shell/src/ipc/project-entry-path.ts
+++ b/packages/desktop-shell/src/ipc/project-entry-path.ts
@@ -1,4 +1,4 @@
-import path, { win32 } from "node:path";
+import { posix, win32 } from "node:path";
 
 export type DesktopProjectEntryTarget = {
   root: string;
@@ -15,7 +15,7 @@ export function resolveProjectEntryPath(
   if (typeof root !== "string" || typeof relativePath !== "string")
     throw new Error("Project entry root and relative path must be strings.");
 
-  const pathApi = platform === "win32" ? win32 : path;
+  const pathApi = platform === "win32" ? win32 : posix;
   const normalizedRoot = root.trim();
   const normalizedRelative = relativePath.trim().replaceAll("\\", "/");
   if (!normalizedRoot || !pathApi.isAbsolute(normalizedRoot))

--- a/packages/desktop-shell/src/ipc/window-ipc.ts
+++ b/packages/desktop-shell/src/ipc/window-ipc.ts
@@ -1,7 +1,8 @@
 import type { BrowserWindowType, IpcMainInvokeEvent } from "../electron.js";
-import { BrowserWindow, clipboard, ipcMain } from "../electron.js";
+import { BrowserWindow, clipboard, ipcMain, shell } from "../electron.js";
 import { desktopLog } from "../logging.js";
 import type { DesktopWindowState, QuitSource } from "../types.js";
+import { resolveProjectEntryPath } from "./project-entry-path.js";
 
 interface RegisterDesktopIpcOptions {
   getCloseToTray: () => boolean;
@@ -63,6 +64,22 @@ export function registerDesktopIpc(options: RegisterDesktopIpcOptions): void {
       throw new Error("desktop.clipboard.writeText expects a string.");
     }
     clipboard.writeText(text);
+    return { ok: true };
+  });
+
+  ipcMain.handle("desktop.files.openProjectEntry", async (_event, target) => {
+    const error = await shell.openPath(resolveProjectEntryPath(target));
+    if (error) throw new Error(error);
+    return { ok: true };
+  });
+
+  ipcMain.handle("desktop.files.revealProjectEntry", (_event, target) => {
+    shell.showItemInFolder(resolveProjectEntryPath(target));
+    return { ok: true };
+  });
+
+  ipcMain.handle("desktop.files.trashProjectEntry", async (_event, target) => {
+    await shell.trashItem(resolveProjectEntryPath(target));
     return { ok: true };
   });
 }

--- a/packages/desktop-shell/src/preload.cjs
+++ b/packages/desktop-shell/src/preload.cjs
@@ -44,5 +44,11 @@ contextBridge.exposeInMainWorld("nerveDesktop", {
   },
   files: {
     getPathForFile: (file) => webUtils.getPathForFile(file),
+    openProjectEntry: (target) =>
+      ipcRenderer.invoke("desktop.files.openProjectEntry", target),
+    revealProjectEntry: (target) =>
+      ipcRenderer.invoke("desktop.files.revealProjectEntry", target),
+    trashProjectEntry: (target) =>
+      ipcRenderer.invoke("desktop.files.trashProjectEntry", target),
   },
 });

--- a/packages/desktop-shell/test/project-entry-path.test.ts
+++ b/packages/desktop-shell/test/project-entry-path.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveProjectEntryPath } from "../src/ipc/project-entry-path.js";
+
+describe("desktop project entry paths", () => {
+  it("resolves nested POSIX and Windows project-relative paths", () => {
+    assert.equal(
+      resolveProjectEntryPath(
+        { root: "/workspace/project", relativePath: "src/main.ts" },
+        "linux",
+      ),
+      "/workspace/project/src/main.ts",
+    );
+    assert.equal(
+      resolveProjectEntryPath(
+        { root: "C:\\workspace\\project", relativePath: "src/main.ts" },
+        "win32",
+      ),
+      "C:\\workspace\\project\\src\\main.ts",
+    );
+  });
+
+  it("rejects absolute, empty, and traversing paths", () => {
+    for (const relativePath of [
+      "",
+      "/tmp/file",
+      "C:/tmp/file",
+      "../file",
+      "src/../../file",
+      "src//file",
+    ]) {
+      assert.throws(() =>
+        resolveProjectEntryPath(
+          { root: "/workspace/project", relativePath },
+          "linux",
+        ),
+      );
+    }
+    assert.throws(() =>
+      resolveProjectEntryPath(
+        { root: "workspace/project", relativePath: "src/main.ts" },
+        "linux",
+      ),
+    );
+  });
+});

--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -298,13 +298,14 @@ export class GitService {
           const { stdout } = await this.runGit(repoDir, [
             "status",
             "--porcelain=v2",
+            "--ignored=matching",
           ]);
           for (const file of parsePorcelainV2(stdout).files) {
             const prefix = repo === "." ? "" : `${repo}/`;
             files.push({
               ...file,
               repo,
-              path: `${prefix}${file.path}`,
+              path: `${prefix}${file.path.replace(/\/$/, "")}`,
               ...(file.renamedFrom
                 ? { renamedFrom: `${prefix}${file.renamedFrom}` }
                 : {}),

--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -24,6 +24,7 @@ import type {
   GithubStatusResponse,
   GitMutationResponse,
   GitOverviewResponse,
+  GitProjectFileStatusResponse,
   GitRecentCommit,
   GitRepoSummary,
 } from "@nervekit/contracts";
@@ -273,6 +274,52 @@ export class GitService {
     );
     repos.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
     return { projectIsRepo: false, repos };
+  }
+
+  async projectFileStatus(
+    projectId: string,
+  ): Promise<GitProjectFileStatusResponse> {
+    const project = this.getProject(projectId);
+    const root = resolve(project.dir);
+    const repoDirs = (await this.isRepo(root))
+      ? [root]
+      : await this.walkForRepos(root, root, 0);
+    const files: GitProjectFileStatusResponse["files"] = [];
+    let nextIndex = 0;
+    const readNext = async (): Promise<void> => {
+      while (nextIndex < repoDirs.length) {
+        const repoDir = repoDirs[nextIndex++];
+        if (!repoDir) continue;
+        const repo =
+          repoDir === root
+            ? "."
+            : repoDir.slice(root.length + 1).replaceAll(sep, "/");
+        try {
+          const { stdout } = await this.runGit(repoDir, [
+            "status",
+            "--porcelain=v2",
+          ]);
+          for (const file of parsePorcelainV2(stdout).files) {
+            const prefix = repo === "." ? "" : `${repo}/`;
+            files.push({
+              ...file,
+              repo,
+              path: `${prefix}${file.path}`,
+              ...(file.renamedFrom
+                ? { renamedFrom: `${prefix}${file.renamedFrom}` }
+                : {}),
+            });
+          }
+        } catch {
+          // Match repository discovery: inaccessible or corrupt repos are skipped.
+        }
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(4, repoDirs.length) }, readNext),
+    );
+    files.sort((left, right) => left.path.localeCompare(right.path));
+    return { files };
   }
 
   async walkForRepos(

--- a/packages/tools/test/git-service-status.test.ts
+++ b/packages/tools/test/git-service-status.test.ts
@@ -8,6 +8,7 @@ import { GitService } from "../src/git/git-service.js";
 const status = [
   "? new.ts",
   "1 .M N... 100644 100644 100644 abc def modified.ts",
+  "! generated/",
 ].join("\n");
 
 describe("GitService project file status", () => {
@@ -15,7 +16,11 @@ describe("GitService project file status", () => {
     const service = new GitService(() => ({ dir: "/repo", name: "repo" }));
     service.isRepo = async () => true;
     service.runGit = async (_cwd, args) => {
-      assert.deepEqual(args, ["status", "--porcelain=v2"]);
+      assert.deepEqual(args, [
+        "status",
+        "--porcelain=v2",
+        "--ignored=matching",
+      ]);
       return { stdout: status, stderr: "" };
     };
 
@@ -23,6 +28,7 @@ describe("GitService project file status", () => {
     assert.deepEqual(
       result.files.map((file) => [file.repo, file.path]),
       [
+        [".", "generated"],
         [".", "modified.ts"],
         [".", "new.ts"],
       ],
@@ -37,7 +43,11 @@ describe("GitService project file status", () => {
       service.isRepo = async () => false;
       service.runGit = async (cwd, args) => {
         assert.equal(cwd, join(root, "packages", "app"));
-        assert.deepEqual(args, ["status", "--porcelain=v2"]);
+        assert.deepEqual(args, [
+          "status",
+          "--porcelain=v2",
+          "--ignored=matching",
+        ]);
         return { stdout: "? src/index.ts", stderr: "" };
       };
 

--- a/packages/tools/test/git-service-status.test.ts
+++ b/packages/tools/test/git-service-status.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { GitService } from "../src/git/git-service.js";
+
+const status = [
+  "? new.ts",
+  "1 .M N... 100644 100644 100644 abc def modified.ts",
+].join("\n");
+
+describe("GitService project file status", () => {
+  it("returns project-relative paths for a root repository", async () => {
+    const service = new GitService(() => ({ dir: "/repo", name: "repo" }));
+    service.isRepo = async () => true;
+    service.runGit = async (_cwd, args) => {
+      assert.deepEqual(args, ["status", "--porcelain=v2"]);
+      return { stdout: status, stderr: "" };
+    };
+
+    const result = await service.projectFileStatus("proj_test");
+    assert.deepEqual(
+      result.files.map((file) => [file.repo, file.path]),
+      [
+        [".", "modified.ts"],
+        [".", "new.ts"],
+      ],
+    );
+  });
+
+  it("prefixes paths from nested repositories", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-git-status-"));
+    try {
+      await mkdir(join(root, "packages", "app", ".git"), { recursive: true });
+      const service = new GitService(() => ({ dir: root, name: "project" }));
+      service.isRepo = async () => false;
+      service.runGit = async (cwd, args) => {
+        assert.equal(cwd, join(root, "packages", "app"));
+        assert.deepEqual(args, ["status", "--porcelain=v2"]);
+        return { stdout: "? src/index.ts", stderr: "" };
+      };
+
+      const result = await service.projectFileStatus("proj_test");
+      assert.equal(result.files[0]?.repo, "packages/app");
+      assert.equal(result.files[0]?.path, "packages/app/src/index.ts");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/workbench-app/package.json
+++ b/packages/workbench-app/package.json
@@ -59,6 +59,7 @@
     "@tanstack/svelte-query": "6.0.0",
     "@xyflow/svelte": "1.6.2",
     "bits-ui": "^2.18.1",
+    "material-icon-theme": "^5.37.0",
     "svelte": "5.56.3",
     "svelte-sonner": "^1.1.1",
     "tailwindcss": "4.3.1",

--- a/packages/workbench-app/src/lib/features/desktop/state/desktop-bridge.svelte.ts
+++ b/packages/workbench-app/src/lib/features/desktop/state/desktop-bridge.svelte.ts
@@ -9,6 +9,11 @@ export interface DesktopNotificationPayload {
   urgency?: "normal" | "attention";
 }
 
+export interface DesktopProjectEntryTarget {
+  root: string;
+  relativePath: string;
+}
+
 export interface NerveDesktopBridge {
   kind: "electron";
   platform: string;
@@ -35,6 +40,15 @@ export interface NerveDesktopBridge {
   };
   files: {
     getPathForFile: (file: File) => string;
+    openProjectEntry: (
+      target: DesktopProjectEntryTarget,
+    ) => Promise<{ ok: true }>;
+    revealProjectEntry: (
+      target: DesktopProjectEntryTarget,
+    ) => Promise<{ ok: true }>;
+    trashProjectEntry: (
+      target: DesktopProjectEntryTarget,
+    ) => Promise<{ ok: true }>;
   };
 }
 

--- a/packages/workbench-app/src/lib/features/filesystem/api/filesystem.api.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/api/filesystem.api.ts
@@ -4,6 +4,8 @@ import type {
   FilesystemFileResponse,
   FilesystemProjectEntriesQuery,
   FilesystemProjectEntriesResponse,
+  FilesystemProjectEntryCreateRequest,
+  FilesystemProjectEntryCreateResponse,
 } from "@nervekit/contracts";
 import {
   apiGet,
@@ -37,6 +39,13 @@ export async function listProjectEntries(
   query: FilesystemProjectEntriesQuery,
 ): Promise<FilesystemProjectEntriesResponse> {
   return (await protocolRequest("filesystem.project.entries.list", query))
+    .result;
+}
+
+export async function createProjectEntry(
+  request: FilesystemProjectEntryCreateRequest,
+): Promise<FilesystemProjectEntryCreateResponse> {
+  return (await protocolRequest("filesystem.project.entries.create", request))
     .result;
 }
 

--- a/packages/workbench-app/src/lib/features/filesystem/components/CreateProjectEntryDialog.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/CreateProjectEntryDialog.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+import { tick } from "svelte";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
+import { Input } from "@nervekit/ui-kit/components/ui/input";
+import { Label } from "@nervekit/ui-kit/components/ui/label";
+
+let {
+  open = $bindable(false),
+  kind,
+  parentPath,
+  onCreate,
+}: {
+  open?: boolean;
+  kind: "file" | "directory";
+  parentPath: string;
+  onCreate: (name: string) => Promise<void>;
+} = $props();
+
+let name = $state("");
+let saving = $state(false);
+let error = $state<string>();
+let input = $state<HTMLInputElement | null>(null);
+
+const title = $derived(kind === "file" ? "New file" : "New folder");
+const valid = $derived(
+  name.trim().length > 0 &&
+    name.trim() !== "." &&
+    name.trim() !== ".." &&
+    !/[\\/\0]/.test(name.trim()),
+);
+
+$effect(() => {
+  if (!open) return;
+  name = "";
+  error = undefined;
+  void tick().then(() => input?.focus());
+});
+
+async function submit(event?: SubmitEvent): Promise<void> {
+  event?.preventDefault();
+  if (!valid || saving) return;
+  saving = true;
+  error = undefined;
+  try {
+    await onCreate(name.trim());
+    open = false;
+  } catch (caught) {
+    error = caught instanceof Error ? caught.message : String(caught);
+  } finally {
+    saving = false;
+  }
+}
+</script>
+
+<Dialog
+  bind:open
+  {title}
+  description={`Create an empty ${kind === "file" ? "file" : "folder"} in ${parentPath || "the project root"}.`}
+  class="max-w-md"
+>
+  <form class="grid gap-2" onsubmit={(event) => void submit(event)}>
+    <Label for="new-project-entry-name">Name</Label>
+    <Input
+      id="new-project-entry-name"
+      bind:ref={input}
+      bind:value={name}
+      maxlength={255}
+      disabled={saving}
+      autocomplete="off"
+      placeholder={kind === "file" ? "example.ts" : "folder-name"}
+    />
+    <p class="text-xs text-muted-foreground">
+      Enter one name without path separators.
+    </p>
+    {#if error}<p class="text-sm text-destructive" role="alert">{error}</p>{/if}
+  </form>
+
+  {#snippet footer()}
+    <Button
+      size="sm"
+      variant="ghost"
+      disabled={saving}
+      onclick={() => (open = false)}>Cancel</Button
+    >
+    <Button size="sm" disabled={!valid || saving} onclick={() => void submit()}>
+      {saving ? "Creating…" : `Create ${kind === "file" ? "file" : "folder"}`}
+    </Button>
+  {/snippet}
+</Dialog>

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -1,18 +1,43 @@
 <script lang="ts">
-import File from "@lucide/svelte/icons/file";
+import ArrowRight from "@lucide/svelte/icons/arrow-right";
+import Copy from "@lucide/svelte/icons/copy";
+import ExternalLink from "@lucide/svelte/icons/external-link";
+import FilePlus from "@lucide/svelte/icons/file-plus";
 import Files from "@lucide/svelte/icons/files";
 import Folder from "@lucide/svelte/icons/folder";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
+import FolderPlus from "@lucide/svelte/icons/folder-plus";
 import Link from "@lucide/svelte/icons/link";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+import Trash2 from "@lucide/svelte/icons/trash-2";
 import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
 import type { ProjectRecord } from "$lib/api";
+import type {
+  FilesystemProjectEntry,
+  GitProjectFileStatus,
+} from "@nervekit/contracts";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
+import ConfirmDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
+import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import { cn } from "@nervekit/ui-kit/core/utils";
+import { getProjectGitFileStatus } from "$lib/api";
+import { writeClipboardText } from "$lib/core/clipboard";
 import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
+import {
+  desktopRuntime,
+  getDesktopBridge,
+} from "$lib/features/desktop/state/desktop-bridge.svelte";
+import { createProjectEntry } from "$lib/features/filesystem/api/filesystem.api";
 import { fileSelectors } from "$lib/features/filesystem/state/file-selectors.svelte";
-import { openFilePane } from "$lib/features/filesystem/state/file-tabs.svelte";
+import {
+  closeFileTabsAtPath,
+  openFilePane,
+} from "$lib/features/filesystem/state/file-tabs.svelte";
 import {
   activateFileExplorerItem,
+  discardFileExplorerPath,
   ensureFileExplorerRoot,
+  loadFileExplorerDirectory,
   refreshFileExplorerProject,
   setFileExplorerItemExpanded,
 } from "$lib/features/filesystem/state/file-explorer-actions.svelte";
@@ -21,8 +46,11 @@ import { fileExplorerState } from "$lib/features/filesystem/state/file-explorer-
 import {
   buildFileExplorerTree,
   fileExplorerEntryNodeId,
+  type FileExplorerEntryItem,
   type FileExplorerTreeItem,
 } from "$lib/features/filesystem/state/file-explorer-tree";
+import { indexFileTreeGitDecorations } from "$lib/features/filesystem/state/file-git-status";
+import { notify } from "$lib/features/notifications/notify.svelte";
 import {
   PanelBanner,
   PanelEmpty,
@@ -31,15 +59,29 @@ import {
   PanelTree,
   PanelView,
 } from "$lib/presentation/panel";
-import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import CreateProjectEntryDialog from "./CreateProjectEntryDialog.svelte";
+import MaterialFileIcon from "./MaterialFileIcon.svelte";
+import {
+  absoluteProjectPath,
+  buildFileExplorerMenu,
+} from "./file-explorer-menu";
 
 let { activeProject }: { activeProject?: ProjectRecord } = $props();
+
+let gitFiles = $state<GitProjectFileStatus[]>([]);
+let pendingCreate = $state<{
+  kind: "file" | "directory";
+  parent: FilesystemProjectEntry;
+}>();
+let createOpen = $state(false);
+let pendingTrash = $state<FilesystemProjectEntry>();
 
 const project = $derived(
   activeProject ? fileExplorerState.projects[activeProject.id] : undefined,
 );
 const root = $derived(project?.directories[""]);
 const nodes = $derived(project ? buildFileExplorerTree(project) : []);
+const gitDecorations = $derived(indexFileTreeGitDecorations(gitFiles));
 const activeFile = $derived(fileSelectors.activeCenterFileView);
 const activeRelativePath = $derived.by(() => {
   const file = activeFile;
@@ -65,12 +107,184 @@ function activate(item: FileExplorerTreeItem): void {
   activateFileExplorerItem(activeProject.id, item);
 }
 
+function openFromMenu(item: FileExplorerEntryItem): void {
+  if (!activeProject || !project) return;
+  if (item.entry.kind === "file") {
+    void openFilePane({ projectId: activeProject.id, path: item.entry.path });
+    return;
+  }
+  if (item.entry.kind === "directory") {
+    const id = fileExplorerEntryNodeId(activeProject.id, item.entry.path);
+    setFileExplorerItemExpanded(
+      activeProject.id,
+      item,
+      !project.expandedIds.has(id),
+    );
+  }
+}
+
+function parentPath(path: string): string {
+  const separator = path.lastIndexOf("/");
+  return separator < 0 ? "" : path.slice(0, separator);
+}
+
+async function refreshGitStatus(projectId: string): Promise<void> {
+  try {
+    const response = await getProjectGitFileStatus(projectId);
+    if (activeProject?.id === projectId) gitFiles = response.files;
+  } catch {
+    // Git decoration is best effort; preserve the last successful status.
+  }
+}
+
+async function refreshAll(projectId: string): Promise<void> {
+  await Promise.all([
+    refreshFileExplorerProject(projectId),
+    refreshGitStatus(projectId),
+  ]);
+}
+
+async function copyPath(text: string, label: string): Promise<void> {
+  try {
+    await writeClipboardText(text);
+    notify.success(`Copied ${label}`);
+  } catch {
+    notify.error("Could not copy to clipboard");
+  }
+}
+
+async function runNativeAction(
+  action: "openProjectEntry" | "revealProjectEntry",
+  entry: FilesystemProjectEntry,
+): Promise<void> {
+  if (!activeProject) return;
+  const bridge = getDesktopBridge();
+  if (!bridge) return;
+  try {
+    await bridge.files[action]({
+      root: activeProject.dir,
+      relativePath: entry.path,
+    });
+  } catch (caught) {
+    notify.error("Could not open project entry", {
+      description: caught instanceof Error ? caught.message : String(caught),
+    });
+  }
+}
+
+function requestCreate(
+  kind: "file" | "directory",
+  parent: FilesystemProjectEntry,
+): void {
+  pendingCreate = { kind, parent };
+  createOpen = true;
+}
+
+async function createEntry(name: string): Promise<void> {
+  const target = pendingCreate;
+  if (!activeProject || !target) return;
+  const response = await createProjectEntry({
+    projectId: activeProject.id,
+    parentPath: target.parent.path,
+    name,
+    kind: target.kind,
+  });
+  await loadFileExplorerDirectory(activeProject.id, target.parent.path, {
+    refresh: true,
+  });
+  setFileExplorerItemExpanded(
+    activeProject.id,
+    { type: "entry", entry: target.parent },
+    true,
+  );
+  await refreshGitStatus(activeProject.id);
+  if (target.kind === "file")
+    await openFilePane({
+      projectId: activeProject.id,
+      path: response.entry.path,
+    });
+  notify.success(target.kind === "file" ? "File created" : "Folder created");
+}
+
+async function movePendingToTrash(): Promise<void> {
+  const entry = pendingTrash;
+  const currentProject = activeProject;
+  const bridge = getDesktopBridge();
+  if (!entry || !currentProject || !bridge) return;
+  try {
+    await bridge.files.trashProjectEntry({
+      root: currentProject.dir,
+      relativePath: entry.path,
+    });
+    closeFileTabsAtPath({
+      projectId: currentProject.id,
+      path: entry.path,
+      descendants: entry.kind === "directory",
+    });
+    discardFileExplorerPath(currentProject.id, entry.path);
+    await Promise.all([
+      loadFileExplorerDirectory(currentProject.id, parentPath(entry.path), {
+        refresh: true,
+      }),
+      refreshGitStatus(currentProject.id),
+    ]);
+    notify.success("Moved to trash");
+  } catch (caught) {
+    notify.error("Could not move entry to trash", {
+      description: caught instanceof Error ? caught.message : String(caught),
+    });
+  } finally {
+    pendingTrash = undefined;
+  }
+}
+
+function itemMenu(item: FileExplorerTreeItem): ContextMenuItem[] {
+  if (item.type !== "entry" || !activeProject) return [];
+  const entry = item.entry;
+  const absolutePath = absoluteProjectPath(
+    activeProject.dir,
+    entry.path,
+    desktopRuntime.platform,
+  );
+  return buildFileExplorerMenu(
+    entry,
+    {
+      open: () => openFromMenu(item),
+      createFile: () => requestCreate("file", entry),
+      createFolder: () => requestCreate("directory", entry),
+      openDefault: () => void runNativeAction("openProjectEntry", entry),
+      reveal: () => void runNativeAction("revealProjectEntry", entry),
+      copyPath: () => void copyPath(absolutePath, "path"),
+      copyRelativePath: () => void copyPath(entry.path, "relative path"),
+      trash: () => (pendingTrash = entry),
+    },
+    desktopRuntime.isDesktop,
+    {
+      open: ArrowRight,
+      copy: Copy,
+      openDefault: ExternalLink,
+      newFile: FilePlus,
+      reveal: FolderOpen,
+      newFolder: FolderPlus,
+      trash: Trash2,
+    },
+  );
+}
+
+$effect(() => {
+  if (!createOpen) pendingCreate = undefined;
+});
+
 $effect(() => {
   const projectId = activeProject?.id;
   if (!projectId || !workbenchStartupState.progressiveActive) return;
-  void ensureFileExplorerRoot(projectId);
+  gitFiles = [];
+  void Promise.all([
+    ensureFileExplorerRoot(projectId),
+    refreshGitStatus(projectId),
+  ]);
   return startFileExplorerRefreshScheduler({
-    refresh: () => refreshFileExplorerProject(projectId),
+    refresh: () => refreshAll(projectId),
   });
 });
 </script>
@@ -84,7 +298,7 @@ $effect(() => {
         loading={busy}
         disabled={!activeProject || !root || busy}
         onclick={() => {
-          if (activeProject) void refreshFileExplorerProject(activeProject.id);
+          if (activeProject) void refreshAll(activeProject.id);
         }}
       />
     {/snippet}
@@ -129,6 +343,7 @@ $effect(() => {
       {nodes}
       ariaLabel={`${activeProject.name} files`}
       virtualized
+      showDisclosure={false}
       expandedIds={project.expandedIds}
       getItemTitle={(item) =>
         item.type === "entry"
@@ -137,22 +352,27 @@ $effect(() => {
             ? item.message
             : "Load more files"}
       getItemSelected={(item) => itemPath(item) === activeRelativePath}
+      getItemTone={(item) =>
+        item.type === "entry"
+          ? gitDecorations.get(item.entry.path)?.tone
+          : undefined}
+      getItemMenuItems={itemMenu}
       onItemActivate={activate}
       onItemExpansionChange={(item, expanded) =>
         setFileExplorerItemExpanded(activeProject.id, item, expanded)}
     >
       {#snippet itemLeading(item)}
         {#if item.type === "entry"}
+          {@const open = project.expandedIds.has(
+            fileExplorerEntryNodeId(activeProject.id, item.entry.path),
+          )}
+          <MaterialFileIcon
+            name={item.entry.name}
+            kind={item.entry.kind}
+            {open}
+          />
           {#if item.entry.symlink}
-            <Link class="size-3.5" aria-hidden="true" />
-          {:else if item.entry.kind === "directory"}
-            {#if project.expandedIds.has(fileExplorerEntryNodeId(activeProject.id, item.entry.path))}
-              <FolderOpen class="size-3.5" aria-hidden="true" />
-            {:else}
-              <Folder class="size-3.5" aria-hidden="true" />
-            {/if}
-          {:else}
-            <File class="size-3.5" aria-hidden="true" />
+            <Link class="size-2.5" aria-hidden="true" />
           {/if}
           {#if item.entry.kind === "directory" && project.directories[item.entry.path]?.loading}
             <Spinner class="ml-0.5 size-3" />
@@ -161,6 +381,44 @@ $effect(() => {
           <TriangleAlert class="size-3.5 text-destructive" aria-hidden="true" />
         {/if}
       {/snippet}
+      {#snippet itemBadges(item)}
+        {#if item.type === "entry" && item.entry.kind === "file"}
+          {@const decoration = gitDecorations.get(item.entry.path)}
+          {#if decoration}
+            <span
+              class={cn(
+                "w-3 text-center text-xs font-medium",
+                decoration.class,
+              )}
+              title={decoration.title}
+              aria-label={decoration.title}>{decoration.label}</span
+            >
+          {/if}
+        {/if}
+      {/snippet}
     </PanelTree>
   {/if}
 </PanelView>
+
+{#if pendingCreate}
+  <CreateProjectEntryDialog
+    bind:open={createOpen}
+    kind={pendingCreate.kind}
+    parentPath={pendingCreate.parent.path}
+    onCreate={createEntry}
+  />
+{/if}
+
+<ConfirmDialog
+  open={Boolean(pendingTrash)}
+  title="Move to trash?"
+  description={pendingTrash
+    ? `“${pendingTrash.name}” will be moved to the operating-system trash and may be recoverable there.`
+    : undefined}
+  confirmLabel="Move to Trash"
+  destructive
+  onConfirm={() => void movePendingToTrash()}
+  onOpenChange={(open) => {
+    if (!open) pendingTrash = undefined;
+  }}
+/>

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -49,7 +49,10 @@ import {
   type FileExplorerEntryItem,
   type FileExplorerTreeItem,
 } from "$lib/features/filesystem/state/file-explorer-tree";
-import { indexFileTreeGitDecorations } from "$lib/features/filesystem/state/file-git-status";
+import {
+  fileTreeGitDecoration,
+  indexFileTreeGitDecorations,
+} from "$lib/features/filesystem/state/file-git-status";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import {
   PanelBanner,
@@ -354,7 +357,7 @@ $effect(() => {
       getItemSelected={(item) => itemPath(item) === activeRelativePath}
       getItemTone={(item) =>
         item.type === "entry"
-          ? gitDecorations.get(item.entry.path)?.tone
+          ? fileTreeGitDecoration(gitDecorations, item.entry.path)?.tone
           : undefined}
       getItemMenuItems={itemMenu}
       onItemActivate={activate}
@@ -383,8 +386,11 @@ $effect(() => {
       {/snippet}
       {#snippet itemBadges(item)}
         {#if item.type === "entry" && item.entry.kind === "file"}
-          {@const decoration = gitDecorations.get(item.entry.path)}
-          {#if decoration}
+          {@const decoration = fileTreeGitDecoration(
+            gitDecorations,
+            item.entry.path,
+          )}
+          {#if decoration?.label}
             <span
               class={cn(
                 "w-3 text-center text-xs font-medium",

--- a/packages/workbench-app/src/lib/features/filesystem/components/MaterialFileIcon.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/MaterialFileIcon.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import { onMount } from "svelte";
+import {
+  ensureMaterialFileIconSprite,
+  materialFileIcon,
+} from "./material-file-icons";
+
+let {
+  name,
+  kind,
+  open = false,
+}: {
+  name: string;
+  kind: "file" | "directory" | "other";
+  open?: boolean;
+} = $props();
+
+let ready = $state(false);
+const src = $derived(materialFileIcon({ name, kind, open }));
+
+onMount(() => {
+  void ensureMaterialFileIconSprite()
+    .then(() => (ready = true))
+    .catch(() => undefined);
+});
+</script>
+
+{#if ready && src}
+  <svg class="size-4 shrink-0" aria-hidden="true">
+    <use href={src}></use>
+  </svg>
+{/if}

--- a/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { FilesystemProjectEntry } from "@nervekit/contracts";
+import {
+  absoluteProjectPath,
+  buildFileExplorerMenu,
+  type FileExplorerMenuActions,
+  type FileExplorerMenuIcons,
+} from "./file-explorer-menu";
+
+const icons = {
+  open: {},
+  copy: {},
+  openDefault: {},
+  newFile: {},
+  reveal: {},
+  newFolder: {},
+  trash: {},
+} as FileExplorerMenuIcons;
+
+const actions: FileExplorerMenuActions = {
+  open() {},
+  createFile() {},
+  createFolder() {},
+  openDefault() {},
+  reveal() {},
+  copyPath() {},
+  copyRelativePath() {},
+  trash() {},
+};
+
+function labels(entry: FilesystemProjectEntry, native: boolean): string[] {
+  return buildFileExplorerMenu(entry, actions, native, icons).flatMap((item) =>
+    "label" in item ? [item.label] : [],
+  );
+}
+
+describe("file explorer menus", () => {
+  it("adds creation only for folders and native actions only on desktop", () => {
+    const file: FilesystemProjectEntry = {
+      name: "index.ts",
+      path: "src/index.ts",
+      kind: "file",
+      symlink: false,
+    };
+    const directory: FilesystemProjectEntry = {
+      name: "src",
+      path: "src",
+      kind: "directory",
+      symlink: false,
+    };
+    assert.deepEqual(labels(file, false), [
+      "Open",
+      "Copy Path",
+      "Copy Relative Path",
+    ]);
+    assert.ok(labels(directory, false).includes("New File"));
+    assert.ok(labels(directory, true).includes("Open in Default Application"));
+    assert.ok(labels(directory, true).includes("Move to Trash"));
+  });
+
+  it("constructs platform display paths without duplicate separators", () => {
+    assert.equal(
+      absoluteProjectPath("/workspace/project/", "src/index.ts", "linux"),
+      "/workspace/project/src/index.ts",
+    );
+    assert.equal(
+      absoluteProjectPath("C:\\workspace\\project\\", "src/index.ts", "win32"),
+      "C:\\workspace\\project\\src\\index.ts",
+    );
+    assert.equal(absoluteProjectPath("/", "etc.txt", "linux"), "/etc.txt");
+  });
+});

--- a/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.ts
@@ -1,0 +1,106 @@
+import type { FilesystemProjectEntry } from "@nervekit/contracts";
+import type {
+  ContextMenuItem,
+  MenuIcon,
+} from "@nervekit/ui-kit/components/ui/context-menu-list";
+
+export type FileExplorerMenuIcons = {
+  open: MenuIcon;
+  copy: MenuIcon;
+  openDefault: MenuIcon;
+  newFile: MenuIcon;
+  reveal: MenuIcon;
+  newFolder: MenuIcon;
+  trash: MenuIcon;
+};
+
+export type FileExplorerMenuActions = {
+  open: () => void;
+  createFile: () => void;
+  createFolder: () => void;
+  openDefault: () => void;
+  reveal: () => void;
+  copyPath: () => void;
+  copyRelativePath: () => void;
+  trash: () => void;
+};
+
+export function absoluteProjectPath(
+  root: string,
+  relativePath: string,
+  platform?: string,
+): string {
+  const separator = platform === "win32" ? "\\" : "/";
+  const normalizedRelative = relativePath
+    .replaceAll("\\", "/")
+    .split("/")
+    .join(separator);
+  const trimmedRoot = root.trim().replace(/[\\/]+$/, "");
+  const base = trimmedRoot || separator;
+  return base.endsWith(separator)
+    ? `${base}${normalizedRelative}`
+    : `${base}${separator}${normalizedRelative}`;
+}
+
+export function buildFileExplorerMenu(
+  entry: FilesystemProjectEntry,
+  actions: FileExplorerMenuActions,
+  nativeActions: boolean,
+  icons: FileExplorerMenuIcons,
+): ContextMenuItem[] {
+  const items: ContextMenuItem[] = [
+    {
+      label: "Open",
+      icon: icons.open,
+      disabled: entry.kind === "directory" && entry.symlink,
+      onSelect: actions.open,
+    },
+  ];
+  if (entry.kind === "directory" && !entry.symlink) {
+    items.push(
+      { type: "separator" },
+      { label: "New File", icon: icons.newFile, onSelect: actions.createFile },
+      {
+        label: "New Folder",
+        icon: icons.newFolder,
+        onSelect: actions.createFolder,
+      },
+    );
+  }
+  if (nativeActions) {
+    items.push(
+      { type: "separator" },
+      {
+        label: "Open in Default Application",
+        icon: icons.openDefault,
+        onSelect: actions.openDefault,
+      },
+      {
+        label: "Reveal in File Manager",
+        icon: icons.reveal,
+        onSelect: actions.reveal,
+      },
+    );
+  }
+  items.push(
+    { type: "separator" },
+    { label: "Copy Path", icon: icons.copy, onSelect: actions.copyPath },
+    {
+      label: "Copy Relative Path",
+      icon: icons.copy,
+      onSelect: actions.copyRelativePath,
+    },
+  );
+  if (nativeActions) {
+    items.push(
+      { type: "separator" },
+      {
+        label: "Move to Trash",
+        icon: icons.trash,
+        destructive: true,
+        onSelect: actions.trash,
+      },
+    );
+  }
+  return items;
+}

--- a/packages/workbench-app/src/lib/features/filesystem/components/material-file-icon-resolver.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/material-file-icon-resolver.ts
@@ -1,0 +1,47 @@
+export type MaterialFileIconData = {
+  file: string;
+  folder: string;
+  folderExpanded: string;
+  fileNames: Record<string, string>;
+  fileExtensions: Record<string, string>;
+  folderNames: Record<string, string>;
+  folderNamesExpanded: Record<string, string>;
+  urls: Record<string, string>;
+};
+
+const sortedExtensions = new WeakMap<MaterialFileIconData, readonly string[]>();
+
+function extensionsFor(data: MaterialFileIconData): readonly string[] {
+  let extensions = sortedExtensions.get(data);
+  if (!extensions) {
+    extensions = Object.keys(data.fileExtensions).sort(
+      (left, right) => right.length - left.length,
+    );
+    sortedExtensions.set(data, extensions);
+  }
+  return extensions;
+}
+
+export function resolveMaterialFileIcon(
+  data: MaterialFileIconData,
+  input: { name: string; kind: "file" | "directory" | "other"; open?: boolean },
+): string {
+  const name = input.name.toLocaleLowerCase();
+  let definition: string | undefined;
+  if (input.kind === "directory") {
+    definition = input.open
+      ? data.folderNamesExpanded[name]
+      : data.folderNames[name];
+    definition ??= input.open ? data.folderExpanded : data.folder;
+  } else {
+    definition = data.fileNames[name];
+    if (!definition) {
+      const extension = extensionsFor(data).find((candidate) =>
+        name.endsWith(`.${candidate}`),
+      );
+      if (extension) definition = data.fileExtensions[extension];
+    }
+    definition ??= data.file;
+  }
+  return data.urls[definition] ?? data.urls[data.file] ?? "";
+}

--- a/packages/workbench-app/src/lib/features/filesystem/components/material-file-icons.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/material-file-icons.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  resolveMaterialFileIcon,
+  type MaterialFileIconData,
+} from "./material-file-icon-resolver";
+
+const data: MaterialFileIconData = {
+  file: "file",
+  folder: "folder",
+  folderExpanded: "folder-open",
+  fileNames: { "package.json": "node" },
+  fileExtensions: { ts: "typescript", "d.ts": "typescript-def" },
+  folderNames: { src: "folder-src" },
+  folderNamesExpanded: { src: "folder-src-open" },
+  urls: {
+    file: "/file.svg",
+    folder: "/folder.svg",
+    "folder-open": "/folder-open.svg",
+    node: "/node.svg",
+    typescript: "/ts.svg",
+    "typescript-def": "/dts.svg",
+    "folder-src": "/src.svg",
+    "folder-src-open": "/src-open.svg",
+  },
+};
+
+describe("Material file icon resolution", () => {
+  it("prefers exact names and compound extensions case-insensitively", () => {
+    assert.equal(
+      resolveMaterialFileIcon(data, { name: "PACKAGE.JSON", kind: "file" }),
+      "/node.svg",
+    );
+    assert.equal(
+      resolveMaterialFileIcon(data, { name: "types.D.TS", kind: "file" }),
+      "/dts.svg",
+    );
+  });
+
+  it("uses named open folders and stable fallbacks", () => {
+    assert.equal(
+      resolveMaterialFileIcon(data, {
+        name: "SRC",
+        kind: "directory",
+        open: true,
+      }),
+      "/src-open.svg",
+    );
+    assert.equal(
+      resolveMaterialFileIcon(data, { name: "unknown", kind: "file" }),
+      "/file.svg",
+    );
+    assert.equal(
+      resolveMaterialFileIcon(data, {
+        name: "unknown",
+        kind: "directory",
+        open: true,
+      }),
+      "/folder-open.svg",
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/features/filesystem/components/material-file-icons.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/material-file-icons.ts
@@ -1,0 +1,40 @@
+import { materialIconThemeData } from "virtual:material-icon-theme";
+import { resolveMaterialFileIcon } from "./material-file-icon-resolver";
+
+let spritePromise: Promise<void> | undefined;
+
+export function ensureMaterialFileIconSprite(): Promise<void> {
+  if (typeof document === "undefined") return Promise.resolve();
+  const existing = document.getElementById("nerve-material-file-icons");
+  if (existing) return Promise.resolve();
+  spritePromise ??= fetch(materialIconThemeData.spriteUrl)
+    .then(async (response) => {
+      if (!response.ok)
+        throw new Error(`Could not load file icons (${response.status}).`);
+      const parsed = new DOMParser().parseFromString(
+        await response.text(),
+        "image/svg+xml",
+      );
+      const source = parsed.documentElement;
+      if (source.localName !== "svg")
+        throw new Error("Material file icon sprite is invalid.");
+      const sprite = document.importNode(source, true);
+      sprite.id = "nerve-material-file-icons";
+      sprite.setAttribute("hidden", "");
+      sprite.setAttribute("aria-hidden", "true");
+      document.body.append(sprite);
+    })
+    .catch((error) => {
+      spritePromise = undefined;
+      throw error;
+    });
+  return spritePromise;
+}
+
+export function materialFileIcon(input: {
+  name: string;
+  kind: "file" | "directory" | "other";
+  open?: boolean;
+}): string {
+  return resolveMaterialFileIcon(materialIconThemeData, input);
+}

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-actions.svelte.ts
@@ -160,6 +160,19 @@ async function runBounded(tasks: Array<() => Promise<void>>): Promise<void> {
   );
 }
 
+export function discardFileExplorerPath(projectId: string, path: string): void {
+  const project = ensureFileExplorerProject(projectId);
+  for (const directoryPath of Object.keys(project.directories)) {
+    if (directoryPath === path || directoryPath.startsWith(`${path}/`))
+      delete project.directories[directoryPath];
+  }
+  const nodeId = fileExplorerEntryNodeId(projectId, path);
+  for (const expandedId of project.expandedIds) {
+    if (expandedId === nodeId || expandedId.startsWith(`${nodeId}/`))
+      project.expandedIds.delete(expandedId);
+  }
+}
+
 export async function refreshFileExplorerProject(
   projectId: string,
 ): Promise<void> {

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { GitProjectFileStatus } from "@nervekit/contracts";
+import {
+  fileGitDecoration,
+  indexFileTreeGitDecorations,
+  indexProjectFileStatuses,
+} from "./file-git-status";
+
+function status(
+  patch: Partial<GitProjectFileStatus> = {},
+): GitProjectFileStatus {
+  return {
+    repo: ".",
+    path: "src/index.ts",
+    index: " ",
+    worktree: " ",
+    staged: false,
+    untracked: false,
+    ...patch,
+  };
+}
+
+describe("file Git decorations", () => {
+  it("indexes status by project-relative path", () => {
+    const file = status();
+    assert.equal(indexProjectFileStatuses([file]).get(file.path), file);
+  });
+
+  it("aggregates the highest-priority color into parent folders", () => {
+    const decorations = indexFileTreeGitDecorations([
+      status({ path: "src/new.ts", untracked: true }),
+      status({ path: "src/nested/changed.ts", worktree: "M" }),
+    ]);
+    assert.equal(decorations.get("src/new.ts")?.tone, "success");
+    assert.equal(decorations.get("src/nested")?.tone, "warning");
+    assert.equal(decorations.get("src")?.tone, "warning");
+  });
+
+  it("uses semantic labels and precedence", () => {
+    assert.deepEqual(fileGitDecoration(status({ untracked: true })), {
+      label: "U",
+      title: "Untracked",
+      class: "text-success",
+      tone: "success",
+    });
+    assert.equal(fileGitDecoration(status({ index: "A" }))?.label, "A");
+    assert.equal(fileGitDecoration(status({ worktree: "M" }))?.label, "M");
+    assert.equal(fileGitDecoration(status({ index: "R" }))?.label, "R");
+    assert.equal(fileGitDecoration(status({ worktree: "D" }))?.label, "D");
+    assert.equal(
+      fileGitDecoration(status({ index: "U", worktree: "M" }))?.label,
+      "!",
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { GitProjectFileStatus } from "@nervekit/contracts";
 import {
   fileGitDecoration,
+  fileTreeGitDecoration,
   indexFileTreeGitDecorations,
   indexProjectFileStatuses,
 } from "./file-git-status";
@@ -35,6 +36,21 @@ describe("file Git decorations", () => {
     assert.equal(decorations.get("src/new.ts")?.tone, "success");
     assert.equal(decorations.get("src/nested")?.tone, "warning");
     assert.equal(decorations.get("src")?.tone, "warning");
+  });
+
+  it("mutes ignored entries, their descendants, and Git metadata", () => {
+    const decorations = indexFileTreeGitDecorations([
+      status({ path: "release", index: "!", worktree: "!" }),
+    ]);
+    assert.equal(
+      fileTreeGitDecoration(decorations, "release/npm/archive.tgz")?.tone,
+      "muted",
+    );
+    assert.equal(fileTreeGitDecoration(decorations, ".git")?.tone, "muted");
+    assert.equal(
+      fileTreeGitDecoration(decorations, ".github/workflows/ci.yml"),
+      undefined,
+    );
   });
 
   it("uses semantic labels and precedence", () => {

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.ts
@@ -1,6 +1,11 @@
 import type { GitProjectFileStatus } from "@nervekit/contracts";
 
-export type FileGitTone = "destructive" | "warning" | "success" | "info";
+export type FileGitTone =
+  | "destructive"
+  | "warning"
+  | "success"
+  | "info"
+  | "muted";
 
 export type FileGitDecoration = {
   label: string;
@@ -22,6 +27,7 @@ const tonePriority: Record<FileGitTone, number> = {
   warning: 3,
   success: 2,
   info: 1,
+  muted: 0,
 };
 
 export function indexFileTreeGitDecorations(
@@ -50,11 +56,40 @@ export function indexFileTreeGitDecorations(
   return decorations;
 }
 
+export function fileTreeGitDecoration(
+  decorations: ReadonlyMap<string, FileGitDecoration>,
+  path: string,
+): FileGitDecoration | undefined {
+  const exact = decorations.get(path);
+  if (exact) return exact;
+  if (path === ".git" || path.startsWith(".git/"))
+    return {
+      label: "",
+      title: "Git metadata",
+      class: "text-muted-foreground",
+      tone: "muted",
+    };
+  let directory = path.slice(0, path.lastIndexOf("/"));
+  while (directory) {
+    const inherited = decorations.get(directory);
+    if (inherited?.tone === "muted") return inherited;
+    directory = directory.slice(0, directory.lastIndexOf("/"));
+  }
+  return undefined;
+}
+
 export function fileGitDecoration(
   file: GitProjectFileStatus | undefined,
 ): FileGitDecoration | undefined {
   if (!file) return undefined;
   const { index, worktree } = file;
+  if (index === "!" || worktree === "!")
+    return {
+      label: "",
+      title: "Ignored by Git",
+      class: "text-muted-foreground",
+      tone: "muted",
+    };
   const conflicted =
     conflictCodes.has(index) ||
     conflictCodes.has(worktree) ||

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-git-status.ts
@@ -1,0 +1,107 @@
+import type { GitProjectFileStatus } from "@nervekit/contracts";
+
+export type FileGitTone = "destructive" | "warning" | "success" | "info";
+
+export type FileGitDecoration = {
+  label: string;
+  title: string;
+  class: string;
+  tone: FileGitTone;
+};
+
+const conflictCodes = new Set(["U"]);
+
+export function indexProjectFileStatuses(
+  files: readonly GitProjectFileStatus[],
+): ReadonlyMap<string, GitProjectFileStatus> {
+  return new Map(files.map((file) => [file.path, file]));
+}
+
+const tonePriority: Record<FileGitTone, number> = {
+  destructive: 4,
+  warning: 3,
+  success: 2,
+  info: 1,
+};
+
+export function indexFileTreeGitDecorations(
+  files: readonly GitProjectFileStatus[],
+): ReadonlyMap<string, FileGitDecoration> {
+  const decorations = new Map<string, FileGitDecoration>();
+  for (const file of files) {
+    const decoration = fileGitDecoration(file);
+    if (!decoration) continue;
+    decorations.set(file.path, decoration);
+    let directory = file.path.slice(0, file.path.lastIndexOf("/"));
+    while (directory) {
+      const current = decorations.get(directory);
+      if (
+        !current ||
+        tonePriority[decoration.tone] > tonePriority[current.tone]
+      ) {
+        decorations.set(directory, {
+          ...decoration,
+          title: `Contains ${decoration.title.toLocaleLowerCase()} files`,
+        });
+      }
+      directory = directory.slice(0, directory.lastIndexOf("/"));
+    }
+  }
+  return decorations;
+}
+
+export function fileGitDecoration(
+  file: GitProjectFileStatus | undefined,
+): FileGitDecoration | undefined {
+  if (!file) return undefined;
+  const { index, worktree } = file;
+  const conflicted =
+    conflictCodes.has(index) ||
+    conflictCodes.has(worktree) ||
+    (index === "A" && worktree === "A") ||
+    (index === "D" && worktree !== " ") ||
+    (worktree === "D" && index !== " ");
+  if (conflicted)
+    return {
+      label: "!",
+      title: "Git conflict",
+      class: "text-destructive",
+      tone: "destructive",
+    };
+  if (index === "D" || worktree === "D")
+    return {
+      label: "D",
+      title: "Deleted",
+      class: "text-destructive",
+      tone: "destructive",
+    };
+  if (file.untracked)
+    return {
+      label: "U",
+      title: "Untracked",
+      class: "text-success",
+      tone: "success",
+    };
+  if (index === "A" || worktree === "A")
+    return {
+      label: "A",
+      title: "Added",
+      class: "text-success",
+      tone: "success",
+    };
+  if (index === "R" || worktree === "R" || index === "C" || worktree === "C")
+    return {
+      label: "R",
+      title: "Renamed",
+      class: "text-info",
+      tone: "info",
+    };
+  if (index === "M" || worktree === "M")
+    return {
+      label: "M",
+      title: "Modified",
+      class: "text-warning",
+      tone: "warning",
+    };
+  return undefined;
+}

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-tabs.svelte.ts
@@ -10,10 +10,12 @@ import {
   addCenterTab,
   nextCenterTabAfterClose,
   removeCenterTab,
+  replaceOpenCenterTabs,
   selectCenterTab,
   setActiveCenterTab,
 } from "$lib/features/workspace/state/center-tabs.svelte";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import { SvelteSet } from "svelte/reactivity";
 
 function encodeFileTabId(projectId: string, path: string): string {
   return `${projectId}:${encodeURIComponent(path)}`;
@@ -102,6 +104,35 @@ export function toggleFileLineWrap(id: string) {
   const view = fileState.fileViews[fileViewKey(id)];
   if (!view) return;
   view.wrapLines = !view.wrapLines;
+}
+
+export function closeFileTabsAtPath(input: {
+  projectId: string;
+  path: string;
+  descendants?: boolean;
+}): void {
+  const matchingIds = new SvelteSet(
+    Object.values(fileState.fileViews)
+      .filter((view) => {
+        const relativePath = view.content?.relativePath ?? view.path;
+        return (
+          view.projectId === input.projectId &&
+          (relativePath === input.path ||
+            (input.descendants && relativePath.startsWith(`${input.path}/`)))
+        );
+      })
+      .map((view) => view.id),
+  );
+  if (matchingIds.size === 0) return;
+
+  const active = workspaceState.activeCenterTab;
+  const closesActive = active?.kind === "file" && matchingIds.has(active.id);
+  const remaining = workspaceState.openCenterTabs.filter(
+    (tab) => tab.kind !== "file" || !matchingIds.has(tab.id),
+  );
+  for (const id of matchingIds) delete fileState.fileViews[fileViewKey(id)];
+  replaceOpenCenterTabs(remaining);
+  if (closesActive) void selectCenterTab(remaining.at(-1));
 }
 
 export function closeFileTab(id: string) {

--- a/packages/workbench-app/src/lib/features/git/api/git.api.ts
+++ b/packages/workbench-app/src/lib/features/git/api/git.api.ts
@@ -20,6 +20,7 @@ import type {
   GithubStatusResponse,
   GitMutationResponse,
   GitOverviewResponse,
+  GitProjectFileStatusResponse,
 } from "@nervekit/contracts";
 import { protocolRequest } from "@nervekit/protocol";
 
@@ -43,6 +44,13 @@ export async function getGitOverview(
       repo,
     })
   ).result;
+}
+
+export async function getProjectGitFileStatus(
+  projectId: string,
+): Promise<GitProjectFileStatusResponse> {
+  return (await protocolRequest("git.project.files.status.get", { projectId }))
+    .result;
 }
 
 export async function listGitBranches(

--- a/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
@@ -63,7 +63,7 @@ let {
   metaMono?: boolean;
   title?: string;
   mono?: boolean;
-  tone?: "default" | "muted" | "destructive";
+  tone?: "default" | "muted" | "destructive" | "success" | "warning" | "info";
   /** Indentation steps for tree-like lists. */
   indent?: number;
   /** Drops the base row inset so the row aligns with the panel's outer padding. */
@@ -119,9 +119,15 @@ const rowStyle = $derived(
 const toneClass = $derived(
   tone === "destructive"
     ? "text-destructive"
-    : tone === "muted"
-      ? "text-muted-foreground"
-      : "text-foreground",
+    : tone === "success"
+      ? "text-success"
+      : tone === "warning"
+        ? "text-warning"
+        : tone === "info"
+          ? "text-info"
+          : tone === "muted"
+            ? "text-muted-foreground"
+            : "text-foreground",
 );
 </script>
 

--- a/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
@@ -7,6 +7,7 @@ import {
   VirtualScroller,
   type VirtualScrollerController,
 } from "@nervekit/ui-kit/components/ui/virtual-list";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
 import { cn } from "@nervekit/ui-kit/core/utils";
 import { tick, type Snippet } from "svelte";
 import { SvelteSet } from "svelte/reactivity";
@@ -46,6 +47,16 @@ type Props = {
    */
   indentItems?: boolean;
   getItemSelected?: (item: T) => boolean;
+  getItemTone?: (
+    item: T,
+  ) =>
+    | "default"
+    | "muted"
+    | "destructive"
+    | "success"
+    | "warning"
+    | "info"
+    | undefined;
   /** Controlled expansion state. Node ids are the ids produced by the builders. */
   expandedIds?: ReadonlySet<string>;
   /** Uncontrolled initial expansion policy. Existing callers default to all. */
@@ -53,6 +64,8 @@ type Props = {
   onItemExpansionChange?: (item: T, expanded: boolean) => void;
   /** Opt into a single fixed-height virtualized viewport for large trees. */
   virtualized?: boolean;
+  /** Hide item disclosure arrows when open/closed leading icons carry state. */
+  showDisclosure?: boolean;
   itemMono?: boolean;
   /** Renders item descriptions on a second line instead of inline. */
   itemStacked?: boolean;
@@ -66,6 +79,7 @@ type Props = {
   itemLabelTrailing?: Snippet<[T]>;
   itemBadges?: Snippet<[T]>;
   itemActions?: Snippet<[T]>;
+  getItemMenuItems?: (item: T) => ContextMenuItem[];
   class?: string;
 };
 
@@ -81,10 +95,12 @@ let {
   itemClass,
   indentItems = true,
   getItemSelected,
+  getItemTone,
   expandedIds,
   defaultExpanded = "all",
   onItemExpansionChange,
   virtualized = false,
+  showDisclosure = true,
   itemMono = false,
   itemStacked = false,
   onItemActivate,
@@ -92,6 +108,7 @@ let {
   itemLabelTrailing,
   itemBadges,
   itemActions,
+  getItemMenuItems,
   class: className,
 }: Props = $props();
 
@@ -112,9 +129,9 @@ const expanded = $derived.by(() => {
 const rows = $derived(visiblePanelTreeRows(nodes, expanded));
 /** Reserve the chevron column so leaf rows align with expandable siblings. */
 const hasExpandableItems = $derived(
-  rows.some((row) => row.node.kind === "item" && isExpandable(row.node)),
+  showDisclosure &&
+    rows.some((row) => row.node.kind === "item" && isExpandable(row.node)),
 );
-
 /** Card grouping: a root row opens a surface that its descendants continue. */
 function cardClass(index: number): string | undefined {
   if (itemVariant !== "card") return undefined;
@@ -273,7 +290,7 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
     />
   {:else}
     {#snippet leafLeading()}
-      {#if expandable}
+      {#if showDisclosure && expandable}
         {#if open}
           <ChevronDown class="size-3" aria-hidden="true" />
         {:else}
@@ -300,14 +317,17 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       metaMono={itemMetaMono}
       title={getItemTitle?.(node.value)}
       selected={getItemSelected?.(node.value) ?? false}
+      tone={getItemTone?.(node.value)}
       mono={itemMono}
       stacked={itemStacked}
-      leading={itemLeading || expandable || hasExpandableItems
+      leading={itemLeading ||
+      (showDisclosure && (expandable || hasExpandableItems))
         ? leafLeading
         : undefined}
       labelTrailing={itemLabelTrailing ? leafLabelTrailing : undefined}
       badges={itemBadges ? leafBadges : undefined}
       actions={itemActions ? leafActions : undefined}
+      menuItems={getItemMenuItems?.(node.value)}
       dense
       alwaysShowActions
       class={cn(cardClass(rowIndex), itemClass)}

--- a/packages/workbench-app/src/virtual-material-icon-theme.d.ts
+++ b/packages/workbench-app/src/virtual-material-icon-theme.d.ts
@@ -1,0 +1,15 @@
+declare module "virtual:material-icon-theme" {
+  export type MaterialIconThemeData = {
+    spriteUrl: string;
+    file: string;
+    folder: string;
+    folderExpanded: string;
+    fileNames: Record<string, string>;
+    fileExtensions: Record<string, string>;
+    folderNames: Record<string, string>;
+    folderNamesExpanded: Record<string, string>;
+    urls: Record<string, string>;
+  };
+
+  export const materialIconThemeData: MaterialIconThemeData;
+}

--- a/packages/workbench-app/vite-material-icon-theme.ts
+++ b/packages/workbench-app/vite-material-icon-theme.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
+
+const virtualId = "virtual:material-icon-theme";
+const resolvedVirtualId = `\0${virtualId}`;
+const developmentSpriteUrl = "/@nerve-material-file-icons.svg";
+
+type MaterialIconManifest = {
+  iconDefinitions: Record<string, { iconPath: string }>;
+  file: string;
+  folder: string;
+  folderExpanded: string;
+  fileNames: Record<string, string>;
+  fileExtensions: Record<string, string>;
+  folderNames: Record<string, string>;
+  folderNamesExpanded: Record<string, string>;
+};
+
+function iconSymbol(svg: string, index: number): string {
+  const opening = svg.match(/<svg\b([^>]*)>/i);
+  const closingIndex = svg.toLocaleLowerCase().lastIndexOf("</svg>");
+  if (!opening || opening.index === undefined || closingIndex < 0)
+    throw new Error(`Material icon ${index} is not a valid SVG.`);
+  const viewBox = opening[1]?.match(/viewBox="([^"]+)"/i)?.[1] ?? "0 0 16 16";
+  let body = svg.slice(opening.index + opening[0].length, closingIndex);
+  const ids = [...body.matchAll(/\bid="([^"]+)"/g)].map((entry) => entry[1]);
+  for (const id of ids) {
+    if (!id) continue;
+    const scoped = `mit-${index}-${id}`;
+    body = body.replaceAll(`id="${id}"`, `id="${scoped}"`);
+    body = body.replaceAll(`#${id}`, `#${scoped}`);
+  }
+  return `<symbol id="mit-${index}" viewBox="${viewBox}">${body}</symbol>`;
+}
+
+export function materialIconThemePlugin(): Plugin {
+  const require = createRequire(import.meta.url);
+  const packageJson = require.resolve("material-icon-theme/package.json");
+  const packageDir = path.dirname(packageJson);
+  const manifestPath = path.join(packageDir, "dist", "material-icons.json");
+  const manifest = JSON.parse(
+    readFileSync(manifestPath, "utf8"),
+  ) as MaterialIconManifest;
+  const referenced = new Set([
+    manifest.file,
+    manifest.folder,
+    manifest.folderExpanded,
+    ...Object.values(manifest.fileNames),
+    ...Object.values(manifest.fileExtensions),
+    ...Object.values(manifest.folderNames),
+    ...Object.values(manifest.folderNamesExpanded),
+  ]);
+  const definitions = [...referenced]
+    .filter((id) => manifest.iconDefinitions[id])
+    .sort();
+  const sprite = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs>${definitions
+    .map((definition, index) => {
+      const iconPath = path.resolve(
+        path.dirname(manifestPath),
+        manifest.iconDefinitions[definition]!.iconPath,
+      );
+      return iconSymbol(readFileSync(iconPath, "utf8"), index);
+    })
+    .join("")}</defs></svg>`;
+  let config!: ResolvedConfig;
+
+  return {
+    name: "nerve-material-icon-theme",
+    configResolved(resolved) {
+      config = resolved;
+    },
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use(developmentSpriteUrl, (_request, response) => {
+        response.setHeader("Content-Type", "image/svg+xml");
+        response.setHeader("Cache-Control", "no-cache");
+        response.end(sprite);
+      });
+    },
+    resolveId(id) {
+      return id === virtualId ? resolvedVirtualId : undefined;
+    },
+    load(id) {
+      if (id !== resolvedVirtualId) return undefined;
+      const spriteExpression =
+        config.command === "build"
+          ? `import.meta.ROLLUP_FILE_URL_${this.emitFile({
+              type: "asset",
+              name: "material-file-icons.svg",
+              source: sprite,
+            })}`
+          : JSON.stringify(developmentSpriteUrl);
+      const serialized = JSON.stringify({
+        file: manifest.file,
+        folder: manifest.folder,
+        folderExpanded: manifest.folderExpanded,
+        fileNames: manifest.fileNames,
+        fileExtensions: manifest.fileExtensions,
+        folderNames: manifest.folderNames,
+        folderNamesExpanded: manifest.folderNamesExpanded,
+      });
+      return [
+        `const spriteUrl = ${spriteExpression};`,
+        `const definitions = ${JSON.stringify(definitions)};`,
+        "const urls = Object.fromEntries(definitions.map((definition, index) => [definition, `#mit-${index}`]));",
+        `export const materialIconThemeData = { ...${serialized}, spriteUrl, urls };`,
+      ].join("\n");
+    },
+  };
+}

--- a/packages/workbench-app/vite.config.ts
+++ b/packages/workbench-app/vite.config.ts
@@ -6,6 +6,7 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, loadEnv } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
+import { materialIconThemePlugin } from "./vite-material-icon-theme";
 
 function nerveHome(env: Record<string, string>): string {
   return env.NERVE_HOME?.trim() || path.join(homedir(), ".nerve");
@@ -60,6 +61,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [
+      materialIconThemePlugin(),
       svelte(),
       tailwindcss(),
       VitePWA({
@@ -101,6 +103,10 @@ export default defineConfig(({ mode }) => {
         },
         workbox: {
           globPatterns: ["**/*.{js,css,html,svg,png,webp,mp3,woff2,json}"],
+          // The complete file-icon sprite is emitted locally but loaded on
+          // demand rather than turning service-worker installation into a
+          // multi-megabyte prerequisite.
+          globIgnores: ["**/material-file-icons-*.svg"],
           maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
           cleanupOutdatedCaches: true,
           // Serve the cached app shell for in-app navigations (fast + offline),

--- a/packages/workbench-server/src/domains/filesystem/filesystem.service.ts
+++ b/packages/workbench-server/src/domains/filesystem/filesystem.service.ts
@@ -27,6 +27,7 @@ import {
   type FilesystemSignal,
   filesystemFileQuerySchema,
   filesystemProjectEntriesQuerySchema,
+  filesystemProjectEntryCreateRequestSchema,
 } from "@nervekit/contracts";
 
 async function pathExists(path: string): Promise<boolean> {
@@ -284,6 +285,58 @@ async function classifyProjectEntry(
     // Broken and inaccessible links stay visible as non-browsable entries.
   }
   return { name: entry.name, path, kind, symlink: true };
+}
+
+function normalizeProjectEntryName(rawName: string): string {
+  const name = rawName.trim();
+  if (
+    !name ||
+    name === "." ||
+    name === ".." ||
+    name.includes("\0") ||
+    name.includes("/") ||
+    name.includes("\\")
+  )
+    throw new Error("Project entry name must be a single path segment.");
+  return name;
+}
+
+export async function createProjectEntry(
+  input: unknown,
+  getProjectDirectory: (projectId: string) => string,
+) {
+  const request = filesystemProjectEntryCreateRequestSchema.parse(input);
+  const parentPath = normalizeProjectRelativeDirectory(request.parentPath);
+  const name = normalizeProjectEntryName(request.name);
+  const root = await realpath(resolve(getProjectDirectory(request.projectId)));
+  const parent = resolve(root, parentPath);
+  if (!isInside(root, parent))
+    throw new Error("Project directory path escapes the project root.");
+
+  const resolvedParent = await realpath(parent);
+  if (!isInside(root, resolvedParent) || resolvedParent !== parent)
+    throw new Error("Project entry parent cannot traverse a symbolic link.");
+  const parentInfo = await stat(resolvedParent);
+  if (!parentInfo.isDirectory())
+    throw new Error(`${parentPath || "."} is not a directory.`);
+
+  const target = join(resolvedParent, name);
+  if (request.kind === "file") {
+    const handle = await open(target, "wx");
+    await handle.close();
+  } else {
+    await mkdir(target);
+  }
+
+  const path = parentPath ? `${parentPath}/${name}` : name;
+  return {
+    entry: {
+      name,
+      path,
+      kind: request.kind,
+      symlink: false,
+    } satisfies FilesystemProjectEntry,
+  };
 }
 
 export async function projectDirectoryEntries(

--- a/packages/workbench-server/src/protocol/method-handlers/git-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/git-method-handlers.ts
@@ -6,6 +6,8 @@ export const gitMethodHandlers = defineWorkbenchMethodHandlers({
     state.registry.git.discoverRepos(params.projectId),
   "git.overview.get": (state, params) =>
     state.registry.git.overview(params.projectId, repo(params)),
+  "git.project.files.status.get": (state, params) =>
+    state.registry.git.projectFileStatus(params.projectId),
   "git.branches.list": (state, params) =>
     state.registry.git.listBranches(params.projectId, repo(params)),
   "git.branch.create": (state, params) =>

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -6,6 +6,7 @@ import {
 } from "../../domains/auth/index.js";
 import { listAvailableSkills } from "../../domains/agents/prompting/resource-loader.js";
 import {
+  createProjectEntry,
   directoryListing,
   projectDirectoryEntries,
 } from "../../domains/filesystem/filesystem.service.js";
@@ -130,6 +131,11 @@ export const platformMethodHandlers = defineWorkbenchMethodHandlers({
     directoryListing(params?.path, params?.showHidden as boolean | undefined),
   "filesystem.project.entries.list": (state, params) =>
     projectDirectoryEntries(
+      params,
+      (projectId) => state.registry.getProject(projectId).dir,
+    ),
+  "filesystem.project.entries.create": (state, params) =>
+    createProjectEntry(
       params,
       (projectId) => state.registry.getProject(projectId).dir,
     ),

--- a/packages/workbench-server/test/filesystem.service.test.ts
+++ b/packages/workbench-server/test/filesystem.service.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import {
+  createProjectEntry,
   directoryListing,
   fileContent,
   normalizeIncomingFilePath,
@@ -45,6 +46,92 @@ describe("filesystem application service", () => {
       all.entries.map((entry) => entry.name),
       [".git", ".hidden", "visible"],
     );
+  });
+
+  it("creates project files and folders without overwriting or escaping", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-project-create-"));
+    const outside = await mkdtemp(join(tmpdir(), "nerve-project-outside-"));
+    try {
+      await mkdir(join(root, "src"));
+      await symlink(outside, join(root, "linked"), "dir");
+      const lookup = () => root;
+
+      const file = await createProjectEntry(
+        {
+          projectId: "project",
+          parentPath: "src",
+          name: "index.ts",
+          kind: "file",
+        },
+        lookup,
+      );
+      assert.deepEqual(file.entry, {
+        name: "index.ts",
+        path: "src/index.ts",
+        kind: "file",
+        symlink: false,
+      });
+      const folder = await createProjectEntry(
+        { projectId: "project", name: "docs", kind: "directory" },
+        lookup,
+      );
+      assert.equal(folder.entry.path, "docs");
+
+      await assert.rejects(
+        createProjectEntry(
+          { projectId: "project", name: "docs", kind: "directory" },
+          lookup,
+        ),
+      );
+      for (const name of ["../escape", "nested/name", "nested\\name", "."]) {
+        await assert.rejects(
+          createProjectEntry(
+            { projectId: "project", name, kind: "file" },
+            lookup,
+          ),
+          /single path segment/,
+        );
+      }
+      await assert.rejects(
+        createProjectEntry(
+          {
+            projectId: "project",
+            parentPath: "../outside",
+            name: "escape.txt",
+            kind: "file",
+          },
+          lookup,
+        ),
+      );
+      await assert.rejects(
+        createProjectEntry(
+          {
+            projectId: "project",
+            parentPath: "missing",
+            name: "file.txt",
+            kind: "file",
+          },
+          lookup,
+        ),
+      );
+      await assert.rejects(
+        createProjectEntry(
+          {
+            projectId: "project",
+            parentPath: "linked",
+            name: "escape.txt",
+            kind: "file",
+          },
+          lookup,
+        ),
+        /symbolic link/,
+      );
+    } finally {
+      await Promise.all([
+        rm(root, { recursive: true, force: true }),
+        rm(outside, { recursive: true, force: true }),
+      ]);
+    }
   });
 
   it("lists all project entries lazily with stable pagination", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,9 @@ importers:
       bits-ui:
         specifier: ^2.18.1
         version: 2.18.1(@internationalized/date@3.12.2)(svelte@5.56.3(@typescript-eslint/types@8.63.0))
+      material-icon-theme:
+        specifier: ^5.37.0
+        version: 5.37.0
       svelte:
         specifier: 5.56.3
         version: 5.56.3(@typescript-eslint/types@8.63.0)
@@ -3299,6 +3302,9 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  chroma-js@3.2.0:
+    resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
+
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
 
@@ -4633,6 +4639,10 @@ packages:
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
+
+  material-icon-theme@5.37.0:
+    resolution: {integrity: sha512-/F5llOVU0DZ88V+wmPlEbBqi8FochPg5XaJ7zqVzGCTTygeFnpIpdVQQTRElEnHyxSWRMfF0wBbOqwFKnujFLA==}
+    engines: {vscode: ^1.55.0}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -9903,6 +9913,8 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  chroma-js@3.2.0: {}
+
   chromium-pickle-js@0.2.0: {}
 
   ci-info@4.3.1: {}
@@ -11479,6 +11491,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 4.0.0
     optional: true
+
+  material-icon-theme@5.37.0:
+    dependencies:
+      chroma-js: 3.2.0
+      fast-deep-equal: 3.1.3
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## Summary

Enriches the project file explorer with modern file icons, git working-tree status, and full entry actions.

### What changed

- **Material file icons** — files and folders now render Material Design icons resolved by file type. The icon sprite is generated at build time and loaded on demand (excluded from the service-worker pre-cache so installs stay lean).
- **Git status decorations** — the tree shows the working-tree state per file (`M`/`A`/`D`/`U`, renames) with themed tones, rolled up to directories, and conflict highlighting. Powered by a new `git.project.files.status.get` protocol operation that walks nested repos via `git status --porcelain=v2`.
- **Context menu** — right-click on any file/folder to:
  - open the file (or expand the folder)
  - reveal in the OS file manager
  - move to trash
  - copy the relative or absolute project path
  - create a new file or folder
- **Create entries** — new `filesystem.project.entries.create` operation with server-side validation (single path segment, no traversal, no symlink escape) plus a create dialog in the UI.
- **Desktop IPC** — new `desktop.files.{openProjectEntry,revealProjectEntry,trashProjectEntry}` handlers backed by a guarded `resolveProjectEntryPath` resolver; open tabs are closed when an entry is trashed.

### Validation

- New unit tests: porcelain v2 status parsing, git file decorations, material icon resolution, explorer menu, and project entry path resolution.
- 36 files changed (+1,563 / −24).

### Notes

- `material-icon-theme` added as a dependency of `workbench-app`.
