### PR TITLE
perf(workbench): make lazy shells actually code-split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/native-host.yml
+++ b/.github/workflows/native-host.yml
@@ -34,9 +34,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -104,9 +101,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -31,9 +31,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 11.17.0
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "ThilinaTLM",
   "license": "Apache-2.0",
   "type": "module",
-  "packageManager": "pnpm@11.17.0",
+  "packageManager": "pnpm@11.20.0",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/desktop-shell/scripts/start-electron.mjs
+++ b/packages/desktop-shell/scripts/start-electron.mjs
@@ -25,7 +25,10 @@ const env = {
 };
 delete env.ELECTRON_RUN_AS_NODE;
 
-const forwardedArgs = process.argv.slice(2);
+// pnpm script forwarding can inject stray "--" separators (e.g. `pnpm desktop
+// -- --host ...`); they are meaningless to Electron once placed after the app
+// path, so drop them before forwarding.
+const forwardedArgs = process.argv.slice(2).filter((arg) => arg !== "--");
 const ozonePlatform = parseElectronOzonePlatform(
   process.env.NERVE_ELECTRON_OZONE_PLATFORM,
 );

--- a/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
@@ -37,7 +37,10 @@ import LazyShellPending from "$lib/app/shell/LazyShellPending.svelte";
 // their feature modules are not parsed during startup. The import fires when
 // the panel is first activated.
 let filesModule = $state<
-  Promise<typeof import("$lib/features/filesystem")> | undefined
+  | Promise<{
+      default: typeof import("$lib/features/filesystem/components/FilesPanelView.svelte").default;
+    }>
+  | undefined
 >();
 let tasksModule = $state<
   | Promise<{
@@ -77,7 +80,9 @@ const tasks = $derived(taskSelectors.scopedTasks);
 const selectedTask = $derived(taskSelectors.selectedTask);
 
 $effect(() => {
-  if (viewId === "files") filesModule ??= import("$lib/features/filesystem");
+  if (viewId === "files")
+    filesModule ??=
+      import("$lib/features/filesystem/components/FilesPanelView.svelte");
   else if (viewId === "tasks")
     tasksModule ??=
       import("$lib/features/tasks/components/TasksPanelView.svelte");
@@ -105,7 +110,7 @@ function focusTasks() {
   {#await filesModule}
     <LazyShellPending />
   {:then module}
-    {@const Component = module?.FilesPanelView}
+    {@const Component = module?.default}
     {#if Component}<Component {activeProject} />{/if}
   {/await}
 {:else if viewId === "conversations"}

--- a/packages/workbench-app/src/lib/features/auth/index.ts
+++ b/packages/workbench-app/src/lib/features/auth/index.ts
@@ -1,6 +1,5 @@
 export * from "./api/auth.api";
 export * from "./api/provider-catalog.api";
-export { default as AuthShell } from "./components/AuthShell.svelte";
 export {
   closeAuthTab,
   loadAuthPanel,

--- a/packages/workbench-app/src/lib/features/filesystem/index.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/index.ts
@@ -1,6 +1,4 @@
 export * from "./api/filesystem.api";
-export { default as FileShell } from "./components/FileShell.svelte";
-export { default as FilesPanelView } from "./components/FilesPanelView.svelte";
 export { fileSelectors } from "./state/file-selectors.svelte";
 export type { FileViewState } from "./state/file-state.svelte";
 export { fileState } from "./state/file-state.svelte";

--- a/packages/workbench-app/src/lib/features/git/index.ts
+++ b/packages/workbench-app/src/lib/features/git/index.ts
@@ -1,6 +1,4 @@
 export * from "./api/git.api";
-export { default as DiffShell } from "./components/DiffShell.svelte";
-export { default as PrShell } from "./components/PrShell.svelte";
 export {
   clearGitContext,
   refreshGitContext,

--- a/packages/workbench-app/src/lib/features/logs/index.ts
+++ b/packages/workbench-app/src/lib/features/logs/index.ts
@@ -1,4 +1,3 @@
 export * from "./api/logs.api";
-export { default as LogsShell } from "./components/LogsShell.svelte";
 export { requestLogsRefresh } from "./state/log-refresh.svelte";
 export { openLogsPane } from "./state/logs.svelte";

--- a/packages/workbench-app/src/lib/features/settings/index.ts
+++ b/packages/workbench-app/src/lib/features/settings/index.ts
@@ -1,5 +1,4 @@
 export * from "./api/settings.api";
-export { default as SettingsShell } from "./components/SettingsShell.svelte";
 export {
   loadSettingsPanel,
   openSettingsPane,

--- a/packages/workbench-app/src/lib/features/tasks/index.ts
+++ b/packages/workbench-app/src/lib/features/tasks/index.ts
@@ -1,6 +1,4 @@
 export * from "./api/tasks.api";
-export { default as TaskShell } from "./components/TaskShell.svelte";
-export { default as TasksPanelView } from "./components/TasksPanelView.svelte";
 export { taskSelectors } from "./state/task-selectors.svelte";
 export { taskState } from "./state/task-state.svelte";
 export { openTaskTab } from "./state/task-tabs.svelte";

--- a/packages/workbench-app/src/lib/presentation/index.ts
+++ b/packages/workbench-app/src/lib/presentation/index.ts
@@ -25,7 +25,6 @@ export type {
 } from "@nervekit/ui-kit/core/utils";
 export { cn } from "@nervekit/ui-kit/core/utils";
 export { default as GitPanelView } from "./git/GitPanelView.svelte";
-export { default as GitPullRequestsPanelView } from "./git/GitPullRequestsPanelView.svelte";
 export * from "./git/git-panel-controller.js";
 export * from "./git/git-panel-types.js";
 export { default as TasksPanelView } from "./tasks/TasksPanelView.svelte";

--- a/packages/workbench-app/vite.config.ts
+++ b/packages/workbench-app/vite.config.ts
@@ -123,6 +123,25 @@ export default defineConfig(({ mode }) => {
         },
       }),
     ],
+    build: {
+      rollupOptions: {
+        onwarn(warning, warn) {
+          // workspace-actions is dynamically imported by the five tab-state
+          // modules (conversations, file, diff, pr, task) to break import
+          // cycles: its module graph transitively imports those tab modules,
+          // so a static import would form an ESM cycle. It is already part of
+          // the static startup graph (via websocket-client), so the dynamic
+          // import cannot move it into another chunk. The warning is expected.
+          if (
+            warning.code === "INEFFECTIVE_DYNAMIC_IMPORT" &&
+            warning.id?.endsWith("workspace-actions.svelte.ts")
+          ) {
+            return;
+          }
+          warn(warning);
+        },
+      },
+    },
     resolve: {
       alias: {
         $lib: path.resolve("./src/lib"),


### PR DESCRIPTION
## Summary

Fixes the `INEFFECTIVE_DYNAMIC_IMPORT` warnings in the workbench-app build. The on-demand shells in `EditorSurface.svelte` / `PanelViewHost.svelte` were never actually lazy: the feature barrels re-exported the shell components, and the barrels are statically imported by the app shell, so those heavy modules were baked into the startup bundle.

**Changes**
- Remove component re-exports from feature barrels (`logs`, `settings`, `tasks`, `auth`, `filesystem`, `git`) and the presentation barrel so the lazy shells only enter the graph via their dynamic imports.
- Point `PanelViewHost`'s files lazy-load at `FilesPanelView.svelte` directly instead of the whole filesystem barrel.
- Document and silence the one remaining `INEFFECTIVE_DYNAMIC_IMPORT` warning (`workspace-actions.svelte.ts`) in `vite.config.ts`: it is a deliberate cycle-breaker for the five tab-state modules (its module graph transitively imports them, so a static import would form an ESM cycle).
- `desktop-shell`: strip stray `--` separators that pnpm script forwarding injects (`pnpm desktop -- --host ...`) before passing args to Electron.
- Bump `packageManager` to `pnpm@11.20.0`.

**Results**
- Main entry chunk: ~1.9 MB → ~1.3 MB (−31%)
- 10 `INEFFECTIVE_DYNAMIC_IMPORT` warnings eliminated (was 11 in the full build)
- PWA precache stays ~flat (lazy chunks are still emitted), but startup parse/execute cost drops

## Validation
- `pnpm fix && pnpm check && pnpm test` — all green (eslint/oxfmt, package boundaries, svelte-check 0 errors/0 warnings, all tests pass)
- `pnpm -w build:workbench-runtime` — clean build, web assets copied
- Launcher arg forwarding verified against compiled `parseDesktopOptions`: `--host 0.0.0.0 --allow-remote --mobile-https` still parse correctly