### PR TITLE
Make composer slash commands functional

### DIFF
--- a/packages/contracts/src/domains/completions/index.ts
+++ b/packages/contracts/src/domains/completions/index.ts
@@ -1,1 +1,2 @@
 export * from "./completion.schema.js";
+export * from "./slash-command.js";

--- a/packages/contracts/src/domains/completions/slash-command.ts
+++ b/packages/contracts/src/domains/completions/slash-command.ts
@@ -1,0 +1,45 @@
+import type { CompletionItem } from "./completion.schema.js";
+
+export const slashCommandNames = ["plan", "code", "compact", "abort"] as const;
+
+export type SlashCommandName = (typeof slashCommandNames)[number];
+
+export type SlashCommand = {
+  name: SlashCommandName;
+};
+
+export const slashCommandCompletionItems = [
+  {
+    label: "/plan",
+    detail: "Switch to Planning mode",
+    info: "Changes the active composer to Planning mode without sending a prompt.",
+    kind: "slash",
+  },
+  {
+    label: "/code",
+    detail: "Switch to Coding mode",
+    info: "Changes the active composer to Coding mode without sending a prompt.",
+    kind: "slash",
+  },
+  {
+    label: "/compact",
+    detail: "Compact conversation context",
+    info: "Summarizes earlier messages to reduce context usage.",
+    kind: "slash",
+  },
+  {
+    label: "/abort",
+    detail: "Stop the active run",
+    info: "Cancels the active agent run.",
+    kind: "slash",
+  },
+] satisfies readonly CompletionItem[];
+
+const slashCommandNameSet = new Set<string>(slashCommandNames);
+
+export function parseSlashCommand(text: string): SlashCommand | undefined {
+  const match = /^\/([a-z]+)$/.exec(text.trim());
+  const name = match?.[1];
+  if (!name || !slashCommandNameSet.has(name)) return undefined;
+  return { name: name as SlashCommandName };
+}

--- a/packages/contracts/test/slash-command.test.ts
+++ b/packages/contracts/test/slash-command.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  parseSlashCommand,
+  slashCommandCompletionItems,
+} from "../src/domains/completions/slash-command.js";
+
+describe("slash commands", () => {
+  it("parses every advertised standalone command", () => {
+    assert.deepEqual(
+      slashCommandCompletionItems.map((item) => item.label),
+      ["/plan", "/code", "/compact", "/abort"],
+    );
+
+    for (const item of slashCommandCompletionItems) {
+      assert.deepEqual(parseSlashCommand(item.label), {
+        name: item.label.slice(1),
+      });
+    }
+  });
+
+  it("allows surrounding whitespace", () => {
+    assert.deepEqual(parseSlashCommand(" \n /plan\t"), { name: "plan" });
+  });
+
+  it("does not reinterpret unknown or argument-bearing prompts", () => {
+    for (const text of [
+      "",
+      "/status",
+      "/Plan",
+      "/plan inspect this",
+      "/compact now",
+      "please /abort",
+    ]) {
+      assert.equal(parseSlashCommand(text), undefined);
+    }
+  });
+});

--- a/packages/workbench-app/src/lib/features/conversations/state/composer-slash-command.test.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/composer-slash-command.test.ts
@@ -1,0 +1,66 @@
+import type { Mode } from "@nervekit/contracts";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  executeComposerSlashCommand,
+  type ComposerSlashCommandActions,
+} from "./composer-slash-command";
+
+function actions(calls: string[]): ComposerSlashCommandActions {
+  return {
+    clearComposer: () => calls.push("clear"),
+    setMode: (mode: Mode) => calls.push(`mode:${mode}`),
+    compact: async () => {
+      calls.push("compact:start");
+      await Promise.resolve();
+      calls.push("compact:done");
+    },
+    abort: async () => {
+      calls.push("abort:start");
+      await Promise.resolve();
+      calls.push("abort:done");
+    },
+  };
+}
+
+describe("composer slash command dispatch", () => {
+  it("clears and switches modes without sending a prompt", async () => {
+    for (const [command, mode] of [
+      ["/plan", "planning"],
+      ["/code", "coding"],
+    ] as const) {
+      const calls: string[] = [];
+      assert.equal(
+        await executeComposerSlashCommand(command, actions(calls)),
+        true,
+      );
+      assert.deepEqual(calls, ["clear", `mode:${mode}`]);
+    }
+  });
+
+  it("clears before awaiting compaction and abort actions", async () => {
+    for (const command of ["/compact", "/abort"] as const) {
+      const calls: string[] = [];
+      assert.equal(
+        await executeComposerSlashCommand(command, actions(calls)),
+        true,
+      );
+      assert.deepEqual(calls, [
+        "clear",
+        `${command.slice(1)}:start`,
+        `${command.slice(1)}:done`,
+      ]);
+    }
+  });
+
+  it("leaves ordinary prompts untouched", async () => {
+    for (const text of ["/status", "/plan inspect first", "normal prompt"]) {
+      const calls: string[] = [];
+      assert.equal(
+        await executeComposerSlashCommand(text, actions(calls)),
+        false,
+      );
+      assert.deepEqual(calls, []);
+    }
+  });
+});

--- a/packages/workbench-app/src/lib/features/conversations/state/composer-slash-command.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/composer-slash-command.ts
@@ -1,0 +1,33 @@
+import { parseSlashCommand, type Mode } from "@nervekit/contracts";
+
+export type ComposerSlashCommandActions = {
+  clearComposer: () => void;
+  setMode: (mode: Mode) => void;
+  compact: () => void | Promise<void>;
+  abort: () => void | Promise<void>;
+};
+
+export async function executeComposerSlashCommand(
+  text: string,
+  actions: ComposerSlashCommandActions,
+): Promise<boolean> {
+  const command = parseSlashCommand(text);
+  if (!command) return false;
+
+  actions.clearComposer();
+  switch (command.name) {
+    case "plan":
+      actions.setMode("planning");
+      break;
+    case "code":
+      actions.setMode("coding");
+      break;
+    case "compact":
+      await actions.compact();
+      break;
+    case "abort":
+      await actions.abort();
+      break;
+  }
+  return true;
+}

--- a/packages/workbench-app/src/lib/features/conversations/state/prompt-send.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/prompt-send.ts
@@ -21,6 +21,7 @@ import {
   currentActiveAgent,
   selectedModel,
   selectedThinkingLevel,
+  setComposerMode,
 } from "$lib/features/conversations/state/composer-config.svelte";
 import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
@@ -33,9 +34,10 @@ import {
 } from "$lib/features/workspace/state/selection.svelte";
 import { loadWorkspaceState } from "$lib/features/workspace/state/workspace-actions.svelte";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import { executeComposerSlashCommand } from "./composer-slash-command";
 import { optimisticUserMessage } from "./conversation-optimistic";
 import { startNewConversationRun } from "./new-conversation-run";
-import { abortActiveRun } from "./run-control";
+import { abortActiveRun, compactActiveConversation } from "./run-control";
 import {
   refreshConversationView,
   upsertAgentRecord,
@@ -58,6 +60,15 @@ export function setActiveComposerText(value: string) {
     return;
   }
   ensureConversationView(selection.conversationId).composerText = value;
+}
+
+function clearActiveComposerText(): void {
+  const pending = activePendingConversation();
+  if (pending) pending.composerText = "";
+  if (selection.conversationId) {
+    ensureConversationView(selection.conversationId).composerText = "";
+  }
+  composerDraft.text = "";
 }
 
 export async function ensureAgent(): Promise<string> {
@@ -333,12 +344,11 @@ export async function sendPrompt() {
     composerDraft.text
   ).trim();
   if (!text || pending?.sending) return;
-  if (text === "/abort") {
-    if (pending) pending.composerText = "";
-    if (view) view.composerText = "";
-    composerDraft.text = "";
-    await abortActiveRun();
-    return;
-  }
-  await sendPromptText(text, { clearComposer: true });
+  const handled = await executeComposerSlashCommand(text, {
+    clearComposer: clearActiveComposerText,
+    setMode: setComposerMode,
+    compact: compactActiveConversation,
+    abort: abortActiveRun,
+  });
+  if (!handled) await sendPromptText(text, { clearComposer: true });
 }

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -1,4 +1,4 @@
-import type { CompletionItem } from "@nervekit/contracts";
+import { slashCommandCompletionItems } from "@nervekit/contracts";
 import type { OrchestratorState } from "../../app/orchestrator-state.js";
 import {
   providerApiKeySecretName,
@@ -16,33 +16,6 @@ import {
   getWorkspaceSnapshotResponse,
 } from "../snapshots.js";
 import { defineWorkbenchMethodHandlers } from "../method-handler-registry.js";
-
-const slashCompletionItems: CompletionItem[] = [
-  {
-    label: "/plan",
-    detail: "Start in planning mode",
-    info: "Ask the agent to inspect first and produce a short plan before changing files.",
-    kind: "slash",
-  },
-  {
-    label: "/code",
-    detail: "Switch to implementation",
-    info: "Frame the next prompt as a coding task.",
-    kind: "slash",
-  },
-  {
-    label: "/status",
-    detail: "Summarize current conversation state",
-    info: "Useful before handing off or resuming a durable conversation.",
-    kind: "slash",
-  },
-  {
-    label: "/abort",
-    detail: "Stop the active run",
-    info: "Cancels the active agent run from the UI.",
-    kind: "slash",
-  },
-];
 
 export const platformMethodHandlers = defineWorkbenchMethodHandlers({
   "status.latestRelease.get": (state) => state.latestRelease.getLatestRelease(),
@@ -119,7 +92,9 @@ export const platformMethodHandlers = defineWorkbenchMethodHandlers({
   "usage.subscription.get": async (state) => ({
     usage: await state.registry.getSubscriptionUsage(),
   }),
-  "completion.slash.list": () => ({ items: slashCompletionItems }),
+  "completion.slash.list": () => ({
+    items: [...slashCommandCompletionItems],
+  }),
   "completion.files.list": async (state, params) => ({
     items: await state.registry.completeFiles(
       params?.projectId,

--- a/packages/workbench-server/src/routes/completion-routes.ts
+++ b/packages/workbench-server/src/routes/completion-routes.ts
@@ -1,40 +1,17 @@
-import type { CompletionItem } from "@nervekit/contracts";
-import { fileCompletionQuerySchema } from "@nervekit/contracts";
+import {
+  fileCompletionQuerySchema,
+  slashCommandCompletionItems,
+} from "@nervekit/contracts";
 import { Hono } from "hono";
 import type { OrchestratorState } from "../app/orchestrator-state.js";
 import { routeHandler } from "../http/responses.js";
 
-const slashCompletionItems: CompletionItem[] = [
-  {
-    label: "/plan",
-    detail: "Start in planning mode",
-    info: "Ask the agent to inspect first and produce a short plan before changing files.",
-    kind: "slash",
-  },
-  {
-    label: "/code",
-    detail: "Switch to implementation",
-    info: "Frame the next prompt as a coding task.",
-    kind: "slash",
-  },
-  {
-    label: "/status",
-    detail: "Summarize current conversation state",
-    info: "Useful before handing off or resuming a durable conversation.",
-    kind: "slash",
-  },
-  {
-    label: "/abort",
-    detail: "Stop the active run",
-    info: "Cancels the active agent run from the UI.",
-    kind: "slash",
-  },
-];
-
 export function createCompletionRoutes(state: OrchestratorState): Hono {
   const app = new Hono();
 
-  app.get("/completions/slash", (c) => c.json({ items: slashCompletionItems }));
+  app.get("/completions/slash", (c) =>
+    c.json({ items: [...slashCommandCompletionItems] }),
+  );
   app.get(
     "/completions/files",
     routeHandler(async (c) => {


### PR DESCRIPTION
## Summary
- make `/plan` and `/code` switch composer modes without sending prompts
- add working `/compact` and retain `/abort`, while removing misleading `/status` completion
- centralize slash-command parsing/completions in contracts and add focused tests

## Validation
- `pnpm fix && pnpm check && pnpm test`