### PR TITLE
fix: stop failing runs when model content exceeds bounded event caps

### DIFF
--- a/packages/contracts/src/domains/agents/agent.events.schema.ts
+++ b/packages/contracts/src/domains/agents/agent.events.schema.ts
@@ -134,7 +134,6 @@ export const agentEventDefinitions = [
   subagentTranscriptEvent(
     "agent.subagent_transcript.content.done",
     transcriptContentSchema.extend({
-      finalText: z.string().max(PUBLIC_EVENT_MAX_STRING_CHARS).optional(),
       redacted: z.boolean().optional(),
     }),
   ),

--- a/packages/contracts/src/domains/conversations/conversation-runtime.events.schema.ts
+++ b/packages/contracts/src/domains/conversations/conversation-runtime.events.schema.ts
@@ -1,14 +1,26 @@
-import { definePublicEvent } from "../events/event-definition.schema.js";
+import {
+  defineContentEvent,
+  definePublicEvent,
+} from "../events/event-definition.schema.js";
 import { conversationEventPayloadSchemas } from "./conversation.schema.js";
 
 export const conversationRuntimeEventDefinitions = Object.entries(
   conversationEventPayloadSchemas,
 ).map(([name, payloadSchema]) =>
-  definePublicEvent(name, payloadSchema, {
-    delivery: "sequenced",
-    supersedable: isBufferedConversationEvent(name),
-    scope: conversationEventScope(name),
-  }),
+  // conversation.entry.appended carries the full authoritative entry
+  // (message text, thinking blocks), so it is validated with the
+  // content-sized guard instead of the strict per-string bounded guard.
+  name === "conversation.entry.appended"
+    ? defineContentEvent(name, payloadSchema, {
+        delivery: "sequenced",
+        supersedable: isBufferedConversationEvent(name),
+        scope: conversationEventScope(name),
+      })
+    : definePublicEvent(name, payloadSchema, {
+        delivery: "sequenced",
+        supersedable: isBufferedConversationEvent(name),
+        scope: conversationEventScope(name),
+      }),
 );
 
 function isBufferedConversationEvent(name: string): boolean {

--- a/packages/contracts/src/domains/conversations/conversation.schema.ts
+++ b/packages/contracts/src/domains/conversations/conversation.schema.ts
@@ -298,7 +298,6 @@ export interface ConversationLiveContentDoneData {
   contentBlockId: string;
   contentIndex: number;
   kind: AgentMessageContentKind;
-  finalText?: string;
   redacted?: boolean;
 }
 
@@ -891,7 +890,6 @@ const conversationLiveContentDeltaDataSchema =
 const conversationLiveContentDoneDataSchema =
   conversationLiveContentBaseDataSchema.extend({
     kind: agentMessageContentKindSchema,
-    finalText: z.string().optional(),
     redacted: z.boolean().optional(),
   });
 

--- a/packages/contracts/src/domains/events/bounded-public-data.schema.ts
+++ b/packages/contracts/src/domains/events/bounded-public-data.schema.ts
@@ -5,11 +5,21 @@ const secretLikeKey =
 const credentialUrl = /^[a-z][a-z0-9+.-]*:\/\/[^/\s]*@/i;
 export const PUBLIC_EVENT_MAX_BYTES = 64 * 1024;
 export const PUBLIC_EVENT_MAX_STRING_CHARS = 16_384;
+/**
+ * Total byte ceiling for events whose payloads carry authoritative content
+ * (e.g. conversation entries with message text and thinking blocks). Content
+ * is unbounded by nature, so such payloads keep the overall byte bound for
+ * broadcast safety but drop the per-string length cap.
+ */
+export const PUBLIC_EVENT_MAX_CONTENT_BYTES = 1024 * 1024;
 
 const maximumDepth = 8;
 const maximumEntries = 256;
 
-function boundedPublicJson() {
+function boundedPublicJson(
+  maxBytes: number,
+  maxStringChars: number | undefined,
+) {
   return z
     .preprocess(stripUndefined, z.json())
     .superRefine((value, context) => {
@@ -23,21 +33,38 @@ function boundedPublicJson() {
         });
         return;
       }
-      if (bytes > PUBLIC_EVENT_MAX_BYTES) {
+      if (bytes > maxBytes) {
         context.addIssue({
           code: "custom",
-          message: `public data may not exceed ${PUBLIC_EVENT_MAX_BYTES} bytes`,
+          message: `public data may not exceed ${maxBytes} bytes`,
         });
       }
-      validateValue(value, context, [], 0);
+      validateValue(value, context, [], 0, maxStringChars);
     });
 }
 
 /** Safety guard composed before every concrete public event payload schema. */
-export const publicEventDataGuardSchema = boundedPublicJson();
+export const publicEventDataGuardSchema = boundedPublicJson(
+  PUBLIC_EVENT_MAX_BYTES,
+  PUBLIC_EVENT_MAX_STRING_CHARS,
+);
 
 /** Bounded JSON for provider/domain values whose shape is intentionally opaque. */
-export const boundedPublicJsonSchema = boundedPublicJson();
+export const boundedPublicJsonSchema = boundedPublicJson(
+  PUBLIC_EVENT_MAX_BYTES,
+  PUBLIC_EVENT_MAX_STRING_CHARS,
+);
+
+/**
+ * Content-sized guard for events that carry authoritative content payloads
+ * (e.g. conversation entries). Keeps the total byte ceiling and the shape
+ * checks, but drops the per-string length cap so single long strings (message
+ * text, thinking blocks) are not rejected.
+ */
+export const boundedPublicContentJsonSchema = boundedPublicJson(
+  PUBLIC_EVENT_MAX_CONTENT_BYTES,
+  undefined,
+);
 
 export const boundedPublicObjectSchema = z
   .preprocess(
@@ -45,7 +72,7 @@ export const boundedPublicObjectSchema = z
     z.record(z.string().min(1).max(128), boundedPublicJsonSchema),
   )
   .superRefine((value, context) => {
-    validateValue(value, context, [], 0);
+    validateValue(value, context, [], 0, PUBLIC_EVENT_MAX_STRING_CHARS);
     if (Object.keys(value).length > maximumEntries) {
       context.addIssue({
         code: "custom",
@@ -69,6 +96,7 @@ function validateValue(
   context: z.core.$RefinementCtx<unknown>,
   path: PropertyKey[],
   depth: number,
+  maxStringChars: number | undefined,
 ): void {
   if (depth > maximumDepth) {
     context.addIssue({
@@ -79,7 +107,7 @@ function validateValue(
     return;
   }
   if (typeof value === "string") {
-    if (value.length > PUBLIC_EVENT_MAX_STRING_CHARS)
+    if (maxStringChars !== undefined && value.length > maxStringChars)
       context.addIssue({
         code: "custom",
         path,
@@ -101,7 +129,13 @@ function validateValue(
         message: "public arrays are too large",
       });
     value.forEach((entry, index) =>
-      validateValue(entry, context, [...path, index], depth + 1),
+      validateValue(
+        entry,
+        context,
+        [...path, index],
+        depth + 1,
+        maxStringChars,
+      ),
     );
     return;
   }
@@ -121,6 +155,6 @@ function validateValue(
         message: "secret-like public data keys are forbidden",
       });
     }
-    validateValue(entry, context, [...path, key], depth + 1);
+    validateValue(entry, context, [...path, key], depth + 1, maxStringChars);
   }
 }

--- a/packages/contracts/src/domains/events/event-definition.schema.ts
+++ b/packages/contracts/src/domains/events/event-definition.schema.ts
@@ -1,6 +1,9 @@
 import type { z } from "zod";
 import type { PeerRole } from "../protocol/envelope.schema.js";
-import { publicEventDataGuardSchema } from "./bounded-public-data.schema.js";
+import {
+  boundedPublicContentJsonSchema,
+  publicEventDataGuardSchema,
+} from "./bounded-public-data.schema.js";
 
 export type EventCoalescing = "latest_by_scope" | "concat_delta";
 export type EventDelivery = "sequenced" | "ephemeral";
@@ -17,16 +20,15 @@ export interface PublicEventDefinition {
 
 const hostRoles = ["workbench_server"] as const;
 
-export function definePublicEvent(
+function defineBoundedEvent(
+  guard: z.ZodType,
   name: string,
   payloadSchema: z.ZodType,
   options: Partial<Omit<PublicEventDefinition, "name" | "payloadSchema">> = {},
 ): PublicEventDefinition {
   return {
     name,
-    payloadSchema: publicEventDataGuardSchema.transform((value) =>
-      payloadSchema.parse(value),
-    ),
+    payloadSchema: guard.transform((value) => payloadSchema.parse(value)),
     delivery: options.delivery ?? "sequenced",
     supersedable: options.supersedable ?? false,
     allowedSourceRoles: options.allowedSourceRoles ?? hostRoles,
@@ -34,4 +36,37 @@ export function definePublicEvent(
       options.delivery === "ephemeral" ? options.coalescing : undefined,
     scope: options.scope ?? [],
   };
+}
+
+export function definePublicEvent(
+  name: string,
+  payloadSchema: z.ZodType,
+  options: Partial<Omit<PublicEventDefinition, "name" | "payloadSchema">> = {},
+): PublicEventDefinition {
+  return defineBoundedEvent(
+    publicEventDataGuardSchema,
+    name,
+    payloadSchema,
+    options,
+  );
+}
+
+/**
+ * Variant of {@link definePublicEvent} for events whose payloads carry
+ * authoritative, potentially large content (e.g. conversation entries with
+ * message text and thinking blocks). The payload is validated with the
+ * content-sized guard: a total byte ceiling for broadcast safety, but no
+ * per-string length cap so model content is never rejected.
+ */
+export function defineContentEvent(
+  name: string,
+  payloadSchema: z.ZodType,
+  options: Partial<Omit<PublicEventDefinition, "name" | "payloadSchema">> = {},
+): PublicEventDefinition {
+  return defineBoundedEvent(
+    boundedPublicContentJsonSchema,
+    name,
+    payloadSchema,
+    options,
+  );
 }

--- a/packages/contracts/test/event-content-profile.test.ts
+++ b/packages/contracts/test/event-content-profile.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  PUBLIC_EVENT_MAX_STRING_CHARS,
+  validatePublicEvent,
+} from "../src/index.js";
+
+/**
+ * Content-sized events (conversation.entry.appended) must accept authoritative
+ * content strings of any length while metadata events keep the strict
+ * per-string bound. Regression for runs failing with
+ * `["finalText"]: "public text is too long"` when model thinking exceeded
+ * PUBLIC_EVENT_MAX_STRING_CHARS.
+ */
+
+function entry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "entry_test",
+    conversationId: "conv_test",
+    agentId: "agent_test",
+    runId: "run_test",
+    turnId: "turn_test",
+    liveMessageId: "msg_test",
+    messageOrdinal: 0,
+    role: "assistant",
+    kind: "message",
+    text: "Short prose.",
+    details: {
+      thinkingBlocks: [{ text: "Short thinking." }],
+    },
+    createdAt: "2026-08-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function entryAppended(entryPayload: Record<string, unknown>) {
+  return {
+    conversationId: "conv_test",
+    agentId: "agent_test",
+    runId: "run_test",
+    turnId: "turn_test",
+    liveMessageId: "msg_test",
+    entry: entryPayload,
+  };
+}
+
+describe("conversation event content profile", () => {
+  it("accepts an entry with a thinking block longer than the strict string cap", () => {
+    const longThinking = "x".repeat(PUBLIC_EVENT_MAX_STRING_CHARS + 500);
+    const parsed = validatePublicEvent(
+      "conversation.entry.appended",
+      entryAppended(
+        entry({
+          details: { thinkingBlocks: [{ text: longThinking }] },
+        }),
+      ),
+      "workbench_server",
+    ) as { entry: { details: { thinkingBlocks: Array<{ text: string }> } } };
+    assert.equal(parsed.entry.details.thinkingBlocks[0]?.text, longThinking);
+  });
+
+  it("accepts an entry with a long assistant text", () => {
+    const longText = "y".repeat(PUBLIC_EVENT_MAX_STRING_CHARS + 100);
+    const parsed = validatePublicEvent(
+      "conversation.entry.appended",
+      entryAppended(entry({ text: longText })),
+      "workbench_server",
+    ) as { entry: { text: string } };
+    assert.equal(parsed.entry.text, longText);
+  });
+
+  it("still enforces a total byte ceiling for content events", () => {
+    // 1 MiB cap: a payload well over it must be rejected even without a
+    // per-string cap.
+    const oversized = entry({
+      details: {
+        thinkingBlocks: [{ text: "z".repeat(1024 * 1024) }],
+      },
+    });
+    assert.throws(() =>
+      validatePublicEvent(
+        "conversation.entry.appended",
+        entryAppended(oversized),
+        "workbench_server",
+      ),
+    );
+  });
+
+  it("rejects secret-like keys even on content events", () => {
+    assert.throws(() =>
+      validatePublicEvent(
+        "conversation.entry.appended",
+        entryAppended(entry({ details: { apiKey: "nope" } })),
+        "workbench_server",
+      ),
+    );
+  });
+});
+
+describe("conversation.live.content.done", () => {
+  it("parses without finalText and keeps the redacted flag", () => {
+    const parsed = validatePublicEvent(
+      "conversation.live.content.done",
+      {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        projectId: "proj_test",
+        runId: "run_test",
+        turnId: "turn_test",
+        liveMessageId: "msg_test",
+        contentBlockId: "block_test",
+        contentIndex: 0,
+        kind: "thinking",
+        redacted: false,
+      },
+      "workbench_server",
+    ) as { finalText?: string; redacted?: boolean };
+    assert.equal(parsed.finalText, undefined);
+    assert.equal(parsed.redacted, false);
+  });
+});
+
+describe("strict guard still applies to metadata events", () => {
+  it("rejects a content delta chunk longer than the strict string cap", () => {
+    assert.throws(() =>
+      validatePublicEvent(
+        "conversation.live.content.delta",
+        {
+          conversationId: "conv_test",
+          agentId: "agent_test",
+          projectId: "proj_test",
+          runId: "run_test",
+          turnId: "turn_test",
+          liveMessageId: "msg_test",
+          contentBlockId: "block_test",
+          contentIndex: 0,
+          kind: "text",
+          offset: 0,
+          delta: "d".repeat(PUBLIC_EVENT_MAX_STRING_CHARS + 1),
+        },
+        "workbench_server",
+      ),
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/state/adapters.ts
+++ b/packages/workbench-app/src/lib/presentation/state/adapters.ts
@@ -812,7 +812,6 @@ function applyLiveContentDone(
   draft.ownBlock(data.turnId, data.liveMessageId, data.contentBlockId);
   const block = ensureActiveTextBlock(state, data, ts);
   if (!block) return;
-  block.text = data.finalText ?? block.text;
   block.done = true;
   block.redacted = data.kind === "thinking" ? data.redacted : undefined;
 }

--- a/packages/workbench-app/src/lib/presentation/state/conversation-events.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/conversation-events.test.ts
@@ -710,4 +710,62 @@ describe("conversation event reducer", () => {
     });
     assert.deepEqual(state.activeRun?.turns, []);
   });
+
+  it("keeps delta-accumulated text when content.done carries no finalText", () => {
+    let state = emptyConversationRenderState("conv_test");
+    state = applyConversationEvent(state, startRun());
+    state = applyConversationEvent(state, startMessage());
+    state = applyConversationEvent(
+      state,
+      evt(3, "conversation.live.content.delta", {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        projectId: "proj_test",
+        runId: "run_test",
+        turnId: "turn_test",
+        liveMessageId: "msg_test",
+        contentBlockId: "block_text",
+        contentIndex: 0,
+        kind: "text",
+        offset: 0,
+        delta: "Hello ",
+      }),
+    );
+    state = applyConversationEvent(
+      state,
+      evt(4, "conversation.live.content.delta", {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        projectId: "proj_test",
+        runId: "run_test",
+        turnId: "turn_test",
+        liveMessageId: "msg_test",
+        contentBlockId: "block_text",
+        contentIndex: 0,
+        kind: "text",
+        offset: 6,
+        delta: "world",
+      }),
+    );
+    state = applyConversationEvent(
+      state,
+      evt(5, "conversation.live.content.done", {
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        projectId: "proj_test",
+        runId: "run_test",
+        turnId: "turn_test",
+        liveMessageId: "msg_test",
+        contentBlockId: "block_text",
+        contentIndex: 0,
+        kind: "text",
+      }),
+    );
+    const block = state.activeRun?.turns[0]?.messages[0]?.blocks[0];
+    assert.equal(
+      block && block.kind !== "tool_call_draft" ? block.text : undefined,
+      "Hello world",
+    );
+    assert.equal(block?.done, true);
+  });
 });

--- a/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
@@ -158,8 +158,9 @@ export async function executeWorkbenchHarness(
     };
     const liveToolDraftReconciler = new LiveToolDraftReconciler({
       conversationRuntime: this.deps.state.conversationRuntime,
-      publish: async (type, data) => {
-        await this.deps.events.publish(type, data);
+      publish: (type, data) => {
+        this.deps.events.publishBestEffort(type, data, type);
+        return Promise.resolve();
       },
       runId,
       getTurnId: () => currentTurnId,
@@ -221,14 +222,18 @@ export async function executeWorkbenchHarness(
     const startLiveTurn = async () => {
       const turn = this.deps.state.conversationRuntime.startTurn(runId);
       currentTurnId = turn.turnId;
-      await this.deps.events.publish("conversation.live.turn.started", {
-        conversationId: conversation.id,
-        agentId: agent.id,
-        projectId: project.id,
-        runId,
-        turnId: turn.turnId,
-        ordinal: turn.ordinal,
-      });
+      this.deps.events.publishBestEffort(
+        "conversation.live.turn.started",
+        {
+          conversationId: conversation.id,
+          agentId: agent.id,
+          projectId: project.id,
+          runId,
+          turnId: turn.turnId,
+          ordinal: turn.ordinal,
+        },
+        "conversation.live.turn.started",
+      );
       return turn.turnId;
     };
     harness.subscribe(async (event) => {
@@ -324,9 +329,10 @@ export async function executeWorkbenchHarness(
         liveToolDraftNames.clear();
         liveToolDraftProgress.clear();
         liveToolDrafts.clear();
-        await this.deps.events.publish(
+        this.deps.events.publishBestEffort(
           "conversation.live.message.started",
           started,
+          "conversation.live.message.started",
         );
         return;
       }
@@ -342,9 +348,10 @@ export async function executeWorkbenchHarness(
             kind: "text",
             delta: update.delta,
           });
-          await this.deps.events.publish(
+          this.deps.events.publishBestEffort(
             "conversation.live.content.delta",
             data,
+            "conversation.live.content.delta",
           );
         } else if (update.type === "thinking_delta") {
           const data = this.deps.state.conversationRuntime.applyContentDelta({
@@ -355,9 +362,10 @@ export async function executeWorkbenchHarness(
             kind: "thinking",
             delta: update.delta,
           });
-          await this.deps.events.publish(
+          this.deps.events.publishBestEffort(
             "conversation.live.content.delta",
             data,
+            "conversation.live.content.delta",
           );
         } else if (update.type === "text_end") {
           const data = this.deps.state.conversationRuntime.finishContent({
@@ -368,9 +376,10 @@ export async function executeWorkbenchHarness(
             kind: "text",
             finalText: update.content,
           });
-          await this.deps.events.publish(
+          this.deps.events.publishBestEffort(
             "conversation.live.content.done",
             data,
+            "conversation.live.content.done",
           );
         } else if (update.type === "thinking_end") {
           const data = this.deps.state.conversationRuntime.finishContent({
@@ -385,9 +394,10 @@ export async function executeWorkbenchHarness(
               update.contentIndex,
             ),
           });
-          await this.deps.events.publish(
+          this.deps.events.publishBestEffort(
             "conversation.live.content.done",
             data,
+            "conversation.live.content.done",
           );
         } else if (update.type === "toolcall_start") {
           const draft = assistantToolCallDraft(
@@ -415,9 +425,10 @@ export async function executeWorkbenchHarness(
             providerToolCallId: draft?.id,
             toolName: draft?.name,
           });
-          await this.deps.events.publish(
+          this.deps.events.publishBestEffort(
             "conversation.live.tool_draft.started",
             data,
+            "conversation.live.tool_draft.started",
           );
         } else if (update.type === "toolcall_delta") {
           const draft = assistantToolCallDraft(
@@ -450,9 +461,10 @@ export async function executeWorkbenchHarness(
                 toolName,
                 delta: update.delta,
               });
-            await this.deps.events.publish(
+            this.deps.events.publishBestEffort(
               "conversation.live.tool_draft.delta",
               data,
+              "conversation.live.tool_draft.delta",
             );
             return;
           }
@@ -474,9 +486,10 @@ export async function executeWorkbenchHarness(
               toolName,
               progress,
             });
-          await this.deps.events.publish(
+          this.deps.events.publishBestEffort(
             "conversation.live.tool_draft.progress",
             data,
+            "conversation.live.tool_draft.progress",
           );
         } else if (update.type === "toolcall_end") {
           liveToolDraftNames.delete(update.contentIndex);
@@ -498,9 +511,10 @@ export async function executeWorkbenchHarness(
             toolName: update.toolCall.name,
             args: toPublicToolCallArgsPreview(update.toolCall.arguments),
           });
-          await this.deps.events.publish(
+          this.deps.events.publishBestEffort(
             "conversation.live.tool_draft.done",
             data,
+            "conversation.live.tool_draft.done",
           );
         }
         return;

--- a/packages/workbench-server/src/domains/agents/subagent-transcript-live.service.ts
+++ b/packages/workbench-server/src/domains/agents/subagent-transcript-live.service.ts
@@ -166,14 +166,11 @@ export class SubagentTranscriptLiveService {
               ? assistantContentRedacted(update.partial, update.contentIndex)
               : undefined,
         });
-        await this.publish(state, "agent.subagent_transcript.content.done", {
-          ...data,
-          finalText:
-            data.finalText &&
-            data.finalText.length <= PUBLIC_EVENT_MAX_STRING_CHARS
-              ? data.finalText
-              : undefined,
-        });
+        await this.publish(
+          state,
+          "agent.subagent_transcript.content.done",
+          data,
+        );
       }
       return;
     }

--- a/packages/workbench-server/src/domains/runs/runtime/conversation-runtime.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/conversation-runtime.ts
@@ -352,7 +352,6 @@ export class ConversationRuntime {
       contentBlockId: block.contentBlockId,
       contentIndex: input.contentIndex,
       kind: input.kind,
-      finalText: input.finalText,
       redacted: input.redacted,
     };
   }

--- a/packages/workbench-server/src/domains/tools/live-tool-output-publisher.ts
+++ b/packages/workbench-server/src/domains/tools/live-tool-output-publisher.ts
@@ -4,7 +4,6 @@ import {
 } from "@nervekit/tools";
 import type { ToolCallRecord } from "@nervekit/contracts";
 import type { ConversationRuntime } from "../runs/runtime/conversation-runtime.js";
-import type { ApplicationLogger } from "../../infrastructure/diagnostics/index.js";
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 
 /** Owns validated, ordered publication of transient tool output. */
@@ -14,7 +13,6 @@ export class LiveToolOutputPublisher {
   constructor(
     private readonly events: StreamLogRegistry,
     private readonly runtime: ConversationRuntime,
-    private readonly logger?: ApplicationLogger,
   ) {}
 
   async publish(
@@ -44,12 +42,12 @@ export class LiveToolOutputPublisher {
         ...input,
         offset: this.runtime.toolOutputOffset(outputRunId, toolCall.id),
       };
-      try {
-        await this.events.publish("conversation.live.tool_output.delta", data);
-        this.runtime.applyToolOutputDelta(input);
-      } catch (error) {
-        await this.reportFailure(toolCall, error);
-      }
+      this.events.publishBestEffort(
+        "conversation.live.tool_output.delta",
+        data,
+        "conversation.live.tool_output.delta",
+      );
+      this.runtime.applyToolOutputDelta(input);
     }
   }
 
@@ -72,23 +70,5 @@ export class LiveToolOutputPublisher {
 
   async drain(toolCallId: string): Promise<void> {
     await this.#tails.get(toolCallId);
-  }
-
-  private async reportFailure(
-    toolCall: ToolCallRecord,
-    error: unknown,
-  ): Promise<void> {
-    await this.logger
-      ?.warn("Live tool output publication failed", {
-        projectId: toolCall.projectId,
-        conversationId: toolCall.conversationId,
-        agentId: toolCall.agentId,
-        runId: toolCall.runId,
-        toolCallId: toolCall.id,
-        context: {
-          error: error instanceof Error ? error.message : String(error),
-        },
-      })
-      .catch(() => undefined);
   }
 }

--- a/packages/workbench-server/src/domains/tools/orchestration-tool-dispatcher.ts
+++ b/packages/workbench-server/src/domains/tools/orchestration-tool-dispatcher.ts
@@ -29,7 +29,6 @@ import {
   createHostToolFactory,
   type HostToolFactory,
 } from "./host-tool-factory.js";
-import type { ApplicationLogger } from "../../infrastructure/diagnostics/index.js";
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { InitializedStorage } from "../../infrastructure/storage/index.js";
 import type { PlanService } from "../plans/plan-service.js";
@@ -95,7 +94,6 @@ export interface OrchestrationToolDispatcherDeps {
     patch: Partial<Omit<ToolCallRecord, "id" | "createdAt">>,
   ): Promise<ToolCallRecord>;
   publishToolCallUpdated(toolCall: ToolCallRecord): Promise<void>;
-  logger?: ApplicationLogger;
 }
 
 type WorkbenchToolExecution = {
@@ -113,7 +111,6 @@ export class OrchestrationToolDispatcher {
     this.liveOutput = new LiveToolOutputPublisher(
       deps.events,
       deps.conversationRuntime,
-      deps.logger,
     );
     this.hostTools = createHostToolFactory<WorkbenchToolExecution>({
       execution: {

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -212,7 +212,6 @@ export class ToolService {
       updateToolCall: (id, patch) => this.updateToolCall(id, patch),
       publishToolCallUpdated: (toolCall) =>
         this.publishToolCallUpdated(toolCall),
-      logger: this.logger,
     });
     this.executor = new ToolExecutorService({
       getToolCall: (id) => this.getToolCall(id),

--- a/packages/workbench-server/test/live-tool-output-publisher.test.ts
+++ b/packages/workbench-server/test/live-tool-output-publisher.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import {
+  conversationStream,
   LIVE_TOOL_OUTPUT_EVENT_MAX_BYTES,
   type ConversationLiveToolOutputDeltaData,
   type ToolCallRecord,
@@ -58,6 +59,9 @@ describe("LiveToolOutputPublisher", () => {
       stream: "stdout",
       chunk: input,
     });
+    // Live publication is best-effort; flush the conversation stream so the
+    // enqueued deltas are processed before asserting on delivered events.
+    await events.withCursor(conversationStream("conv_test"), () => undefined);
 
     assert.equal(published.map((event) => event.delta).join(""), input);
     assert.ok(
@@ -75,17 +79,14 @@ describe("LiveToolOutputPublisher", () => {
     await events.shutdown();
   });
 
-  it("contains publication failures and diagnoses them", async () => {
-    const warnings: unknown[] = [];
+  it("delegates live publication to best-effort and never rejects", async () => {
+    const calls: Array<{ type: string; context: string }> = [];
     const publisher = new LiveToolOutputPublisher(
       {
-        publish: async () => Promise.reject(new Error("disk unavailable")),
+        publishBestEffort: (type: string, _data: unknown, context: string) =>
+          void calls.push({ type, context }),
       } as never,
       runtime(),
-      {
-        warn: async (_message: string, data: unknown) =>
-          void warnings.push(data),
-      } as never,
     );
 
     await assert.doesNotReject(
@@ -95,6 +96,11 @@ describe("LiveToolOutputPublisher", () => {
         chunk: "still supervised",
       }),
     );
-    assert.equal(warnings.length, 1);
+    assert.deepEqual(calls, [
+      {
+        type: "conversation.live.tool_output.delta",
+        context: "conversation.live.tool_output.delta",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Runs fail hard with a `ZodError` (`["finalText"]: "public text is too long"`) whenever an assistant message's thinking or text block exceeds the 16,384-char public-event string cap — e.g. a long reasoning block (observed at 16,854 chars) kills the whole run with `EXECUTION_FAILED`.

Root cause: two conversation events duplicated **full, unbounded model content** into payloads validated by the strict bounded guard:
- `conversation.live.content.done.finalText` (full block text on `thinking_end`/`text_end`)
- `conversation.entry.appended.entry` (full durable entry incl. `details.thinkingBlocks`)

The subagent path "fixed" this by truncating `finalText` — which loses thinking details client-side. This PR implements the architecturally correct fix instead: **content is state, not event payload.**

## Changes

- **`conversation.live.content.done` drops `finalText`** — full text already flows via small per-event deltas (live) and the durable entry/snapshot (REST resync on gaps), so connected clients never lose thinking details and gap clients recover via the existing snapshot resync. The event remains a "block settled + redacted" signal.
- **`conversation.entry.appended` gets a content-sized validation profile** — new `defineContentEvent` + `boundedPublicContentJsonSchema` (1 MiB total ceiling, no per-string cap, keeps depth/entries/secret-key checks), keeping the full authoritative entry in the event while preserving broadcast safety. `PUBLIC_EVENT_MAX_CONTENT_BYTES` (1 MiB) added.
- **`conversation.live.*` publishes are best-effort** (`publishBestEffort`) across the harness execution, tool-draft reconciliation, and live tool-output publisher — a live notification failure can never fail a run again; failures are diagnosed via the registry's `onPublishFailed`. The publisher's now-redundant custom logger path was removed.
- **Subagent transcript path** drops the truncation workaround; the subagent panel keeps full thinking via its deltas.
- **Client** keeps delta-accumulated text on `content.done` (removes the `finalText ?? block.text` override).

## Tests

- New `packages/contracts/test/event-content-profile.test.ts`: entry with a >16K thinking block parses; 1 MiB cap enforced; secret-like keys still rejected; `content.done` parses without `finalText`; strict guard still rejects oversized deltas.
- Client reducer test: delta-accumulated text survives `content.done` without `finalText`.
- `live-tool-output-publisher.test.ts` updated for best-effort semantics.

`pnpm fix && pnpm check && pnpm test` all green (contracts 47, ui-kit 38, protocol 21, harness 38, tools 230, workbench-app 297, workbench-server 394, desktop-shell 51, scripts 11).
