### PR TITLE
Polish model selector dialogs

### DIFF
--- a/packages/workbench-app/src/lib/features/settings/components/pages/models/AddScopedModelsDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/models/AddScopedModelsDialog.svelte
@@ -7,7 +7,9 @@ import { Checkbox } from "@nervekit/ui-kit/components/ui/checkbox";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
 import { Label } from "@nervekit/ui-kit/components/ui/label";
 import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
+import ModelCatalogRow from "../../shared/ModelCatalogRow.svelte";
 import {
   authenticatedRealModelOptions,
   modelKey,
@@ -83,7 +85,7 @@ function save(): void {
   bind:open
   title="Scope composer models"
   description="Pick the authenticated models to show in the composer. Leave everything unchecked to keep all models available."
-  size="wide"
+  size="md"
   flush
 >
   <div class="grid max-h-[min(70vh,32rem)] grid-rows-[auto_minmax(0,1fr)]">
@@ -116,48 +118,46 @@ function save(): void {
       {/if}
     </div>
 
-    <div class="min-h-0 p-1.5">
-      {#if availableModels.length === 0}
-        <p class="px-1 py-2 text-sm text-muted-foreground">
-          Authenticate a provider before choosing scoped models.
-        </p>
-      {:else if filteredModels.length === 0}
-        <p class="px-1 py-2 text-sm text-muted-foreground">
-          No models match the current filters.
-        </p>
-      {:else}
-        <VirtualScroller
-          items={filteredModels}
-          getKey={(entry) => entry.key}
-          estimateSize={() => 48}
-          viewportClass="max-h-[min(52vh,24rem)]"
-          viewportAriaLabel="Authenticated models"
-        >
-          {#snippet row({ item: entry })}
-            {@const checked = selectedKeys.has(entry.key)}
-            <Label
-              class="flex cursor-pointer items-center gap-3 rounded-md border border-transparent px-2 py-1.5 font-normal hover:bg-accent/50 has-data-[state=checked]:border-primary/60 has-data-[state=checked]:bg-primary/8"
-            >
-              <Checkbox
-                size="sm"
-                {checked}
-                onCheckedChange={(value) => toggleModel(entry, value === true)}
-                aria-label={entry.displayName}
-              />
-              <span class="grid min-w-0 gap-0.5">
-                <span class="truncate text-sm text-foreground"
-                  >{entry.displayName}</span
-                >
-                <span class="truncate text-xs text-muted-foreground">
-                  {entry.providerLabel} ·
-                  <span class="font-mono">{entry.model.modelId}</span>
-                </span>
-              </span>
-            </Label>
-          {/snippet}
-        </VirtualScroller>
-      {/if}
-    </div>
+    <Tooltip.Provider delayDuration={200} disableHoverableContent>
+      <div class="min-h-0 p-1.5">
+        {#if availableModels.length === 0}
+          <p class="px-1 py-2 text-sm text-muted-foreground">
+            Authenticate a provider before choosing scoped models.
+          </p>
+        {:else if filteredModels.length === 0}
+          <p class="px-1 py-2 text-sm text-muted-foreground">
+            No models match the current filters.
+          </p>
+        {:else}
+          <VirtualScroller
+            items={filteredModels}
+            getKey={(entry) => entry.key}
+            estimateSize={() => 48}
+            viewportClass="max-h-[min(52vh,24rem)]"
+            viewportAriaLabel="Authenticated models"
+          >
+            {#snippet row({ item: entry })}
+              {@const checked = selectedKeys.has(entry.key)}
+              <Label
+                class="flex cursor-pointer items-center gap-2.5 rounded-md border border-transparent px-2 py-1.5 font-normal transition-colors hover:bg-accent/50 has-data-checked:border-primary/60 has-data-checked:bg-primary/8"
+              >
+                <ModelCatalogRow {entry}>
+                  {#snippet leading()}
+                    <Checkbox
+                      size="sm"
+                      {checked}
+                      onCheckedChange={(value) =>
+                        toggleModel(entry, value === true)}
+                      aria-label={entry.displayName}
+                    />
+                  {/snippet}
+                </ModelCatalogRow>
+              </Label>
+            {/snippet}
+          </VirtualScroller>
+        {/if}
+      </div>
+    </Tooltip.Provider>
   </div>
 
   {#snippet footer()}

--- a/packages/workbench-app/src/lib/features/settings/components/shared/ModelCatalogRow.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/shared/ModelCatalogRow.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import ArrowUpFromLine from "@lucide/svelte/icons/arrow-up-from-line";
+import Braces from "@lucide/svelte/icons/braces";
+import Brain from "@lucide/svelte/icons/brain";
+import Image from "@lucide/svelte/icons/image";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
+import {
+  formatTokenCapacity,
+  supportsImageInput,
+} from "$lib/presentation/utils/model";
+import type { ModelCatalogEntry } from "$lib/presentation/utils/model-catalog";
+
+type Props = {
+  entry: ModelCatalogEntry;
+  leading: Snippet;
+};
+
+let { entry, leading }: Props = $props();
+
+const contextLabel = $derived(
+  entry.model.contextWindow > 0
+    ? `Context window: ${entry.model.contextWindow.toLocaleString()} tokens`
+    : "Context window unknown",
+);
+const outputLabel = $derived(
+  `Maximum output: ${entry.model.maxOutputTokens.toLocaleString()} tokens`,
+);
+</script>
+
+{@render leading()}
+<span class="grid min-w-0 flex-1 gap-0.5">
+  <span class="truncate text-xs font-medium text-foreground">
+    {entry.displayName}
+  </span>
+  <span class="truncate text-xs text-muted-foreground">
+    {entry.providerLabel} ·
+    <span class="font-mono">{entry.model.modelId}</span>
+  </span>
+</span>
+<span
+  class="flex flex-none items-center gap-1.5 text-xs text-muted-foreground tabular-nums"
+>
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        <span
+          {...props}
+          class="inline-flex items-center gap-1 rounded-sm"
+          aria-label={contextLabel}
+        >
+          <Braces class="size-3.5" aria-hidden="true" />
+          <span>{formatTokenCapacity(entry.model.contextWindow)}</span>
+        </span>
+      {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content side="top">{contextLabel}</Tooltip.Content>
+  </Tooltip.Root>
+
+  {#if entry.model.maxOutputTokens > 0}
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <span
+            {...props}
+            class="inline-flex items-center gap-1 rounded-sm"
+            aria-label={outputLabel}
+          >
+            <ArrowUpFromLine class="size-3.5" aria-hidden="true" />
+            <span>{formatTokenCapacity(entry.model.maxOutputTokens)}</span>
+          </span>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content side="top">{outputLabel}</Tooltip.Content>
+    </Tooltip.Root>
+  {/if}
+
+  {#if entry.model.reasoning}
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <span
+            {...props}
+            class="inline-flex rounded-sm"
+            aria-label="Reasoning support"
+          >
+            <Brain class="size-3.5" aria-hidden="true" />
+          </span>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content side="top">Supports reasoning</Tooltip.Content>
+    </Tooltip.Root>
+  {/if}
+
+  {#if supportsImageInput(entry.model)}
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <span
+            {...props}
+            class="inline-flex rounded-sm"
+            aria-label="Image input support"
+          >
+            <Image class="size-3.5" aria-hidden="true" />
+          </span>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content side="top">Accepts image input</Tooltip.Content>
+    </Tooltip.Root>
+  {/if}
+</span>

--- a/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
@@ -1,21 +1,15 @@
 <script lang="ts">
 import type { ModelInfo, ModelSelection, ThinkingLevel } from "$lib/api";
-import ArrowUpFromLine from "@lucide/svelte/icons/arrow-up-from-line";
-import Braces from "@lucide/svelte/icons/braces";
-import Brain from "@lucide/svelte/icons/brain";
-import Image from "@lucide/svelte/icons/image";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
-import { PopoverRow } from "@nervekit/ui-kit/components/ui/popover-panel";
+import { Label } from "@nervekit/ui-kit/components/ui/label";
+import * as RadioGroup from "@nervekit/ui-kit/components/ui/radio-group";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
 import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
 import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
-import {
-  formatTokenCapacity,
-  modelKey,
-  supportsImageInput,
-} from "$lib/presentation/utils/model";
+import { modelKey } from "$lib/presentation/utils/model";
+import ModelCatalogRow from "./ModelCatalogRow.svelte";
 import {
   buildModelCatalog,
   filterModelCatalog,
@@ -58,7 +52,7 @@ let {
   onSave,
 }: Props = $props();
 
-let selectedKey = $state<string | undefined>();
+let selectedKey = $state("");
 let thinkingLevel = $state<ThinkingLevel>("off");
 let query = $state("");
 let providerFilter = $state("all");
@@ -77,7 +71,7 @@ const thinkingLevels = $derived<ThinkingLevel[]>(
 
 $effect(() => {
   if (open && !lastOpen) {
-    selectedKey = selectedModel ? modelKey(selectedModel) : undefined;
+    selectedKey = selectedModel ? modelKey(selectedModel) : "";
     thinkingLevel = selectedThinkingLevel;
     query = "";
     providerFilter = "all";
@@ -97,21 +91,6 @@ const providerChips = $derived(modelProviderFacets(catalog));
 const filteredModels = $derived(
   filterModelCatalog(catalog, query, providerFilter),
 );
-
-function capabilitySummary(model: ModelInfo): string {
-  const parts = [
-    model.contextWindow > 0
-      ? `Context ${model.contextWindow.toLocaleString()} tokens`
-      : "Context window unknown",
-  ];
-  if (model.maxOutputTokens > 0)
-    parts.push(`Max output ${model.maxOutputTokens.toLocaleString()} tokens`);
-  parts.push(model.reasoning ? "Reasoning model" : "No reasoning");
-  parts.push(
-    supportsImageInput(model) ? "Accepts image input" : "Text input only",
-  );
-  return parts.join(" · ");
-}
 
 function save(): void {
   if (!selectedModelInfo) return;
@@ -177,7 +156,7 @@ function useFallback(): void {
             No models match the current filters.
           </p>
         {:else}
-          <div class="grid min-h-0">
+          <RadioGroup.Root bind:value={selectedKey} class="grid min-h-0 gap-0">
             <VirtualScroller
               items={filteredModels}
               getKey={(entry) => entry.key}
@@ -187,60 +166,22 @@ function useFallback(): void {
               viewportAriaLabel="Available models"
             >
               {#snippet row({ item: entry })}
-                <PopoverRow
-                  label={entry.displayName}
-                  selected={selectedKey === entry.key}
-                  class="px-2 py-1.5 aria-pressed:border-primary/60"
-                  onclick={() => (selectedKey = entry.key)}
+                <Label
+                  class="flex cursor-pointer items-center gap-2.5 rounded-md border border-border bg-transparent px-2 py-1.5 font-normal transition-colors hover:bg-accent has-data-checked:border-primary/60 has-data-checked:bg-accent"
                 >
-                  {#snippet detail()}
-                    <span class="truncate text-xs text-muted-foreground">
-                      {entry.providerLabel} ·
-                      <span class="font-mono">{entry.model.modelId}</span>
-                    </span>
-                  {/snippet}
-                  {#snippet trailing()}
-                    <Tooltip.Root>
-                      <Tooltip.Trigger>
-                        {#snippet child({ props })}
-                          <span
-                            {...props}
-                            class="flex flex-none items-center gap-1 text-[0.6875rem] text-muted-foreground tabular-nums"
-                            aria-label={capabilitySummary(entry.model)}
-                          >
-                            <span class="inline-flex items-center gap-0.5">
-                              <Braces class="size-3" aria-hidden="true" />
-                              {formatTokenCapacity(entry.model.contextWindow)}
-                            </span>
-                            {#if entry.model.maxOutputTokens > 0}
-                              <span class="inline-flex items-center gap-0.5">
-                                <ArrowUpFromLine
-                                  class="size-3"
-                                  aria-hidden="true"
-                                />
-                                {formatTokenCapacity(
-                                  entry.model.maxOutputTokens,
-                                )}
-                              </span>
-                            {/if}
-                            {#if entry.model.reasoning}
-                              <Brain class="size-3" aria-hidden="true" />
-                            {/if}
-                            {#if supportsImageInput(entry.model)}
-                              <Image class="size-3" aria-hidden="true" />
-                            {/if}
-                          </span>
-                        {/snippet}
-                      </Tooltip.Trigger>
-                      <Tooltip.Content side="left">
-                        {capabilitySummary(entry.model)}
-                      </Tooltip.Content>
-                    </Tooltip.Root>
-                  {/snippet}
-                </PopoverRow>
+                  <ModelCatalogRow {entry}>
+                    {#snippet leading()}
+                      <RadioGroup.Item
+                        value={entry.key}
+                        size="sm"
+                        aria-label={entry.displayName}
+                      />
+                    {/snippet}
+                  </ModelCatalogRow>
+                </Label>
               {/snippet}
             </VirtualScroller>
-          </div>
+          </RadioGroup.Root>
         {/if}
       </div>
     </Tooltip.Provider>


### PR DESCRIPTION
## Summary
- align scoped model selector width with agent model dialogs
- use radio controls for single selection and checkboxes for scoped multi-selection
- share polished, accessible model capability indicators across selectors

## Validation
- pnpm fix && pnpm check && pnpm test