### PR TITLE
Add OS-friendly window headers

### DIFF
--- a/packages/contracts/src/domains/settings/settings.schema.ts
+++ b/packages/contracts/src/domains/settings/settings.schema.ts
@@ -12,6 +12,9 @@ export type ColorTheme = z.infer<typeof colorThemeSchema>;
 export const colorModeSchema = z.enum(["system", "light", "dark"]);
 export type ColorMode = z.infer<typeof colorModeSchema>;
 
+export const headerTypeSchema = z.enum(["auto", "linux", "windows", "macos"]);
+export type HeaderType = z.infer<typeof headerTypeSchema>;
+
 export const permissionLevelSchema = z.enum([
   "autonomous",
   "supervised",
@@ -169,6 +172,7 @@ export const settingsSchema = z.object({
   }),
   desktop: z.object({
     closeToTray: z.boolean().default(true),
+    headerType: headerTypeSchema.default("auto"),
   }),
   notifications: z
     .object({
@@ -243,6 +247,7 @@ export const defaultSettings: Settings = {
   },
   desktop: {
     closeToTray: true,
+    headerType: "auto",
   },
   notifications: {
     systemEnabled: true,
@@ -315,6 +320,7 @@ export const updateSettingsRequestSchema = z.object({
   desktop: z
     .object({
       closeToTray: z.boolean().optional(),
+      headerType: headerTypeSchema.optional(),
     })
     .optional(),
   notifications: z

--- a/packages/contracts/test/settings.test.ts
+++ b/packages/contracts/test/settings.test.ts
@@ -16,6 +16,7 @@ describe("settings schema", () => {
       lastAgentSelection: undefined,
       notifications: undefined,
       ui: { theme: undefined, colorMode: undefined, zoomLevel: undefined },
+      desktop: { closeToTray: true, headerType: undefined },
       tools: undefined,
       skills: undefined,
     });
@@ -37,6 +38,10 @@ describe("settings schema", () => {
       theme: "nerve",
       colorMode: "system",
       zoomLevel: 0,
+    });
+    assert.deepEqual(settings.desktop, {
+      closeToTray: true,
+      headerType: "auto",
     });
     assert.deepEqual(settings.notifications, {
       systemEnabled: true,
@@ -123,6 +128,7 @@ describe("settings schema", () => {
         shellPath: "C:\\Program Files\\Git\\bin\\bash.exe",
       },
       ui: { theme: "ocean", colorMode: "dark" },
+      desktop: { headerType: "macos" },
       defaultApprovalPolicy: { autoApproveReadOnly: false },
       lastAgentSelection: {
         approvalPolicy: { autoApproveReadOnly: false },
@@ -168,6 +174,13 @@ describe("settings schema", () => {
       );
     }
     assert.deepEqual(parsed.ui, { theme: "ocean", colorMode: "dark" });
+    assert.deepEqual(parsed.desktop, { headerType: "macos" });
+    assert.equal(
+      updateSettingsRequestSchema.safeParse({
+        desktop: { headerType: "beos" },
+      }).success,
+      false,
+    );
     for (const ui of [{ theme: "unknown" }, { colorMode: "sepia" }]) {
       assert.equal(
         updateSettingsRequestSchema.safeParse({ ui }).success,

--- a/packages/workbench-app/src/lib/api.ts
+++ b/packages/workbench-app/src/lib/api.ts
@@ -53,6 +53,7 @@ export type {
   GithubPrOverview,
   GithubPrReviewSummary,
   GithubStatusResponse,
+  HeaderType,
   GitMutationResponse,
   GitOverviewResponse,
   GitRecentCommit,

--- a/packages/workbench-app/src/lib/app/shell/MacTrafficLight.svelte
+++ b/packages/workbench-app/src/lib/app/shell/MacTrafficLight.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+type Props = {
+  kind: "close" | "minimize" | "maximize";
+  class?: string;
+};
+
+let { kind, class: className }: Props = $props();
+
+const colors = {
+  close: { border: "#e24b41", fill: "#ed6a5f", symbol: "#460804" },
+  minimize: { border: "#e1a73e", fill: "#f6be50", symbol: "#90591d" },
+  maximize: { border: "#2dac2f", fill: "#61c555", symbol: "#2a6218" },
+} as const;
+</script>
+
+<!-- Adapted from https://github.com/lwouis/macos-traffic-light-buttons-as-SVG
+     (CC0-1.0). The source artwork's fixed colors are intentional. -->
+<svg
+  viewBox="0 0 85.4 85.4"
+  class={className}
+  aria-hidden="true"
+  focusable="false"
+>
+  <circle cx="42.7" cy="42.7" r="42.7" fill={colors[kind].border} />
+  <circle cx="42.7" cy="42.7" r="39.1" fill={colors[kind].fill} />
+  <g
+    fill={colors[kind].symbol}
+    class="opacity-0 group-hover/window-controls:opacity-100 group-focus-within/window-controls:opacity-100"
+  >
+    {#if kind === "close"}
+      <path
+        d="m22.5 57.8 35.3-35.3c1.4-1.4 3.6-1.4 5 0l.1.1c1.4 1.4 1.4 3.6 0 5L27.6 62.9c-1.4 1.4-3.6 1.4-5 0l-.1-.1c-1.3-1.4-1.3-3.6 0-5Z"
+      />
+      <path
+        d="m27.6 22.5 35.3 35.3c1.4 1.4 1.4 3.6 0 5l-.1.1c-1.4 1.4-3.6 1.4-5 0L22.5 27.6c-1.4-1.4-1.4-3.6 0-5l.1-.1c1.4-1.3 3.6-1.3 5 0Z"
+      />
+    {:else if kind === "minimize"}
+      <path
+        d="M17.8 39.1h49.9c1.9 0 3.5 1.6 3.5 3.5v.1c0 1.9-1.6 3.5-3.5 3.5H17.8c-1.9 0-3.5-1.6-3.5-3.5v-.1c0-1.9 1.5-3.5 3.5-3.5Z"
+      />
+    {:else}
+      <path
+        d="M31.2 20.8h26.7c3.6 0 6.5 2.9 6.5 6.5V54Zm23.2 43.7H27.6c-3.6 0-6.5-2.9-6.5-6.5V31.2Z"
+      />
+    {/if}
+  </g>
+</svg>

--- a/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
+++ b/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
-import Copy from "@lucide/svelte/icons/copy";
 import CloudCog from "@lucide/svelte/icons/cloud-cog";
-import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import Logs from "@lucide/svelte/icons/logs";
-import Minus from "@lucide/svelte/icons/minus";
 import Settings from "@lucide/svelte/icons/settings";
-import Square from "@lucide/svelte/icons/square";
-import X from "@lucide/svelte/icons/x";
 import { Toolbar } from "bits-ui";
 import { NerveMark } from "$lib/presentation";
 import { ShellTitlebar } from "$lib/presentation/shell";
@@ -18,11 +13,14 @@ import { Button } from "@nervekit/ui-kit/components/ui/button";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
 import type { LatestRelease } from "@nervekit/contracts";
 import VersionIndicator from "$lib/app/shell/VersionIndicator.svelte";
+import WindowControls from "$lib/app/shell/WindowControls.svelte";
+import type { ResolvedHeaderType } from "$lib/app/shell/header-type";
 
 type Props = {
   projects?: ProjectSwitcherItem[];
   activeProjectKey?: string;
   desktop?: boolean;
+  headerType?: ResolvedHeaderType;
   maximized?: boolean;
   closeToTray?: boolean;
   quitting?: boolean;
@@ -47,6 +45,7 @@ let {
   projects = [],
   activeProjectKey,
   desktop = false,
+  headerType = "linux",
   maximized = false,
   closeToTray = true,
   quitting = false,
@@ -69,6 +68,19 @@ let {
 </script>
 
 <ShellTitlebar {desktop}>
+  {#snippet leadingControls()}
+    {#if desktop && headerType === "macos"}
+      <WindowControls
+        {headerType}
+        {maximized}
+        {closeToTray}
+        {quitting}
+        {onMinimize}
+        {onToggleMaximize}
+        {onClose}
+      />
+    {/if}
+  {/snippet}
   {#snippet left()}
     <span class="inline-flex items-center gap-1.5 text-foreground">
       <span class="brand-mark"><NerveMark compact /></span>
@@ -126,57 +138,17 @@ let {
       >
         <Settings size={16} strokeWidth={2.1} />
       </Button>
-      {#if desktop}
+      {#if desktop && headerType !== "macos"}
         <span class="mx-0.5 h-5 w-px bg-border" aria-hidden="true"></span>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          class="[-webkit-app-region:no-drag]"
-          ariaLabel="Minimize window"
-          title="Minimize"
-          disabled={quitting}
-          onclick={() => onMinimize?.()}
-        >
-          <Minus size={16} strokeWidth={2.1} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          class="[-webkit-app-region:no-drag]"
-          ariaLabel={maximized ? "Restore window" : "Maximize window"}
-          title={maximized ? "Restore" : "Maximize"}
-          disabled={quitting}
-          onclick={() => onToggleMaximize?.()}
-        >
-          {#if maximized}
-            <Copy size={15} strokeWidth={2.1} />
-          {:else}
-            <Square size={14} strokeWidth={2.1} />
-          {/if}
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          class="[-webkit-app-region:no-drag] hover:bg-destructive-solid hover:text-destructive-solid-foreground focus-visible:bg-destructive-solid focus-visible:text-destructive-solid-foreground"
-          ariaLabel={quitting
-            ? "Closing Nerve"
-            : closeToTray
-              ? "Close window to tray"
-              : "Close Nerve"}
-          title={quitting
-            ? "Closing Nerve…"
-            : closeToTray
-              ? "Close to tray"
-              : "Close Nerve"}
-          disabled={quitting}
-          onclick={() => onClose?.()}
-        >
-          {#if quitting}
-            <Spinner />
-          {:else}
-            <X size={16} strokeWidth={2.1} />
-          {/if}
-        </Button>
+        <WindowControls
+          {headerType}
+          {maximized}
+          {closeToTray}
+          {quitting}
+          {onMinimize}
+          {onToggleMaximize}
+          {onClose}
+        />
       {/if}
     </Toolbar.Root>
   {/snippet}

--- a/packages/workbench-app/src/lib/app/shell/TitlebarContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/TitlebarContainer.svelte
@@ -38,6 +38,7 @@ import {
 } from "$lib/features/workspace";
 import { quickProjectItems } from "$lib/features/projects";
 import { responsive } from "$lib/app/shell/responsive.svelte";
+import { resolveHeaderType } from "$lib/app/shell/header-type";
 
 const projectItems = $derived(workspaceSelectors.projectSwitcherItems);
 const status = $derived(workspaceSelectors.status);
@@ -58,6 +59,12 @@ const quickProjects = $derived(
 );
 const activeCenterTab = $derived(workspaceSelectors.activeCenterTab);
 const settingsDraft = $derived(settingsSelectors.settingsDraft);
+const headerType = $derived(
+  resolveHeaderType(
+    settingsDraft?.desktop.headerType ?? "auto",
+    desktopRuntime.platform,
+  ),
+);
 const desktopQuitting = $derived(
   desktopRuntime.quitting || desktopShutdownState.quitRequested,
 );
@@ -124,6 +131,7 @@ async function handleDesktopClose() {
   projects={quickProjects}
   activeProjectKey={workspaceState.selectedProjectKey}
   desktop={desktopRuntime.isDesktop}
+  {headerType}
   maximized={desktopRuntime.windowState.maximized}
   closeToTray={settingsDraft?.desktop.closeToTray ?? true}
   quitting={desktopQuitting}

--- a/packages/workbench-app/src/lib/app/shell/WindowControls.svelte
+++ b/packages/workbench-app/src/lib/app/shell/WindowControls.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+import ChevronDown from "@lucide/svelte/icons/chevron-down";
+import ChevronUp from "@lucide/svelte/icons/chevron-up";
+import Copy from "@lucide/svelte/icons/copy";
+import Diamond from "@lucide/svelte/icons/diamond";
+import Minus from "@lucide/svelte/icons/minus";
+import Square from "@lucide/svelte/icons/square";
+import X from "@lucide/svelte/icons/x";
+import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import type { ResolvedHeaderType } from "./header-type";
+import MacTrafficLight from "./MacTrafficLight.svelte";
+
+type Props = {
+  headerType: ResolvedHeaderType;
+  maximized?: boolean;
+  closeToTray?: boolean;
+  quitting?: boolean;
+  onMinimize?: () => void;
+  onToggleMaximize?: () => void;
+  onClose?: () => void;
+};
+
+let {
+  headerType,
+  maximized = false,
+  closeToTray = true,
+  quitting = false,
+  onMinimize,
+  onToggleMaximize,
+  onClose,
+}: Props = $props();
+
+const closeLabel = $derived(
+  quitting
+    ? "Closing Nerve"
+    : closeToTray
+      ? "Close window to tray"
+      : "Close Nerve",
+);
+const closeTitle = $derived(
+  quitting ? "Closing Nerve…" : closeToTray ? "Close to tray" : "Close Nerve",
+);
+</script>
+
+{#if headerType === "macos"}
+  <div
+    class="group/window-controls mr-1.5 flex flex-none items-center gap-2 [-webkit-app-region:no-drag]"
+    aria-label="Window controls"
+  >
+    <button
+      type="button"
+      class="size-3.5 rounded-full p-0 focus-visible:outline-2 focus-visible:outline-ring disabled:opacity-50"
+      aria-label={closeLabel}
+      title={closeTitle}
+      disabled={quitting}
+      onclick={() => onClose?.()}
+    >
+      {#if quitting}
+        <Spinner class="size-3.5" />
+      {:else}
+        <MacTrafficLight kind="close" class="size-3.5" />
+      {/if}
+    </button>
+    <button
+      type="button"
+      class="size-3.5 rounded-full p-0 focus-visible:outline-2 focus-visible:outline-ring disabled:opacity-50"
+      aria-label="Minimize window"
+      title="Minimize"
+      disabled={quitting}
+      onclick={() => onMinimize?.()}
+    >
+      <MacTrafficLight kind="minimize" class="size-3.5" />
+    </button>
+    <button
+      type="button"
+      class="size-3.5 rounded-full p-0 focus-visible:outline-2 focus-visible:outline-ring disabled:opacity-50"
+      aria-label={maximized ? "Restore window" : "Maximize window"}
+      title={maximized ? "Restore" : "Maximize"}
+      disabled={quitting}
+      onclick={() => onToggleMaximize?.()}
+    >
+      <MacTrafficLight kind="maximize" class="size-3.5" />
+    </button>
+  </div>
+{:else if headerType === "windows"}
+  <div
+    class="flex flex-none items-center gap-0.5 [-webkit-app-region:no-drag]"
+    aria-label="Window controls"
+  >
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="size-7 rounded-full"
+      ariaLabel="Minimize window"
+      title="Minimize"
+      disabled={quitting}
+      onclick={() => onMinimize?.()}
+    >
+      <Minus class="size-3.5" strokeWidth={1.75} />
+    </Button>
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="size-7 rounded-full"
+      ariaLabel={maximized ? "Restore window" : "Maximize window"}
+      title={maximized ? "Restore" : "Maximize"}
+      disabled={quitting}
+      onclick={() => onToggleMaximize?.()}
+    >
+      {#if maximized}
+        <Copy class="size-3" strokeWidth={1.75} />
+      {:else}
+        <Square class="size-3" strokeWidth={1.75} />
+      {/if}
+    </Button>
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="size-7 rounded-full hover:bg-destructive-solid hover:text-destructive-solid-foreground focus-visible:bg-destructive-solid focus-visible:text-destructive-solid-foreground"
+      ariaLabel={closeLabel}
+      title={closeTitle}
+      disabled={quitting}
+      onclick={() => onClose?.()}
+    >
+      {#if quitting}
+        <Spinner />
+      {:else}
+        <X class="size-3.5" strokeWidth={1.75} />
+      {/if}
+    </Button>
+  </div>
+{:else}
+  <div
+    class="flex flex-none items-center gap-0.5 [-webkit-app-region:no-drag]"
+    aria-label="Window controls"
+  >
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="group/linux-control size-7 rounded-full hover:bg-transparent focus-visible:bg-transparent"
+      ariaLabel="Minimize window"
+      title="Minimize"
+      disabled={quitting}
+      onclick={() => onMinimize?.()}
+    >
+      <span
+        class="flex size-4.5 items-center justify-center rounded-full group-hover/linux-control:bg-foreground group-hover/linux-control:text-background group-focus-visible/linux-control:bg-foreground group-focus-visible/linux-control:text-background"
+      >
+        <ChevronDown class="size-3.5" strokeWidth={2} />
+      </span>
+    </Button>
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="group/linux-control size-7 rounded-full hover:bg-transparent focus-visible:bg-transparent"
+      ariaLabel={maximized ? "Restore window" : "Maximize window"}
+      title={maximized ? "Restore" : "Maximize"}
+      disabled={quitting}
+      onclick={() => onToggleMaximize?.()}
+    >
+      <span
+        class="flex size-4.5 items-center justify-center rounded-full group-hover/linux-control:bg-foreground group-hover/linux-control:text-background group-focus-visible/linux-control:bg-foreground group-focus-visible/linux-control:text-background"
+      >
+        {#if maximized}
+          <Diamond class="size-2.5" strokeWidth={2} />
+        {:else}
+          <ChevronUp class="size-3.5" strokeWidth={2} />
+        {/if}
+      </span>
+    </Button>
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      class="group/linux-control size-7 rounded-full hover:bg-transparent focus-visible:bg-transparent"
+      ariaLabel={closeLabel}
+      title={closeTitle}
+      disabled={quitting}
+      onclick={() => onClose?.()}
+    >
+      {#if quitting}
+        <Spinner />
+      {:else}
+        <span
+          class="flex size-4.5 items-center justify-center rounded-full group-hover/linux-control:bg-destructive/20 group-hover/linux-control:text-destructive group-focus-visible/linux-control:bg-destructive/20 group-focus-visible/linux-control:text-destructive"
+        >
+          <X class="size-3.5" strokeWidth={2} />
+        </span>
+      {/if}
+    </Button>
+  </div>
+{/if}

--- a/packages/workbench-app/src/lib/app/shell/header-type.test.ts
+++ b/packages/workbench-app/src/lib/app/shell/header-type.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveHeaderType } from "./header-type";
+
+describe("resolveHeaderType", () => {
+  it("maps Electron platforms in auto mode", () => {
+    assert.equal(resolveHeaderType("auto", "darwin"), "macos");
+    assert.equal(resolveHeaderType("auto", "win32"), "windows");
+    assert.equal(resolveHeaderType("auto", "linux"), "linux");
+  });
+
+  it("uses Linux as the neutral fallback", () => {
+    assert.equal(resolveHeaderType("auto"), "linux");
+    assert.equal(resolveHeaderType("auto", "freebsd"), "linux");
+  });
+
+  it("honors explicit overrides", () => {
+    assert.equal(resolveHeaderType("macos", "linux"), "macos");
+    assert.equal(resolveHeaderType("windows", "darwin"), "windows");
+    assert.equal(resolveHeaderType("linux", "win32"), "linux");
+  });
+});

--- a/packages/workbench-app/src/lib/app/shell/header-type.ts
+++ b/packages/workbench-app/src/lib/app/shell/header-type.ts
@@ -1,0 +1,13 @@
+import type { HeaderType } from "@nervekit/contracts";
+
+export type ResolvedHeaderType = Exclude<HeaderType, "auto">;
+
+export function resolveHeaderType(
+  headerType: HeaderType,
+  platform?: string,
+): ResolvedHeaderType {
+  if (headerType !== "auto") return headerType;
+  if (platform === "darwin") return "macos";
+  if (platform === "win32") return "windows";
+  return "linux";
+}

--- a/packages/workbench-app/src/lib/features/settings/components/pages/workbench/WorkbenchSettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/workbench/WorkbenchSettingsPage.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
-import type { ColorMode, ColorTheme, Settings } from "$lib/api";
+import type { ColorMode, ColorTheme, HeaderType, Settings } from "$lib/api";
 import {
   SettingsRow,
   SettingsSection,
+  SettingsSelectRow,
   SettingsToggleRow,
 } from "$lib/presentation/components/settings";
 import type { SettingsChange } from "../settings-change";
 import ColorModePicker from "./ColorModePicker.svelte";
 import ThemePreviewPicker from "./ThemePreviewPicker.svelte";
+import SelectField from "@nervekit/ui-kit/components/ui/select-field";
+
+const headerTypeOptions = [
+  { value: "auto", label: "Auto" },
+  { value: "linux", label: "Linux" },
+  { value: "windows", label: "Windows" },
+  { value: "macos", label: "macOS" },
+];
 
 type Props = {
   settingsDraft: Settings;
@@ -37,6 +46,12 @@ function setColorMode(value: string): void {
   onSettingsChange?.({ ui: { colorMode } }, { immediate: true });
 }
 
+function setHeaderType(value: string): void {
+  const headerType = value as HeaderType;
+  settingsDraft.desktop.headerType = headerType;
+  onSettingsChange?.({ desktop: { headerType } }, { immediate: true });
+}
+
 function setCloseToTray(checked: boolean): void {
   settingsDraft.desktop.closeToTray = checked;
   onSettingsChange?.(
@@ -63,6 +78,20 @@ function setCloseToTray(checked: boolean): void {
 </SettingsSection>
 
 <SettingsSection id="desktop" title="Desktop">
+  <SettingsSelectRow
+    label="Header style"
+    description="Auto follows your operating system. Choose another style to override it."
+  >
+    {#snippet control(disabled)}
+      <SelectField
+        items={headerTypeOptions}
+        value={settingsDraft.desktop.headerType}
+        ariaLabel="Header style"
+        {disabled}
+        onValueChange={setHeaderType}
+      />
+    {/snippet}
+  </SettingsSelectRow>
   <SettingsToggleRow
     label="Close to system tray"
     description="Hide Nerve in the tray instead of quitting."

--- a/packages/workbench-app/src/lib/presentation/shell/ShellTitlebar.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/ShellTitlebar.svelte
@@ -3,10 +3,12 @@ import type { Snippet } from "svelte";
 
 let {
   desktop = false,
+  leadingControls,
   left,
   actions,
 }: {
   desktop?: boolean;
+  leadingControls?: Snippet;
   left: Snippet;
   actions?: Snippet;
 } = $props();
@@ -20,6 +22,9 @@ let {
   }`}
 >
   <div class="flex min-w-0 flex-1 items-center gap-2.5 overflow-hidden">
+    {#if leadingControls}
+      {@render leadingControls()}
+    {/if}
     {@render left()}
   </div>
   {#if actions}


### PR DESCRIPTION
## Summary
- add persisted auto, Linux, Windows, and macOS header styles
- render platform-specific window controls with polished Linux states and CC0 macOS traffic-light artwork
- expose the header preference in Workbench settings and resolve auto from Electron
- cover settings compatibility and platform resolution with tests

## Validation
- `pnpm fix && pnpm check && pnpm test`