### PR TITLE
Polish dialogs with compact unified surfaces

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/packages/ui-kit/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -10,8 +10,8 @@ let {
 }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
 </script>
 
-<!-- Accent header band shared with DialogShell; the inner block stacks the
-     title and description. -->
+<!-- Compact header shared with DialogShell; the inner block stacks the title
+     and description on the unified dialog surface. -->
 <div
   bind:this={ref}
   data-slot="alert-dialog-header"

--- a/packages/ui-kit/src/styles/components/dialog.css
+++ b/packages/ui-kit/src/styles/components/dialog.css
@@ -1,7 +1,7 @@
 /*
  * Shared modal chrome for DialogShell and ConfirmDialog/AlertDialog.
  * One visual language across every modal: flat sidebar-tinted scrim, card
- * surface with the theme radius, and accent header/footer bands. Entrance and
+ * surface with the theme radius and compact, unified chrome. Entrance and
  * exit motion comes from tw-animate data-state utilities applied by the
  * components; content inside a dialog body is styled by consumers with
  * Tailwind token utilities.
@@ -75,26 +75,27 @@
   max-height: calc(100dvh - 3rem);
 }
 
-/* Confirmation dialogs: a miniature of the banded shell. */
+/* Confirmation dialogs use the same surface in a tighter two-row layout. */
 .dialog-content-confirm {
+  grid-template-rows: auto auto;
   width: min(26rem, calc(100vw - 32px));
   width: min(26rem, calc(100dvw - 2rem));
 }
 
-/* Header/footer bands: a gentle tint over the card surface with hairline
- * separators, not opaque accent stripes. */
+/* Header and footer remain visually connected to the body. Hairlines clarify
+ * fixed chrome around scrolling content without introducing separate bands. */
 .dialog-header,
 .dialog-footer {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  background: color-mix(in oklab, var(--accent) 40%, transparent);
-  padding: 0.6rem 0.875rem;
+  gap: 0.5rem;
+  background: var(--card);
+  padding: 0.5rem 0.75rem;
 }
 
 .dialog-header {
   justify-content: space-between;
-  border-bottom: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
 }
 
 .dialog-header-actions {
@@ -108,14 +109,15 @@
 }
 
 .dialog-footer {
+  flex-wrap: wrap;
   justify-content: flex-end;
-  border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  border-top: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
 }
 
 .dialog-title-block {
   display: grid;
   min-width: min(16rem, 40%);
-  gap: 0.16rem;
+  gap: 0.125rem;
 }
 
 .dialog-title {
@@ -130,6 +132,7 @@
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--text-xs);
+  line-height: 1.35;
 }
 
 .dialog-close {
@@ -138,16 +141,15 @@
   width: 1.5rem;
   height: 1.5rem;
   place-items: center;
-  border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  background: var(--input);
+  background: transparent;
   color: var(--muted-foreground);
   cursor: pointer;
 }
 
 .dialog-close:hover {
-  border-color: var(--border);
-  background: var(--card);
+  background: var(--accent);
   color: var(--foreground);
 }
 
@@ -169,4 +171,18 @@
 .dialog-body-flush {
   overflow: hidden;
   padding: 0;
+}
+
+.dialog-content-confirm .dialog-header {
+  border-bottom: 0;
+  padding: 0.75rem 0.75rem 0.25rem;
+}
+
+.dialog-content-confirm .dialog-title-block {
+  min-width: 0;
+}
+
+.dialog-content-confirm .dialog-footer {
+  border-top: 0;
+  padding: 0.5rem 0.75rem 0.75rem;
 }

--- a/packages/workbench-app/src/lib/features/audio/components/AudioInputAuthRequiredDialog.svelte
+++ b/packages/workbench-app/src/lib/features/audio/components/AudioInputAuthRequiredDialog.svelte
@@ -26,7 +26,7 @@ function openProviderSettings() {
   bind:open
   title="Connect ChatGPT to use voice input"
   description="Voice input needs a ChatGPT OAuth connection before Nerve can transcribe recordings."
-  class="audio-auth-required-dialog"
+  size="sm"
 >
   <div class="audio-auth-body">
     <div class="audio-auth-summary">
@@ -68,12 +68,6 @@ function openProviderSettings() {
 </Dialog>
 
 <style>
-/* DialogShell portals its content (escape-hatch reason 5); the compound
- * selector keeps this ahead of `.dialog-content`'s default width. */
-:global(.dialog-content.audio-auth-required-dialog) {
-  width: min(560px, calc(100vw - 32px));
-}
-
 .audio-auth-body {
   display: grid;
   gap: 0.85rem;

--- a/packages/workbench-app/src/lib/features/auth/components/AddProviderDialog.svelte
+++ b/packages/workbench-app/src/lib/features/auth/components/AddProviderDialog.svelte
@@ -63,7 +63,7 @@ onDestroy(() => {
   bind:open
   title={flowController.dialogTitle}
   description={flowController.dialogDescription}
-  class="add-provider-dialog"
+  size="md"
   closeOnInteractOutside={false}
   onOpenChange={handleOpenChange}
 >

--- a/packages/workbench-app/src/lib/features/auth/components/CustomProviderDialog.svelte
+++ b/packages/workbench-app/src/lib/features/auth/components/CustomProviderDialog.svelte
@@ -158,6 +158,7 @@ async function submit() {
   bind:open
   title={editing ? `Edit ${provider?.displayName}` : "Add custom provider"}
   description="Connect an OpenAI-compatible or other pi-ai supported endpoint."
+  size="md"
 >
   <div class="provider-form">
     <div class="field-grid">

--- a/packages/workbench-app/src/lib/features/auth/components/ModelDefinitionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/auth/components/ModelDefinitionDialog.svelte
@@ -136,6 +136,7 @@ async function submit() {
   bind:open
   title={editing ? `Edit ${model?.name}` : "Add model"}
   description="Register a model under a configured or authenticated provider."
+  size="md"
 >
   <div class="grid gap-3">
     <div class="grid gap-1.5">

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryGraph.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationHistoryGraph.svelte
@@ -237,7 +237,7 @@ function minimapNodeColor(node: Node): string {
 </script>
 
 <div
-  class="history-graph relative h-full min-h-0 overflow-hidden bg-background"
+  class="history-graph relative h-full min-h-0 overflow-hidden bg-transparent"
 >
   {#if hasConversation}
     <div class="flex h-full min-h-0">
@@ -292,7 +292,7 @@ function minimapNodeColor(node: Node): string {
 
       {#if inspectorOpen && selection}
         <aside
-          class="flex min-w-80 w-1/3 max-w-md shrink-0 flex-col overflow-hidden border-l bg-card"
+          class="flex min-w-80 w-1/3 max-w-md shrink-0 flex-col overflow-hidden border-l bg-card max-[900px]:absolute max-[900px]:inset-y-0 max-[900px]:right-0 max-[900px]:z-10 max-[900px]:w-[min(24rem,70%)] max-[900px]:shadow-lg max-[640px]:w-full max-[640px]:min-w-0 max-[640px]:max-w-none"
           aria-label="Conversation entry details"
         >
           <div class="flex items-center justify-between border-b px-3 py-2">
@@ -405,5 +405,11 @@ function minimapNodeColor(node: Node): string {
 
 .history-graph :global(.svelte-flow__attribution a) {
   color: inherit;
+}
+
+@media (max-width: 640px) {
+  .history-graph :global(.svelte-flow__minimap) {
+    display: none;
+  }
 }
 </style>

--- a/packages/workbench-app/src/lib/features/filesystem/components/CreateProjectEntryDialog.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/CreateProjectEntryDialog.svelte
@@ -57,7 +57,7 @@ async function submit(event?: SubmitEvent): Promise<void> {
   bind:open
   {title}
   description={`Create an empty ${kind === "file" ? "file" : "folder"} in ${parentPath || "the project root"}.`}
-  class="max-w-md"
+  size="sm"
 >
   <form class="grid gap-2" onsubmit={(event) => void submit(event)}>
     <Label for="new-project-entry-name">Name</Label>

--- a/packages/workbench-app/src/lib/features/onboarding/components/GuideCatalogDialog.svelte
+++ b/packages/workbench-app/src/lib/features/onboarding/components/GuideCatalogDialog.svelte
@@ -99,7 +99,7 @@ const navigationIsPrimary = $derived(guide.completed || !guide.available);
     </div>
 
     <section
-      class="grid min-h-64 content-center gap-4 px-2 py-5 sm:grid-cols-[auto_1fr] sm:items-start sm:px-6"
+      class="grid min-h-56 content-center gap-4 px-2 py-3 sm:grid-cols-[auto_1fr] sm:items-start sm:px-5"
       aria-live="polite"
       aria-labelledby="current-guide-title"
     >

--- a/packages/workbench-app/src/lib/features/projects/components/DirectoryPickerSearch.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/DirectoryPickerSearch.svelte
@@ -36,7 +36,7 @@ let {
 </script>
 
 <div
-  class="flex items-center gap-2 border-b border-b-border/60 py-1.5 pr-2.5 pl-3"
+  class="flex items-center gap-2 border-b border-b-border/60 py-1.5 pr-2.5 pl-3 max-[520px]:gap-1 max-[520px]:pr-1.5 max-[520px]:pl-2"
 >
   {#if onBack}
     <Button
@@ -56,7 +56,7 @@ let {
   >
     {#each crumbs as crumb, i (crumb.path)}
       {#if i > 0}<ChevronRight
-          class="flex-none text-muted-foreground/55"
+          class="flex-none text-muted-foreground/55 max-[520px]:hidden"
           size={13}
           strokeWidth={2.2}
           aria-hidden="true"
@@ -68,7 +68,7 @@ let {
         >
       {:else}
         <button
-          class="max-w-48 cursor-pointer overflow-hidden rounded-sm border-0 bg-transparent px-1 py-0.5 text-ellipsis whitespace-nowrap text-muted-foreground transition-[color,background-color,border-color,box-shadow] duration-120 not-disabled:hover:bg-accent not-disabled:hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none max-[560px]:max-w-28"
+          class="max-w-48 cursor-pointer overflow-hidden rounded-sm border-0 bg-transparent px-1 py-0.5 text-ellipsis whitespace-nowrap text-muted-foreground transition-[color,background-color,border-color,box-shadow] duration-120 not-disabled:hover:bg-accent not-disabled:hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none max-[560px]:max-w-28 max-[520px]:hidden"
           type="button"
           title={crumb.path}
           disabled={loading}
@@ -104,7 +104,7 @@ let {
     <Switch
       bind:checked={showHidden}
       label="Hidden"
-      class="h-7 gap-1.5 rounded-sm border border-border/60 bg-input px-1.5 text-xs"
+      class="h-7 gap-1.5 rounded-sm border border-border/60 bg-input px-1.5 text-xs max-[520px]:gap-1 max-[520px]:px-1"
     />
   </div>
 </div>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationsDialog.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationsDialog.svelte
@@ -134,7 +134,6 @@ function openAndClose(conversationId: string) {
 :global(.dialog-content.project-conversations-dialog .dialog-body) {
   display: flex;
   overflow: hidden;
-  background: var(--card);
 }
 
 .conversations-modal {

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
@@ -490,14 +490,19 @@ $effect(() => {
  * selector keeps it ahead of `.dialog-content`'s default width. */
 :global(.dialog-content.project-picker-dialog) {
   width: min(680px, calc(100vw - 24px));
+  width: min(680px, calc(100dvw - 1.5rem));
   min-height: min(82vh, 520px);
+  min-height: min(82dvh, 520px);
   max-height: min(82vh, 720px);
+  max-height: min(82dvh, 720px);
 }
 
 @media (max-width: 560px) {
   :global(.dialog-content.project-picker-dialog) {
     width: calc(100vw - 12px);
+    width: calc(100dvw - 0.75rem);
     max-height: calc(100vh - 12px);
+    max-height: calc(100dvh - 0.75rem);
   }
 }
 </style>

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -210,12 +210,14 @@ function projectMenu(project: ProjectRecord): ContextMenuItem[] {
               class="flex-none pl-2 text-xs whitespace-nowrap text-muted-foreground tabular-nums"
             >
               {chats} chat{chats === 1 ? "" : "s"}
-              <span class="px-1 text-muted-foreground/50" aria-hidden="true"
-                >·</span
-              >
-              {lastAccessedAt === undefined
-                ? "Not accessed"
-                : `Accessed ${lastAccessLabel(lastAccessedAt)}`}
+              <span class="max-[520px]:hidden">
+                <span class="px-1 text-muted-foreground/50" aria-hidden="true"
+                  >·</span
+                >
+                {lastAccessedAt === undefined
+                  ? "Not accessed"
+                  : `Accessed ${lastAccessLabel(lastAccessedAt)}`}
+              </span>
             </span>
           </div>
         </ContextMenu>

--- a/packages/workbench-app/src/lib/features/prompt-suggestions/components/CreatePromptSuggestionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/prompt-suggestions/components/CreatePromptSuggestionDialog.svelte
@@ -98,9 +98,9 @@ async function submit() {
   bind:open
   title="New prompt suggestion"
   description="Create a reusable composer prompt in your user profile or the current project."
-  class="max-w-2xl"
+  size="md"
 >
-  <div class="grid max-h-[70vh] gap-4 overflow-y-auto">
+  <div class="grid gap-4">
     <div class="grid gap-1.5">
       <Label>Scope</Label>
       <SelectField items={scopeItems} bind:value={scope} disabled={saving} />

--- a/packages/workbench-app/src/lib/features/prompt-suggestions/components/PromptSuggestionTrustDialog.svelte
+++ b/packages/workbench-app/src/lib/features/prompt-suggestions/components/PromptSuggestionTrustDialog.svelte
@@ -43,7 +43,7 @@ function decideLater() {
   {open}
   title="Allow prompt suggestion JavaScript?"
   description="Some prompt suggestions include JavaScript that decides when the suggestion appears."
-  class="max-w-2xl"
+  size="md"
   onOpenChange={(next) => {
     if (!next) decideLater();
   }}
@@ -65,7 +65,9 @@ function decideLater() {
 
     <div class="grid gap-2">
       {#each requests as request (request.trustId)}
-        <section class="grid gap-1 rounded-md border border-border bg-card p-3">
+        <section
+          class="grid gap-1 rounded-md border border-border bg-transparent p-3"
+        >
           <div class="flex items-center justify-between gap-3">
             <strong class="text-sm font-medium text-foreground"
               >{request.label}</strong

--- a/packages/workbench-app/src/lib/features/settings/components/pages/models/AddScopedModelsDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/models/AddScopedModelsDialog.svelte
@@ -93,7 +93,7 @@ function save(): void {
     class="grid max-h-[min(70vh,32rem)] grid-rows-[auto_minmax(0,1fr)]"
     data-tour-id="setup-scoped-models-catalog"
   >
-    <div class="grid gap-2 border-b border-border/50 px-3.5 pt-3 pb-2.5">
+    <div class="grid gap-1.5 border-b border-border/50 px-3 pt-2.5 pb-2">
       <SearchInput
         bind:value={query}
         placeholder="Search models"

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/IntegrationSettingsCard.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/IntegrationSettingsCard.svelte
@@ -241,6 +241,7 @@ function setFieldValue(key: IntegrationFieldKey, value: string): void {
   bind:open={dialogOpen}
   title={`Configure ${provider.label}`}
   description={provider.docsHint}
+  size="sm"
 >
   <form
     class="grid gap-3"

--- a/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
@@ -122,7 +122,7 @@ function useFallback(): void {
   flush
   closeOnInteractOutside={false}
 >
-  <div class="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+  <div class="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)_auto]">
     <div class="grid gap-1.5 border-b border-border/50 px-3 pt-2.5 pb-2">
       <SearchInput
         bind:value={query}
@@ -192,49 +192,46 @@ function useFallback(): void {
         {/if}
       </div>
     </Tooltip.Provider>
+
+    <div class="grid gap-1 border-t border-border/50 px-3 py-2">
+      <span class="text-xs text-muted-foreground">Thinking level</span>
+      <ToggleGroup.Root
+        type="single"
+        size="xs"
+        spacing={1}
+        variant="outline"
+        value={thinkingLevel}
+        aria-label="Thinking level"
+        class="min-w-0 flex-wrap justify-start"
+        onValueChange={(value) => {
+          if (value) thinkingLevel = value as ThinkingLevel;
+        }}
+      >
+        {#each thinkingLevels as level (level)}
+          <ToggleGroup.Item
+            value={level}
+            class="flex-none rounded-full text-xs capitalize data-[state=on]:text-primary"
+            >{level}</ToggleGroup.Item
+          >
+        {/each}
+      </ToggleGroup.Root>
+    </div>
   </div>
 
   {#snippet footer()}
-    <div class="grid w-full gap-2">
-      <div class="grid gap-1">
-        <span class="text-xs text-muted-foreground">Thinking level</span>
-        <ToggleGroup.Root
-          type="single"
-          size="xs"
-          spacing={1}
-          variant="outline"
-          value={thinkingLevel}
-          aria-label="Thinking level"
-          class="min-w-0 flex-wrap justify-start"
-          onValueChange={(value) => {
-            if (value) thinkingLevel = value as ThinkingLevel;
-          }}
-        >
-          {#each thinkingLevels as level (level)}
-            <ToggleGroup.Item
-              value={level}
-              class="flex-none rounded-full text-xs capitalize data-[state=on]:text-primary"
-              >{level}</ToggleGroup.Item
-            >
-          {/each}
-        </ToggleGroup.Root>
-      </div>
-      <div class="flex flex-wrap items-center justify-end gap-2">
-        <Button size="sm" variant="ghost" onclick={() => (open = false)}
-          >Cancel</Button
-        >
-        {#if fallbackOption}
-          <Button
-            size="sm"
-            variant="outline"
-            title={fallbackOption.detail}
-            onclick={useFallback}>{fallbackOption.actionLabel}</Button
-          >
-        {/if}
-        <Button size="sm" onclick={save} disabled={!selectedModelInfo}
-          >{confirmLabel}</Button
-        >
-      </div>
-    </div>
+    <Button size="sm" variant="ghost" onclick={() => (open = false)}
+      >Cancel</Button
+    >
+    {#if fallbackOption}
+      <Button
+        size="sm"
+        variant="outline"
+        title={fallbackOption.detail}
+        onclick={useFallback}>{fallbackOption.actionLabel}</Button
+      >
+    {/if}
+    <Button size="sm" onclick={save} disabled={!selectedModelInfo}
+      >{confirmLabel}</Button
+    >
   {/snippet}
 </Dialog>

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunsDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunsDialog.svelte
@@ -76,7 +76,7 @@ function openRun(taskId: string): void {
   onOpenChange={handleOpenChange}
 >
   <div class="flex min-h-0 flex-col">
-    <div class="flex shrink-0 items-center border-b border-border p-2">
+    <div class="flex shrink-0 items-center border-b border-border/60 p-2">
       <SearchInput
         bind:value={filter}
         class="flex-1"

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanImplementationModelDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanImplementationModelDialog.svelte
@@ -135,7 +135,7 @@ $effect(() => {
   onOpenChange={handleOpenChange}
   class="max-w-xl"
 >
-  <div class="grid gap-4">
+  <div class="grid gap-3">
     <section class="grid gap-2">
       <p
         class="m-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
@@ -196,7 +196,7 @@ $effect(() => {
                 {@const active = entry.key === selectedModelKey}
                 <button
                   type="button"
-                  class={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+                  class={`flex w-full items-center justify-between gap-3 rounded-md border px-2.5 py-1.5 text-left text-sm transition-colors ${
                     active
                       ? "border-primary/40 bg-primary/10 text-primary"
                       : "border-transparent text-foreground hover:bg-accent"
@@ -218,7 +218,7 @@ $effect(() => {
     </section>
 
     {#if selectedModel}
-      <section class="grid gap-2 border-t border-border pt-4">
+      <section class="grid gap-2 border-t border-border/60 pt-3">
         <p
           class="m-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
         >


### PR DESCRIPTION
## Summary
- unify dialog headers, bodies, and footers on one compact card surface
- standardize modal sizing, scrolling, model catalog controls, and narrow project layouts
- make conversation history details responsive while preserving graph interactions
- tighten confirmation dialogs without changing their existing behavior or variants

## Validation
- `pnpm fix && pnpm check && pnpm test`
- visually checked representative form, catalog, onboarding, and project dialogs at desktop and narrow widths