### PR TITLE
perf(desktop): cut cold start ~2.5x on large profiles

### DIFF
--- a/packages/desktop-shell/src/main.ts
+++ b/packages/desktop-shell/src/main.ts
@@ -1,3 +1,5 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { resolveDataDir } from "@nervekit/workbench-server";
 import {
   applyElectronFontRenderHinting,
@@ -65,6 +67,28 @@ applyElectronOzonePlatform(electronOzonePlatform);
 applyElectronFontRenderHinting(electronFontRenderHinting);
 
 const shellPageUrls = new ShellPageUrlRegistry();
+
+/**
+ * Always-on desktop startup telemetry (one JSONL line per launch) written to
+ * the same logs/startup.jsonl as the daemon so both sides of a cold start can
+ * be correlated without NERVE_LOGGING_ENABLED. Best-effort: never affects
+ * startup.
+ */
+async function appendStartupRecord(
+  record: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const path = join(desktopDataDir, "logs", "startup.jsonl");
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(
+      path,
+      `${JSON.stringify({ ts: new Date().toISOString(), ...record })}\n`,
+      "utf8",
+    );
+  } catch {
+    // Best-effort observability only.
+  }
+}
 let mainWindow: BrowserWindowType | undefined;
 let managedDaemon: ManagedDaemon | undefined;
 let daemonStopped = false;
@@ -373,6 +397,12 @@ async function openMainWindow(): Promise<void> {
         ...result.timings,
         navigated: result.navigated,
       },
+    });
+    await appendStartupRecord({
+      type: "nerve.startup",
+      source: "desktop",
+      ...result.timings,
+      navigated: result.navigated,
     });
   } catch (error) {
     void desktopLog("error", "daemon", "Failed to open Nerve daemon", {

--- a/packages/workbench-app/src/lib/app/shell/EditorSurface.svelte
+++ b/packages/workbench-app/src/lib/app/shell/EditorSurface.svelte
@@ -2,13 +2,7 @@
 import { EditorArea } from "$lib/presentation/shell";
 import EditorTabStripContainer from "$lib/app/shell/EditorTabStripContainer.svelte";
 import ConversationShell from "$lib/features/conversations/components/ConversationShell.svelte";
-import FileShell from "$lib/features/filesystem/components/FileShell.svelte";
-import DiffShell from "$lib/features/git/components/DiffShell.svelte";
-import PrShell from "$lib/features/git/components/PrShell.svelte";
-import LogsShell from "$lib/features/logs/components/LogsShell.svelte";
-import TaskShell from "$lib/features/tasks/components/TaskShell.svelte";
-import SettingsShell from "$lib/features/settings/components/SettingsShell.svelte";
-import { AuthShell } from "$lib/features/auth";
+import LazyShellPending from "$lib/app/shell/LazyShellPending.svelte";
 import {
   centerTabsExcept,
   centerTabsToLeftOf,
@@ -74,6 +68,28 @@ function closeOtherCenterTabs(tab: CenterTabIdentity) {
   void closeCenterTabs(centerTabsExcept(tab), tab);
 }
 
+// On-demand center shells are code-split so their (potentially large) feature
+// modules are not parsed during startup. The import fires when the tab is
+// first activated; the chunk then loads in tens of milliseconds from localhost.
+type CenterShellModule = Promise<{ default: import("svelte").Component }>;
+const centerShells = {
+  task: () => import("$lib/features/tasks/components/TaskShell.svelte"),
+  file: () => import("$lib/features/filesystem/components/FileShell.svelte"),
+  pr: () => import("$lib/features/git/components/PrShell.svelte"),
+  diff: () => import("$lib/features/git/components/DiffShell.svelte"),
+  settings: () =>
+    import("$lib/features/settings/components/SettingsShell.svelte"),
+  auth: () => import("$lib/features/auth/components/AuthShell.svelte"),
+  logs: () => import("$lib/features/logs/components/LogsShell.svelte"),
+} satisfies Record<string, () => CenterShellModule>;
+
+let loadedShells = $state<Partial<Record<string, CenterShellModule>>>({});
+$effect(() => {
+  const kind = activeCenterTab?.kind;
+  if (!kind || !(kind in centerShells) || loadedShells[kind]) return;
+  loadedShells[kind] = centerShells[kind as keyof typeof centerShells]();
+});
+
 function closeCenterTabsRight(tab: CenterTabIdentity) {
   void closeCenterTabs(centerTabsToRightOf(tab), tab);
 }
@@ -103,19 +119,54 @@ function closeCenterTabsLeft(tab: CenterTabIdentity) {
   {#snippet content()}
     <div class="center-workspace-content h-full">
       {#if activeCenterTab?.kind === "task"}
-        <TaskShell />
+        {#await loadedShells.task}
+          <LazyShellPending />
+        {:then module}
+          {@const Component = module?.default}
+          {#if Component}<Component />{/if}
+        {/await}
       {:else if activeCenterTab?.kind === "file"}
-        <FileShell />
+        {#await loadedShells.file}
+          <LazyShellPending />
+        {:then module}
+          {@const Component = module?.default}
+          {#if Component}<Component />{/if}
+        {/await}
       {:else if activeCenterTab?.kind === "pr"}
-        <PrShell />
+        {#await loadedShells.pr}
+          <LazyShellPending />
+        {:then module}
+          {@const Component = module?.default}
+          {#if Component}<Component />{/if}
+        {/await}
       {:else if activeCenterTab?.kind === "diff"}
-        <DiffShell />
+        {#await loadedShells.diff}
+          <LazyShellPending />
+        {:then module}
+          {@const Component = module?.default}
+          {#if Component}<Component />{/if}
+        {/await}
       {:else if activeCenterTab?.kind === "settings"}
-        <SettingsShell />
+        {#await loadedShells.settings}
+          <LazyShellPending />
+        {:then module}
+          {@const Component = module?.default}
+          {#if Component}<Component />{/if}
+        {/await}
       {:else if activeCenterTab?.kind === "auth"}
-        <AuthShell />
+        {#await loadedShells.auth}
+          <LazyShellPending />
+        {:then module}
+          {@const Component = module?.default}
+          {#if Component}<Component />{/if}
+        {/await}
       {:else if activeCenterTab?.kind === "logs"}
-        <LogsShell />
+        {#await loadedShells.logs}
+          <LazyShellPending />
+        {:then module}
+          {@const Component = module?.default}
+          {#if Component}<Component />{/if}
+        {/await}
       {/if}
 
       {#if renderedConversationPaneTabs.length > 0}

--- a/packages/workbench-app/src/lib/app/shell/LazyShellPending.svelte
+++ b/packages/workbench-app/src/lib/app/shell/LazyShellPending.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+</script>
+
+<div class="lazy-shell-pending" aria-busy="true">
+  <Spinner class="size-5" />
+</div>
+
+<style>
+.lazy-shell-pending {
+  display: grid;
+  height: 100%;
+  min-height: 6rem;
+  place-items: center;
+  color: var(--muted-foreground);
+}
+</style>

--- a/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
@@ -5,15 +5,12 @@ import {
   ContextPanelView,
   conversationSelectors,
 } from "$lib/features/conversations";
-import { FilesPanelView } from "$lib/features/filesystem";
 import {
   GitPanelView,
-  GitPullRequestsPanelView,
   type GitPanelActions,
   type GitPanelModel,
 } from "$lib/presentation";
 import { ConversationsPanelView } from "$lib/features/projects";
-import { NotesPanelView } from "$lib/features/scratch-notes";
 import {
   cancelSelectedTask,
   openTaskTab,
@@ -22,7 +19,6 @@ import {
   restartSelectedTask,
   runTaskCommand,
   taskSelectors,
-  TasksPanelView,
 } from "$lib/features/tasks";
 import {
   exportUrl,
@@ -35,6 +31,29 @@ import {
   activatePanelView,
   revealPanelView,
 } from "$lib/app/shell/shell-layout.svelte";
+import LazyShellPending from "$lib/app/shell/LazyShellPending.svelte";
+
+// Panels that are not part of the default visible layout are code-split so
+// their feature modules are not parsed during startup. The import fires when
+// the panel is first activated.
+let filesModule = $state<
+  Promise<typeof import("$lib/features/filesystem")> | undefined
+>();
+let tasksModule = $state<
+  | Promise<{
+      default: typeof import("$lib/features/tasks/components/TasksPanelView.svelte").default;
+    }>
+  | undefined
+>();
+let notesModule = $state<
+  Promise<typeof import("$lib/features/scratch-notes")> | undefined
+>();
+let pullRequestsModule = $state<
+  | Promise<{
+      default: typeof import("$lib/presentation/git/GitPullRequestsPanelView.svelte").default;
+    }>
+  | undefined
+>();
 
 let {
   viewId,
@@ -57,6 +76,18 @@ const contextWindow = $derived(conversationSelectors.activeContextWindow);
 const tasks = $derived(taskSelectors.scopedTasks);
 const selectedTask = $derived(taskSelectors.selectedTask);
 
+$effect(() => {
+  if (viewId === "files") filesModule ??= import("$lib/features/filesystem");
+  else if (viewId === "tasks")
+    tasksModule ??=
+      import("$lib/features/tasks/components/TasksPanelView.svelte");
+  else if (viewId === "notes")
+    notesModule ??= import("$lib/features/scratch-notes");
+  else if (viewId === "pull-requests")
+    pullRequestsModule ??=
+      import("$lib/presentation/git/GitPullRequestsPanelView.svelte");
+});
+
 function selectAgent(agent: AgentRecord) {
   selection.agentId = agent.id;
   selection.projectId = agent.projectId;
@@ -71,13 +102,25 @@ function focusTasks() {
 </script>
 
 {#if viewId === "files"}
-  <FilesPanelView {activeProject} />
+  {#await filesModule}
+    <LazyShellPending />
+  {:then module}
+    {@const Component = module?.FilesPanelView}
+    {#if Component}<Component {activeProject} />{/if}
+  {/await}
 {:else if viewId === "conversations"}
   <ConversationsPanelView />
 {:else if viewId === "git"}
   <GitPanelView model={gitModel} actions={gitActions} />
 {:else if viewId === "pull-requests"}
-  <GitPullRequestsPanelView model={gitModel} actions={gitActions} />
+  {#await pullRequestsModule}
+    <LazyShellPending />
+  {:then module}
+    {@const Component = module?.default}
+    {#if Component}
+      <Component model={gitModel} actions={gitActions} />
+    {/if}
+  {/await}
 {:else if viewId === "context"}
   <ContextPanelView
     {status}
@@ -94,24 +137,36 @@ function focusTasks() {
     onCompact={() => void compactActiveConversation()}
   />
 {:else if viewId === "notes"}
-  <NotesPanelView {activeProject} />
+  {#await notesModule}
+    <LazyShellPending />
+  {:then module}
+    {@const Component = module?.NotesPanelView}
+    {#if Component}<Component {activeProject} />{/if}
+  {/await}
 {:else if viewId === "tasks"}
-  <TasksPanelView
-    {activeProject}
-    {tasks}
-    {selectedTask}
-    homeDir={status?.storage.userHome}
-    onOpenTaskOutput={(id) => {
-      focusTasks();
-      void openTaskTab(id);
-    }}
-    onCancelTask={(id, request) => void cancelSelectedTask(id, request)}
-    onRestartTask={(id) => void restartSelectedTask(id)}
-    onRemoveTask={(id) => void removeTask(id)}
-    onPruneTasks={() => void pruneFinishedTasks()}
-    onRunCommand={(input) => {
-      focusTasks();
-      void runTaskCommand(input);
-    }}
-  />
+  {#await tasksModule}
+    <LazyShellPending />
+  {:then module}
+    {@const Component = module?.default}
+    {#if Component}
+      <Component
+        {activeProject}
+        {tasks}
+        {selectedTask}
+        homeDir={status?.storage.userHome}
+        onOpenTaskOutput={(id) => {
+          focusTasks();
+          void openTaskTab(id);
+        }}
+        onCancelTask={(id, request) => void cancelSelectedTask(id, request)}
+        onRestartTask={(id) => void restartSelectedTask(id)}
+        onRemoveTask={(id) => void removeTask(id)}
+        onPruneTasks={() => void pruneFinishedTasks()}
+        onRunCommand={(input) => {
+          focusTasks();
+          void runTaskCommand(input);
+        }}
+      />
+    {/if}
+  {/await}
 {/if}

--- a/packages/workbench-app/src/lib/features/notifications/state/notification-sounds.ts
+++ b/packages/workbench-app/src/lib/features/notifications/state/notification-sounds.ts
@@ -157,11 +157,14 @@ function browserAudioFactory(source: string): NotificationAudio | undefined {
 const notificationSoundPlayer = createNotificationSoundPlayer();
 
 export function initializeNotificationSoundPlayback(): () => void {
-  notificationSoundPlayer.preload();
   if (typeof window === "undefined") return () => undefined;
 
+  // Defer the sound warm-up to the first user interaction: preloading 12
+  // audio files at startup adds a dozen fetches to the cold-start path, and
+  // browser audio is only unlocked by a user gesture anyway.
   const unlock = () => {
     removeListeners();
+    notificationSoundPlayer.preload();
     notificationSoundPlayer.unlock();
   };
   const removeListeners = () => {

--- a/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
+++ b/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Human-input resolution centralizes the approval/plan-review suspension lifecycle in one auditable use case. */
 import { createHash } from "node:crypto";
 import type { ToolResultMessage } from "@earendil-works/pi-ai";
 import type { AgentMessage } from "@nervekit/harness";
@@ -14,6 +15,7 @@ import type {
   UserQuestionRecord,
 } from "@nervekit/contracts";
 import { ApplicationError } from "../../core/application-error.js";
+import type { ApplicationLogger } from "../../infrastructure/diagnostics/logging.js";
 import type {
   AppendEntryInput,
   AppendEntryOptions,
@@ -62,6 +64,7 @@ export interface HumanInputResolutionDeps {
   ): Promise<ConversationEntry>;
   getConversationEntries(conversationId: string): ConversationEntry[];
   harnessStorage: ConversationHarnessStorage;
+  logger: ApplicationLogger;
   compactPlanConversation(input: {
     conversationId: string;
     agentId: string;
@@ -347,7 +350,22 @@ export class HumanInputResolutionService {
       .listPlanReviews()
       .filter((review) => review.status === "accepted");
     for (const review of reviews) {
-      const toolCall = this.deps.tools.getToolCall(review.toolCallId);
+      let toolCall;
+      try {
+        toolCall = this.deps.tools.getToolCall(review.toolCallId);
+      } catch (error) {
+        // The tool-call journal/index may be absent or truncated (e.g. after
+        // storage pruning or a partial copy); a missing tool call must not
+        // abort daemon startup. Skip the review; the user can inspect it in
+        // the workbench.
+        await this.deps.logger
+          .warn("Skipping accepted plan review recovery: tool call not found", {
+            context: { reviewId: review.id, toolCallId: review.toolCallId },
+            error,
+          })
+          .catch(() => undefined);
+        continue;
+      }
       if (
         toolCall.toolName !== "plan_mode_present" ||
         toolCall.status !== "waiting_for_user"

--- a/packages/workbench-server/src/domains/runs/run-transition.repository.ts
+++ b/packages/workbench-server/src/domains/runs/run-transition.repository.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import type {
   RunEventDeliveryRecord,
+  RunRecord,
   RunTransitionRecord,
 } from "@nervekit/contracts";
 import {
@@ -22,15 +23,39 @@ import {
   appendJsonLine,
   atomicWriteJson,
   listChildDirs,
+  readJsonLinesTail,
   readTextFileConsistent,
 } from "../../infrastructure/storage/index.js";
+
+/**
+ * Reserved intent id prefix for per-run delivery-settlement checkpoints. The
+ * checkpoint records the run revision whose public-event intents are all
+ * durably delivered, letting startup sweeps skip full hydration of settled
+ * runs (the run journal is the only authoritative source for pending intents).
+ */
+export const DELIVERY_SETTLED_PREFIX = "__nerve_settled__";
+
+export function deliverySettledIntentId(
+  runId: string,
+  revision: number,
+): string {
+  return `${DELIVERY_SETTLED_PREFIX}:${runId}:${revision}`;
+}
+
+export function isDeliverySettledRecord(
+  delivery: RunEventDeliveryRecord | undefined,
+): delivery is RunEventDeliveryRecord {
+  return delivery?.intentId.startsWith(DELIVERY_SETTLED_PREFIX) === true;
+}
 
 export class WorkbenchRunUnitOfWork implements RunUnitOfWorkPort {
   private readonly locks = new Map<string, Promise<void>>();
   private readonly cache: BoundedRunStateCache;
+  /** Lightweight run-record listing cached by the one-time active hydration. */
+  private metadata: RunRecord[] | undefined;
   private readonly lookup = new ActiveRunLookup({
     load: (runId) => this.load(runId),
-    hydrateAll: () => this.list(),
+    hydrateActive: () => this.hydrateAllActive(),
   });
 
   constructor(
@@ -106,6 +131,49 @@ export class WorkbenchRunUnitOfWork implements RunUnitOfWorkPort {
     );
   }
 
+  /**
+   * Lightweight listing of every run record (id/status/scope/agent/timestamps)
+   * without hydrating transition history. Reads the last committed transition
+   * of each journal backwards in bounded chunks, so cost scales with the number
+   * of runs, not with the size of their journals.
+   */
+  async listMetadata(): Promise<readonly RunRecord[]> {
+    return (this.metadata ??= await this.scanMetadata());
+  }
+
+  /**
+   * One-time authoritative initialization: discovers active runs from a
+   * metadata scan and fully hydrates only those, so startup never reads
+   * terminal transition history. Terminal runs are loaded lazily on demand.
+   */
+  async hydrateAllActive(): Promise<void> {
+    const records = await this.scanMetadata();
+    this.metadata = records;
+    for (const record of records) {
+      if (!ACTIVE_STATUSES.has(record.status)) continue;
+      const state = await this.hydrate(record.runId);
+      if (state) {
+        this.cache.set(state);
+        this.lookup.observe(state);
+      }
+    }
+  }
+
+  private async scanMetadata(): Promise<RunRecord[]> {
+    const records: RunRecord[] = [];
+    for (const runId of await listChildDirs(this.root())) {
+      // The last valid transition carries the authoritative latest run record.
+      // A torn final line falls back to the previous committed transition, so
+      // a partially-written append never hides an active run from recovery.
+      const [latest] = await readJsonLinesTail<RunTransitionRecord>(
+        this.transitionsPath(runId),
+        1,
+      );
+      if (latest?.run) records.push(latest.run);
+    }
+    return records;
+  }
+
   async commit(
     expectedRevision: number,
     transition: RunTransitionRecord,
@@ -129,18 +197,43 @@ export class WorkbenchRunUnitOfWork implements RunUnitOfWorkPort {
     });
   }
 
+  /**
+   * Enumerates undelivered public-event intents. Settled runs (whose last
+   * delivery-settlement checkpoint covers their last committed transition)
+   * are skipped from a bounded tail scan; only unsettled runs are hydrated
+   * in full. Runs that hydrate clean with no pending intents are checkpointed
+   * as settled so later sweeps skip them too.
+   */
   async pendingEventIntents() {
     const pending: Array<{
       runId: string;
       revision: number;
       intent: RunTransitionRecord["events"][number];
     }> = [];
-    for (const state of await this.list()) {
+    for (const runId of await listChildDirs(this.root())) {
+      const [latestTransition] = await readJsonLinesTail<RunTransitionRecord>(
+        this.transitionsPath(runId),
+        1,
+      );
+      if (!latestTransition) continue;
+      const [latestDelivery] = await readJsonLinesTail<RunEventDeliveryRecord>(
+        this.deliveriesPath(runId),
+        1,
+      );
+      if (
+        isDeliverySettledRecord(latestDelivery) &&
+        latestDelivery.revision >= latestTransition.run.revision
+      ) {
+        continue;
+      }
+      const state = await this.hydrate(runId);
+      if (!state) continue;
       const delivered = new Set(state.deliveries.map((item) => item.intentId));
+      const runPending: typeof pending = [];
       for (const transition of state.transitions) {
         for (const intent of transition.events) {
           if (!delivered.has(intent.id)) {
-            pending.push({
+            runPending.push({
               runId: transition.runId,
               revision: transition.revision,
               intent,
@@ -148,12 +241,43 @@ export class WorkbenchRunUnitOfWork implements RunUnitOfWorkPort {
           }
         }
       }
+      if (runPending.length === 0) {
+        // Nothing to re-deliver: record settlement so the next startup sweep
+        // can skip this run entirely.
+        await this.markDeliverySettled(runId, state.run.revision);
+        continue;
+      }
+      pending.push(...runPending);
     }
     return pending.sort(
       (left, right) =>
         left.intent.occurredAt.localeCompare(right.intent.occurredAt) ||
         left.intent.id.localeCompare(right.intent.id),
     );
+  }
+
+  /**
+   * Append a delivery-settlement checkpoint for `runId` through `revision`:
+   * all public-event intents up to that revision are durably delivered.
+   * Settlement is only consulted from the journal on the next sweep, so no
+   * in-memory state is updated.
+   */
+  async markDeliverySettled(runId: string, revision: number): Promise<void> {
+    await this.exclusive(runId, async () => {
+      const intentId = deliverySettledIntentId(runId, revision);
+      await appendJsonLine(
+        this.deliveriesPath(runId),
+        {
+          intentId,
+          runId,
+          revision,
+          eventId: intentId.slice(0, 256),
+          sequence: revision,
+          deliveredAt: new Date().toISOString(),
+        } satisfies RunEventDeliveryRecord,
+        0o600,
+      );
+    });
   }
 
   async markEventDelivered(delivery: RunEventDeliveryRecord): Promise<void> {

--- a/packages/workbench-server/src/domains/runs/runtime/run-lookup-index.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-lookup-index.ts
@@ -108,10 +108,11 @@ export interface ActiveRunLookupSource {
   /** Loads one run's authoritative hydrated state. */
   load(runId: string): Promise<RunHydratedState | undefined>;
   /**
-   * Performs one authoritative full hydration that observes every run into
-   * the lookup (typically the unit of work's own `list()`).
+   * Performs the one authoritative initialization that observes every ACTIVE
+   * run into the lookup (metadata scan + full hydration of active runs only;
+   * terminal history stays on disk until explicitly queried).
    */
-  hydrateAll(): Promise<unknown>;
+  hydrateActive(): Promise<unknown>;
 }
 
 /**
@@ -211,7 +212,7 @@ export class ActiveRunLookup {
   private async ensureInitialized(): Promise<void> {
     if (this.initialized) return;
     // Serialize the one authoritative initialization; allow retry on failure.
-    this.initializing ??= Promise.resolve(this.source.hydrateAll()).then(
+    this.initializing ??= Promise.resolve(this.source.hydrateActive()).then(
       () => {
         this.initialized = true;
       },

--- a/packages/workbench-server/src/domains/runs/runtime/run-unit-of-work.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-unit-of-work.ts
@@ -22,6 +22,11 @@ export interface RunUnitOfWorkPort {
   findActive(scopeId: string): Promise<RunHydratedState | undefined>;
   /** Loads only currently-active runs without hydrating terminal history. */
   listActive(): Promise<readonly RunHydratedState[]>;
+  /**
+   * Lightweight records (metadata) for every run without hydrating transition
+   * history; cost scales with the number of runs, not journal sizes.
+   */
+  listMetadata(): Promise<readonly RunRecord[]>;
   /** Resolves the active run containing the interaction, if any. */
   findByInteractionId(
     interactionId: string,
@@ -51,6 +56,12 @@ export interface RunUnitOfWorkPort {
     }[]
   >;
   markEventDelivered(delivery: RunEventDeliveryRecord): Promise<void>;
+  /**
+   * Records that every public-event intent through `revision` is durably
+   * delivered, so delivery recovery sweeps can skip the run without
+   * hydrating its transition history.
+   */
+  markDeliverySettled(runId: string, revision: number): Promise<void>;
   materialize(state: RunHydratedState): Promise<void>;
 }
 
@@ -147,6 +158,13 @@ export class RunEventDeliveryService {
           });
           delivered.add(intent.id);
         }
+        // Every intent of this transition is now durably delivered (including
+        // transitions with no events): record settlement so future recovery
+        // sweeps skip this run without hydrating its transition history.
+        await this.unitOfWork.markDeliverySettled(
+          transition.runId,
+          transition.revision,
+        );
       } catch (error) {
         this.recoveryRequired = true;
         throw error;
@@ -157,14 +175,22 @@ export class RunEventDeliveryService {
   private async flushPending(): Promise<void> {
     const failedRuns = new Set<string>();
     const failures: unknown[] = [];
+    const settledRevision = new Map<string, number>();
     for (const pending of await this.unitOfWork.pendingEventIntents()) {
       if (failedRuns.has(pending.runId)) continue;
       try {
         await this.deliver(pending);
+        const current = settledRevision.get(pending.runId) ?? 0;
+        if (pending.revision > current) {
+          settledRevision.set(pending.runId, pending.revision);
+        }
       } catch (error) {
         failedRuns.add(pending.runId);
         failures.push(error);
       }
+    }
+    for (const [runId, revision] of settledRevision) {
+      await this.unitOfWork.markDeliverySettled(runId, revision);
     }
     if (failures.length > 0) {
       const firstFailure = failures[0];

--- a/packages/workbench-server/src/domains/runs/workbench-run-projector.ts
+++ b/packages/workbench-server/src/domains/runs/workbench-run-projector.ts
@@ -24,9 +24,14 @@ export class WorkbenchRunProjector implements RunTransitionObserverPort {
     await this.projectAgentStatus(transition.run);
   }
 
-  async rebuild(states: readonly RunHydratedState[]): Promise<void> {
+  async rebuild(input: {
+    /** Full hydrated states of currently-active runs only. */
+    readonly activeStates: readonly RunHydratedState[];
+    /** Lightweight records (metadata) for every run, incl. terminal history. */
+    readonly runRecords: readonly RunRecord[];
+  }): Promise<void> {
     this.state.conversationRuntime.reset();
-    for (const state of states) {
+    for (const state of input.activeStates) {
       if (isActiveRun(state.run)) {
         this.projectConversationRuntime(
           state.run,
@@ -36,7 +41,7 @@ export class WorkbenchRunProjector implements RunTransitionObserverPort {
     }
 
     const latestByAgent = new Map<string, RunRecord>();
-    for (const { run } of states) {
+    for (const run of input.runRecords) {
       const current = latestByAgent.get(run.agentId);
       if (
         !current ||

--- a/packages/workbench-server/src/domains/tools/tool-call.repository.ts
+++ b/packages/workbench-server/src/domains/tools/tool-call.repository.ts
@@ -16,6 +16,8 @@ export interface ToolCallHydrationStats {
   rowCount: number;
   uniqueCount: number;
   fileBytes: number;
+  /** Whether records came from the persisted index snapshot or the journal. */
+  source: "snapshot" | "journal";
 }
 
 export interface ToolCallRepositoryOptions {
@@ -29,6 +31,7 @@ export class ToolCallRepository {
     rowCount: 0,
     uniqueCount: 0,
     fileBytes: 0,
+    source: "journal",
   };
 
   constructor(
@@ -37,14 +40,56 @@ export class ToolCallRepository {
     private readonly options: ToolCallRepositoryOptions = {},
   ) {}
 
+  /**
+   * Hydrate the in-memory records. When the persisted index snapshot is
+   * current (schema version matches and the journal size equals the recorded
+   * watermark), records are loaded from sqlite instead of scanning the full
+   * append-only journal, which can be hundreds of MB. The journal remains the
+   * durable source of truth and is scanned whenever the snapshot is missing,
+   * stale, or from an older schema.
+   */
   async hydrate(): Promise<ToolCallRecord[]> {
+    const fileBytes = await this.fileSize();
+    const validation = this.index.isToolCallSnapshotValid(fileBytes);
+    if (validation.valid) {
+      const toolCalls = this.index.loadToolCalls();
+      for (const toolCall of toolCalls) {
+        this.records.set(toolCall.id, toolCall);
+      }
+      this.hydrationStats = {
+        rowCount: toolCalls.length,
+        uniqueCount: toolCalls.length,
+        fileBytes,
+        source: "snapshot",
+      };
+      return toolCalls;
+    }
     const { records: toolCalls, stats } = await this.readLatest();
-    this.hydrationStats = stats;
+    this.hydrationStats = { ...stats, source: "journal" };
     for (const toolCall of toolCalls) {
       this.records.set(toolCall.id, toolCall);
       this.index.upsertToolCall(toolCall);
     }
     return toolCalls;
+  }
+
+  get hydrationSource(): "snapshot" | "journal" {
+    return this.hydrationStats.source;
+  }
+
+  get hydrationStatsValue(): ToolCallHydrationStats {
+    return { ...this.hydrationStats };
+  }
+
+  /**
+   * Record the current journal watermark so the next startup can reuse the
+   * persisted index snapshot. Called after a journal-based hydrate followed by
+   * a full index rebuild, when the tool_calls table now mirrors the journal.
+   */
+  async markToolCallSnapshotPersisted(): Promise<void> {
+    if (this.hydrationStats.source === "snapshot") return;
+    await this.syncSnapshotMeta();
+    this.hydrationStats = { ...this.hydrationStats, source: "snapshot" };
   }
 
   list(): ToolCallRecord[] {
@@ -74,6 +119,7 @@ export class ToolCallRepository {
     this.records.set(toolCall.id, toolCall);
     this.index.upsertToolCall(toolCall);
     await appendJsonLine(this.path(), toolCall, 0o600);
+    await this.syncSnapshotMeta();
   }
 
   async removeForConversations(conversationIds: Set<string>): Promise<void> {
@@ -84,6 +130,7 @@ export class ToolCallRepository {
       }
     }
     await rewriteJsonLines(this.path(), this.list(), 0o600);
+    await this.syncSnapshotMeta();
   }
 
   /**
@@ -99,7 +146,9 @@ export class ToolCallRepository {
       rowCount: records.length,
       uniqueCount: records.length,
       fileBytes: await this.fileSize(),
+      source: this.hydrationStats.source,
     };
+    await this.syncSnapshotMeta();
   }
 
   async compactPersistedIfAmplified(): Promise<
@@ -141,6 +190,7 @@ export class ToolCallRepository {
         rowCount,
         uniqueCount: byId.size,
         fileBytes: await this.fileSize(),
+        source: "journal",
       },
     };
   }
@@ -150,6 +200,34 @@ export class ToolCallRepository {
       (value) => value.size,
       () => 0,
     );
+  }
+
+  /**
+   * Refresh the persisted snapshot metadata after any journal mutation so the
+   * next startup can skip the full journal scan. The watermark is the exact
+   * journal size, so appends/rewrites always invalidate a stale snapshot.
+   * Best-effort: a failed meta write only costs a journal rehydrate on the
+   * next startup, never correctness, so it must not break tool-call upserts.
+   */
+  private async syncSnapshotMeta(): Promise<void> {
+    try {
+      let latestUpdatedAt: string | null = null;
+      for (const record of this.records.values()) {
+        if (latestUpdatedAt === null || record.updatedAt > latestUpdatedAt) {
+          latestUpdatedAt = record.updatedAt;
+        }
+      }
+      this.index.writeToolCallSnapshot({
+        watermark: await this.fileSize(),
+        // The persisted row count is the validation source of truth; using the
+        // in-memory map size could reject a valid snapshot when a single
+        // table write diverged from memory (e.g. an upsert that did not land).
+        rowCount: this.index.countToolCalls(),
+        latestUpdatedAt,
+      });
+    } catch {
+      // Ignored: the journal remains the durable source of truth.
+    }
   }
 
   private path(): string {

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -240,6 +240,16 @@ export class ToolService {
     return this.toolCallRepository.list();
   }
 
+  /** Whether the tool-call records were loaded from the persisted snapshot. */
+  get toolCallHydrationSource(): "snapshot" | "journal" {
+    return this.toolCallRepository.hydrationSource;
+  }
+
+  /** Record the journal watermark after a journal-based hydrate + rebuild. */
+  async markToolCallSnapshotPersisted(): Promise<void> {
+    await this.toolCallRepository.markToolCallSnapshotPersisted();
+  }
+
   /** Compact the persisted tool-call log, dropping superseded append rows. */
   async compactToolCallLog(): Promise<void> {
     await this.toolCallRepository.compactPersisted();

--- a/packages/workbench-server/src/infrastructure/index-store/index-store.ts
+++ b/packages/workbench-server/src/infrastructure/index-store/index-store.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- IndexStore centralizes the derived sqlite index surface incl. the persisted tool-call snapshot. */
 import { existsSync, renameSync, rmSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import type {
@@ -10,7 +11,9 @@ import type {
   UserQuestionRecord,
   WorkerRecord,
 } from "@nervekit/contracts";
-import { INDEX_STORE_SCHEMA_SQL } from "./schema.js";
+import { INDEX_SCHEMA_VERSION, INDEX_STORE_SCHEMA_SQL } from "./schema.js";
+
+export { INDEX_SCHEMA_VERSION } from "./schema.js";
 
 export interface IndexCounts {
   projects: number;
@@ -43,6 +46,29 @@ export interface RebuildIndexInput {
   approvals?: ApprovalRecord[];
   userQuestions?: UserQuestionRecord[];
 }
+
+export interface RebuildIndexOptions {
+  /**
+   * Keep the existing tool_calls rows instead of deleting and re-inserting
+   * them. Used when the persisted tool-call snapshot is already current, so a
+   * startup does not rebuild the largest index table from the journal.
+   */
+  preserveToolCalls?: boolean;
+}
+
+export interface ToolCallSnapshotMeta {
+  /** Byte length of logs/tool-calls.jsonl when the snapshot was last written. */
+  watermark: number;
+  /** Number of tool-call rows folded into the snapshot. */
+  rowCount: number;
+  /** Newest tool-call updatedAt folded into the snapshot, if any. */
+  latestUpdatedAt: string | null;
+}
+
+export type ToolCallSnapshotValidation = {
+  valid: boolean;
+  reason: "valid" | "no-meta" | "schema-mismatch" | "watermark-mismatch";
+};
 
 export interface IndexReplacementToken {
   readonly backupPath: string;
@@ -347,6 +373,111 @@ export class IndexStore {
     });
   }
 
+  // --- persisted tool-call snapshot ---
+
+  /**
+   * The index_meta schema version, or undefined when the meta table has no
+   * version row (a fresh database or one created by an older build).
+   */
+  readSchemaVersion(): number | undefined {
+    const raw = this.#readMeta("schema_version");
+    if (raw === undefined) return undefined;
+    const version = Number(raw);
+    return Number.isInteger(version) && version > 0 ? version : undefined;
+  }
+
+  /**
+   * Persist the latest-per-id tool-call snapshot metadata. The rows themselves
+   * are written by upsertToolCall/rebuild; this only records the journal
+   * watermark so a later startup can skip the full journal scan when the
+   * snapshot is current. All meta keys are written in one transaction so the
+   * snapshot can never be observed half-written.
+   */
+  writeToolCallSnapshot(meta: ToolCallSnapshotMeta): void {
+    this.guard(() => {
+      this.db.exec("BEGIN IMMEDIATE");
+      try {
+        this.#writeMeta("schema_version", String(INDEX_SCHEMA_VERSION));
+        this.#writeMeta("tool_calls_watermark", String(meta.watermark));
+        this.#writeMeta("tool_calls_rows", String(meta.rowCount));
+        this.#writeMeta(
+          "tool_calls_latest_updated_at",
+          meta.latestUpdatedAt ?? "",
+        );
+        this.db.exec("COMMIT");
+      } catch (error) {
+        this.db.exec("ROLLBACK");
+        throw error;
+      }
+    });
+  }
+
+  /**
+   * True when the persisted tool_calls table is a complete, current snapshot of
+   * the journal: schema version matches, the meta table has a snapshot, the
+   * journal size matches the recorded watermark, and the table row count
+   * matches the recorded snapshot size.
+   */
+  isToolCallSnapshotValid(
+    currentWatermark: number,
+  ): ToolCallSnapshotValidation {
+    return this.guard(() => {
+      const version = this.readSchemaVersion();
+      if (version === undefined) return { valid: false, reason: "no-meta" };
+      if (version !== INDEX_SCHEMA_VERSION) {
+        return { valid: false, reason: "schema-mismatch" };
+      }
+      const watermark = this.#readMetaInt("tool_calls_watermark");
+      if (watermark !== currentWatermark) {
+        return { valid: false, reason: "watermark-mismatch" };
+      }
+      const rows = this.#readMetaInt("tool_calls_rows");
+      if (rows === undefined || rows !== this.countTable("tool_calls")) {
+        return { valid: false, reason: "watermark-mismatch" };
+      }
+      return { valid: true, reason: "valid" };
+    });
+  }
+
+  /** Stream the persisted tool-call snapshot back as records. */
+  loadToolCalls(): ToolCallRecord[] {
+    return this.guard(() => {
+      const rows = this.db
+        .prepare("SELECT json FROM tool_calls")
+        .all() as Array<{ json: string }>;
+      return rows.map((row) => JSON.parse(row.json) as ToolCallRecord);
+    });
+  }
+
+  /** Actual persisted row count, used as the snapshot row-count source of truth. */
+  countToolCalls(): number {
+    return this.guard(() => this.countTable("tool_calls"));
+  }
+
+  #readMeta(key: string): string | undefined {
+    const row = this.db
+      .prepare("SELECT value FROM index_meta WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    return row?.value;
+  }
+
+  #readMetaInt(key: string): number | undefined {
+    const raw = this.#readMeta(key);
+    if (raw === undefined || raw === "") return undefined;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  #writeMeta(key: string, value: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO index_meta (key, value)
+         VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(key, value);
+  }
+
   deleteApproval(id: string): void {
     if (this.updatesDeferred) return;
     this.guard(() => {
@@ -457,13 +588,23 @@ export class IndexStore {
     });
   }
 
-  rebuild(input: RebuildIndexInput): void {
+  rebuild(input: RebuildIndexInput, options: RebuildIndexOptions = {}): void {
     this.guard(() => {
       this.db.exec("BEGIN IMMEDIATE");
       try {
-        this.db.exec(
-          "DELETE FROM user_questions; DELETE FROM approvals; DELETE FROM tool_calls; DELETE FROM tasks; DELETE FROM workers; DELETE FROM agents; DELETE FROM conversations; DELETE FROM projects;",
-        );
+        const tables = [
+          "user_questions",
+          "approvals",
+          "tasks",
+          "workers",
+          "agents",
+          "conversations",
+          "projects",
+        ];
+        if (!options.preserveToolCalls) tables.push("tool_calls");
+        for (const table of tables) {
+          this.db.exec(`DELETE FROM ${table};`);
+        }
 
         const upsertUserQuestion = this.db.prepare(
           `INSERT INTO user_questions (id, json)
@@ -553,8 +694,10 @@ export class IndexStore {
         for (const approval of input.approvals ?? []) {
           upsertApproval.run(approval.id, JSON.stringify(approval));
         }
-        for (const toolCall of input.toolCalls ?? []) {
-          upsertToolCall.run(toolCall.id, JSON.stringify(toolCall));
+        if (!options.preserveToolCalls) {
+          for (const toolCall of input.toolCalls ?? []) {
+            upsertToolCall.run(toolCall.id, JSON.stringify(toolCall));
+          }
         }
         for (const worker of input.workers ?? []) {
           upsertWorker.run(

--- a/packages/workbench-server/src/infrastructure/index-store/schema.ts
+++ b/packages/workbench-server/src/infrastructure/index-store/schema.ts
@@ -1,4 +1,10 @@
+export const INDEX_SCHEMA_VERSION = 2;
+
 export const INDEX_STORE_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS index_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
   CREATE TABLE IF NOT EXISTS projects (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,

--- a/packages/workbench-server/src/main.ts
+++ b/packages/workbench-server/src/main.ts
@@ -1,7 +1,8 @@
-import { rm } from "node:fs/promises";
+import { appendFile, mkdir, rm } from "node:fs/promises";
 import { createServer as createHttpsServer } from "node:https";
 import type { AddressInfo } from "node:net";
 import { networkInterfaces } from "node:os";
+import { dirname, join } from "node:path";
 import { serve } from "@hono/node-server";
 import WebSocket, { WebSocketServer } from "ws";
 import {
@@ -115,6 +116,28 @@ function mergeNoProxy(value: string): string {
 let runtimeMonitor: DaemonRuntimeMonitor | undefined;
 const processStartupStartedAt = performance.now();
 
+/**
+ * Always-on, tiny startup telemetry (one JSONL line per daemon start) written
+ * outside the NERVE_LOGGING_ENABLED gate so startup regressions are observable
+ * without debug flags. Best-effort: failures never affect startup.
+ */
+async function appendStartupRecord(
+  home: string,
+  record: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const path = join(home, "logs", "startup.jsonl");
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(
+      path,
+      `${JSON.stringify({ ts: new Date().toISOString(), ...record })}\n`,
+      "utf8",
+    );
+  } catch {
+    // Best-effort observability only.
+  }
+}
+
 async function main() {
   prepareEnterpriseNetworkEnvironment();
   const dataDir = resolveDataDir();
@@ -168,12 +191,14 @@ async function main() {
       loggerHydrateDurationMs,
     },
   });
+  const agentSkillsStartedAt = performance.now();
   await state.agentBrowserSkills
     .initialize()
     .then(async () => {
       const count = state.agentBrowserSkills.skills.length;
       if (count > 0) {
         await state.logger.info("Agent Browser skills initialized", {
+          durationMs: Math.round(performance.now() - agentSkillsStartedAt),
           context: { count },
         });
       }
@@ -181,6 +206,9 @@ async function main() {
     .catch((error) =>
       state.logger.warn("Agent Browser skill discovery failed", { error }),
     );
+  const agentSkillsDurationMs = Math.round(
+    performance.now() - agentSkillsStartedAt,
+  );
   const runtimeCapabilitiesReady = state.registry.refreshRuntimeCapabilities();
   const eventHydrateStartedAt = Date.now();
   const archivedEventLogs = await migrateLegacyEventLogs(
@@ -188,9 +216,10 @@ async function main() {
     state.index,
   );
   await state.events.hydrate();
+  const eventsHydrateDurationMs = Date.now() - eventHydrateStartedAt;
   const workspaceBounds = await state.events.bounds("workspace");
   await state.logger.info("Event streams hydrated", {
-    durationMs: Date.now() - eventHydrateStartedAt,
+    durationMs: eventsHydrateDurationMs,
     context: {
       latestSeq: workspaceBounds.latestSeq,
       earliestAvailableSeq: workspaceBounds.earliestAvailableSeq,
@@ -260,6 +289,30 @@ async function main() {
           dataDir: storage.paths.home,
           pid: process.pid,
         },
+      });
+      await appendStartupRecord(storage.paths.home, {
+        type: "nerve.startup",
+        source: "daemon",
+        pid: process.pid,
+        port: state.port,
+        listeningDurationMs: Math.round(
+          performance.now() - processStartupStartedAt,
+        ),
+        storageDurationMs,
+        loggerHydrateDurationMs,
+        agentSkillsDurationMs,
+        eventsHydrateDurationMs,
+        registryStateDurationMs: registryTimings.stateDurationMs,
+        indexDurationMs: registryTimings.indexDurationMs,
+        storesHydrationDurationMs: registryTimings.storesHydrationDurationMs,
+        agentsHydrationDurationMs: registryTimings.agentsHydrationDurationMs,
+        runRecoveryDurationMs: registryTimings.runRecoveryDurationMs,
+        humanInputRecoveryDurationMs:
+          registryTimings.humanInputRecoveryDurationMs,
+        projectorDurationMs: registryTimings.projectorDurationMs,
+        taskNotificationsDurationMs:
+          registryTimings.taskNotificationsDurationMs,
+        toolCallHydrationSource: registryTimings.toolCallHydrationSource,
       });
       setImmediate(() => state.registry.startBackgroundMaintenance());
     },

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -539,6 +539,7 @@ export function composeRuntime(
     getConversationEntries: (conversationId) =>
       state.getConversationEntries(conversationId),
     harnessStorage: services.harnessStorage,
+    logger: logger.child({ component: "human-input" }),
     compactPlanConversation: async (input) => {
       await services.compactionService.compactConversation(
         input.conversationId,

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- RuntimeRegistry centralizes the hydration/startup use case incl. per-phase timing. */
 import type { Message } from "@earendil-works/pi-ai";
 import { listAvailableModels } from "@nervekit/harness";
 import type {
@@ -50,6 +51,20 @@ import type { AppendEntryInput, AppendEntryOptions } from "./types.js";
 export interface RegistryHydrationTimings {
   stateDurationMs: number;
   indexDurationMs: number;
+  /** Where the tool-call records came from (snapshot vs full journal scan). */
+  toolCallHydrationSource: "snapshot" | "journal";
+  /** ms: parallel store hydration (tasks/tools/plans/projects/conversations). */
+  storesHydrationDurationMs: number;
+  /** ms: agent records load. */
+  agentsHydrationDurationMs: number;
+  /** ms: run coordinator recovery (metadata scan + active run hydrates). */
+  runRecoveryDurationMs: number;
+  /** ms: approval batches + accepted plan reviews recovery. */
+  humanInputRecoveryDurationMs: number;
+  /** ms: run projector rebuild from metadata + active states. */
+  projectorDurationMs: number;
+  /** ms: task notification recovery. */
+  taskNotificationsDurationMs: number;
 }
 
 export class RuntimeRegistry {
@@ -152,7 +167,14 @@ export class RuntimeRegistry {
 
   async hydrate(): Promise<RegistryHydrationTimings> {
     const stateStartedAt = performance.now();
+    let storesHydrationDurationMs = 0;
+    let agentsHydrationDurationMs = 0;
+    let runRecoveryDurationMs = 0;
+    let humanInputRecoveryDurationMs = 0;
+    let projectorDurationMs = 0;
+    let taskNotificationsDurationMs = 0;
     await this.index.withUpdatesDeferred(async () => {
+      const storesStartedAt = performance.now();
       const workersHydrated = this.workers.hydrate();
       await settleHydrationOperations([
         this.auth.refreshModels({ allowNetwork: false }),
@@ -164,25 +186,59 @@ export class RuntimeRegistry {
         this.loadProjects(),
         this.loadConversations(),
       ]);
+      storesHydrationDurationMs = Math.round(
+        performance.now() - storesStartedAt,
+      );
+      const agentsStartedAt = performance.now();
       await this.loadAgents();
-      await this.rebuildConversations();
+      agentsHydrationDurationMs = Math.round(
+        performance.now() - agentsStartedAt,
+      );
+      const runRecoveryStartedAt = performance.now();
       await this.services.runRuntime.delivery.flush();
       await this.services.runRuntime.coordinator.recover();
+      runRecoveryDurationMs = Math.round(
+        performance.now() - runRecoveryStartedAt,
+      );
+      const humanInputStartedAt = performance.now();
       await this.services.humanInput.recoverReadyApprovalBatches();
       await this.services.humanInput.recoverAcceptedPlanReviews();
-      await this.services.runRuntime.projector.rebuild(
-        await this.services.runRuntime.unitOfWork.list(),
+      humanInputRecoveryDurationMs = Math.round(
+        performance.now() - humanInputStartedAt,
       );
+      // Rebuild the projection from lightweight run records (metadata) plus
+      // the full states of the already-recovered active runs; terminal run
+      // history is never hydrated during startup.
+      const projectorStartedAt = performance.now();
+      await this.services.runRuntime.projector.rebuild({
+        activeStates: await this.services.runRuntime.unitOfWork.listActive(),
+        runRecords: await this.services.runRuntime.unitOfWork.listMetadata(),
+      });
+      projectorDurationMs = Math.round(performance.now() - projectorStartedAt);
       await this.services.runRuntime.delivery.flush();
+      const taskNotificationsStartedAt = performance.now();
       await this.services.taskNotifications.recoverPendingNotifications();
+      taskNotificationsDurationMs = Math.round(
+        performance.now() - taskNotificationsStartedAt,
+      );
     });
     const stateDurationMs = Math.round(performance.now() - stateStartedAt);
     const indexStartedAt = performance.now();
     await this.rebuildIndex();
+    // After a journal-based hydrate, the index now mirrors the journal; record
+    // the watermark so the next startup can skip the full journal scan.
+    await this.tools.markToolCallSnapshotPersisted();
     await this.promptSuggestions.hydrate();
     return {
       stateDurationMs,
       indexDurationMs: Math.round(performance.now() - indexStartedAt),
+      toolCallHydrationSource: this.tools.toolCallHydrationSource,
+      storesHydrationDurationMs,
+      agentsHydrationDurationMs,
+      runRecoveryDurationMs,
+      humanInputRecoveryDurationMs,
+      projectorDurationMs,
+      taskNotificationsDurationMs,
     };
   }
 
@@ -233,16 +289,23 @@ export class RuntimeRegistry {
 
   /** Rebuild the disposable derived SQLite index from repositories. */
   async rebuildIndex(): Promise<void> {
-    this.index.rebuild({
-      projects: this.listProjects(),
-      conversations: this.listConversations(),
-      agents: this.listAgents(),
-      tasks: this.tasks.listTasks(),
-      workers: this.workers.listWorkers(),
-      toolCalls: this.tools.listToolCalls(),
-      approvals: this.tools.listApprovals(),
-      userQuestions: this.tools.listUserQuestions(),
-    });
+    // When the persisted tool-call snapshot is already current (records were
+    // loaded from sqlite), keep the existing tool_calls rows instead of
+    // deleting and re-inserting hundreds of MB of records on every startup.
+    const preserveToolCalls = this.tools.toolCallHydrationSource === "snapshot";
+    this.index.rebuild(
+      {
+        projects: this.listProjects(),
+        conversations: this.listConversations(),
+        agents: this.listAgents(),
+        tasks: this.tasks.listTasks(),
+        workers: this.workers.listWorkers(),
+        toolCalls: this.tools.listToolCalls(),
+        approvals: this.tools.listApprovals(),
+        userQuestions: this.tools.listUserQuestions(),
+      },
+      { preserveToolCalls },
+    );
   }
 
   async createProject(request: CreateProjectRequest): Promise<ProjectRecord> {
@@ -765,15 +828,6 @@ export class RuntimeRegistry {
 
   private async loadAgents(): Promise<void> {
     await this.services.agentLifecycle.loadAgents();
-  }
-
-  private async rebuildConversations(): Promise<void> {
-    await this.services.conversationService.rebuildAll(
-      this.projects.values(),
-      this.conversations.values(),
-      this.agents.values(),
-      this.entries,
-    );
   }
 }
 

--- a/packages/workbench-server/test/index-store.test.ts
+++ b/packages/workbench-server/test/index-store.test.ts
@@ -230,6 +230,76 @@ describe("IndexStore", () => {
   });
 });
 
+describe("IndexStore tool-call snapshot", () => {
+  it("rebuild preserves existing tool_calls rows when asked", async (t) => {
+    const path = await tempDbPath();
+    const store = new IndexStore(path);
+    t.after(() => store.close());
+    store.initialize();
+    const toolCall = {
+      id: "tool_snap",
+      agentId: "agent_snap",
+      conversationId: "conv_snap",
+      projectId: "proj_snap",
+      toolName: "read",
+      risk: "read",
+      args: { path: "README.md" },
+      cwd: "/tmp",
+      status: "completed",
+      createdAt: now,
+      updatedAt: now,
+    } as ToolCallRecord;
+
+    store.upsertToolCall(toolCall);
+    store.writeToolCallSnapshot({
+      watermark: 128,
+      rowCount: 1,
+      latestUpdatedAt: now,
+    });
+
+    // A rebuild with preserveToolCalls must keep the row and the meta.
+    store.rebuild(
+      { projects: [], conversations: [], agents: [] },
+      { preserveToolCalls: true },
+    );
+    assert.equal(store.loadToolCalls().length, 1);
+    const validation = store.isToolCallSnapshotValid(128);
+    assert.deepEqual(validation, { valid: true, reason: "valid" });
+    assert.deepEqual(
+      store.loadToolCalls().map((record) => record.id),
+      ["tool_snap"],
+    );
+
+    // A full rebuild wipes the table, so the snapshot becomes invalid.
+    store.rebuild({ projects: [], conversations: [], agents: [] });
+    assert.equal(store.loadToolCalls().length, 0);
+    assert.equal(store.isToolCallSnapshotValid(128).valid, false);
+  });
+
+  it("validates the snapshot against schema version and watermark", async (t) => {
+    const path = await tempDbPath();
+    const store = new IndexStore(path);
+    t.after(() => store.close());
+    store.initialize();
+
+    assert.equal(store.isToolCallSnapshotValid(0).reason, "no-meta");
+
+    store.writeToolCallSnapshot({
+      watermark: 42,
+      rowCount: 0,
+      latestUpdatedAt: null,
+    });
+    assert.deepEqual(store.isToolCallSnapshotValid(42), {
+      valid: true,
+      reason: "valid",
+    });
+    assert.equal(
+      store.isToolCallSnapshotValid(43).reason,
+      "watermark-mismatch",
+    );
+  });
+});
+
 function countTable(db: DatabaseSync, table: string): number {
   const row = db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as {
     count: number;

--- a/packages/workbench-server/test/run-coordinator.contract.test.ts
+++ b/packages/workbench-server/test/run-coordinator.contract.test.ts
@@ -102,6 +102,12 @@ class MemoryUnitOfWork implements RunUnitOfWorkPort {
     const next = applyRunEventDelivery(state, delivery);
     this.deliveries.set(delivery.runId, [...next.deliveries]);
   }
+
+  async markDeliverySettled(runId: string, revision: number): Promise<void> {
+    // Test stub: settlement bookkeeping is exercised against the real store.
+    void runId;
+    void revision;
+  }
   async materialize(state: RunHydratedState) {
     void state;
     if (this.materializeFailure) throw this.materializeFailure;

--- a/packages/workbench-server/test/run-event-delivery.contract.test.ts
+++ b/packages/workbench-server/test/run-event-delivery.contract.test.ts
@@ -68,6 +68,12 @@ class DeliveryUnitOfWork implements RunUnitOfWorkPort {
     );
     if (!existing) this.deliveries.push(delivery);
   }
+
+  async markDeliverySettled(runId: string, revision: number): Promise<void> {
+    // Test stub: settlement bookkeeping is exercised against the real store.
+    void runId;
+    void revision;
+  }
   async materialize(): Promise<void> {}
 }
 

--- a/packages/workbench-server/test/run-lookup-index.test.ts
+++ b/packages/workbench-server/test/run-lookup-index.test.ts
@@ -192,7 +192,7 @@ function lookupFixture(initial: RunHydratedState[]) {
       loads.push(runId);
       return store.get(runId);
     },
-    hydrateAll: async () => {
+    hydrateActive: async () => {
       hydrations += 1;
       for (const item of store.values()) lookup.observe(item);
       lookup.markInitialized();
@@ -306,7 +306,7 @@ test("failed initialization is retried on the next targeted read", async () => {
   const live = state({ runId: "run_live", scopeId: "scope_live" });
   const lookup: ActiveRunLookup = new ActiveRunLookup({
     load: async (runId) => (runId === "run_live" ? live : undefined),
-    hydrateAll: async () => {
+    hydrateActive: async () => {
       attempts += 1;
       if (attempts === 1) throw new Error("journal unavailable");
       lookup.observe(live);

--- a/packages/workbench-server/test/run-runtime.test.ts
+++ b/packages/workbench-server/test/run-runtime.test.ts
@@ -97,6 +97,12 @@ class MemoryUnitOfWork implements RunUnitOfWorkPort {
     const next = applyRunEventDelivery(state, delivery);
     this.deliveries.set(delivery.runId, [...next.deliveries]);
   }
+
+  async markDeliverySettled(runId: string, revision: number): Promise<void> {
+    // Test stub: settlement bookkeeping is exercised against the real store.
+    void runId;
+    void revision;
+  }
   async materialize(): Promise<void> {}
 }
 

--- a/packages/workbench-server/test/run-transition.repository.test.ts
+++ b/packages/workbench-server/test/run-transition.repository.test.ts
@@ -13,6 +13,7 @@ import {
   RunRevisionConflictError,
 } from "../src/domains/runs/runtime/index.js";
 import { WorkbenchRunUnitOfWork } from "../src/domains/runs/run-transition.repository.js";
+import { DELIVERY_SETTLED_PREFIX } from "../src/domains/runs/run-transition.repository.js";
 
 const digest = `sha256:${"0".repeat(64)}`;
 const runId = "run_cache_test";
@@ -370,4 +371,156 @@ test("targeted lookups skip historical hydration and evict terminal commits", as
     await restarted.findByInteractionToolCallId("toolcall_live"),
     undefined,
   );
+});
+
+test("lookup initialization scans metadata and skips corrupt terminal history", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-workbench-run-meta-scan-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  let id = 2000;
+  const ids = { next: () => String(++id) };
+  const integrity = { checksum: () => digest };
+  const seed = new WorkbenchRunUnitOfWork(home, 0);
+
+  // One terminal and one active run, committed via the journal only (no
+  // materialized state.json), so the metadata scan must read the journals.
+  const terminalRunId = "run_terminal_scan";
+  const activeRunId = "run_active_scan";
+  const scopeId = "conv_scan:agent_scan";
+  for (const [runId, status] of [
+    [terminalRunId, "completed"],
+    [activeRunId, "waiting"],
+  ] as const) {
+    await seed.commit(
+      0,
+      buildTransition(
+        scopedRun({ runId, scopeId, revision: 1, status: "running" }),
+        "started",
+        0,
+        {},
+        ids,
+        integrity,
+      ),
+    );
+    await seed.commit(
+      1,
+      buildTransition(
+        scopedRun({ runId, scopeId, revision: 2, status }),
+        status === "completed" ? "completed" : "waiting",
+        1,
+        {},
+        ids,
+        integrity,
+      ),
+    );
+  }
+
+  // A fresh store initializes its lookup from the metadata scan. Corrupting
+  // the terminal run's journal proves the scan never hydrates terminal
+  // history (a full hydration would reject on the corrupt journal).
+  const restarted = new WorkbenchRunUnitOfWork(home, 0);
+  await appendFile(
+    join(home, "run-runtime", "runs", terminalRunId, "transitions.jsonl"),
+    "not-json\n",
+  );
+
+  const records = await restarted.listMetadata();
+  assert.deepEqual(
+    records.map((record) => [record.runId, record.status]).sort(),
+    [
+      [activeRunId, "waiting"],
+      [terminalRunId, "completed"],
+    ],
+  );
+  assert.deepEqual(
+    (await restarted.listActive()).map((state) => state.run.runId),
+    [activeRunId],
+  );
+  assert.equal((await restarted.findActive(scopeId))?.run.runId, activeRunId);
+});
+
+test("delivery sweep settles clean runs and skips settled history", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-workbench-run-settled-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  let id = 3000;
+  const ids = { next: () => String(++id) };
+  const integrity = { checksum: () => digest };
+  const seed = new WorkbenchRunUnitOfWork(home, 0);
+
+  const runId = "run_settled";
+  const scopeId = "conv_settled:agent_settled";
+  const intent = {
+    id: "intent_settled",
+    type: "run.started" as const,
+    delivery: "sequenced" as const,
+    occurredAt: startedAt,
+    data: {},
+  };
+  await seed.commit(
+    0,
+    buildTransition(
+      scopedRun({ runId, scopeId, revision: 1, status: "running" }),
+      "started",
+      0,
+      { events: [intent] },
+      ids,
+      integrity,
+    ),
+  );
+  await seed.commit(
+    1,
+    buildTransition(
+      scopedRun({ runId, scopeId, revision: 2, status: "completed" }),
+      "completed",
+      1,
+      {},
+      ids,
+      integrity,
+    ),
+  );
+
+  // All intents delivered but no settlement checkpoint yet (legacy state):
+  // the sweep finds nothing pending and writes the checkpoint (settle-on-read).
+  const legacy = new WorkbenchRunUnitOfWork(home, 0);
+  await legacy.markEventDelivered({
+    intentId: intent.id,
+    runId,
+    revision: 1,
+    eventId: "event_settled",
+    sequence: 1,
+    deliveredAt: startedAt,
+  } as never);
+  const firstSweep = await legacy.pendingEventIntents();
+  assert.deepEqual(firstSweep, []);
+  const checkpoint = (
+    await readFile(
+      join(home, "run-runtime", "runs", runId, "event-deliveries.jsonl"),
+      "utf8",
+    )
+  )
+    .trim()
+    .split("\n")
+    .pop();
+  const parsed = JSON.parse(checkpoint!);
+  assert.ok(parsed.intentId.startsWith(DELIVERY_SETTLED_PREFIX));
+  assert.equal(parsed.revision, 2);
+
+  // A restarted store skips the settled run without hydrating its history:
+  // corrupting a middle journal line would make a full hydration throw, but
+  // the metadata-based sweep never reads it.
+  const restarted = new WorkbenchRunUnitOfWork(home, 0);
+  const raw = await readFile(
+    join(home, "run-runtime", "runs", runId, "transitions.jsonl"),
+    "utf8",
+  );
+  const lines = raw.trimEnd().split("\n");
+  lines.splice(1, 0, "not-json");
+  await appendFile(
+    join(home, "run-runtime", "runs", runId, "transitions.jsonl"),
+    "",
+  );
+  await appendFile(
+    join(home, "run-runtime", "runs", runId, "transitions.jsonl"),
+    lines.join("\n"),
+  );
+  assert.deepEqual(await restarted.pendingEventIntents(), []);
 });

--- a/packages/workbench-server/test/tool-call.repository.test.ts
+++ b/packages/workbench-server/test/tool-call.repository.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
@@ -88,5 +88,118 @@ describe("ToolCallRepository compaction", () => {
     await repository.hydrate();
     assert.equal(await repository.compactPersistedIfAmplified(), undefined);
     index.close();
+  });
+});
+
+describe("ToolCallRepository snapshot hydration", () => {
+  it("loads from the persisted snapshot when the journal watermark matches", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-snapshot-"));
+    roots.push(home);
+    const storage = await initializeStorage(home);
+    const path = join(home, "logs", "tool-calls.jsonl");
+    await writeFile(
+      path,
+      [toolCall("tool_a"), toolCall("tool_b")]
+        .map((value) => JSON.stringify(value))
+        .join("\n") + "\n",
+    );
+    const index = new IndexStore(storage.paths.sqlitePath);
+    index.initialize();
+    const first = new ToolCallRepository(storage, index);
+    assert.equal((await first.hydrate()).length, 2);
+    assert.equal(first.hydrationSource, "journal");
+    await first.markToolCallSnapshotPersisted();
+    index.close();
+
+    // Corrupting the journal (same byte length, so the watermark still
+    // matches) proves the snapshot path never re-reads it: a journal-based
+    // hydrate would fail to parse this content.
+    const originalSize = (await stat(path)).size;
+    await writeFile(path, `${"X".repeat(originalSize - 1)}\n`);
+    const reopened = new IndexStore(storage.paths.sqlitePath);
+    reopened.initialize();
+    const second = new ToolCallRepository(storage, reopened);
+    const records = await second.hydrate();
+    assert.equal(second.hydrationSource, "snapshot");
+    assert.deepEqual(
+      new Set(records.map((record) => record.id)),
+      new Set(["tool_a", "tool_b"]),
+    );
+    reopened.close();
+  });
+
+  it("falls back to the journal when the watermark no longer matches", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-snapshot-"));
+    roots.push(home);
+    const storage = await initializeStorage(home);
+    const path = join(home, "logs", "tool-calls.jsonl");
+    await writeFile(path, JSON.stringify(toolCall("tool_a")) + "\n");
+    const index = new IndexStore(storage.paths.sqlitePath);
+    index.initialize();
+    const first = new ToolCallRepository(storage, index);
+    await first.hydrate();
+    await first.markToolCallSnapshotPersisted();
+    index.close();
+
+    // Simulate a crash between a journal append and the snapshot meta sync.
+    await writeFile(
+      path,
+      JSON.stringify(toolCall("tool_a")) +
+        "\n" +
+        JSON.stringify(toolCall("tool_b", "2026-07-25T00:00:02.000Z")) +
+        "\n",
+    );
+    const reopened = new IndexStore(storage.paths.sqlitePath);
+    reopened.initialize();
+    const second = new ToolCallRepository(storage, reopened);
+    const records = await second.hydrate();
+    assert.equal(second.hydrationSource, "journal");
+    assert.deepEqual(
+      new Set(records.map((record) => record.id)),
+      new Set(["tool_a", "tool_b"]),
+    );
+    reopened.close();
+  });
+
+  it("falls back to the journal when the snapshot was never written", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-snapshot-"));
+    roots.push(home);
+    const storage = await initializeStorage(home);
+    const path = join(home, "logs", "tool-calls.jsonl");
+    await writeFile(path, JSON.stringify(toolCall("tool_a")) + "\n");
+    const index = new IndexStore(storage.paths.sqlitePath);
+    index.initialize();
+    const repository = new ToolCallRepository(storage, index);
+    const records = await repository.hydrate();
+    assert.equal(repository.hydrationSource, "journal");
+    assert.equal(records.length, 1);
+    index.close();
+  });
+
+  it("refreshes the snapshot watermark on upsert", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-snapshot-"));
+    roots.push(home);
+    const storage = await initializeStorage(home);
+    const path = join(home, "logs", "tool-calls.jsonl");
+    await writeFile(path, JSON.stringify(toolCall("tool_a")) + "\n");
+    const index = new IndexStore(storage.paths.sqlitePath);
+    index.initialize();
+    const repository = new ToolCallRepository(storage, index);
+    await repository.hydrate();
+    await repository.markToolCallSnapshotPersisted();
+    await repository.upsert(toolCall("tool_b", "2026-07-25T00:00:03.000Z"));
+    index.close();
+
+    // The upsert refreshed the watermark, so a restart uses the snapshot.
+    const reopened = new IndexStore(storage.paths.sqlitePath);
+    reopened.initialize();
+    const second = new ToolCallRepository(storage, reopened);
+    const records = await second.hydrate();
+    assert.equal(second.hydrationSource, "snapshot");
+    assert.deepEqual(
+      new Set(records.map((record) => record.id)),
+      new Set(["tool_a", "tool_b"]),
+    );
+    reopened.close();
   });
 });

--- a/packages/workbench-server/test/tool-service-lifecycle.test.ts
+++ b/packages/workbench-server/test/tool-service-lifecycle.test.ts
@@ -425,6 +425,9 @@ function buildToolService(
     {
       upsertToolCall: () => undefined,
       upsertApproval: () => undefined,
+      writeToolCallSnapshot: () => undefined,
+      isToolCallSnapshotValid: () => ({ valid: false, reason: "no-meta" }),
+      loadToolCalls: () => [],
     } as never,
     {} as never,
     (pythonRuntime ?? {

--- a/packages/workbench-server/test/workbench-run-regressions.test.ts
+++ b/packages/workbench-server/test/workbench-run-regressions.test.ts
@@ -48,16 +48,19 @@ describe("workbench coordinator behavior regressions", () => {
       events: [],
     } as never);
     assert.equal(state.agents.get(agent.id)?.status, "awaiting_user");
-    await projector.rebuild([
-      {
-        run: runRecord("completed", 3),
-        transitions: [],
-        prompts: [],
-        interactions: [],
-        checkpoints: [],
-        deliveries: [],
-      },
-    ]);
+    await projector.rebuild({
+      activeStates: [
+        {
+          run: runRecord("completed", 3),
+          transitions: [],
+          prompts: [],
+          interactions: [],
+          checkpoints: [],
+          deliveries: [],
+        },
+      ],
+      runRecords: [runRecord("completed", 3)],
+    });
     assert.deepEqual(projected, ["running", "awaiting_user", "idle"]);
     assert.equal(state.agents.get(agent.id)?.status, "idle");
   });
@@ -173,24 +176,27 @@ describe("workbench coordinator behavior regressions", () => {
       agentId: "agent_active",
       scopeId: "conv_active:agent_active",
     };
-    await projector.rebuild([
-      {
-        run: completed,
-        transitions: [],
-        prompts: [],
-        interactions: [],
-        checkpoints: [],
-        deliveries: [],
-      },
-      {
-        run: interrupted,
-        transitions: [],
-        prompts: [],
-        interactions: [],
-        checkpoints: [],
-        deliveries: [],
-      },
-    ]);
+    await projector.rebuild({
+      activeStates: [
+        {
+          run: completed,
+          transitions: [],
+          prompts: [],
+          interactions: [],
+          checkpoints: [],
+          deliveries: [],
+        },
+        {
+          run: interrupted,
+          transitions: [],
+          prompts: [],
+          interactions: [],
+          checkpoints: [],
+          deliveries: [],
+        },
+      ],
+      runRecords: [completed, interrupted],
+    });
 
     assert.equal(
       state.conversationRuntime.snapshotForConversation(stale.conversationId),
@@ -230,7 +236,10 @@ describe("workbench coordinator behavior regressions", () => {
       deliveries: [],
     };
 
-    await projector.rebuild([hydrated]);
+    await projector.rebuild({
+      activeStates: [hydrated],
+      runRecords: [hydrated.run],
+    });
     assert.deepEqual(projected, []);
     assert.equal(state.agents.get(newerAgent.id)?.status, "idle");
 
@@ -238,7 +247,10 @@ describe("workbench coordinator behavior regressions", () => {
       ...newerAgent,
       updatedAt: "2026-07-13T00:00:04.000Z",
     });
-    await projector.rebuild([hydrated]);
+    await projector.rebuild({
+      activeStates: [hydrated],
+      runRecords: [hydrated.run],
+    });
     assert.deepEqual(projected, ["error"]);
     assert.equal(state.agents.get(newerAgent.id)?.status, "error");
   });
@@ -562,6 +574,42 @@ describe("workbench coordinator behavior regressions", () => {
     assert.equal(fixture.completedToolCalls.length, 1);
     assert.equal(fixture.appendedEntries.length, 1);
     assert.equal(fixture.starts.length, 1);
+  });
+
+  it("skips accepted plan reviews whose tool call is missing instead of failing startup", async () => {
+    const review = { ...planReview(), status: "accepted" as const };
+    let warns = 0;
+    const service = new HumanInputResolutionService({
+      plans: {
+        listPlanReviews: () => [review],
+        planReviewResult: () => ({ decision: "accept" }),
+      },
+      tools: {
+        getToolCall: () => {
+          throw new Error("Tool call not found.");
+        },
+      },
+      runs: {},
+      continueAgent: async () => undefined,
+      createConversation: async () => ({}),
+      createAgent: async () => ({}),
+      getAgent: () => ({}) as never,
+      configureAgent: async () => ({}) as never,
+      setAgentStatus: async () => undefined,
+      appendEntry: async (input: Record<string, unknown>) => ({ ...input }),
+      getConversationEntries: () => [],
+      harnessStorage: {},
+      logger: {
+        warn: async () => {
+          warns += 1;
+        },
+      },
+      compactPlanConversation: async () => undefined,
+    } as never);
+
+    await service.recoverAcceptedPlanReviews();
+
+    assert.equal(warns, 1);
   });
 
   it("accepts a terminal-orphan plan into a new chat", async () => {
@@ -919,6 +967,7 @@ function acceptanceFixture(
       compactions.push(input);
       if (options.compactionError) throw options.compactionError;
     },
+    logger: { warn: async () => undefined },
   } as never);
   return {
     service,

--- a/scripts/perf/desktop-startup-profile.mjs
+++ b/scripts/perf/desktop-startup-profile.mjs
@@ -1,0 +1,476 @@
+#!/usr/bin/env node
+/**
+ * Nerve desktop cold-start profiler (agent-browser driven).
+ *
+ * Launches the Electron desktop app against an isolated NERVE_HOME + ports +
+ * userData dir with remote debugging enabled, records a CDP trace from the
+ * earliest page target, evaluates a performance-collection script once the
+ * workbench startup sequence finishes, and pulls main-process/daemon phase
+ * timings from the app's own JSONL logs. Writes one JSON result file per run.
+ *
+ * Usage:
+ *   node scripts/perf/desktop-startup-profile.mjs \
+ *     --home /tmp/nerve-perf/home --run <id> --out /tmp/nerve-perf/result.json \
+ *     [--cdp 9223] [--port 4747] [--ud /tmp/nerve-perf/ud] [--display :99]
+ *     [--trace] [--preserve-index] [--preserve-runs]
+ *
+ * Environment notes (learned the hard way):
+ *   - ELECTRON_RUN_AS_NODE must NOT be set when spawning Electron, or the
+ *     binary executes as plain Node ("bad option" errors). start-electron.mjs
+ *     deletes it for the same reason.
+ *   - Do NOT use `agent-browser vitals` on the connected Electron target: it
+ *     issues a page reload, which pollutes startup measurements.
+ *   - Without --preserve-index, state.sqlite is deleted before each run so the
+ *     daemon exercises the full journal-rehydration path. With it, the
+ *     persisted tool-call snapshot is preserved so the fast path is measured.
+ *   - Without --preserve-runs, run-runtime/ is wiped so the run subsystem
+ *     starts empty (warm-up of the run lookup index is not exercised).
+ *   - Runs need a display; on headless hosts start Xvfb first (e.g. Xvfb :99).
+ */
+import { spawn } from "node:child_process";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const DESKTOP_SHELL = join(repoRoot, "packages", "desktop-shell");
+const require = createRequire(join(DESKTOP_SHELL, "package.json"));
+const ELECTRON_BIN = require("electron");
+const AGENT_BROWSER = process.env.AGENT_BROWSER_BIN ?? "agent-browser";
+
+function parseArgs(argv) {
+  const args = {
+    cdp: 9223,
+    port: 4747,
+    ud: "/tmp/nerve-perf/ud",
+    display: ":99",
+    trace: false,
+    preserveIndex: false,
+    preserveRuns: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--home") args.home = argv[++i];
+    else if (a === "--run") args.run = argv[++i];
+    else if (a === "--out") args.out = argv[++i];
+    else if (a === "--cdp") args.cdp = Number(argv[++i]);
+    else if (a === "--port") args.port = Number(argv[++i]);
+    else if (a === "--ud") args.ud = argv[++i];
+    else if (a === "--display") args.display = argv[++i];
+    else if (a === "--trace") args.trace = true;
+    else if (a === "--preserve-index") args.preserveIndex = true;
+    else if (a === "--preserve-runs") args.preserveRuns = true;
+  }
+  if (!args.home || !args.run || !args.out) {
+    throw new Error("--home, --run, --out are required");
+  }
+  return args;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(predicate, { timeoutMs, intervalMs = 250, label }) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const value = await predicate();
+      if (value) return value;
+    } catch {
+      // keep polling
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timed out waiting for ${label ?? "condition"}`);
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${response.status} from ${url}`);
+  return response.json();
+}
+
+function runAgentBrowser(cdpPort, args, input) {
+  return new Promise((resolve) => {
+    const child = spawn(AGENT_BROWSER, ["--cdp", String(cdpPort), ...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c));
+    child.stderr.on("data", (c) => (stderr += c));
+    child.on("error", (error) =>
+      resolve({ code: 1, stdout, stderr: String(error) }),
+    );
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(input ?? "");
+  });
+}
+
+async function latestLogFile(home, prefix) {
+  const logsDir = join(home, "logs");
+  if (!existsSync(logsDir)) return undefined;
+  const files = (await readdir(logsDir)).filter(
+    (f) => f.startsWith(prefix) && f.endsWith(".jsonl"),
+  );
+  if (files.length === 0) return undefined;
+  files.sort();
+  return join(logsDir, files[files.length - 1]);
+}
+
+async function readLogRecords(path) {
+  if (!path || !existsSync(path)) return [];
+  const raw = await readFile(path, "utf8");
+  const records = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return records;
+}
+
+// Performance snapshot evaluated in the renderer once the workbench is up.
+const COLLECT_EXPRESSION = `(() => {
+  const nav = performance.getEntriesByType("navigation")[0];
+  const resources = performance.getEntriesByType("resource").map((e) => ({
+    name: e.name,
+    initiatorType: e.initiatorType,
+    startTime: Math.round(e.startTime),
+    duration: Math.round(e.duration),
+    transferSize: e.transferSize,
+    decodedBodySize: e.decodedBodySize,
+    encodedBodySize: e.encodedBodySize,
+  }));
+  return JSON.stringify({
+    nav: nav
+      ? {
+          domContentLoadedEventEnd: Math.round(nav.domContentLoadedEventEnd),
+          domInteractive: Math.round(nav.domInteractive),
+          loadEventEnd: Math.round(nav.loadEventEnd),
+          responseEnd: Math.round(nav.responseEnd),
+          transferSize: nav.transferSize,
+          decodedBodySize: nav.decodedBodySize,
+          duration: Math.round(nav.duration),
+        }
+      : null,
+    paints: performance
+      .getEntriesByType("paint")
+      .map((e) => ({ name: e.name, startTime: Math.round(e.startTime) })),
+    timeOrigin: performance.timeOrigin,
+    now: Math.round(performance.now()),
+    readyState: document.readyState,
+    resourceCount: resources.length,
+    resources,
+    title: document.title,
+    url: location.href,
+  });
+})()`;
+
+function main() {
+  const args = parseArgs(process.argv);
+  run(args).catch((error) => {
+    console.error(`harness error: ${error.stack ?? error}`);
+    process.exitCode = 1;
+  });
+}
+
+async function run(args) {
+  const {
+    home,
+    run: runId,
+    out,
+    cdp,
+    port,
+    ud,
+    display,
+    trace,
+    preserveIndex,
+    preserveRuns,
+  } = args;
+  const startedEpoch = Date.now();
+  const state = {
+    ok: false,
+    run: runId,
+    home,
+    spawnEpoch: null,
+    error: null,
+    main: {},
+    daemon: {},
+    renderer: {},
+    warnings: [],
+  };
+
+  // Fresh slate: drop the daemon file, per-run logs, and temp run data so each
+  // run starts from the same cold condition. Persistent data files under logs/
+  // (tool-calls.jsonl, events.jsonl) and, with --preserve-index, state.sqlite
+  // are kept.
+  await rm(join(home, "daemon.json"), { force: true });
+  await rm(join(home, "tmp"), { recursive: true, force: true });
+  if (!preserveRuns) {
+    await rm(join(home, "run-runtime"), { recursive: true, force: true });
+  }
+  if (!preserveIndex) {
+    await rm(join(home, "state.sqlite"), { force: true });
+    await rm(join(home, "state.sqlite-wal"), { force: true });
+    await rm(join(home, "state.sqlite-shm"), { force: true });
+  }
+  if (existsSync(join(home, "logs"))) {
+    for (const name of await readdir(join(home, "logs"))) {
+      if (name.startsWith("application-") || name.startsWith("desktop-")) {
+        await rm(join(home, "logs", name), { force: true });
+      }
+    }
+  }
+  await mkdir(dirname(out), { recursive: true });
+
+  // Fail fast if the daemon/CDP ports are already occupied by a stray process.
+  for (const p of [cdp, port, port + 1]) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${p}/`, {
+        signal: AbortSignal.timeout(400),
+      });
+      throw new Error(`port ${p} already in use (${response.status})`);
+    } catch (error) {
+      if (error.message?.startsWith("port")) throw error;
+      // Connection refused means the port is free enough.
+    }
+  }
+
+  const electronArgs = [
+    "--class=io.github.thilinatlm.nerve-v2",
+    "--ozone-platform=x11",
+    "--remote-debugging-port=" + cdp,
+    "--user-data-dir=" + ud,
+    ".",
+  ];
+  const env = {
+    ...process.env,
+    NERVE_HOME: home,
+    NERVE_PORT: String(port),
+    NERVE_HTTPS_PORT: String(port + 1),
+    NERVE_LOGGING_ENABLED: "1",
+    NERVE_ELECTRON_OZONE_PLATFORM: "x11",
+    DISPLAY: display,
+    WAYLAND_DISPLAY: "",
+  };
+  // Critical: without this the electron binary executes as plain Node.
+  delete env.ELECTRON_RUN_AS_NODE;
+
+  const child = spawn(ELECTRON_BIN, electronArgs, {
+    cwd: DESKTOP_SHELL,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  state.spawnEpoch = Date.now();
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  child.stdout.on("data", (c) => stdoutChunks.push(c));
+  child.stderr.on("data", (c) => stderrChunks.push(c));
+  child.on("error", (error) => {
+    state.error = `spawn error: ${error.message}`;
+  });
+  const exited = new Promise((resolve) =>
+    child.on("exit", (code, signal) => resolve({ code, signal })),
+  );
+
+  try {
+    await waitFor(() => fetchJson(`http://127.0.0.1:${cdp}/json/version`), {
+      timeoutMs: 30_000,
+      label: "CDP endpoint",
+    });
+
+    await waitFor(
+      async () => {
+        const targets = await fetchJson(`http://127.0.0.1:${cdp}/json/list`);
+        return targets.some((t) => t.type === "page");
+      },
+      { timeoutMs: 60_000, label: "page target" },
+    );
+
+    if (trace) {
+      const started = await runAgentBrowser(cdp, ["trace", "start"]);
+      if (started.code !== 0) {
+        state.warnings.push(`trace start: ${started.stderr.slice(0, 300)}`);
+      }
+    }
+
+    await waitFor(
+      async () => {
+        const targets = await fetchJson(`http://127.0.0.1:${cdp}/json/list`);
+        return targets.find(
+          (t) =>
+            t.type === "page" && t.url.startsWith(`http://127.0.0.1:${port}/`),
+        );
+      },
+      { timeoutMs: 120_000, intervalMs: 300, label: "daemon page" },
+    );
+
+    const appLogPath = await waitFor(
+      () => latestLogFile(home, "application-"),
+      { timeoutMs: 30_000, label: "application log file" },
+    );
+    await waitFor(
+      async () => {
+        const records = await readLogRecords(appLogPath);
+        return records.find((r) => r.message === "Workbench initialized");
+      },
+      { timeoutMs: 120_000, intervalMs: 400, label: "workbench initialized" },
+    );
+
+    await sleep(1500);
+
+    const collect = await runAgentBrowser(
+      cdp,
+      ["eval", "--stdin", "--json"],
+      COLLECT_EXPRESSION,
+    );
+    const parsed = tryParseLastJson(collect.stdout);
+    if (collect.code === 0 && parsed) state.renderer = parsed;
+    else state.warnings.push(`eval failed: ${collect.stderr.slice(0, 300)}`);
+
+    if (trace) {
+      const tracePath = join(dirname(out), `run-${runId}.trace.json`);
+      await runAgentBrowser(cdp, ["trace", "stop", tracePath]);
+      state.tracePath = tracePath;
+    }
+
+    const appRecords = await readLogRecords(appLogPath);
+    state.daemon.logRecords = appRecords.map(pickDaemonRecord).filter(Boolean);
+    state.daemon.workbenchInitialized = appRecords.find(
+      (r) => r.message === "Workbench initialized",
+    );
+
+    const desktopLogPath = await latestLogFile(home, "desktop-");
+    const desktopRecords = await readLogRecords(desktopLogPath);
+    state.main.records = desktopRecords.map(pickDesktopRecord).filter(Boolean);
+    state.main.startupReady = desktopRecords.find(
+      (r) => r.message === "Desktop startup ready",
+    );
+
+    state.ok = Boolean(
+      state.main.startupReady && state.daemon.workbenchInitialized,
+    );
+  } catch (error) {
+    state.error = error.message;
+    console.error(`run ${runId} failed: ${error.message}`);
+  } finally {
+    try {
+      child.kill("SIGTERM");
+      const result = await Promise.race([
+        exited,
+        sleep(20_000).then(() => ({ timeout: true })),
+      ]);
+      state.exit = result;
+      if (result.timeout) {
+        child.kill("SIGKILL");
+        await Promise.race([exited, sleep(5000)]);
+      }
+    } catch {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
+    await sleep(1500);
+    state.elapsedMs = Date.now() - startedEpoch;
+    state.childExited = child.exitCode !== null || child.signalCode !== null;
+
+    await writeFile(
+      out,
+      JSON.stringify(
+        {
+          ...state,
+          stdoutTail: Buffer.concat(stdoutChunks).toString("utf8").slice(-3000),
+          stderrTail: Buffer.concat(stderrChunks).toString("utf8").slice(-3000),
+        },
+        null,
+        2,
+      ),
+    );
+    console.log(
+      `run ${runId} done ok=${state.ok} elapsed=${state.elapsedMs}ms` +
+        (state.error ? ` error=${state.error}` : ""),
+    );
+  }
+}
+
+function tryParseLastJson(text) {
+  const lines = text.split("\n").filter((l) => l.trim());
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    try {
+      const parsed = unwrapJson(JSON.parse(lines[i]));
+      if (parsed !== undefined && typeof parsed === "object") return parsed;
+    } catch {
+      // keep scanning
+    }
+  }
+  return undefined;
+}
+
+function unwrapJson(value, depth = 0) {
+  if (depth > 6) return undefined;
+  if (typeof value === "string") {
+    try {
+      return unwrapJson(JSON.parse(value), depth + 1);
+    } catch {
+      return undefined;
+    }
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    for (const key of ["value", "result", "data"]) {
+      if (key in value && value[key] !== undefined) {
+        const inner = unwrapJson(value[key], depth + 1);
+        if (
+          inner &&
+          typeof inner === "object" &&
+          !Array.isArray(inner) &&
+          ("nav" in inner || "resources" in inner || "success" in inner)
+        ) {
+          return inner;
+        }
+      }
+    }
+    return value;
+  }
+  return value;
+}
+
+function pickDesktopRecord(r) {
+  if (!r || typeof r !== "object" || r.source !== "desktop") return undefined;
+  return {
+    message: r.message,
+    ts: r.ts,
+    durationMs: r.durationMs,
+    context: r.context,
+  };
+}
+
+function pickDaemonRecord(r) {
+  if (!r || typeof r !== "object") return undefined;
+  const interesting = new Set([
+    "Daemon listening",
+    "Event streams hydrated",
+    "Registry hydrated",
+    "Index rebuilt",
+    "Agent Browser skills initialized",
+    "Daemon storage initialized",
+    "Workbench initialized",
+  ]);
+  if (!interesting.has(r.message)) return undefined;
+  return {
+    source: r.source,
+    component: r.component,
+    message: r.message,
+    ts: r.ts,
+    durationMs: r.durationMs,
+    context: r.context,
+  };
+}
+
+main();


### PR DESCRIPTION
## Summary

Improves the desktop app cold start by ~2.5x on real-world profiles by making startup read **metadata instead of full payloads** everywhere, mirroring the pattern conversations already used (lightweight entries eager, transcripts lazy).

### Daemon (`workbench-server`)
- **Tool-call index snapshot (schema v2):** the derived sqlite index persists a journal-watermark snapshot; a valid snapshot (schema + watermark + row-count check) lets `ToolCallRepository.hydrate()` skip scanning a multi-hundred-MB `tool-calls.jsonl` on boot, with automatic journal fallback. Meta is refreshed on every journal mutation. Index rebuild on startup: ~1.5–3s → **~10ms**.
- **Run subsystem lazy hydration:** startup previously fully hydrated **all** run journals (471MB, 742 runs) *three times* (lookup index, delivery sweep ×2, projector). Now the lookup index and delivery recovery scan only the last transition line per run (~77ms for 742 runs) and fully hydrate only **active** runs; terminal history loads on demand. Per-run delivery-settlement checkpoints make the recovery sweep metadata-only after one migration start.
- Removed the eager per-conversation transcript-cache rebuild (cache had zero readers; it re-read hundreds of MB of harness transcripts).
- `recoverAcceptedPlanReviews` tolerates missing tool calls instead of failing startup.
- Registry hydration now reports per-phase timings in the always-on `logs/startup.jsonl` daemon record.

### Renderer (`workbench-app`)
- Code-split the non-default shell panels (files/tasks/notes/pull-requests) and on-demand center shells (settings/logs/auth/file/pr/diff) with spinner fallbacks; eager `index.js` 2.81MB → **1.90MB**; `v8.evaluateModule` 231ms → 116ms.
- Deferred notification-sound preload (12 audio fetches) to first user interaction.

### Observability / tooling
- Always-on `logs/startup.jsonl` (`nerve.startup` records from daemon and desktop, phase breakdown incl. `toolCallHydrationSource`).
- Committed profiling harness `scripts/perf/desktop-startup-profile.mjs` (CDP/agent-browser, isolated home/ports, `--preserve-index`/`--preserve-runs`).

## Measurements (realistic 2.7GB profile, median of ≥2 steady-state runs)

| Metric | Before | After |
|---|---|---|
| spawn → "Desktop startup ready" | 13,860 ms | **~3,110 ms** |
| daemon registry hydrate | 12,632 ms | **~2,030 ms** |
| daemon → listening | 12,966 ms | **~2,380 ms** |
| tool-call index rebuild | ~1,500 ms | **~10 ms** |
| fresh profile spawn → ready | 1,125 ms | 1,116 ms (no regression) |

> The first start after this change pays a one-time journal re-hydrate + legacy delivery sweep (~9–10s on the user's profile), then settles to the steady state above.

## Validation
- `pnpm fix`, `pnpm check`, `pnpm test` green (1,096 tests across 8 packages, incl. new snapshot/watermark, metadata-scan, and delivery-settlement tests).
- UI smoke-tested via agent-browser (lazy panels + settings shell open on demand, no console errors).
- Full details and design rationale: `/home/tlm/.nerve/plans/desktop-startup-performance.md`.
