### PR TITLE
fix(tasks): retain Windows bash output while resolving process identity

### DIFF
--- a/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.test.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { syntaxTree } from "@codemirror/language";
+import { ensureSyntaxTree } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
 import type { CodeLanguageId } from "./code-mirror-config";
 import {
@@ -63,7 +63,8 @@ describe("CodeMirror viewer helpers", () => {
         extensions: [await loadCodeLanguage(id)],
       });
 
-      assert.equal(syntaxTree(state).length, doc.length, id);
+      const tree = await ensureSyntaxTree(state, doc.length, 10_000);
+      assert.equal(tree?.length, doc.length, id);
     }
   });
 

--- a/packages/workbench-server/src/domains/filesystem/filesystem.service.ts
+++ b/packages/workbench-server/src/domains/filesystem/filesystem.service.ts
@@ -16,6 +16,7 @@ import {
   isAbsolute,
   join,
   parse,
+  posix,
   relative,
   resolve,
   win32,
@@ -483,7 +484,7 @@ export function normalizeIncomingFilePath(
     if (!path.startsWith("//")) path = path.replaceAll("/", "\\");
   }
 
-  const pathApi = platform === "win32" ? win32 : { isAbsolute, resolve };
+  const pathApi = platform === "win32" ? win32 : posix;
   return pathApi.isAbsolute(path)
     ? pathApi.resolve(path)
     : pathApi.resolve(root, path);

--- a/packages/workbench-server/src/domains/tasks/process-runtime/darwin-driver.ts
+++ b/packages/workbench-server/src/domains/tasks/process-runtime/darwin-driver.ts
@@ -131,34 +131,31 @@ async function ports(runtime: TaskRuntime): Promise<TaskListeningPort[]> {
 }
 
 export const darwinProcessRuntimeDriver: ProcessRuntimeDriver = {
-  async spawn(command, options) {
+  spawn(command, options) {
     const child = spawnShell(command, options);
     const { exited, closed } = observeProcessLifecycle(child);
     if (!child.pid) throw new Error("Spawned process has no PID");
-    const current = await fingerprint(child.pid);
-    return {
-      child,
-      exited,
-      closed,
-      runtime: {
-        version: 2,
-        platform: "darwin",
-        childPid: child.pid,
-        processGroupId: child.pid,
-        detached: true,
-        shell: true,
-        spawnedAt: new Date().toISOString(),
-        identity:
-          current.kind === "found"
-            ? { kind: "darwin", startFingerprint: current.value }
-            : { kind: "legacy_unverified" },
-        capabilities: {
-          identity: current.kind === "found",
-          processTree: true,
-          listeningPorts: true,
-        },
+    const pid = child.pid;
+    const spawnedAt = new Date().toISOString();
+    const runtime = fingerprint(pid).then((current) => ({
+      version: 2 as const,
+      platform: "darwin" as const,
+      childPid: pid,
+      processGroupId: pid,
+      detached: true,
+      shell: true,
+      spawnedAt,
+      identity:
+        current.kind === "found"
+          ? ({ kind: "darwin", startFingerprint: current.value } as const)
+          : ({ kind: "legacy_unverified" } as const),
+      capabilities: {
+        identity: current.kind === "found",
+        processTree: true,
+        listeningPorts: true,
       },
-    };
+    }));
+    return { child, exited, closed, runtime };
   },
   inspect,
   terminate,

--- a/packages/workbench-server/src/domains/tasks/process-runtime/linux-driver.ts
+++ b/packages/workbench-server/src/domains/tasks/process-runtime/linux-driver.ts
@@ -148,33 +148,30 @@ async function terminate(
 }
 
 export const linuxProcessRuntimeDriver: ProcessRuntimeDriver = {
-  async spawn(command, options) {
+  spawn(command, options) {
     const child = spawnShell(command, options);
     const { exited, closed } = observeProcessLifecycle(child);
     if (!child.pid) throw new Error("Spawned process has no PID");
-    const identity = await procIdentity(child.pid);
-    return {
-      child,
-      exited,
-      closed,
-      runtime: {
-        version: 2,
-        platform: "linux",
-        childPid: child.pid,
-        processGroupId: child.pid,
-        detached: true,
-        shell: true,
-        spawnedAt: new Date().toISOString(),
-        identity: identity
-          ? { kind: "linux", startTimeTicks: identity.start }
-          : { kind: "legacy_unverified" },
-        capabilities: {
-          identity: Boolean(identity),
-          processTree: true,
-          listeningPorts: true,
-        },
+    const pid = child.pid;
+    const spawnedAt = new Date().toISOString();
+    const runtime = procIdentity(pid).then((identity) => ({
+      version: 2 as const,
+      platform: "linux" as const,
+      childPid: pid,
+      processGroupId: pid,
+      detached: true,
+      shell: true,
+      spawnedAt,
+      identity: identity
+        ? ({ kind: "linux", startTimeTicks: identity.start } as const)
+        : ({ kind: "legacy_unverified" } as const),
+      capabilities: {
+        identity: Boolean(identity),
+        processTree: true,
+        listeningPorts: true,
       },
-    };
+    }));
+    return { child, exited, closed, runtime };
   },
   inspect,
   terminate,

--- a/packages/workbench-server/src/domains/tasks/process-runtime/types.ts
+++ b/packages/workbench-server/src/domains/tasks/process-runtime/types.ts
@@ -23,7 +23,7 @@ export type ProcessLifecycleResult =
 
 export interface SpawnedProcess {
   child: ChildProcess;
-  runtime: TaskRuntime;
+  runtime: Promise<TaskRuntime>;
   exited: Promise<ProcessLifecycleResult>;
   closed: Promise<ProcessLifecycleResult>;
 }
@@ -35,7 +35,7 @@ export interface TerminationResult {
 }
 
 export interface ProcessRuntimeDriver {
-  spawn(command: string, options: SpawnProcessOptions): Promise<SpawnedProcess>;
+  spawn(command: string, options: SpawnProcessOptions): SpawnedProcess;
   inspect(runtime: TaskRuntime): Promise<RuntimeInspection>;
   terminate(
     runtime: TaskRuntime,

--- a/packages/workbench-server/src/domains/tasks/process-runtime/windows-driver.ts
+++ b/packages/workbench-server/src/domains/tasks/process-runtime/windows-driver.ts
@@ -59,15 +59,10 @@ async function inspect(runtime: TaskRuntime): Promise<RuntimeInspection> {
   return { evidence: "alive_verified", runtime };
 }
 
-async function terminate(
+async function terminateVerified(
   runtime: TaskRuntime,
   signal: NodeJS.Signals,
 ): Promise<TerminationResult> {
-  const evidence = await inspect(runtime);
-  if (evidence.evidence === "exited_verified")
-    return { attempted: false, method: "none" };
-  if (evidence.evidence !== "alive_verified")
-    return { attempted: false, method: "none", error: evidence.detail };
   const args =
     signal === "SIGKILL"
       ? ["/F", "/T", "/PID", String(runtime.childPid)]
@@ -85,6 +80,18 @@ async function terminate(
       ? undefined
       : result.stderr || `taskkill exited ${result.code}`,
   };
+}
+
+async function terminate(
+  runtime: TaskRuntime,
+  signal: NodeJS.Signals,
+): Promise<TerminationResult> {
+  const evidence = await inspect(runtime);
+  if (evidence.evidence === "exited_verified")
+    return { attempted: false, method: "none" };
+  if (evidence.evidence !== "alive_verified")
+    return { attempted: false, method: "none", error: evidence.detail };
+  return terminateVerified(evidence.runtime, signal);
 }
 
 async function listeningPorts(
@@ -125,33 +132,30 @@ async function listeningPorts(
 }
 
 export const windowsProcessRuntimeDriver: ProcessRuntimeDriver = {
-  async spawn(command, options) {
+  spawn(command, options) {
     const child = spawnShell(command, options);
     const { exited, closed } = observeProcessLifecycle(child);
     if (!child.pid) throw new Error("Spawned process has no PID");
-    const created = await creationDate(child.pid);
-    return {
-      child,
-      exited,
-      closed,
-      runtime: {
-        version: 2,
-        platform: "win32",
-        childPid: child.pid,
-        detached: false,
-        shell: true,
-        spawnedAt: new Date().toISOString(),
-        identity:
-          created.kind === "found"
-            ? { kind: "win32", creationDate: created.value }
-            : { kind: "legacy_unverified" },
-        capabilities: {
-          identity: created.kind === "found",
-          processTree: true,
-          listeningPorts: true,
-        },
+    const pid = child.pid;
+    const spawnedAt = new Date().toISOString();
+    const runtime = creationDate(pid).then((created) => ({
+      version: 2 as const,
+      platform: "win32" as const,
+      childPid: pid,
+      detached: false,
+      shell: true,
+      spawnedAt,
+      identity:
+        created.kind === "found"
+          ? ({ kind: "win32", creationDate: created.value } as const)
+          : ({ kind: "legacy_unverified" } as const),
+      capabilities: {
+        identity: created.kind === "found",
+        processTree: true,
+        listeningPorts: true,
       },
-    };
+    }));
+    return { child, exited, closed, runtime };
   },
   inspect,
   terminate,
@@ -168,7 +172,7 @@ export const windowsProcessRuntimeDriver: ProcessRuntimeDriver = {
         error: stopped ? undefined : created.detail,
       };
     }
-    return terminate(
+    return terminateVerified(
       {
         version: 2,
         platform: "win32",

--- a/packages/workbench-server/src/domains/tasks/task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-service.ts
@@ -276,12 +276,20 @@ export class TaskService {
             id,
             this.watchReadiness(id, request),
           );
-        if (request.timeoutMs)
+        if (request.timeoutMs) {
+          const elapsedMs = Math.max(
+            0,
+            Date.parse(this.now()) - Date.parse(current.startedAt),
+          );
           this.launchBackground(
             "runtime_timeout",
             id,
-            this.watchRuntimeTimeout(id, request.timeoutMs),
+            this.watchRuntimeTimeout(
+              id,
+              Math.max(0, request.timeoutMs - elapsedMs),
+            ),
           );
+        }
         return current;
       });
     } catch (error) {

--- a/packages/workbench-server/src/domains/tasks/task-supervisor.ts
+++ b/packages/workbench-server/src/domains/tasks/task-supervisor.ts
@@ -35,7 +35,7 @@ export interface SpawnManagedTaskOptions {
 
 export interface SpawnedManagedTask {
   child: ChildProcess;
-  runtime: TaskRuntime;
+  runtime: Promise<TaskRuntime>;
   exited: Promise<ProcessLifecycleResult>;
   closed: Promise<ProcessLifecycleResult>;
 }
@@ -54,10 +54,7 @@ export interface TerminateTaskResult {
 }
 
 export interface TaskSupervisor {
-  spawn(
-    command: string,
-    options: SpawnManagedTaskOptions,
-  ): SpawnedManagedTask | Promise<SpawnedManagedTask>;
+  spawn(command: string, options: SpawnManagedTaskOptions): SpawnedManagedTask;
   terminate(
     child: ChildProcess,
     signal: NodeJS.Signals,
@@ -100,7 +97,7 @@ export function spawnManagedTask(
   });
   return {
     child,
-    runtime: runtimeForChild(child, process.platform),
+    runtime: Promise.resolve(runtimeForChild(child, process.platform)),
     ...observeProcessLifecycle(child),
   };
 }

--- a/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
@@ -284,7 +284,12 @@ export function createWorkbenchTaskResources(
           recursive: true,
           mode: 0o755,
         });
-        const spawned = await supervisor.spawn(input.command, {
+        const logCursor = createTaskLogCursor(
+          await logs.latestLogSeq(
+            join(repository.taskDir(input.taskId), "logs.jsonl"),
+          ),
+        );
+        const spawned = supervisor.spawn(input.command, {
           cwd: input.cwd,
           env: input.env,
           shellPath: storage.settings.runtime.shellPath,
@@ -303,11 +308,7 @@ export function createWorkbenchTaskResources(
         const exitPromise = exited.then(terminalResult);
         const closePromise = closed.then(terminalResult);
         const state: WorkbenchManagedTask = {
-          ...createTaskLogCursor(
-            await logs.latestLogSeq(
-              join(repository.taskDir(input.taskId), "logs.jsonl"),
-            ),
-          ),
+          ...logCursor,
           child,
           stopping: false,
           finalized: false,
@@ -342,6 +343,20 @@ export function createWorkbenchTaskResources(
               }
             });
         };
+        const streamCompletion = (stream: NodeJS.ReadableStream | null) => {
+          if (!stream) return Promise.resolve();
+          return new Promise<void>((resolve) => {
+            let complete = false;
+            const finish = () => {
+              if (complete) return;
+              complete = true;
+              resolve();
+            };
+            stream.once("end", finish);
+            stream.once("close", finish);
+            stream.once("error", finish);
+          });
+        };
         child.stdout?.on("data", (chunk: Buffer) =>
           queueDecodedOutput(
             "stdout",
@@ -356,6 +371,10 @@ export function createWorkbenchTaskResources(
             child.stderr ?? undefined,
           ),
         );
+        const outputCompleted = Promise.all([
+          streamCompletion(child.stdout),
+          streamCompletion(child.stderr),
+        ]);
         let settled = false;
         const finish = async (exit: TaskProcessExit) => {
           if (settled) return;
@@ -378,8 +397,8 @@ export function createWorkbenchTaskResources(
           if (result.kind === "error")
             queueDecodedOutput("stderr", result.error.message);
         });
-        state.finalizationPromise = closePromise
-          .then(async ({ exitCode, signal }) => {
+        state.finalizationPromise = Promise.all([closePromise, outputCompleted])
+          .then(async ([{ exitCode, signal }]) => {
             await finish({
               exitCode: exitCode ?? undefined,
               signal: signal ?? undefined,
@@ -394,7 +413,18 @@ export function createWorkbenchTaskResources(
             });
             return undefined;
           });
-        return runtime;
+        try {
+          return await runtime;
+        } catch (error) {
+          const termination = await supervisor.terminate(child, "SIGKILL");
+          if (termination.error) {
+            throw new Error(
+              `Runtime identity failed and process termination failed: ${termination.error}`,
+              { cause: error },
+            );
+          }
+          throw error;
+        }
       },
       signal: async (task, cancelOptions) => {
         const state = managed.get(task.id);
@@ -403,9 +433,13 @@ export function createWorkbenchTaskResources(
         if (state)
           await logs.flushOutputBuffers(task, state, async () => undefined);
         const child = state?.child;
-        if (child)
-          await supervisor.terminate(child, cancelOptions.signal ?? "SIGTERM");
-        else if (task.runtime) {
+        if (child) {
+          const result = await supervisor.terminate(
+            child,
+            cancelOptions.signal ?? "SIGTERM",
+          );
+          if (result.error) throw new Error(result.error);
+        } else if (task.runtime) {
           const result = await supervisor.terminateRuntime(
             task.runtime,
             cancelOptions.signal ?? "SIGTERM",

--- a/packages/workbench-server/src/domains/tasks/workbench-task-service-foreground.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-service-foreground.ts
@@ -80,7 +80,8 @@ export async function runForegroundBashWithPromotion(
   let abortHandler: (() => void) | undefined;
   const abortPromise = new Promise<"aborted">((resolveAbort) => {
     abortHandler = () => resolveAbort("aborted");
-    input.signal?.addEventListener("abort", abortHandler, { once: true });
+    if (input.signal?.aborted) abortHandler();
+    else input.signal?.addEventListener("abort", abortHandler, { once: true });
   });
   let promotionTimer: NodeJS.Timeout | undefined;
   let promotionPromise: Promise<"promote"> | undefined;
@@ -114,10 +115,26 @@ export async function runForegroundBashWithPromotion(
   }
 
   if (outcome === "aborted") {
-    await this.cancelTask(task.id, {
+    const terminalPromise = this.managed.get(task.id)?.terminalPromise;
+    const cancelled = await this.cancelTask(task.id, {
+      signal: "SIGKILL",
       reason: "Foreground bash aborted.",
-    }).catch(() => undefined);
-    await this.removeTask(task.id).catch(() => undefined);
+    }).catch(() => this.getTask(task.id));
+    if (isActiveTaskStatus(cancelled.status)) {
+      await this.backgroundActiveTask(task.id, {
+        visibility: "background",
+        completion: { inject: false, outputTailLineCount: 80 },
+        notifications: {
+          enabled: true,
+          ready: false,
+          terminal: true,
+          outputTailLineCount: 80,
+        },
+      }).catch(() => undefined);
+    } else {
+      await terminalPromise?.catch(() => undefined);
+      await this.removeTask(task.id).catch(() => undefined);
+    }
     throw new Error("Command aborted.");
   }
 

--- a/packages/workbench-server/test/explore-subagent-isolation.test.ts
+++ b/packages/workbench-server/test/explore-subagent-isolation.test.ts
@@ -363,7 +363,7 @@ function hasErrorCode(expected: string): (error: unknown) => boolean {
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + 15_000;
   while (Date.now() < deadline) {
     if (predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 10));

--- a/packages/workbench-server/test/filesystem.service.test.ts
+++ b/packages/workbench-server/test/filesystem.service.test.ts
@@ -53,7 +53,11 @@ describe("filesystem application service", () => {
     const outside = await mkdtemp(join(tmpdir(), "nerve-project-outside-"));
     try {
       await mkdir(join(root, "src"));
-      await symlink(outside, join(root, "linked"), "dir");
+      await symlink(
+        outside,
+        join(root, "linked"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
       const lookup = () => root;
 
       const file = await createProjectEntry(
@@ -207,7 +211,7 @@ describe("filesystem application service", () => {
     }
   });
 
-  it("shows links but does not classify links that escape the project", async () => {
+  it("shows links but does not classify links that escape the project", async (t) => {
     const root = await mkdtemp(join(tmpdir(), "nerve-project-links-"));
     const outside = await mkdtemp(join(tmpdir(), "nerve-project-outside-"));
     try {
@@ -215,11 +219,22 @@ describe("filesystem application service", () => {
         writeFile(join(root, "target.txt"), "target"),
         writeFile(join(outside, "outside.txt"), "outside"),
       ]);
-      await Promise.all([
-        symlink(join(root, "target.txt"), join(root, "inside-link")),
-        symlink(join(outside, "outside.txt"), join(root, "outside-link")),
-        symlink(join(root, "missing"), join(root, "broken-link")),
-      ]);
+      try {
+        await Promise.all([
+          symlink(join(root, "target.txt"), join(root, "inside-link")),
+          symlink(join(outside, "outside.txt"), join(root, "outside-link")),
+          symlink(join(root, "missing"), join(root, "broken-link")),
+        ]);
+      } catch (error) {
+        if (
+          process.platform === "win32" &&
+          (error as NodeJS.ErrnoException).code === "EPERM"
+        ) {
+          t.skip("Windows file symlinks require Developer Mode or elevation.");
+          return;
+        }
+        throw error;
+      }
       const result = await projectDirectoryEntries(
         { projectId: "project" },
         () => root,

--- a/packages/workbench-server/test/helpers/registry-conversation.ts
+++ b/packages/workbench-server/test/helpers/registry-conversation.ts
@@ -22,7 +22,12 @@ after(async () => {
   await Promise.allSettled(states.map(shutdownOrchestratorState));
   await Promise.all(
     roots.map((root) =>
-      rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 }),
+      rm(root, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 100,
+      }),
     ),
   );
 });

--- a/packages/workbench-server/test/helpers/workbench-task-service.ts
+++ b/packages/workbench-server/test/helpers/workbench-task-service.ts
@@ -125,6 +125,10 @@ export function fakeChild(pid = 1234): FakeChild {
       child.emit("exit", exitCode, signal);
     },
     emitClose(exitCode: number | null, signal: NodeJS.Signals | null) {
+      child.stdout.emit("end");
+      child.stdout.emit("close");
+      child.stderr.emit("end");
+      child.stderr.emit("close");
       child.emit("exit", exitCode, signal);
       child.emit("close", exitCode, signal);
     },
@@ -148,6 +152,7 @@ export function runtimeMetadata(
 export type FakeSupervisorOptions = {
   child?: FakeChild | FakeChild[];
   runtime?: TaskRuntime | TaskRuntime[];
+  runtimeReady?: Promise<TaskRuntime>;
   onSpawn?: (command: string, options: SpawnManagedTaskOptions) => void;
   onTerminate?: (signal: NodeJS.Signals) => void | Promise<void>;
   onTerminateRuntime?: (
@@ -224,7 +229,12 @@ export function fakeSupervisor(options: FakeSupervisorOptions): {
         });
         const closed = lifecycle();
         options.onSpawn?.(command, spawnOptions);
-        return { child, runtime, exited, closed };
+        return {
+          child,
+          runtime: options.runtimeReady ?? Promise.resolve(runtime),
+          exited,
+          closed,
+        };
       },
       async terminate(terminatedChild, signal) {
         assert.ok(children.includes(terminatedChild as FakeChild));

--- a/packages/workbench-server/test/process-runtime-driver.test.ts
+++ b/packages/workbench-server/test/process-runtime-driver.test.ts
@@ -25,30 +25,32 @@ test("replays process exit, close, and error outcomes to late consumers", async 
 });
 
 test("captures an immediate command close while resolving runtime identity", async () => {
-  const spawned = await defaultProcessRuntimeDriver.spawn("printf done", {
+  const spawned = defaultProcessRuntimeDriver.spawn("printf done", {
     cwd: process.cwd(),
   });
   assert.equal((await spawned.exited).kind, "closed");
   assert.equal((await spawned.closed).kind, "closed");
+  assert.equal((await spawned.runtime).platform, process.platform);
 });
 
 if (process.platform === "linux") {
   test("captures a verifiable Linux identity and refuses stale identity", async () => {
-    const spawned = await defaultProcessRuntimeDriver.spawn("sleep 30", {
+    const spawned = defaultProcessRuntimeDriver.spawn("sleep 30", {
       cwd: process.cwd(),
     });
+    const runtime = await spawned.runtime;
     try {
       assert.equal(
-        (await defaultProcessRuntimeDriver.inspect(spawned.runtime)).evidence,
+        (await defaultProcessRuntimeDriver.inspect(runtime)).evidence,
         "alive_verified",
       );
       const stale = {
-        ...spawned.runtime,
+        ...runtime,
         identity: {
           kind: "linux" as const,
           startTimeTicks:
-            spawned.runtime.identity?.kind === "linux"
-              ? spawned.runtime.identity.startTimeTicks + 1
+            runtime.identity?.kind === "linux"
+              ? runtime.identity.startTimeTicks + 1
               : 1,
         },
       };
@@ -62,7 +64,7 @@ if (process.platform === "linux") {
       );
       assert.equal(refused.attempted, false);
     } finally {
-      await defaultProcessRuntimeDriver.terminate(spawned.runtime, "SIGKILL");
+      await defaultProcessRuntimeDriver.terminate(runtime, "SIGKILL");
     }
   });
 }

--- a/packages/workbench-server/test/task-service.contract.test.ts
+++ b/packages/workbench-server/test/task-service.contract.test.ts
@@ -74,6 +74,7 @@ function servicePortsForRecords(
     readiness?: TaskServicePorts["readiness"];
     diagnostics?: TaskServicePorts["diagnostics"];
     timers?: TaskServicePorts["timers"];
+    clock?: TaskServicePorts["clock"];
   } = {},
 ): TaskServicePorts {
   return {
@@ -103,12 +104,44 @@ function servicePortsForRecords(
     },
     readiness: options.readiness,
     events: { publish: async (event) => void events.push(event) },
-    clock: { now: () => new Date("2026-07-11T00:00:00.000Z") },
+    clock:
+      options.clock ??
+      ({ now: () => new Date("2026-07-11T00:00:00.000Z") } as const),
     ids: { next: () => "task_contract" },
     diagnostics: options.diagnostics,
     timers: options.timers,
   };
 }
+
+test("runtime timeout includes process startup and identity delay", async () => {
+  const records = new Map<string, TaskRecord>();
+  const events: DomainEventIntent[] = [];
+  const sleeps: number[] = [];
+  let elapsedMs = 0;
+  const epoch = Date.parse("2026-07-11T00:00:00.000Z");
+  const ports = servicePortsForRecords(records, events, {
+    spawn: async () => {
+      elapsedMs = 600;
+      return { pid: 42, startedAt: new Date(epoch).toISOString() };
+    },
+    clock: { now: () => new Date(epoch + elapsedMs) },
+    timers: {
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+        await new Promise<void>(() => undefined);
+      },
+    },
+  });
+
+  await new TaskService(ports).start({
+    cwd: "/workspace",
+    command: "sleep 60",
+    timeoutMs: 1_000,
+  });
+  await Promise.resolve();
+
+  assert.deepEqual(sleeps, [400]);
+});
 
 test("cancellation is terminal only after process-exit evidence", async () => {
   const pending = fixture({ waitForExit: "timeout" });

--- a/packages/workbench-server/test/workbench-task-service-foreground.test.ts
+++ b/packages/workbench-server/test/workbench-task-service-foreground.test.ts
@@ -110,6 +110,115 @@ describe("task manager foreground bash auto-promotion", () => {
     assert.throws(() => manager.getTask(started.id), /Task not found/);
   });
 
+  it("captures output before delayed runtime identity resolves", async () => {
+    const child = fakeChild();
+    let resolveRuntime!: (runtime: ReturnType<typeof runtimeMetadata>) => void;
+    const runtimeReady = new Promise<ReturnType<typeof runtimeMetadata>>(
+      (resolve) => {
+        resolveRuntime = resolve;
+      },
+    );
+    let spawned!: () => void;
+    const didSpawn = new Promise<void>((resolve) => {
+      spawned = resolve;
+    });
+    const { supervisor } = fakeSupervisor({
+      child,
+      runtimeReady,
+      onSpawn: spawned,
+    });
+    const { manager, storage } = await createManager(supervisor);
+
+    const run = manager.runForegroundBashWithPromotion({
+      command: "printf early",
+      cwd: storage.paths.home,
+      projectId: "proj_test",
+      conversationId: "conv_test",
+      agentId: "agent_test",
+      origin: { kind: "agent_tool", toolCallId: "tool_test" },
+    });
+    await didSpawn;
+    child.stdout.emit("data", Buffer.from("early out\n"));
+    child.stderr.emit("data", Buffer.from("early err\n"));
+    child.emitClose(0, null);
+    resolveRuntime(runtimeMetadata({ childPid: child.pid }));
+
+    const result = await run;
+
+    assert.equal(result.kind, "completed_foreground");
+    assert.equal(result.result.stdout, "early out");
+    assert.equal(result.result.stderr, "early err");
+    assert.equal(result.result.content, "early out\nearly err\n");
+  });
+
+  it("waits for output streams to drain after process close", async () => {
+    const child = fakeChild();
+    const { supervisor } = fakeSupervisor({ child });
+    const { manager, storage, events } = await createManager(supervisor);
+    const started = waitForTaskEvent(events, "task.started");
+    const run = manager.runForegroundBashWithPromotion({
+      command: "printf buffered",
+      cwd: storage.paths.home,
+      projectId: "proj_test",
+      conversationId: "conv_test",
+      agentId: "agent_test",
+      origin: { kind: "agent_tool", toolCallId: "tool_test" },
+    });
+    await started;
+    let settled = false;
+    void run.then(() => {
+      settled = true;
+    });
+
+    child.emit("exit", 0, null);
+    child.emit("close", 0, null);
+    await Promise.resolve();
+    assert.equal(settled, false);
+
+    child.stdout.emit("data", Buffer.from("buffered out\n"));
+    child.stdout.emit("end");
+    child.stdout.emit("close");
+    child.stderr.emit("end");
+    child.stderr.emit("close");
+    const result = await run;
+
+    assert.equal(result.kind, "completed_foreground");
+    assert.equal(result.result.stdout, "buffered out");
+  });
+
+  it(
+    "force-kills the process tree when foreground bash is aborted",
+    { timeout: 2_000 },
+    async () => {
+      const child = fakeChild();
+      const { supervisor, terminateSignals } = fakeSupervisor({
+        child,
+        onTerminate(signal) {
+          child.emitClose(null, signal);
+        },
+      });
+      const { manager, storage, events } = await createManager(supervisor);
+      const abort = new AbortController();
+      const started = waitForTaskEvent(events, "task.started");
+      const run = manager.runForegroundBashWithPromotion({
+        command: "sleep forever",
+        cwd: storage.paths.home,
+        projectId: "proj_test",
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        origin: { kind: "agent_tool", toolCallId: "tool_test" },
+        signal: abort.signal,
+      });
+      const task = await started;
+
+      abort.abort();
+
+      await assert.rejects(run, /aborted/i);
+      assert.deepEqual(terminateSignals, ["SIGKILL"]);
+      assert.throws(() => manager.getTask(task.id), /Task not found/);
+    },
+  );
+
   it("hydrates exited foreground bash tasks as visible interrupted tasks", async () => {
     const runtime = runtimeMetadata({ childPid: 4321, processGroupId: 4321 });
     const { supervisor } = fakeSupervisor({ runtime });


### PR DESCRIPTION
Closes #110

## Summary

On Windows 11, short Bash commands (echo, pwd, git status, …) intermittently returned empty output, while longer commands could hang or end with `Command aborted`.

Root cause: the foreground task path spawned Git Bash, then **awaited a PowerShell/CIM process-identity query (up to 3 s) before attaching stdout/stderr listeners**. Fast commands wrote output and exited during the lookup, so output was lost and finalization produced `(no output)`.

## Changes

- **Synchronous spawn with async identity**: `ProcessRuntimeDriver.spawn` now returns immediately; `runtime` is a `Promise<TaskRuntime>` resolved after identity discovery (CIM on Windows, `/proc` on Linux, `ps` fingerprint on Darwin). Stream listeners attach before any post-spawn async work.
- **Drain before finalize**: stdout/stderr streams must emit end/close before command results are finalized, so buffered output arriving after process close is retained.
- **Timeout accounting**: startup + identity-discovery time now counts toward the configured command timeout.
- **Abort handling**: foreground bash abort force-kills the complete process tree (`SIGKILL`, `taskkill /F /T /PID` on Windows); if termination cannot be confirmed the task record is preserved as a background task for diagnostics; aborts received during startup are no longer missed.
- **No duplicate CIM queries**: Windows termination splits taskkill into `terminateVerified` so `terminateChild` inspects identity only once.
- **Regression tests**: output-before-identity, drain-after-close, abort force-kill, and timeout-includes-startup.
- **CI hardening** (bundled): host-independent `posix` path API, Windows symlink handling, async `ensureSyntaxTree` in the code-mirror test, and flaky-test deadline/retry bumps.

## Validation

`pnpm fix && pnpm check && pnpm test` — all green (all 8 test suites, ~1,091 tests, 0 failures).

Note: Windows-specific runtime behavior cannot be exercised on Linux CI; the new unit tests model the same logic.