### PR TITLE
Make Git refresh event driven

### DIFF
--- a/packages/contracts/src/domains/git/git.events.schema.ts
+++ b/packages/contracts/src/domains/git/git.events.schema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { definePublicEvent } from "../events/event-definition.schema.js";
 
+const repositoryScope = ["projectId", "repo"] as const;
+
 export const gitEventDefinitions = [
   definePublicEvent(
     "git.repository.changed",
@@ -15,6 +17,19 @@ export const gitEventDefinitions = [
         })
         .optional(),
     }),
-    { scope: ["projectId", "repo"] },
+    { scope: repositoryScope },
+  ),
+  definePublicEvent(
+    "git.repository.invalidated",
+    z.object({
+      projectId: z.string().startsWith("proj_"),
+      repo: z.string().min(1).max(1_024),
+      source: z.literal("filesystem"),
+    }),
+    {
+      delivery: "ephemeral",
+      coalescing: "latest_by_scope",
+      scope: repositoryScope,
+    },
   ),
 ];

--- a/packages/contracts/test/protocol.schema.test.ts
+++ b/packages/contracts/test/protocol.schema.test.ts
@@ -408,6 +408,31 @@ describe("Protocol v1 shared schemas", () => {
       parsePublicEventEnvelope(publicEvent, "workbench_server").type,
       "git.repository.changed",
     );
+    const invalidation = {
+      projectId: "proj_test",
+      repo: ".",
+      source: "filesystem",
+    };
+    assert.deepEqual(
+      validatePublicEvent(
+        "git.repository.invalidated",
+        invalidation,
+        "workbench_server",
+      ),
+      invalidation,
+    );
+    assert.throws(
+      () =>
+        parsePublicEventEnvelope(
+          {
+            ...publicEvent,
+            type: "git.repository.invalidated",
+            data: invalidation,
+          },
+          "workbench_server",
+        ),
+      /cannot use event.batch/,
+    );
     assert.throws(
       () =>
         parsePublicEventEnvelope(

--- a/packages/tools/src/git/git-overview.ts
+++ b/packages/tools/src/git/git-overview.ts
@@ -16,7 +16,12 @@ export async function summarizeRepo(
   const [stdout, stable] = await Promise.all([
     statusOutput === undefined
       ? service
-          .runGit(repoDir, ["status", "--porcelain=v2", "--branch"])
+          .runGit(repoDir, [
+            "--no-optional-locks",
+            "status",
+            "--porcelain=v2",
+            "--branch",
+          ])
           .then((result) => result.stdout)
       : Promise.resolve(statusOutput),
     service.stableRepoMetadata(repoDir),
@@ -58,6 +63,7 @@ export async function overview(
 ): Promise<GitOverviewResponse> {
   const repoDir = service.resolveRepoDir(projectId, relativePath);
   const statusPromise = service.runGit(repoDir, [
+    "--no-optional-locks",
     "status",
     "--porcelain=v2",
     "--branch",

--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -81,6 +81,12 @@ import { parsePorcelainV2 } from "./git-status.js";
 const MAX_DISCOVERY_DEPTH = 2;
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", ".next"]);
 
+function observedCommand(args: readonly string[]): string {
+  return args[0] === "--no-optional-locks"
+    ? (args[1] ?? "unknown")
+    : (args[0] ?? "unknown");
+}
+
 export class GitService {
   readonly #stableMetadataCache: GitRepositoryMetadataCache;
   readonly #githubApi: GithubApiClient;
@@ -123,7 +129,7 @@ export class GitService {
       const result = await runGitCommand(bin, cwd, args);
       this.observeCommand({
         bin,
-        command: args[0] ?? "unknown",
+        command: observedCommand(args),
         durationMs: performance.now() - startedAt,
         succeeded: true,
       });
@@ -131,7 +137,7 @@ export class GitService {
     } catch (error) {
       this.observeCommand({
         bin,
-        command: args[0] ?? "unknown",
+        command: observedCommand(args),
         durationMs: performance.now() - startedAt,
         succeeded: false,
       });

--- a/packages/tools/test/git-service-overview.test.ts
+++ b/packages/tools/test/git-service-overview.test.ts
@@ -27,7 +27,7 @@ describe("GitService overview snapshots", () => {
     service.runGit = async (_cwd, args) => {
       calls.push(args);
       const command = args.join(" ");
-      if (command === "status --porcelain=v2 --branch") {
+      if (command === "--no-optional-locks status --porcelain=v2 --branch") {
         return { stdout: status, stderr: "" };
       }
       if (
@@ -78,7 +78,7 @@ describe("GitService overview snapshots", () => {
 
     const overview = await service.overview("proj_test", ".");
     await service.overview("proj_test", ".");
-    assert.equal(calls.filter((args) => args[0] === "status").length, 2);
+    assert.equal(calls.filter((args) => args[1] === "status").length, 2);
     assert.equal(calls.filter((args) => args[0] === "for-each-ref").length, 1);
     assert.equal(calls.filter((args) => args[0] === "remote").length, 1);
     assert.equal(calls.filter((args) => args[0] === "rev-parse").length, 0);

--- a/packages/workbench-app/src/lib/app/shell/WorkbenchShellContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/WorkbenchShellContainer.svelte
@@ -25,18 +25,21 @@ import { workspaceSelectors } from "$lib/features/workspace";
 
 const isCompact = $derived(responsive.isCompact);
 const activeEditorTab = $derived(workspaceSelectors.activeCenterTab);
-const gitPanelEnabled = $derived(
-  Object.entries(shellLayout.current.docks).some(([dockId, dock]) => {
-    const gitViewActive =
-      dock.activeViewId === "git" || dock.activeViewId === "pull-requests";
-    if (!gitViewActive) return false;
+function panelViewEnabled(viewIds: readonly string[]): boolean {
+  return Object.entries(shellLayout.current.docks).some(([dockId, dock]) => {
+    if (!dock.activeViewId || !viewIds.includes(dock.activeViewId))
+      return false;
     if (!isCompact) return !dock.collapsed;
     return dockId === "left" ? shellSheets.primary : shellSheets.secondary;
-  }),
-);
+  });
+}
+
+const gitPanelEnabled = $derived(panelViewEnabled(["git", "pull-requests"]));
+const pullRequestsPanelEnabled = $derived(panelViewEnabled(["pull-requests"]));
 const gitPanel = createWorkbenchGitPanelAdapter(
   () => workspaceSelectors.activeProject,
   () => gitPanelEnabled,
+  () => pullRequestsPanelEnabled,
 );
 
 let lastTabKey: string | undefined;

--- a/packages/workbench-app/src/lib/features/git/state/git-auto-refresh-scheduler.test.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-auto-refresh-scheduler.test.ts
@@ -4,7 +4,10 @@ import {
   GitAutoRefreshScheduler,
   type GitAutoRefreshDemand,
 } from "./git-auto-refresh-scheduler.js";
-import { GIT_AUTO_REFRESH_COOLDOWN_MS } from "./git-refresh-policy.js";
+import {
+  GIT_OVERVIEW_AUTO_REFRESH_COOLDOWN_MS,
+  GIT_PR_AUTO_REFRESH_COOLDOWN_MS,
+} from "./git-refresh-policy.js";
 
 type Timer = { at: number; callback: () => void; cancelled: boolean };
 
@@ -47,7 +50,10 @@ function setup() {
   const clock = new FakeClock();
   const dispatches: Array<{ at: number; demand: GitAutoRefreshDemand }> = [];
   const scheduler = new GitAutoRefreshScheduler(
-    GIT_AUTO_REFRESH_COOLDOWN_MS,
+    {
+      overview: GIT_OVERVIEW_AUTO_REFRESH_COOLDOWN_MS,
+      prs: GIT_PR_AUTO_REFRESH_COOLDOWN_MS,
+    },
     (_key, demand) => dispatches.push({ at: clock.now(), demand }),
     clock,
   );
@@ -55,58 +61,57 @@ function setup() {
 }
 
 describe("GitAutoRefreshScheduler", () => {
-  it("dispatches first demand immediately and coalesces one trailing refresh", () => {
+  it("dispatches first demand immediately and coalesces one trailing overview", () => {
     const { clock, dispatches, scheduler } = setup();
     scheduler.schedule("repo", { overview: true });
-    clock.advanceTo(5_000);
+    clock.advanceTo(1_000);
     scheduler.schedule("repo", { overview: true });
-    clock.advanceTo(10_000);
+    clock.advanceTo(2_000);
     scheduler.schedule("repo", { overview: true });
     assert.deepEqual(dispatches, [{ at: 0, demand: { overview: true } }]);
 
-    clock.advanceTo(20_000);
+    clock.advanceTo(3_000);
     assert.deepEqual(dispatches, [
       { at: 0, demand: { overview: true } },
-      { at: 20_000, demand: { overview: true } },
+      { at: 3_000, demand: { overview: true } },
     ]);
-    clock.advanceTo(40_000);
+    clock.advanceTo(6_000);
     assert.equal(dispatches.length, 2);
   });
 
-  it("merges targets while retaining independent cooldown boundaries", () => {
+  it("retains independent overview and PR cooldown boundaries", () => {
     const { clock, dispatches, scheduler } = setup();
-    scheduler.schedule("repo", { overview: true });
-    clock.advanceTo(5_000);
-    scheduler.schedule("repo", { prs: true });
-    clock.advanceTo(10_000);
     scheduler.schedule("repo", { overview: true, prs: true });
+    clock.advanceTo(1_000);
+    scheduler.schedule("repo", { overview: true, prs: true });
+    clock.advanceTo(3_000);
+    clock.advanceTo(30_000);
 
-    clock.advanceTo(20_000);
-    clock.advanceTo(25_000);
     assert.deepEqual(dispatches, [
-      { at: 0, demand: { overview: true } },
-      { at: 5_000, demand: { prs: true } },
-      { at: 20_000, demand: { overview: true } },
-      { at: 25_000, demand: { prs: true } },
+      { at: 0, demand: { overview: true, prs: true } },
+      { at: 3_000, demand: { overview: true } },
+      { at: 30_000, demand: { prs: true } },
     ]);
   });
 
-  it("lets a direct refresh satisfy queued demand and reset eligibility", () => {
+  it("lets a direct refresh consume older queued demand", () => {
     const { clock, dispatches, scheduler } = setup();
     scheduler.schedule("repo", { prs: true });
     clock.advanceTo(5_000);
     scheduler.schedule("repo", { prs: true });
     clock.advanceTo(10_000);
     scheduler.noteDirectStart("repo", { prs: true });
-    clock.advanceTo(11_000);
-    scheduler.schedule("repo", { prs: true });
 
-    clock.advanceTo(29_999);
+    clock.advanceTo(40_000);
     assert.deepEqual(dispatches, [{ at: 0, demand: { prs: true } }]);
-    clock.advanceTo(30_000);
-    assert.deepEqual(dispatches, [
-      { at: 0, demand: { prs: true } },
-      { at: 30_000, demand: { prs: true } },
-    ]);
+  });
+
+  it("preserves demand that arrives after a direct refresh starts", () => {
+    const { clock, dispatches, scheduler } = setup();
+    scheduler.noteDirectStart("repo", { overview: true });
+    clock.advanceTo(500);
+    scheduler.schedule("repo", { overview: true });
+    clock.advanceTo(3_000);
+    assert.deepEqual(dispatches, [{ at: 3_000, demand: { overview: true } }]);
   });
 });

--- a/packages/workbench-app/src/lib/features/git/state/git-auto-refresh-scheduler.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-auto-refresh-scheduler.ts
@@ -31,7 +31,7 @@ export class GitAutoRefreshScheduler {
   readonly #entries = new Map<string, Entry>();
 
   constructor(
-    readonly cooldownMs: number,
+    readonly cooldownMs: Record<GitAutoRefreshTarget, number>,
     readonly dispatch: (key: string, demand: GitAutoRefreshDemand) => void,
     readonly clock: Clock = systemClock,
   ) {}
@@ -72,7 +72,7 @@ export class GitAutoRefreshScheduler {
       const lastStartedAt = entry.lastStartedAt[target];
       if (
         lastStartedAt === undefined ||
-        now - lastStartedAt >= this.cooldownMs
+        now - lastStartedAt >= this.cooldownMs[target]
       ) {
         due[target] = true;
         entry.pending[target] = false;
@@ -93,7 +93,7 @@ export class GitAutoRefreshScheduler {
       const lastStartedAt = entry.lastStartedAt[target];
       return lastStartedAt === undefined
         ? 0
-        : Math.max(0, this.cooldownMs - (now - lastStartedAt));
+        : Math.max(0, this.cooldownMs[target] - (now - lastStartedAt));
     });
     if (delays.length === 0) return;
     entry.timer = this.clock.setTimeout(

--- a/packages/workbench-app/src/lib/features/git/state/git-event-policy.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-event-policy.ts
@@ -1,0 +1,45 @@
+import type { WorkbenchEvent } from "$lib/core/events/event-bus";
+import type { GitAutoRefreshDemand } from "./git-auto-refresh-scheduler";
+
+const PR_RELEVANT_REASONS = new Set([
+  "branch.created",
+  "branch.switched",
+  "branch.synced",
+  "base.updated",
+  "remote.fetched",
+  "remote.pulled",
+  "remote.pushed",
+  "github.pr.checked_out",
+]);
+
+export type GitEventRefreshRequest = {
+  projectId: string;
+  repo: string;
+  demand: GitAutoRefreshDemand;
+};
+
+export function gitEventRefreshRequest(
+  event: Pick<WorkbenchEvent, "type" | "data">,
+): GitEventRefreshRequest | undefined {
+  const projectId = stringValue(event.data?.projectId);
+  const repo = stringValue(event.data?.repo);
+  if (!projectId?.startsWith("proj_") || !repo) return undefined;
+
+  if (event.type === "git.repository.invalidated") {
+    return { projectId, repo, demand: { overview: true } };
+  }
+  if (event.type !== "git.repository.changed") return undefined;
+  const reason = stringValue(event.data?.reason);
+  return {
+    projectId,
+    repo,
+    demand: {
+      overview: true,
+      ...(reason && PR_RELEVANT_REASONS.has(reason) ? { prs: true } : {}),
+    },
+  };
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/packages/workbench-app/src/lib/features/git/state/git-events.test.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-events.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { gitEventRefreshRequest } from "./git-event-policy.js";
+
+describe("Git event refresh policy", () => {
+  it("maps filesystem and mutation reasons to the narrowest demand", () => {
+    assert.deepEqual(
+      gitEventRefreshRequest({
+        type: "git.repository.invalidated",
+        data: {
+          projectId: "proj_one",
+          repo: ".",
+          source: "filesystem",
+        },
+      }),
+      { projectId: "proj_one", repo: ".", demand: { overview: true } },
+    );
+    assert.deepEqual(
+      gitEventRefreshRequest({
+        type: "git.repository.changed",
+        data: {
+          projectId: "proj_one",
+          repo: ".",
+          reason: "file.staged",
+        },
+      }),
+      { projectId: "proj_one", repo: ".", demand: { overview: true } },
+    );
+    assert.deepEqual(
+      gitEventRefreshRequest({
+        type: "git.repository.changed",
+        data: {
+          projectId: "proj_one",
+          repo: ".",
+          reason: "remote.pushed",
+        },
+      }),
+      {
+        projectId: "proj_one",
+        repo: ".",
+        demand: { overview: true, prs: true },
+      },
+    );
+  });
+
+  it("ignores malformed, project-less, and unrelated events", () => {
+    assert.equal(
+      gitEventRefreshRequest({
+        type: "git.repository.changed",
+        data: { repo: ".", reason: "remote.pushed" },
+      }),
+      undefined,
+    );
+    assert.equal(
+      gitEventRefreshRequest({
+        type: "project.updated",
+        data: { projectId: "proj_one", repo: "." },
+      }),
+      undefined,
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/features/git/state/git-events.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-events.ts
@@ -1,0 +1,37 @@
+import { onEvent, type WorkbenchEvent } from "$lib/core/events/event-bus";
+import type { GitAutoRefreshDemand } from "./git-auto-refresh-scheduler";
+import { gitEventRefreshRequest } from "./git-event-policy";
+import {
+  invalidateGitOverviewFromFilesystem,
+  scheduleAutomaticGitRefresh,
+} from "./git-panel.svelte";
+
+type ScheduleRefresh = (
+  projectId: string,
+  repo: string,
+  demand: GitAutoRefreshDemand,
+) => void;
+
+export function registerGitEventHandlers(
+  schedule: ScheduleRefresh = scheduleAutomaticGitRefresh,
+): () => void {
+  const handle = (event: WorkbenchEvent): void => {
+    try {
+      const request = gitEventRefreshRequest(event);
+      if (!request) return;
+      if (event.type === "git.repository.invalidated") {
+        invalidateGitOverviewFromFilesystem(request.projectId, request.repo);
+        return;
+      }
+      schedule(request.projectId, request.repo, request.demand);
+    } catch {
+      // Event reducers must not prevent workspace cursor advancement.
+    }
+  };
+  const unregisterInvalidated = onEvent("git.repository.invalidated", handle);
+  const unregisterChanged = onEvent("git.repository.changed", handle);
+  return () => {
+    unregisterInvalidated();
+    unregisterChanged();
+  };
+}

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
@@ -1,4 +1,4 @@
-import { SvelteMap } from "svelte/reactivity";
+import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import type { ProjectRecord } from "$lib/api";
 import type { GithubPrListFilters } from "@nervekit/contracts";
 import {
@@ -45,18 +45,26 @@ import {
 import { syncOpenPrViews } from "./pr-tabs.svelte";
 import {
   GITHUB_STATUS_STALE_MS,
-  GIT_AUTO_REFRESH_COOLDOWN_MS,
+  GIT_OVERVIEW_AUTO_REFRESH_COOLDOWN_MS,
+  GIT_PR_AUTO_REFRESH_COOLDOWN_MS,
   GIT_STALE_MS,
   githubPrFiltersFingerprint,
+  isFresh,
   PR_PENDING_POLL_MS,
+  PR_STALE_MS,
 } from "./git-refresh-policy";
 
 function automaticRefreshKey(projectId: string, repo: string): string {
   return JSON.stringify([projectId, repo]);
 }
 
+const visibleOverviewDemand = new SvelteSet<string>();
+
 const automaticRefreshScheduler = new GitAutoRefreshScheduler(
-  GIT_AUTO_REFRESH_COOLDOWN_MS,
+  {
+    overview: GIT_OVERVIEW_AUTO_REFRESH_COOLDOWN_MS,
+    prs: GIT_PR_AUTO_REFRESH_COOLDOWN_MS,
+  },
   (key, demand) => {
     const [projectId, repo] = JSON.parse(key) as [string, string];
     const state = ensureGitRepoState(projectId, repo);
@@ -80,6 +88,33 @@ const automaticRefreshScheduler = new GitAutoRefreshScheduler(
     ]);
   },
 );
+
+export function setGitOverviewRefreshVisible(
+  projectId: string,
+  repo: string,
+  visible: boolean,
+): void {
+  const key = automaticRefreshKey(projectId, repo);
+  if (visible) visibleOverviewDemand.add(key);
+  else visibleOverviewDemand.delete(key);
+}
+
+export function invalidateGitOverviewFromFilesystem(
+  projectId: string,
+  repo: string,
+): void {
+  const state =
+    gitPanelState.projects[gitProjectStateKey(projectId)]?.repoStates[
+      gitRepoStateKey(repo)
+    ];
+  if (!state) return;
+  state.overviewInvalidated = true;
+  if (
+    visibleOverviewDemand.has(automaticRefreshKey(projectId, repo)) &&
+    (typeof document === "undefined" || document.visibilityState === "visible")
+  )
+    scheduleAutomaticGitRefresh(projectId, repo, { overview: true });
+}
 
 export function scheduleAutomaticGitRefresh(
   projectId: string,
@@ -220,6 +255,7 @@ export async function refreshGitOverview(
   state.requestSeq = requestSeq;
   state.overviewRequestInFlight = true;
   if (!options.silent) state.loadingOverview = true;
+  state.overviewInvalidated = false;
   try {
     if (options.force)
       await queryClient.invalidateQueries({
@@ -234,6 +270,7 @@ export async function refreshGitOverview(
     mergeRepoSummary(projectId, next.repo);
     patchGitOverviewState(state, next);
   } catch (error) {
+    state.overviewInvalidated = true;
     if (!options.silent)
       notify.error(`Git overview failed: ${errorMessage(error)}`);
   } finally {
@@ -396,6 +433,7 @@ export async function refreshPrs(
             setPrsIfChanged(state, prs);
             syncOpenPrViews(projectId, repo, prs);
             state.prsError = undefined;
+            state.prsLoadedAt = Date.now();
           }
         } catch (error) {
           if (state.prsRequestSeq === requestSeq && !nextSilent) {
@@ -437,8 +475,27 @@ export function autoRefreshGitOverview(projectId: string, repo: string): void {
     gitPanelState.projects[gitProjectStateKey(projectId)]?.repoStates[
       gitRepoStateKey(repo)
     ];
-  if (!state) return;
+  if (state?.overviewInvalidated) {
+    scheduleAutomaticGitRefresh(projectId, repo, { overview: true });
+    return;
+  }
+  if (!state || isFresh(state.loadedAt, Date.now(), GIT_STALE_MS)) return;
   scheduleAutomaticGitRefresh(projectId, repo, { overview: true });
+}
+
+export function autoRefreshPrsIfStale(projectId: string, repo: string): void {
+  if (typeof document !== "undefined" && document.visibilityState !== "visible")
+    return;
+  const state =
+    gitPanelState.projects[gitProjectStateKey(projectId)]?.repoStates[
+      gitRepoStateKey(repo)
+    ];
+  if (
+    !state?.github?.authenticated ||
+    isFresh(state.prsLoadedAt, Date.now(), PR_STALE_MS)
+  )
+    return;
+  scheduleAutomaticGitRefresh(projectId, repo, { prs: true });
 }
 
 export function selectGitProject(project: ProjectRecord): void {

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
@@ -73,6 +73,7 @@ export type GitPanelRepoState = {
   prsRequestSeq: number;
   overviewRequestInFlight: boolean;
   overviewRefreshQueued: boolean;
+  overviewInvalidated: boolean;
   lastRepoSummaryFingerprint?: string;
   lastChangesFingerprint?: string;
   lastRecentCommitsFingerprint?: string;
@@ -81,6 +82,7 @@ export type GitPanelRepoState = {
   lastGithubFingerprint?: string;
   loaded: boolean;
   loadedAt?: number;
+  prsLoadedAt?: number;
   requestSeq: number;
 };
 
@@ -182,6 +184,7 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     prsRequestSeq: 0,
     overviewRequestInFlight: false,
     overviewRefreshQueued: false,
+    overviewInvalidated: false,
     lastRepoSummaryFingerprint: undefined,
     lastChangesFingerprint: undefined,
     lastRecentCommitsFingerprint: undefined,
@@ -190,6 +193,7 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     lastGithubFingerprint: undefined,
     loaded: false,
     loadedAt: undefined,
+    prsLoadedAt: undefined,
     requestSeq: 0,
   };
 }

--- a/packages/workbench-app/src/lib/features/git/state/git-refresh-policy.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-refresh-policy.ts
@@ -1,8 +1,10 @@
 import type { GithubPr, GithubPrListFilters } from "@nervekit/contracts";
 
 export const GIT_STALE_MS = 30_000;
-export const GIT_AUTO_REFRESH_COOLDOWN_MS = 20_000;
+export const GIT_OVERVIEW_AUTO_REFRESH_COOLDOWN_MS = 3_000;
+export const GIT_PR_AUTO_REFRESH_COOLDOWN_MS = 30_000;
 export const GITHUB_STATUS_STALE_MS = 5 * 60_000;
+export const PR_STALE_MS = 60_000;
 export const PR_PENDING_POLL_MS = 10_000;
 
 export function githubPrFiltersFingerprint(

--- a/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
@@ -9,7 +9,6 @@ import {
   type GitRemoteOperation,
 } from "$lib/presentation";
 import type { ProjectRecord } from "$lib/api";
-import { hasPendingPrChecks } from "$lib/features/git/checks";
 import { openDiffPane } from "$lib/features/git/state/diff-tabs.svelte";
 import { openPrPane } from "$lib/features/git/state/pr-tabs.svelte";
 import { gitSelectors } from "$lib/features/git/state/git-selectors.svelte";
@@ -17,11 +16,12 @@ import {
   gitProjectStateKey,
   gitRepoStateKey,
 } from "$lib/core/state/state-keys";
-import { GIT_AUTO_REFRESH_COOLDOWN_MS } from "./git-refresh-policy";
+import { pendingPollTargets, PR_PENDING_POLL_MS } from "./git-refresh-policy";
 import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
 import { shouldActivateGitPanel } from "./git-startup-policy";
 import {
   autoRefreshGitOverview,
+  autoRefreshPrsIfStale,
   bulkStageGitFiles,
   createGitRepoBranch,
   fetchGitRepo,
@@ -35,15 +35,14 @@ import {
   refreshGitOverview,
   refreshGitProject,
   refreshPrs,
-  scheduleAutomaticGitRefresh,
   selectGitProject,
+  setGitOverviewRefreshVisible,
   selectGitRepo,
   switchBaseAndPullGitRepo,
   switchGitRepoBranch,
   syncGitRepo,
 } from "./git-panel.svelte";
 
-const GITHUB_CHECKS_POLL_MS = 10_000;
 const unsupported = disabledCapability(
   "Select a project to use Git operations.",
 );
@@ -51,6 +50,7 @@ const unsupported = disabledCapability(
 export function createWorkbenchGitPanelAdapter(
   activeProject: () => ProjectRecord | undefined,
   enabled: () => boolean = () => true,
+  pullRequestsEnabled: () => boolean = enabled,
 ): { readonly model: GitPanelModel; readonly actions: GitPanelActions } {
   const adapter = {
     get model(): GitPanelModel {
@@ -279,23 +279,29 @@ export function createWorkbenchGitPanelAdapter(
     const repository = projectState?.selectedRepo;
     if (!active || !project || !projectState?.repos.length || !repository)
       return;
-    const refresh = () => autoRefreshGitOverview(project.id, repository);
-    const refreshWhenVisible = () => {
-      if (document.visibilityState === "visible") refresh();
+    setGitOverviewRefreshVisible(project.id, repository, true);
+    const refreshIfStale = () => {
+      autoRefreshGitOverview(project.id, repository);
+      if (pullRequestsEnabled()) autoRefreshPrsIfStale(project.id, repository);
     };
-    refresh();
-    const interval = window.setInterval(refresh, GIT_AUTO_REFRESH_COOLDOWN_MS);
-    window.addEventListener("focus", refresh);
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === "visible") refreshIfStale();
+    };
+    refreshIfStale();
+    window.addEventListener("focus", refreshIfStale);
     document.addEventListener("visibilitychange", refreshWhenVisible);
     return () => {
-      window.clearInterval(interval);
-      window.removeEventListener("focus", refresh);
+      setGitOverviewRefreshVisible(project.id, repository, false);
+      window.removeEventListener("focus", refreshIfStale);
       document.removeEventListener("visibilitychange", refreshWhenVisible);
     };
   });
 
   $effect(() => {
-    const active = workbenchStartupState.progressiveActive && enabled();
+    const active =
+      workbenchStartupState.progressiveActive &&
+      enabled() &&
+      pullRequestsEnabled();
     const project = activeProject();
     const projectState = project
       ? gitPanelState.projects[gitProjectStateKey(project.id)]
@@ -306,33 +312,30 @@ export function createWorkbenchGitPanelAdapter(
       : undefined;
     const pullRequests = repoState?.prs ?? [];
     const activePr = gitSelectors.activeCenterPrView;
-    const hasPendingOutsideActiveDetail = pullRequests.some(
-      (pr) =>
-        pr.checks.status === "pending" &&
-        !(
-          activePr &&
-          activePr.projectId === project?.id &&
-          activePr.repo === repository &&
-          activePr.number === pr.number &&
-          activePr.checks.data?.checks.status === "pending"
-        ),
-    );
     if (
       !active ||
       !project ||
       !projectState?.repos.length ||
       !repository ||
       !repoState?.repoSummary?.hasGithubRemote ||
-      !repoState.github?.authenticated ||
-      !hasPendingPrChecks([...pullRequests]) ||
-      !hasPendingOutsideActiveDetail
+      !repoState.github?.authenticated
     )
       return;
+    const activePrMatches =
+      activePr?.projectId === project.id && activePr.repo === repository;
+    const targets = pendingPollTargets({
+      visible: document.visibilityState === "visible",
+      prs: pullRequests,
+      activePrNumber: activePrMatches ? activePr?.number : undefined,
+      activePrPending:
+        activePrMatches && activePr?.checks.data?.checks.status === "pending",
+    });
+    if (!targets.pollList) return;
     const refresh = () => {
       if (document.visibilityState === "visible")
-        scheduleAutomaticGitRefresh(project.id, repository, { prs: true });
+        void refreshPrs(project.id, repository, true, true);
     };
-    const interval = window.setInterval(refresh, GITHUB_CHECKS_POLL_MS);
+    const interval = window.setInterval(refresh, PR_PENDING_POLL_MS);
     return () => window.clearInterval(interval);
   });
 

--- a/packages/workbench-app/src/lib/features/register-feature-events.ts
+++ b/packages/workbench-app/src/lib/features/register-feature-events.ts
@@ -1,6 +1,7 @@
 import { registerAuthEventHandlers } from "$lib/features/auth/state/auth-events";
 import { registerConversationEventHandlers } from "$lib/features/conversations/state/conversation-events";
 import { registerNotificationEventHandlers } from "$lib/features/notifications/state/notification-events";
+import { registerGitEventHandlers } from "$lib/features/git/state/git-events";
 import { registerPromptSuggestionEventHandlers } from "$lib/features/prompt-suggestions/state/prompt-suggestions-events";
 import { registerSettingsEventHandlers } from "$lib/features/settings/state/settings-events";
 import { registerTaskEventHandlers } from "$lib/features/tasks/state/task-events";
@@ -17,6 +18,7 @@ export function registerFeatureEventHandlers(): () => void {
     registerUsageEventHandlers(),
     registerNotificationEventHandlers(),
     registerPromptSuggestionEventHandlers(),
+    registerGitEventHandlers(),
   ];
   return () => {
     for (const dispose of unregister.splice(0)) dispose();

--- a/packages/workbench-server/src/domains/tools/git-repository-watcher.ts
+++ b/packages/workbench-server/src/domains/tools/git-repository-watcher.ts
@@ -1,0 +1,284 @@
+import {
+  readFileSync,
+  watch as watchFs,
+  type FSWatcher,
+  type WatchOptions,
+} from "node:fs";
+import { dirname, isAbsolute, join, normalize, resolve, sep } from "node:path";
+
+export type GitRepositoryInvalidation = {
+  readonly projectId: string;
+  readonly repo: string;
+  readonly source: "filesystem";
+};
+
+export interface GitRepositoryInvalidationPublisher {
+  publishBestEffort(
+    type: "git.repository.invalidated",
+    data: GitRepositoryInvalidation,
+    context: string,
+  ): void;
+}
+
+type WatchListener = (
+  eventType: string,
+  filename: string | Buffer | null,
+) => void;
+type WatchFunction = (
+  path: string,
+  options: WatchOptions,
+  listener: WatchListener,
+) => FSWatcher;
+
+type Clock = {
+  setTimeout(
+    callback: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+};
+
+type WatchedRepository = {
+  projectId: string;
+  repo: string;
+  repoDir: string;
+  touchedAt: number;
+  watchers: FSWatcher[];
+  quietTimer?: ReturnType<typeof setTimeout>;
+  maxTimer?: ReturnType<typeof setTimeout>;
+  metadataChanged: boolean;
+};
+
+export type GitRepositoryWatcherOptions = {
+  readonly watch?: WatchFunction;
+  readonly clock?: Clock;
+  readonly now?: () => number;
+  readonly quietMs?: number;
+  readonly maxWaitMs?: number;
+  readonly maxRepositories?: number;
+  readonly onWarning?: (message: string, error: unknown) => void;
+  readonly onRepositoryMetadataChanged?: (repoDir: string) => void;
+};
+
+const systemClock: Clock = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+export class GitRepositoryWatcher {
+  readonly #entries = new Map<string, WatchedRepository>();
+  readonly #watch: WatchFunction;
+  readonly #clock: Clock;
+  readonly #now: () => number;
+  readonly #quietMs: number;
+  readonly #maxWaitMs: number;
+  readonly #maxRepositories: number;
+  #closed = false;
+
+  constructor(
+    readonly publisher: GitRepositoryInvalidationPublisher,
+    readonly options: GitRepositoryWatcherOptions = {},
+  ) {
+    this.#watch = options.watch ?? watchFs;
+    this.#clock = options.clock ?? systemClock;
+    this.#now = options.now ?? Date.now;
+    this.#quietMs = options.quietMs ?? 300;
+    this.#maxWaitMs = options.maxWaitMs ?? 2_000;
+    this.#maxRepositories = options.maxRepositories ?? 16;
+  }
+
+  watch(projectId: string, repo: string, repoDir: string): void {
+    if (this.#closed) return;
+    const key = repositoryKey(projectId, repo);
+    const existing = this.#entries.get(key);
+    if (existing?.repoDir === repoDir) {
+      existing.touchedAt = this.#now();
+      return;
+    }
+    if (existing) this.#remove(key, existing);
+
+    const entry: WatchedRepository = {
+      projectId,
+      repo,
+      repoDir,
+      touchedAt: this.#now(),
+      watchers: [],
+      metadataChanged: false,
+    };
+    try {
+      entry.watchers.push(
+        this.#watch(
+          repoDir,
+          { recursive: true, persistent: false },
+          (_eventType, filename) => {
+            const change = classifyWorktreePath(filename);
+            if (change) this.#invalidate(entry, change === "metadata");
+          },
+        ),
+      );
+      for (const gitDir of externalGitDirs(repoDir)) {
+        entry.watchers.push(
+          this.#watch(
+            gitDir,
+            { recursive: true, persistent: false },
+            (_eventType, filename) => {
+              if (relevantGitPath(filename)) this.#invalidate(entry, true);
+            },
+          ),
+        );
+      }
+      for (const watcher of entry.watchers) {
+        watcher.on("error", (error) => {
+          this.options.onWarning?.("Git repository watcher failed", error);
+          if (this.#entries.get(key) === entry) this.#remove(key, entry);
+        });
+      }
+      this.#entries.set(key, entry);
+      this.#evictOverflow();
+    } catch (error) {
+      closeWatchers(entry.watchers);
+      this.options.onWarning?.("Could not watch Git repository", error);
+    }
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const [key, entry] of this.#entries) this.#remove(key, entry);
+  }
+
+  #invalidate(entry: WatchedRepository, metadataChanged: boolean): void {
+    if (
+      this.#closed ||
+      !this.#entries.has(repositoryKey(entry.projectId, entry.repo))
+    )
+      return;
+    entry.metadataChanged ||= metadataChanged;
+    if (entry.quietTimer) this.#clock.clearTimeout(entry.quietTimer);
+    entry.quietTimer = this.#clock.setTimeout(
+      () => this.#flush(entry),
+      this.#quietMs,
+    );
+    entry.maxTimer ??= this.#clock.setTimeout(
+      () => this.#flush(entry),
+      this.#maxWaitMs,
+    );
+  }
+
+  #flush(entry: WatchedRepository): void {
+    if (entry.quietTimer) this.#clock.clearTimeout(entry.quietTimer);
+    if (entry.maxTimer) this.#clock.clearTimeout(entry.maxTimer);
+    entry.quietTimer = undefined;
+    entry.maxTimer = undefined;
+    const metadataChanged = entry.metadataChanged;
+    entry.metadataChanged = false;
+    if (
+      this.#closed ||
+      !this.#entries.has(repositoryKey(entry.projectId, entry.repo))
+    )
+      return;
+    try {
+      if (metadataChanged)
+        this.options.onRepositoryMetadataChanged?.(entry.repoDir);
+      this.publisher.publishBestEffort(
+        "git.repository.invalidated",
+        {
+          projectId: entry.projectId,
+          repo: entry.repo,
+          source: "filesystem",
+        },
+        "git repository watcher",
+      );
+    } catch (error) {
+      this.options.onWarning?.("Could not publish Git invalidation", error);
+    }
+  }
+
+  #evictOverflow(): void {
+    while (this.#entries.size > this.#maxRepositories) {
+      const oldest = [...this.#entries.entries()].sort(
+        ([, left], [, right]) => left.touchedAt - right.touchedAt,
+      )[0];
+      if (!oldest) return;
+      this.#remove(oldest[0], oldest[1]);
+    }
+  }
+
+  #remove(key: string, entry: WatchedRepository): void {
+    if (entry.quietTimer) this.#clock.clearTimeout(entry.quietTimer);
+    if (entry.maxTimer) this.#clock.clearTimeout(entry.maxTimer);
+    closeWatchers(entry.watchers);
+    this.#entries.delete(key);
+  }
+}
+
+function repositoryKey(projectId: string, repo: string): string {
+  return JSON.stringify([projectId, repo]);
+}
+
+function closeWatchers(watchers: readonly FSWatcher[]): void {
+  for (const watcher of watchers) watcher.close();
+}
+
+function pathText(filename: string | Buffer | null): string | undefined {
+  if (filename === null) return undefined;
+  return normalize(filename.toString()).split(sep).join("/");
+}
+
+function classifyWorktreePath(
+  filename: string | Buffer | null,
+): "worktree" | "metadata" | undefined {
+  const path = pathText(filename);
+  if (path === undefined || path === ".git") return "metadata";
+  if (!path.startsWith(".git/")) return "worktree";
+  return relevantGitPath(path.slice(5)) ? "metadata" : undefined;
+}
+
+function relevantGitPath(filename: string | Buffer | null): boolean {
+  const path = pathText(filename);
+  if (path === undefined) return true;
+  if (path.endsWith(".lock")) return false;
+  if (
+    path === "HEAD" ||
+    path === "index" ||
+    path === "packed-refs" ||
+    path === "config" ||
+    path === "MERGE_HEAD" ||
+    path === "CHERRY_PICK_HEAD" ||
+    path === "REVERT_HEAD"
+  )
+    return true;
+  return (
+    path.startsWith("refs/") ||
+    path.startsWith("rebase-") ||
+    path.startsWith("sequencer/") ||
+    path.startsWith("BISECT_")
+  );
+}
+
+function externalGitDirs(repoDir: string): string[] {
+  const dotGit = join(repoDir, ".git");
+  try {
+    const firstLine = readFileSync(dotGit, "utf8").split(/\r?\n/, 1)[0]?.trim();
+    if (!firstLine?.toLowerCase().startsWith("gitdir:")) return [];
+    const value = firstLine.slice("gitdir:".length).trim();
+    if (!value) return [];
+    const gitDir = isAbsolute(value)
+      ? normalize(value)
+      : resolve(dirname(dotGit), value);
+    const commonDir = resolveCommonGitDir(gitDir);
+    return commonDir && commonDir !== gitDir ? [gitDir, commonDir] : [gitDir];
+  } catch {
+    return [];
+  }
+}
+
+function resolveCommonGitDir(gitDir: string): string | undefined {
+  try {
+    const value = readFileSync(join(gitDir, "commondir"), "utf8").trim();
+    if (!value) return undefined;
+    return isAbsolute(value) ? normalize(value) : resolve(gitDir, value);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/workbench-server/src/domains/tools/git-repository-watching.ts
+++ b/packages/workbench-server/src/domains/tools/git-repository-watching.ts
@@ -1,0 +1,21 @@
+import { GitService } from "@nervekit/tools";
+import type { GitRepositoryWatcher } from "./git-repository-watcher.js";
+
+/** Registers repositories for native invalidation before reading an overview. */
+export function withGitRepositoryWatching(
+  service: GitService,
+  watcher: Pick<GitRepositoryWatcher, "watch">,
+): GitService {
+  return new Proxy(service, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver) as unknown;
+      if (property !== "overview" || typeof value !== "function") {
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+      return (projectId: string, repo: string) => {
+        watcher.watch(projectId, repo, target.resolveRepoDir(projectId, repo));
+        return target.overview(projectId, repo);
+      };
+    },
+  });
+}

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -1,5 +1,7 @@
 import { generateSummary, resolveAgentModel } from "@nervekit/harness";
 import { withGitMutationEvents } from "../domains/tools/git-mutation-publisher.js";
+import { GitRepositoryWatcher } from "../domains/tools/git-repository-watcher.js";
+import { withGitRepositoryWatching } from "../domains/tools/git-repository-watching.js";
 import { GitService } from "@nervekit/tools";
 import {
   AgentLifecycleService,
@@ -95,6 +97,7 @@ export interface RuntimeServices {
   plans: PlanService;
   tools: ToolService;
   git: GitService;
+  gitRepositoryWatcher: GitRepositoryWatcher;
   fileCompletions: FileCompletionService;
   promptSuggestions: PromptSuggestionService;
   taskDefinitions: TaskDefinitionService;
@@ -363,38 +366,46 @@ export function composeRuntime(
       services.agentLifecycle.setAgentModeInternal(agentId, mode, reason),
   );
   const gitLogger = logger.child({ component: "git" });
+  const gitService = new GitService(getProject, {
+    onCommandCompleted: (observation) => {
+      if (observation.durationMs < 250) return;
+      void gitLogger.warn("Slow Git command", {
+        durationMs: Math.round(observation.durationMs),
+        context: {
+          bin: observation.bin,
+          command: observation.command,
+          succeeded: observation.succeeded,
+        },
+      });
+    },
+    onGithubRequestCompleted: (observation) => {
+      if (observation.durationMs < 250) return;
+      void gitLogger.warn("Slow GitHub API request", {
+        durationMs: Math.round(observation.durationMs),
+        context: {
+          operation: observation.operation,
+          status: observation.status,
+          succeeded: observation.succeeded,
+        },
+      });
+    },
+    onOverviewCompleted: (observation) => {
+      if (observation.durationMs < 500) return;
+      void gitLogger.warn("Slow Git overview", {
+        durationMs: Math.round(observation.durationMs),
+        context: { succeeded: observation.succeeded },
+      });
+    },
+  });
+  services.gitRepositoryWatcher = new GitRepositoryWatcher(events, {
+    onRepositoryMetadataChanged: (repoDir) =>
+      gitService.invalidateStableRepoMetadata(repoDir),
+    onWarning: (message, error) => {
+      void gitLogger.warn(message, { error });
+    },
+  });
   services.git = withGitMutationEvents(
-    new GitService(getProject, {
-      onCommandCompleted: (observation) => {
-        if (observation.durationMs < 250) return;
-        void gitLogger.warn("Slow Git command", {
-          durationMs: Math.round(observation.durationMs),
-          context: {
-            bin: observation.bin,
-            command: observation.command,
-            succeeded: observation.succeeded,
-          },
-        });
-      },
-      onGithubRequestCompleted: (observation) => {
-        if (observation.durationMs < 250) return;
-        void gitLogger.warn("Slow GitHub API request", {
-          durationMs: Math.round(observation.durationMs),
-          context: {
-            operation: observation.operation,
-            status: observation.status,
-            succeeded: observation.succeeded,
-          },
-        });
-      },
-      onOverviewCompleted: (observation) => {
-        if (observation.durationMs < 500) return;
-        void gitLogger.warn("Slow Git overview", {
-          durationMs: Math.round(observation.durationMs),
-          context: { succeeded: observation.succeeded },
-        });
-      },
-    }),
+    withGitRepositoryWatching(gitService, services.gitRepositoryWatcher),
     events,
   );
   const promptSuggestionTrustRepository = new PromptSuggestionTrustRepository(

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -152,6 +152,7 @@ export class RuntimeRegistry {
    */
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
+    this.services.gitRepositoryWatcher.close();
     await this.services.tasks.shutdown();
     this.services.taskNotifications.stop();
     await Promise.allSettled([...this.backgroundOperations]);

--- a/packages/workbench-server/test/git-repository-watcher.test.ts
+++ b/packages/workbench-server/test/git-repository-watcher.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import type { FSWatcher } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { mkdtemp } from "node:fs/promises";
+import { GitRepositoryWatcher } from "../src/domains/tools/git-repository-watcher.js";
+
+type Timer = { at: number; callback: () => void; cancelled: boolean };
+
+class FakeClock {
+  nowMs = 0;
+  timers: Timer[] = [];
+
+  setTimeout(
+    callback: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout> {
+    const timer = { at: this.nowMs + delayMs, callback, cancelled: false };
+    this.timers.push(timer);
+    return timer as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void {
+    (timer as unknown as Timer).cancelled = true;
+  }
+
+  advanceTo(nowMs: number): void {
+    while (true) {
+      const next = this.timers
+        .filter((timer) => !timer.cancelled && timer.at <= nowMs)
+        .sort((left, right) => left.at - right.at)[0];
+      if (!next) break;
+      next.cancelled = true;
+      this.nowMs = next.at;
+      next.callback();
+    }
+    this.nowMs = nowMs;
+  }
+}
+
+class FakeWatcher extends EventEmitter {
+  closed = false;
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function setup(
+  options: { maxRepositories?: number; publisherThrows?: boolean } = {},
+) {
+  const clock = new FakeClock();
+  const watches: Array<{
+    path: string;
+    watcher: FakeWatcher;
+    listener: (event: string, filename: string | Buffer | null) => void;
+  }> = [];
+  const publications: unknown[] = [];
+  const warnings: string[] = [];
+  const metadataChanges: string[] = [];
+  const watcher = new GitRepositoryWatcher(
+    {
+      publishBestEffort: (_type, data) => {
+        if (options.publisherThrows) throw new Error("publish failed");
+        publications.push(data);
+      },
+    },
+    {
+      clock,
+      now: () => clock.nowMs,
+      quietMs: 300,
+      maxWaitMs: 2_000,
+      maxRepositories: options.maxRepositories,
+      watch: (path, _watchOptions, listener) => {
+        const target = new FakeWatcher();
+        watches.push({ path, watcher: target, listener });
+        return target as unknown as FSWatcher;
+      },
+      onWarning: (message) => warnings.push(message),
+      onRepositoryMetadataChanged: (repoDir) => metadataChanges.push(repoDir),
+    },
+  );
+  return {
+    clock,
+    metadataChanges,
+    publications,
+    warnings,
+    watcher,
+    watches,
+  };
+}
+
+describe("GitRepositoryWatcher", () => {
+  it("trailing-debounces a repository burst and ignores noisy git internals", () => {
+    const { clock, publications, watcher, watches } = setup();
+    watcher.watch("proj_one", ".", "/repo");
+    const emit = watches[0]?.listener;
+    assert.ok(emit);
+
+    emit("change", ".git/objects/aa/object");
+    emit("change", ".git/index.lock");
+    clock.advanceTo(1_000);
+    assert.equal(publications.length, 0);
+
+    emit("change", "src/a.ts");
+    clock.advanceTo(1_200);
+    emit("change", "src/b.ts");
+    clock.advanceTo(1_499);
+    assert.equal(publications.length, 0);
+    clock.advanceTo(1_500);
+    assert.deepEqual(publications, [
+      { projectId: "proj_one", repo: ".", source: "filesystem" },
+    ]);
+  });
+
+  it("flushes continuous writes at the maximum wait and isolates repositories", () => {
+    const { clock, publications, watcher, watches } = setup();
+    watcher.watch("proj_one", ".", "/one");
+    watcher.watch("proj_two", "nested", "/two");
+    const first = watches[0]?.listener;
+    const second = watches[1]?.listener;
+    assert.ok(first && second);
+
+    first("change", "a.ts");
+    for (let at = 250; at < 2_000; at += 250) {
+      clock.advanceTo(at);
+      first("change", "a.ts");
+    }
+    second("change", "b.ts");
+    clock.advanceTo(2_000);
+    assert.deepEqual(publications, [
+      { projectId: "proj_one", repo: ".", source: "filesystem" },
+    ]);
+    clock.advanceTo(2_050);
+    assert.deepEqual(publications[1], {
+      projectId: "proj_two",
+      repo: "nested",
+      source: "filesystem",
+    });
+  });
+
+  it("watches external worktree gitdirs and closes evicted resources", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-git-watch-"));
+    const worktree = join(root, "worktree");
+    const gitDir = join(root, "git", "worktrees", "one");
+    await Promise.all([mkdir(worktree), mkdir(gitDir, { recursive: true })]);
+    await writeFile(join(worktree, ".git"), "gitdir: ../git/worktrees/one\n");
+
+    const { watcher, watches } = setup({ maxRepositories: 1 });
+    watcher.watch("proj_one", ".", worktree);
+    assert.deepEqual(
+      watches.map((entry) => entry.path),
+      [worktree, gitDir],
+    );
+    watcher.watch("proj_two", ".", join(root, "other"));
+    assert.equal(watches[0]?.watcher.closed, true);
+    assert.equal(watches[1]?.watcher.closed, true);
+    watcher.close();
+    assert.equal(watches[2]?.watcher.closed, true);
+  });
+
+  it("contains publication failures and cancels pending timers on close", () => {
+    const { clock, metadataChanges, warnings, watcher, watches } = setup({
+      publisherThrows: true,
+    });
+    watcher.watch("proj_one", ".", "/repo");
+    watches[0]?.listener("change", ".git/HEAD");
+    clock.advanceTo(300);
+    assert.deepEqual(warnings, ["Could not publish Git invalidation"]);
+    assert.deepEqual(metadataChanges, ["/repo"]);
+
+    watches[0]?.listener("change", "next.ts");
+    watcher.close();
+    clock.advanceTo(3_000);
+    assert.equal(warnings.length, 1);
+    assert.equal(watches[0]?.watcher.closed, true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace idle Git overview polling with debounced native filesystem invalidations
- coalesce Git and pull-request refresh demand with target-specific cooldowns and visibility/staleness gating
- support worktrees, metadata cache invalidation, watcher lifecycle cleanup, and ephemeral protocol events
- keep system Git as the authoritative status implementation and avoid optional-lock watcher feedback loops

## Validation
- `pnpm fix && pnpm check && pnpm test`