### PR TITLE
Refine settings model picker controls

### DIFF
--- a/packages/workbench-app/src/lib/features/settings/components/pages/agents/AgentDefaultsSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/agents/AgentDefaultsSection.svelte
@@ -213,13 +213,12 @@ function setAutoApproveReadOnly(autoApproveReadOnly: boolean): void {
   >
     {#snippet summaryMeta()}
       {#if savedDefaultModelInfo}
-        {providerDisplayName(savedDefaultModelInfo.provider)} ·
-        <span class="font-mono">{savedDefaultModelInfo.modelId}</span>
-        · {defaultThinkingLevel}
+        {providerDisplayName(savedDefaultModelInfo.provider)}
       {:else if defaultModelInfo}
-        Currently {modelDisplayName(defaultModelInfo)} · {defaultThinkingLevel}
+        Currently {modelDisplayName(defaultModelInfo)} ·
+        {providerDisplayName(defaultModelInfo.provider)}
       {:else}
-        No scoped model available · {defaultThinkingLevel}
+        No scoped model available
       {/if}
     {/snippet}
     {#snippet policy()}

--- a/packages/workbench-app/src/lib/features/settings/components/pages/agents/ExploreAgentSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/agents/ExploreAgentSection.svelte
@@ -89,12 +89,9 @@ function saveExploreModel(selection: {
   >
     {#snippet summaryMeta()}
       {#if selectedModelInfo}
-        {providerDisplayName(selectedModelInfo.provider)} ·
-        <span class="font-mono">{selectedModelInfo.modelId}</span>
-        · {settingsDraft.exploreAgent.thinkingLevel}
+        {providerDisplayName(selectedModelInfo.provider)}
       {:else}
-        Use the platform fallback model · {settingsDraft.exploreAgent
-          .thinkingLevel}
+        Use the platform fallback model
       {/if}
     {/snippet}
     {#snippet policy()}

--- a/packages/workbench-app/src/lib/features/settings/components/pages/agents/ModelPickerRow.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/agents/ModelPickerRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
-import ChevronsUpDown from "@lucide/svelte/icons/chevrons-up-down";
 import Info from "@lucide/svelte/icons/info";
+import MousePointerClick from "@lucide/svelte/icons/mouse-pointer-click";
 import type { ModelInfo, ModelSelection, ThinkingLevel } from "$lib/api";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
@@ -54,54 +54,65 @@ let {
 let dialogOpen = $state(false);
 </script>
 
-<SettingsRow {label} {description} layout="stacked">
-  <div class="flex items-center gap-1.5">
-    <!-- Select-like trigger styled to match the choice cards above it. -->
-    <button
-      type="button"
-      aria-haspopup="dialog"
-      aria-label={`${label}: ${summaryTitle}. Change model`}
-      data-tour-id={tourId}
-      class="flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-2 rounded-sm border border-border/50 px-2 py-1.5 text-left transition-colors hover:bg-accent/40"
-      onclick={() => (dialogOpen = true)}
+<SettingsRow {label} {description}>
+  {#snippet control()}
+    <div
+      class="relative w-64 min-w-0 max-w-full cursor-pointer rounded-md border border-primary/60 bg-primary/8 shadow-xs transition-colors hover:bg-primary/12"
+      role="group"
+      aria-label={label}
     >
-      <span class="grid min-w-0 gap-0.5">
-        <span class="truncate text-sm font-medium text-foreground"
-          >{summaryTitle}</span
-        >
-        <span class="truncate text-xs text-muted-foreground">
-          {@render summaryMeta()}
-        </span>
-      </span>
-      <ChevronsUpDown
-        class="size-3.5 flex-none text-muted-foreground"
-        aria-hidden="true"
-      />
-    </button>
-    {#if policy}
-      <Tooltip.Provider delayDuration={200}>
-        <Tooltip.Root>
-          <Tooltip.Trigger>
-            {#snippet child({ props })}
-              <Button
-                {...props}
-                variant="ghost"
-                size="icon-xs"
-                ariaLabel={policyLabel}
-              >
-                <Info class="size-3.5" aria-hidden="true" />
-              </Button>
-            {/snippet}
-          </Tooltip.Trigger>
-          <Tooltip.Content side="top" class="max-w-xs p-0">
-            <div class="grid divide-y divide-border/40">
-              {@render policy()}
-            </div>
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </Tooltip.Provider>
-    {/if}
-  </div>
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-label={`${label}: ${summaryTitle}. Change model`}
+        data-tour-id={tourId}
+        class="absolute inset-0 cursor-pointer rounded-md outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+        onclick={() => (dialogOpen = true)}
+      ></button>
+      <div
+        class="pointer-events-none relative flex min-w-0 items-center gap-2 px-2.5 py-1.5"
+      >
+        <div class="grid min-w-0 flex-1 gap-0.5">
+          <div class="flex min-w-0 items-center gap-1">
+            <span class="truncate text-sm font-medium text-foreground"
+              >{summaryTitle}</span
+            >
+            {#if policy}
+              <Tooltip.Provider delayDuration={200}>
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    {#snippet child({ props })}
+                      <Button
+                        {...props}
+                        variant="ghost"
+                        size="icon-xs"
+                        class="pointer-events-auto -my-1 flex-none cursor-pointer text-primary hover:bg-primary/10"
+                        ariaLabel={policyLabel}
+                      >
+                        <Info class="size-3.5" aria-hidden="true" />
+                      </Button>
+                    {/snippet}
+                  </Tooltip.Trigger>
+                  <Tooltip.Content side="top" class="max-w-xs p-0">
+                    <div class="grid divide-y divide-border/40">
+                      {@render policy()}
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              </Tooltip.Provider>
+            {/if}
+          </div>
+          <span class="truncate text-xs text-muted-foreground">
+            {@render summaryMeta()}
+          </span>
+        </div>
+        <MousePointerClick
+          class="size-3.5 flex-none text-primary"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  {/snippet}
 </SettingsRow>
 
 <SingleModelSelectionDialog


### PR DESCRIPTION
## Summary
- align the default and explore model pickers with standard inline settings rows
- simplify model summaries to avoid repeated model IDs and thinking levels
- present policy info beside the model name and use a primary-tinted, clearly clickable dialog trigger
- add pointer feedback and a mouse-pointer-click affordance for changing the selection

## Validation
- `pnpm fix && pnpm check && pnpm test`