### PR TITLE
feat(ask-user): composer-grade reply input and markdown line breaks

### DIFF
--- a/packages/contracts/src/domains/tools/records.schema.ts
+++ b/packages/contracts/src/domains/tools/records.schema.ts
@@ -244,7 +244,6 @@ export const userQuestionRecordSchema = z.object({
   question: z.string().min(1),
   context: z.string().optional(),
   recommendation: z.string().optional(),
-  placeholder: z.string().optional(),
   status: userQuestionStatusSchema,
   answer: z.string().optional(),
   dismissedReason: z.string().optional(),

--- a/packages/tools/src/catalog/core/interaction.tools.ts
+++ b/packages/tools/src/catalog/core/interaction.tools.ts
@@ -16,11 +16,6 @@ const askUserParameters = Type.Object(
         description: "Optional current leaning or recommendation and why",
       }),
     ),
-    placeholder: Type.Optional(
-      Type.String({
-        description: "Optional placeholder text for the reply input",
-      }),
-    ),
   },
   { additionalProperties: false },
 );

--- a/packages/tools/src/runtime/orchestration/args.ts
+++ b/packages/tools/src/runtime/orchestration/args.ts
@@ -35,7 +35,6 @@ export function parseQuestion(args: Record<string, unknown>) {
     question,
     context: optionalString(args.context),
     recommendation: optionalString(args.recommendation),
-    placeholder: optionalString(args.placeholder),
   };
 }
 

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -48,6 +48,7 @@
     "paneforge": "^1.0.2",
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",

--- a/packages/ui-kit/src/lib/core/components/Markdown.svelte
+++ b/packages/ui-kit/src/lib/core/components/Markdown.svelte
@@ -27,6 +27,8 @@ import {
 type Props = {
   text: string;
   trimCodeBlocks?: boolean;
+  /** Convert Markdown soft line endings into semantic hard breaks. */
+  preserveLineBreaks?: boolean;
   /** Bound streaming work while deferring Shiki until completion. */
   streaming?: boolean;
   linkBasePath?: string;
@@ -34,44 +36,64 @@ type Props = {
   onCopy?: (ok: boolean) => void;
 };
 
-type StreamingValue = { source: string; trim: boolean };
+type StreamingValue = {
+  source: string;
+  trim: boolean;
+  preserveLineBreaks: boolean;
+};
 
 let {
   text,
   trimCodeBlocks = true,
+  preserveLineBreaks = false,
   streaming = false,
   linkBasePath,
   onOpenFile,
   onCopy,
 }: Props = $props();
 
-function renderStreamingPrefix(source: string, trim: boolean): string {
+function renderStreamingPrefix(
+  source: string,
+  trim: boolean,
+  preserveBreaks: boolean,
+): string {
   if (!source) return "";
-  return decorateMarkdownHtml(renderMarkdown(source, { cache: false }), trim);
+  return decorateMarkdownHtml(
+    renderMarkdown(source, {
+      cache: false,
+      preserveLineBreaks: preserveBreaks,
+    }),
+    trim,
+  );
 }
 
 const initialRender = untrack(() => {
   const parts = streaming ? splitStreamingMarkdown(text) : undefined;
   return {
-    html: streaming ? "" : renderBestAvailableMarkdown(text, trimCodeBlocks),
+    html: streaming
+      ? ""
+      : renderBestAvailableMarkdown(text, trimCodeBlocks, preserveLineBreaks),
     prefixHtml: parts
-      ? renderStreamingPrefix(parts.prefix, trimCodeBlocks)
+      ? renderStreamingPrefix(parts.prefix, trimCodeBlocks, preserveLineBreaks)
       : "",
     prefixSource: parts?.prefix ?? "",
     tail: parts?.tail ?? "",
     streaming,
     source: text,
     trim: trimCodeBlocks,
+    preserveLineBreaks,
   };
 });
 let html = $state(initialRender.html);
 let streamingPrefixHtml = $state(initialRender.prefixHtml);
 let streamingPrefixSource = initialRender.prefixSource;
 let streamingPrefixTrim = initialRender.trim;
+let streamingPrefixPreserveLineBreaks = initialRender.preserveLineBreaks;
 let streamingTail = $state(initialRender.tail);
 let showingStreaming = $state(initialRender.streaming);
 let lastEnqueuedSource = initialRender.source;
 let lastEnqueuedTrim = initialRender.trim;
+let lastEnqueuedPreserveLineBreaks = initialRender.preserveLineBreaks;
 let highlightToken = 0;
 
 async function handleClick(event: MouseEvent) {
@@ -145,11 +167,17 @@ function commitStreaming(value: StreamingValue) {
   const parts = splitStreamingMarkdown(value.source);
   if (
     parts.prefix !== streamingPrefixSource ||
-    value.trim !== streamingPrefixTrim
+    value.trim !== streamingPrefixTrim ||
+    value.preserveLineBreaks !== streamingPrefixPreserveLineBreaks
   ) {
-    streamingPrefixHtml = renderStreamingPrefix(parts.prefix, value.trim);
+    streamingPrefixHtml = renderStreamingPrefix(
+      parts.prefix,
+      value.trim,
+      value.preserveLineBreaks,
+    );
     streamingPrefixSource = parts.prefix;
     streamingPrefixTrim = value.trim;
+    streamingPrefixPreserveLineBreaks = value.preserveLineBreaks;
   }
   streamingTail = parts.tail;
   showingStreaming = true;
@@ -161,16 +189,24 @@ const streamingScheduler = new LatestPresentationScheduler<StreamingValue>(
 );
 
 /** Full render + async Shiki highlight. Used only for finalized content. */
-function renderWithHighlight(source: string, trim: boolean) {
-  const cachedHighlighted = getHighlightedMarkdownSync(source, trim);
+function renderWithHighlight(
+  source: string,
+  trim: boolean,
+  preserveBreaks: boolean,
+) {
+  const cachedHighlighted = getHighlightedMarkdownSync(
+    source,
+    trim,
+    preserveBreaks,
+  );
   if (cachedHighlighted !== undefined) {
     html = cachedHighlighted;
     highlightToken += 1;
     return;
   }
-  html = renderDecoratedMarkdown(source, trim);
+  html = renderDecoratedMarkdown(source, trim, preserveBreaks);
   const token = (highlightToken += 1);
-  renderHighlightedMarkdown(source, trim)
+  renderHighlightedMarkdown(source, trim, preserveBreaks)
     .then((highlighted) => {
       if (token === highlightToken) {
         html = highlighted;
@@ -178,7 +214,7 @@ function renderWithHighlight(source: string, trim: boolean) {
     })
     .catch(() => {
       if (token === highlightToken) {
-        html = renderDecoratedMarkdown(source, trim);
+        html = renderDecoratedMarkdown(source, trim, preserveBreaks);
       }
     });
 }
@@ -186,22 +222,35 @@ function renderWithHighlight(source: string, trim: boolean) {
 $effect(() => {
   const source = text;
   const trim = trimCodeBlocks;
+  const preserveBreaks = preserveLineBreaks;
   if (!streaming) {
-    if (showingStreaming) streamingScheduler.flushNow({ source, trim });
+    if (showingStreaming) {
+      streamingScheduler.flushNow({
+        source,
+        trim,
+        preserveLineBreaks: preserveBreaks,
+      });
+    }
     showingStreaming = false;
-    renderWithHighlight(source, trim);
+    renderWithHighlight(source, trim, preserveBreaks);
     lastEnqueuedSource = source;
     lastEnqueuedTrim = trim;
+    lastEnqueuedPreserveLineBreaks = preserveBreaks;
     return;
   }
 
   const priority =
     !showingStreaming ||
     trim !== lastEnqueuedTrim ||
+    preserveBreaks !== lastEnqueuedPreserveLineBreaks ||
     appendedNewline(lastEnqueuedSource, source);
   lastEnqueuedSource = source;
   lastEnqueuedTrim = trim;
-  streamingScheduler.enqueue({ source, trim }, { priority });
+  lastEnqueuedPreserveLineBreaks = preserveBreaks;
+  streamingScheduler.enqueue(
+    { source, trim, preserveLineBreaks: preserveBreaks },
+    { priority },
+  );
 });
 
 $effect(() => () => streamingScheduler.destroy());

--- a/packages/ui-kit/src/lib/core/components/markdown-render.test.ts
+++ b/packages/ui-kit/src/lib/core/components/markdown-render.test.ts
@@ -25,6 +25,22 @@ describe("Mermaid fence detection", () => {
   });
 });
 
+describe("Markdown line breaks", () => {
+  it("preserves soft line endings only when requested", () => {
+    const source = `first line ${Math.random()}\nsecond line`;
+    const standard = renderDecoratedMarkdown(source, true);
+    const preserved = renderDecoratedMarkdown(source, true, true);
+
+    assert.doesNotMatch(standard, /<br\s*\/?\s*>/);
+    assert.match(preserved, /<br\s*\/?\s*>/);
+    assert.notEqual(
+      standard,
+      preserved,
+      "render caches remain isolated by line-break mode",
+    );
+  });
+});
+
 describe("markdown-render caching", () => {
   it("keeps streaming cache bypass output equivalent to finalized decoration", () => {
     const source = `streaming ${Math.random()} with **markdown**`;

--- a/packages/ui-kit/src/lib/core/components/markdown-render.ts
+++ b/packages/ui-kit/src/lib/core/components/markdown-render.ts
@@ -4,17 +4,20 @@ import { LruCache } from "@nervekit/ui-kit/core/utils/lru-cache";
 import { trimTextPreview } from "@nervekit/ui-kit/core/utils/text-preview";
 import rehypeSanitize from "rehype-sanitize";
 import rehypeStringify from "rehype-stringify";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 
-const markdownProcessor = unified()
-  .use(remarkParse)
-  .use(remarkGfm)
-  .use(remarkRehype)
-  .use(rehypeSanitize)
-  .use(rehypeStringify);
+function createMarkdownProcessor(preserveLineBreaks: boolean) {
+  const processor = unified().use(remarkParse).use(remarkGfm);
+  if (preserveLineBreaks) processor.use(remarkBreaks);
+  return processor.use(remarkRehype).use(rehypeSanitize).use(rehypeStringify);
+}
+
+const markdownProcessor = createMarkdownProcessor(false);
+const lineBreakMarkdownProcessor = createMarkdownProcessor(true);
 
 // Content-keyed memoization for the (pure) render products. Re-mounts (tab
 // switches, virtual-scroll remounts) and run-completion re-renders reuse work
@@ -25,8 +28,19 @@ const decoratedCache = new LruCache<string, string>(MARKDOWN_CACHE_MAX);
 const highlightedCache = new LruCache<string, string>(MARKDOWN_CACHE_MAX);
 const highlightInflight = new Map<string, Promise<string>>();
 
-function signatureFor(source: string, trimCodeBlocks: boolean): string {
-  return `${trimCodeBlocks ? "t" : "f"}\0${source}`;
+function sourceSignatureFor(
+  source: string,
+  preserveLineBreaks: boolean,
+): string {
+  return `${preserveLineBreaks ? "breaks" : "standard"}\0${source}`;
+}
+
+function signatureFor(
+  source: string,
+  trimCodeBlocks: boolean,
+  preserveLineBreaks: boolean,
+): string {
+  return `${trimCodeBlocks ? "t" : "f"}\0${sourceSignatureFor(source, preserveLineBreaks)}`;
 }
 
 function escapeHtml(source: string): string {
@@ -43,6 +57,8 @@ export type RenderMarkdownOptions = {
    * those transient prefixes would only churn/pollute the LRU.
    */
   cache?: boolean;
+  /** Convert Markdown soft line endings into semantic hard breaks. */
+  preserveLineBreaks?: boolean;
 };
 
 /** Render markdown source to sanitized HTML (before code-block decoration). */
@@ -51,17 +67,22 @@ export function renderMarkdown(
   options: RenderMarkdownOptions = {},
 ): string {
   const useCache = options.cache ?? true;
+  const preserveLineBreaks = options.preserveLineBreaks ?? false;
+  const key = sourceSignatureFor(source, preserveLineBreaks);
   if (useCache) {
-    const cached = parseCache.get(source);
+    const cached = parseCache.get(key);
     if (cached !== undefined) return cached;
   }
   let html: string;
   try {
-    html = String(markdownProcessor.processSync(source));
+    const processor = preserveLineBreaks
+      ? lineBreakMarkdownProcessor
+      : markdownProcessor;
+    html = String(processor.processSync(source));
   } catch {
     html = escapeHtml(source);
   }
-  if (useCache) parseCache.set(source, html);
+  if (useCache) parseCache.set(key, html);
   return html;
 }
 
@@ -210,11 +231,15 @@ export async function highlightMarkdownHtml(
 export function renderDecoratedMarkdown(
   source: string,
   trimCodeBlocks: boolean,
+  preserveLineBreaks = false,
 ): string {
-  const key = signatureFor(source, trimCodeBlocks);
+  const key = signatureFor(source, trimCodeBlocks, preserveLineBreaks);
   const cached = decoratedCache.get(key);
   if (cached !== undefined) return cached;
-  const html = decorateMarkdownHtml(renderMarkdown(source), trimCodeBlocks);
+  const html = decorateMarkdownHtml(
+    renderMarkdown(source, { preserveLineBreaks }),
+    trimCodeBlocks,
+  );
   decoratedCache.set(key, html);
   return html;
 }
@@ -226,8 +251,11 @@ export function renderDecoratedMarkdown(
 export function getHighlightedMarkdownSync(
   source: string,
   trimCodeBlocks: boolean,
+  preserveLineBreaks = false,
 ): string | undefined {
-  return highlightedCache.get(signatureFor(source, trimCodeBlocks));
+  return highlightedCache.get(
+    signatureFor(source, trimCodeBlocks, preserveLineBreaks),
+  );
 }
 
 /**
@@ -237,10 +265,11 @@ export function getHighlightedMarkdownSync(
 export function renderBestAvailableMarkdown(
   source: string,
   trimCodeBlocks: boolean,
+  preserveLineBreaks = false,
 ): string {
   return (
-    getHighlightedMarkdownSync(source, trimCodeBlocks) ??
-    renderDecoratedMarkdown(source, trimCodeBlocks)
+    getHighlightedMarkdownSync(source, trimCodeBlocks, preserveLineBreaks) ??
+    renderDecoratedMarkdown(source, trimCodeBlocks, preserveLineBreaks)
   );
 }
 
@@ -251,13 +280,17 @@ export function renderBestAvailableMarkdown(
 export function renderHighlightedMarkdown(
   source: string,
   trimCodeBlocks: boolean,
+  preserveLineBreaks = false,
 ): Promise<string> {
-  const key = signatureFor(source, trimCodeBlocks);
+  const key = signatureFor(source, trimCodeBlocks, preserveLineBreaks);
   const cached = highlightedCache.get(key);
   if (cached !== undefined) return Promise.resolve(cached);
   const inflight = highlightInflight.get(key);
   if (inflight) return inflight;
-  const promise = highlightMarkdownHtml(renderMarkdown(source), trimCodeBlocks)
+  const promise = highlightMarkdownHtml(
+    renderMarkdown(source, { preserveLineBreaks }),
+    trimCodeBlocks,
+  )
     .then((html) => {
       highlightedCache.set(key, html);
       highlightInflight.delete(key);

--- a/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/conversation-capabilities.svelte.ts
@@ -19,6 +19,13 @@ import {
   confluenceSiteUrl,
   jiraSiteUrl,
 } from "$lib/features/conversations/state/atlassian-site-urls.svelte";
+import { uploadClipboardImage } from "$lib/features/filesystem/api/filesystem.api";
+import { resolveDroppedPaths } from "$lib/features/conversations/adapters/dropped-paths";
+import { getDesktopBridge } from "$lib/features/desktop/state/desktop-bridge.svelte";
+import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
+import { selection } from "$lib/features/workspace/state/selection.svelte";
+import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import { completeFiles } from "$lib/features/workspace/state/workspace-actions.svelte";
 
 /**
  * Build the workbench capability object consumed by the shared conversation
@@ -39,6 +46,25 @@ export function workbenchConversationUiCapabilities(): ConversationUiCapabilitie
       micShortcutAria: getShortcutAriaLabel("composer.toggleMic"),
       TranscriptionActivity,
       AudioAuthDialog: AudioInputAuthRequiredDialog,
+    },
+    askReply: {
+      pasteImage: uploadClipboardImage,
+      dropFiles: async (files) => {
+        const bridge = getDesktopBridge();
+        const project = workspaceState.projects.find(
+          (item) => item.id === selection.projectId,
+        );
+        if (!bridge?.files || !project) {
+          throw new Error("Native file paths are unavailable in this window.");
+        }
+        return resolveDroppedPaths(
+          files,
+          project.dir,
+          bridge.files.getPathForFile,
+        );
+      },
+      slashCompletions: () => conversationState.slashCompletions,
+      fileCompletions: completeFiles,
     },
   };
 }

--- a/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
@@ -39,9 +39,10 @@ import {
 type Props = {
   value: string;
   placeholder?: string;
+  ariaLabel?: string;
   disabled?: boolean;
   focusToken?: number;
-  slashCompletions?: CompletionItem[];
+  slashCompletions?: readonly CompletionItem[];
   fileCompletions?: (query: string) => Promise<CompletionItem[]>;
   onChange?: (value: string) => void;
   onSubmit?: () => void;
@@ -63,6 +64,7 @@ const projectReferenceSection: CompletionSection = {
 let {
   value,
   placeholder = "Ask the Nerve agent",
+  ariaLabel = "Prompt editor drop area",
   disabled = false,
   focusToken = 0,
   slashCompletions = [],
@@ -781,7 +783,7 @@ onDestroy(() => view?.destroy());
   class="composer-editor relative"
   class:disabled
   role="group"
-  aria-label="Prompt editor drop area"
+  aria-label={ariaLabel}
   ondragentercapture={handleFileDragEnter}
   ondragovercapture={handleFileDragOver}
   ondragleavecapture={handleFileDragLeave}
@@ -801,10 +803,10 @@ onDestroy(() => view?.destroy());
 
 <style>
 .composer-editor {
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  background: var(--input);
+  background: var(--background);
   transition:
     border-color 160ms ease,
     box-shadow 160ms ease,

--- a/packages/workbench-app/src/lib/presentation/context.svelte.ts
+++ b/packages/workbench-app/src/lib/presentation/context.svelte.ts
@@ -1,4 +1,5 @@
 import type {
+  CompletionItem,
   EventEnvelope,
   SubagentTranscriptSnapshot,
   ToolCallRecord,
@@ -68,6 +69,23 @@ export interface SubagentTranscriptObserver {
   error: (message: string) => void;
 }
 
+/**
+ * Composer-grade reply surface for the ask-user card: clipboard image paste,
+ * dropped-file path resolution, and the same slash/file auto-completions the
+ * prompt composer offers. Every member is optional; the reply input degrades
+ * to a plain editor (plus voice) when a host does not provide them.
+ */
+export interface AskReplyComposerCapability {
+  /** Upload a pasted clipboard image; resolves to the text to insert. */
+  pasteImage?: (file: File) => Promise<string>;
+  /** Resolve dropped native files to project-relative path mentions. */
+  dropFiles?: (files: readonly File[]) => Promise<readonly string[]>;
+  /** Reactive getter for slash-command completion items. */
+  slashCompletions?: () => readonly CompletionItem[];
+  /** Project file reference completions for "@" mentions. */
+  fileCompletions?: (query: string) => Promise<CompletionItem[]>;
+}
+
 export interface ConversationUiCapabilities {
   /** Fetch a full tool-call record for the details dialog. */
   fetchToolCall?: (toolCallId: string) => Promise<ToolCallRecord>;
@@ -79,6 +97,8 @@ export interface ConversationUiCapabilities {
   ) => () => void;
   /** Voice input integration for the ask-user card. */
   voice?: VoiceInputCapability;
+  /** Composer-grade reply input (paste image, completions, file drop) for the ask-user card. */
+  askReply?: AskReplyComposerCapability;
   /** Site URLs used to build external Jira/Confluence links. */
   atlassian?: AtlassianLinkCapability;
 }

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/AskUserToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/AskUserToolView.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-import { onDestroy, tick } from "svelte";
+import { onDestroy } from "svelte";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import Mic from "@lucide/svelte/icons/mic";
 import Send from "@lucide/svelte/icons/send";
 import X from "@lucide/svelte/icons/x";
 import { notify } from "@nervekit/ui-kit/core/notify";
+import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
+import ComposerEditor from "$lib/presentation/components/composer/ComposerEditor.svelte";
 import type { UserQuestionRecord } from "../../../state/tool-types";
 import type {
   ToolCallDisplayRecord,
@@ -17,7 +19,8 @@ import {
 } from "../../../context.svelte";
 import ToolFooter from "./ToolFooter.svelte";
 
-const voice = getConversationUiCapabilities().voice;
+const capabilities = getConversationUiCapabilities();
+const voice = capabilities.voice;
 const TranscriptionActivity = voice?.TranscriptionActivity;
 const AudioInputAuthRequiredDialog = voice?.AudioAuthDialog;
 
@@ -26,6 +29,7 @@ type Props = {
   view: Extract<ToolView, { kind: "ask_user" }>;
   questionRecord?: UserQuestionRecord;
   detailsAction?: { label: string; onClick: () => void };
+  onOpenFile?: (path: string, line?: number) => void;
   onAnswerUserQuestion?: (
     questionId: string,
     answer: string,
@@ -37,6 +41,7 @@ let {
   view,
   questionRecord,
   detailsAction,
+  onOpenFile,
   onAnswerUserQuestion,
   onDismissUserQuestion,
 }: Props = $props();
@@ -55,7 +60,7 @@ let localResolution = $state<
   { kind: "answered"; answer: string } | { kind: "dismissed" } | undefined
 >();
 let audioAuthDialogOpen = $state(false);
-let replyInputEl = $state<HTMLTextAreaElement | undefined>(undefined);
+let replyFocusToken = $state(0);
 let lastAutoFocusedQuestionId = $state<string | undefined>(undefined);
 let registeredTargetKey: string | undefined;
 let registeredTarget: VoiceInputTarget | undefined;
@@ -72,6 +77,11 @@ const context = $derived(questionRecord?.context ?? view.context);
 const recommendation = $derived(
   questionRecord?.recommendation ?? view.recommendation,
 );
+const askReply = capabilities.askReply;
+const slashCompletions = $derived(askReply?.slashCompletions?.() ?? []);
+const fileCompletions = $derived(askReply?.fileCompletions);
+const replyPasteImage = $derived(askReply?.pasteImage);
+const replyDropFiles = $derived(askReply?.dropFiles);
 // The locally submitted text bridges the gap between a successful RPC and
 // the authoritative tool result arriving through durable events.
 const submittedAnswer = $derived(
@@ -180,11 +190,9 @@ $effect(() => {
   const questionId = pending && questionRecord ? questionRecord.id : undefined;
   if (!questionId || questionId === lastAutoFocusedQuestionId) return;
   lastAutoFocusedQuestionId = questionId;
-  void tick().then(() => {
-    if (pending && questionRecord?.id === questionId) {
-      replyInputEl?.focus({ preventScroll: true });
-    }
-  });
+  if (pending && questionRecord?.id === questionId) {
+    replyFocusToken += 1;
+  }
 });
 
 onDestroy(() => clearRegisteredVoiceTarget(true));
@@ -265,18 +273,6 @@ function handleReplyKeydown(event: KeyboardEvent) {
   ) {
     event.preventDefault();
     toggleRecording();
-    return;
-  }
-
-  const enterKey = event.key === "Enter" || event.code === "NumpadEnter";
-  if (
-    enterKey &&
-    (event.ctrlKey || event.metaKey) &&
-    !event.altKey &&
-    !event.shiftKey
-  ) {
-    event.preventDefault();
-    submitAnswer();
   }
 }
 
@@ -285,20 +281,41 @@ function handleMicContextMenu(event: MouseEvent) {
   event.preventDefault();
   void voice.session.cancel(voiceTarget);
 }
+
+// CodeMirror owns the editor's key handling; Alt+V (mic) isn't bound there, so
+// a plain DOM listener on the wrapper keeps the shortcut working without
+// tripping a11y's keydown-on-non-interactive-element rule.
+function replyFieldKeydown(node: HTMLElement) {
+  node.addEventListener("keydown", handleReplyKeydown);
+  return {
+    destroy() {
+      node.removeEventListener("keydown", handleReplyKeydown);
+    },
+  };
+}
 </script>
 
-<div class="ask">
+<div class="ask select-text">
   {#if question}
-    <p class="question">{question}</p>
+    <div class="question">
+      <Markdown text={question} preserveLineBreaks {onOpenFile} />
+    </div>
   {/if}
   {#if context}
-    <p class="meta"><span class="meta-label">context</span> {context}</p>
+    <div class="meta">
+      <span class="meta-label">context</span>
+      <div class="meta-body">
+        <Markdown text={context} preserveLineBreaks {onOpenFile} />
+      </div>
+    </div>
   {/if}
   {#if recommendation}
-    <p class="meta">
+    <div class="meta">
       <span class="meta-label">recommendation</span>
-      {recommendation}
-    </p>
+      <div class="meta-body">
+        <Markdown text={recommendation} preserveLineBreaks {onOpenFile} />
+      </div>
+    </div>
   {/if}
 
   {#if pending && questionRecord}
@@ -322,17 +339,27 @@ function handleMicContextMenu(event: MouseEvent) {
         submitAnswer();
       }}
     >
-      <div class="reply-field">
-        <textarea
-          class="reply-input"
-          bind:this={replyInputEl}
-          bind:value={answer}
-          rows="3"
+      <div
+        class="reply-field"
+        role="group"
+        aria-label="Reply input"
+        use:replyFieldKeydown
+      >
+        <ComposerEditor
+          value={answer}
           disabled={Boolean(submitting)}
-          placeholder={questionRecord.placeholder ??
-            "Reply to the agent's question"}
-          aria-label="Reply to agent question"
-          onkeydown={handleReplyKeydown}></textarea>
+          placeholder="Reply to the agent's question"
+          ariaLabel="Reply to agent question"
+          focusToken={replyFocusToken}
+          {slashCompletions}
+          {fileCompletions}
+          onChange={(value) => {
+            answer = value;
+          }}
+          onSubmit={submitAnswer}
+          onPasteImage={replyPasteImage}
+          onDropFiles={replyDropFiles}
+        />
         {#if voice && supportsAudioRecording && TranscriptionActivity}
           <div class="reply-voice-controls">
             <TranscriptionActivity
@@ -376,17 +403,6 @@ function handleMicContextMenu(event: MouseEvent) {
         {#snippet actions()}
           <Button
             size="sm"
-            type="submit"
-            disabled={!trimmedAnswer || Boolean(submitting)}
-          >
-            {#if submitting === "answer"}
-              <Spinner class="size-3.5" />Sending…
-            {:else}
-              <Send size={14} strokeWidth={2.4} />Reply
-            {/if}
-          </Button>
-          <Button
-            size="sm"
             variant="secondary"
             type="button"
             disabled={Boolean(submitting)}
@@ -398,6 +414,17 @@ function handleMicContextMenu(event: MouseEvent) {
               <X size={14} strokeWidth={2.4} />Dismiss
             {/if}
           </Button>
+          <Button
+            size="sm"
+            type="submit"
+            disabled={!trimmedAnswer || Boolean(submitting)}
+          >
+            {#if submitting === "answer"}
+              <Spinner class="size-3.5" />Sending…
+            {:else}
+              <Send size={14} strokeWidth={2.4} />Reply
+            {/if}
+          </Button>
         {/snippet}
       </ToolFooter>
       {#if submitError}
@@ -405,10 +432,12 @@ function handleMicContextMenu(event: MouseEvent) {
       {/if}
     </form>
   {:else if submittedAnswer}
-    <p class="meta answer">
+    <div class="meta answer">
       <span class="meta-label">answer</span>
-      {submittedAnswer}
-    </p>
+      <div class="meta-body">
+        <Markdown text={submittedAnswer} preserveLineBreaks {onOpenFile} />
+      </div>
+    </div>
   {:else if dismissed}
     <p class="meta">
       <span class="meta-label">dismissed</span>
@@ -429,18 +458,35 @@ function handleMicContextMenu(event: MouseEvent) {
 
 .question {
   margin: 0;
-  font-weight: 600;
+}
+
+.question :global(.markdown) {
   color: var(--foreground);
 }
 
 .meta {
+  display: grid;
+  gap: 0.15rem;
   margin: 0;
+  min-width: 0;
+  font-size: var(--text-sm);
+  color: var(--muted-foreground);
+}
+
+.meta-body {
+  min-width: 0;
+}
+
+.meta :global(.markdown) {
   font-size: var(--text-sm);
   color: var(--muted-foreground);
 }
 
 .answer {
-  white-space: pre-wrap;
+  color: var(--foreground);
+}
+
+.answer :global(.markdown) {
   color: var(--foreground);
 }
 
@@ -497,26 +543,6 @@ function handleMicContextMenu(event: MouseEvent) {
 
 .reply-field {
   position: relative;
-}
-
-.reply-input {
-  width: 100%;
-  min-height: 4.5rem;
-  resize: vertical;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  background: var(--background);
-  color: var(--foreground);
-  padding: 0.55rem 2.4rem 2.85rem 0.65rem;
-  font: inherit;
-  font-size: var(--text-sm);
-  line-height: 1.4;
-}
-
-.reply-input:focus {
-  outline: 2px solid color-mix(in oklab, var(--ring) 45%, transparent);
-  outline-offset: 1px;
-  border-color: var(--primary);
 }
 
 .reply-voice-controls {

--- a/packages/workbench-server/src/domains/agents/run/sequential-tool-approval-batch.ts
+++ b/packages/workbench-server/src/domains/agents/run/sequential-tool-approval-batch.ts
@@ -223,7 +223,6 @@ function canonicalWaitCommand(
     batchToolCallIds,
     prompt: question?.question ?? reason,
     context: question?.context,
-    placeholder: question?.placeholder,
     required: true,
     checkpoint,
   };

--- a/packages/workbench-server/src/domains/tools/interaction-session.service.ts
+++ b/packages/workbench-server/src/domains/tools/interaction-session.service.ts
@@ -48,7 +48,6 @@ export class InteractionSessionService {
       question: stringArg(args, "question"),
       context: optionalStringArg(args.context),
       recommendation: optionalStringArg(args.recommendation),
-      placeholder: optionalStringArg(args.placeholder),
       status: "pending",
       requestedAt: now,
       updatedAt: now,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       rehype-stringify:
         specifier: ^10.0.1
         version: 10.0.1
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1(supports-color@7.2.0)
@@ -3085,15 +3088,30 @@ packages:
 
   '@volar/language-server@2.4.28':
     resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@volar/language-service@2.4.28':
     resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@volar/source-map@2.4.28':
     resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vscode/emmet-helper@2.11.0':
     resolution: {integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==}
@@ -4977,6 +4995,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -5644,6 +5665,9 @@ packages:
 
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-directive@4.0.0:
     resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
@@ -6557,16 +6581,22 @@ packages:
     resolution: {integrity: sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
+      typescript: '*'
     peerDependenciesMeta:
       '@volar/language-service':
+        optional: true
+      typescript:
         optional: true
 
   volar-service-typescript@0.0.71:
     resolution: {integrity: sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
+      typescript: '*'
     peerDependenciesMeta:
       '@volar/language-service':
+        optional: true
+      typescript:
         optional: true
 
   volar-service-yaml@0.0.71:
@@ -6947,17 +6977,17 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@volar/kit': 2.4.28(typescript@5.9.3)
       '@volar/language-core': 2.4.28
-      '@volar/language-server': 2.4.28
-      '@volar/language-service': 2.4.28
+      '@volar/language-server': 2.4.28(typescript@5.9.3)
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
       muggle-string: 0.4.1
       tinyglobby: 0.2.17
-      volar-service-css: 0.0.71(@volar/language-service@2.4.28)
-      volar-service-emmet: 0.0.71(@volar/language-service@2.4.28)
-      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
-      volar-service-prettier: 0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6)
-      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
-      volar-service-typescript-twoslash-queries: 0.0.71(@volar/language-service@2.4.28)
-      volar-service-yaml: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-css: 0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))
+      volar-service-emmet: 0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))
+      volar-service-html: 0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))
+      volar-service-prettier: 0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))(prettier@3.9.6)
+      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3)
+      volar-service-typescript-twoslash-queries: 0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3)
+      volar-service-yaml: 0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -9868,8 +9898,8 @@ snapshots:
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
-      '@volar/language-service': 2.4.28
-      '@volar/typescript': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      '@volar/typescript': 2.4.28(typescript@5.9.3)
       typesafe-path: 0.2.2
       typescript: 5.9.3
       vscode-languageserver-textdocument: 1.0.12
@@ -9879,32 +9909,38 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.4.28
 
-  '@volar/language-server@2.4.28':
+  '@volar/language-server@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@volar/language-service': 2.4.28
-      '@volar/typescript': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      '@volar/typescript': 2.4.28(typescript@5.9.3)
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
       vscode-languageserver-protocol: 3.18.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@volar/language-service@2.4.28':
+  '@volar/language-service@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       vscode-languageserver-protocol: 3.18.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@vscode/emmet-helper@2.11.0':
     dependencies:
@@ -12293,6 +12329,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -13215,6 +13256,12 @@ snapshots:
       '@types/hast': 3.0.4
       rehype-parse: 9.0.1
       rehype-stringify: 10.0.1
+      unified: 11.0.5
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
 
   remark-directive@4.0.0(supports-color@7.2.0):
@@ -14268,45 +14315,46 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  volar-service-css@0.0.71(@volar/language-service@2.4.28):
+  volar-service-css@0.0.71(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       vscode-css-languageservice: 6.3.10
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
-  volar-service-emmet@0.0.71(@volar/language-service@2.4.28):
+  volar-service-emmet@0.0.71(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       '@emmetio/css-parser': 0.4.1
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
-  volar-service-html@0.0.71(@volar/language-service@2.4.28):
+  volar-service-html@0.0.71(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       vscode-html-languageservice: 5.6.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
-  volar-service-prettier@0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6):
+  volar-service-prettier@0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))(prettier@3.9.6):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
       prettier: 3.9.6
 
-  volar-service-typescript-twoslash-queries@0.0.71(@volar/language-service@2.4.28):
+  volar-service-typescript-twoslash-queries@0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      typescript: 5.9.3
 
-  volar-service-typescript@0.0.71(@volar/language-service@2.4.28):
+  volar-service-typescript@0.0.71(@volar/language-service@2.4.28(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       path-browserify: 1.0.1
       semver: 7.8.5
@@ -14315,14 +14363,15 @@ snapshots:
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
+      typescript: 5.9.3
 
-  volar-service-yaml@0.0.71(@volar/language-service@2.4.28):
+  volar-service-yaml@0.0.71(@volar/language-service@2.4.28(typescript@5.9.3)):
     dependencies:
       vscode-uri: 3.1.0
       yaml-language-server: 1.23.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28
+      '@volar/language-service': 2.4.28(typescript@5.9.3)
 
   vscode-css-languageservice@6.3.10:
     dependencies:


### PR DESCRIPTION
## Summary

Upgrades the **ask-user** tool card into a composer-grade reply surface and adds preserved line breaks to Markdown rendering.

### Ask-user card
- Replaces the plain `<textarea>` reply with the full CodeMirror-based `ComposerEditor`, bringing clipboard image paste, file drop, slash-command completions, and `@` file completions to the reply input.
- Question, context, recommendation, and submitted answer now render as Markdown with preserved line breaks.
- Autofocus switches to a focus token flow; Alt+V mic shortcut is preserved via a wrapper-level keydown listener.

### New `askReply` conversation capability
- `ConversationUiCapabilities.askReply` lets hosts supply `pasteImage`, `dropFiles`, `slashCompletions`, and `fileCompletions`. Each member is optional, so hosts degrade gracefully to a plain editor.
- Workbench wires this up with clipboard image upload, dropped-path resolution, and the composer's existing completion sources.

### Markdown line breaks (ui-kit)
- New `preserveLineBreaks` option on the `Markdown` component and render pipeline via `remark-breaks`.
- Render caches and streaming paths are now keyed by line-break mode so the two modes stay isolated.

### Cleanup / polish
- Removes the now-unused `placeholder` parameter from the `ask_user` tool schema, catalog, arg parsing, server session service, and approval batch.
- `ComposerEditor`: adds `ariaLabel` prop, accepts readonly completion items, fixes overflow so dropdowns render outside the frame, and uses the background token for the editor surface.

## Validation
- `pnpm fix && pnpm check && pnpm test` green (see CI status / local run).
