### PR TITLE
Refine projects dialog actions

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/button/button.svelte
+++ b/packages/ui-kit/src/lib/components/ui/button/button.svelte
@@ -7,7 +7,7 @@ import type {
 import { type VariantProps, tv } from "tailwind-variants";
 
 export const buttonVariants = tv({
-  base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 data-[active]:bg-muted data-[active]:text-foreground [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 data-[active]:bg-muted data-[active]:text-foreground [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 cursor-pointer items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   variants: {
     variant: {
       default: "bg-primary text-primary-foreground hover:bg-primary/80",

--- a/packages/workbench-app/src/lib/features/onboarding/guide-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/guide-state.svelte.ts
@@ -279,6 +279,26 @@ async function settlePreparation(): Promise<void> {
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 }
 
+async function settleTargetAnimations(
+  target: HTMLElement | undefined,
+): Promise<void> {
+  if (!target) return;
+  const animations: Animation[] = [];
+  for (
+    let element: HTMLElement | null = target;
+    element;
+    element = element.parentElement
+  ) {
+    for (const animation of element.getAnimations()) {
+      if (["pending", "running"].includes(animation.playState))
+        animations.push(animation);
+    }
+  }
+  if (animations.length === 0) return;
+  await Promise.allSettled(animations.map((animation) => animation.finished));
+  await settlePreparation();
+}
+
 async function prepareTourStep(step: TourStep): Promise<void> {
   const requestId = ++preparationId;
   guideState.preparing = true;
@@ -295,6 +315,7 @@ async function prepareTourStep(step: TourStep): Promise<void> {
     if (conversationSelectors.activeConversation) openConversationHistory();
   }
   await settlePreparation();
+  await settleTargetAnimations(visibleTarget(step.targetId));
   if (requestId !== preparationId || guideState.mode !== "tour") return;
   guideState.targetAvailable = Boolean(visibleTarget(step.targetId));
   guideState.preparing = false;
@@ -343,6 +364,7 @@ async function prepareSetupStep(
     inline: "nearest",
   });
   await settlePreparation();
+  await settleTargetAnimations(target);
   if (
     requestId !== preparationId ||
     !["preparing-coach", "coach"].includes(guideState.mode)

--- a/packages/workbench-app/src/lib/features/onboarding/setup-guide-content.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/setup-guide-content.ts
@@ -35,9 +35,9 @@ export const setupGuideSteps: Record<
     },
     {
       id: "open-project-browse",
-      title: "Browse for a project",
+      title: "Open a project folder",
       description:
-        "Choose Browse to find and open a project folder from your computer.",
+        "Choose Open to find and open a project folder from your computer.",
       targetId: "guide-project-browse",
       fallback:
         "The project browser is already open when there are no recent projects.",

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
@@ -380,11 +380,24 @@ $effect(() => {
 <Dialog
   flush
   bind:open
-  title="Switch project"
+  title="Projects"
   description="Choose a recent project or browse for a folder."
   class="project-picker-dialog"
   onOpenChange={handleOpenChange}
 >
+  {#snippet headerActions()}
+    {#if mode === "recent"}
+      <Button
+        variant="outline"
+        size="sm"
+        data-tour-id="guide-project-browse"
+        onclick={() => enterBrowse()}
+      >
+        <FolderSearch size={14} strokeWidth={2.2} />
+        Open
+      </Button>
+    {/if}
+  {/snippet}
   <div
     class={`grid h-full min-h-0 ${
       mode === "recent"
@@ -462,15 +475,6 @@ $effect(() => {
           ? ""
           : "s"}
       </span>
-      <Button
-        variant="outline"
-        size="sm"
-        data-tour-id="guide-project-browse"
-        onclick={() => enterBrowse()}
-      >
-        <FolderSearch size={14} strokeWidth={2.2} />
-        Browse
-      </Button>
     {:else}
       <DirectoryPickerFooter
         path={openTargetPath}

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -233,7 +233,7 @@ function projectMenu(project: ProjectRecord): ContextMenuItem[] {
           ? "No recent projects match your search."
           : "No recent projects yet."}
       </p>
-      <span class="text-xs">Use Browse below to open a project folder.</span>
+      <span class="text-xs">Use Open above to open a project folder.</span>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- rename the project switcher dialog to Projects and move folder browsing into a header Open action
- add pointer cursors to shared shadcn buttons
- wait for target animations before showing guide steps and update the project guide copy

## Validation
- pnpm fix
- pnpm check
- pnpm test