### PR TITLE
Add Tavily web search setup guide

### DIFF
--- a/packages/workbench-app/src/lib/features/onboarding/components/GuideCatalogDialog.svelte
+++ b/packages/workbench-app/src/lib/features/onboarding/components/GuideCatalogDialog.svelte
@@ -9,6 +9,7 @@ import FolderOpen from "@lucide/svelte/icons/folder-open";
 import KeyRound from "@lucide/svelte/icons/key-round";
 import Mic from "@lucide/svelte/icons/mic";
 import PanelsTopLeft from "@lucide/svelte/icons/panels-top-left";
+import Search from "@lucide/svelte/icons/search";
 import SlidersHorizontal from "@lucide/svelte/icons/sliders-horizontal";
 import type { Component } from "svelte";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
@@ -49,6 +50,7 @@ const icons: Record<GuideId, Component> = {
   voice: Mic,
   "scoped-models": SlidersHorizontal,
   "agent-defaults": Bot,
+  "web-search": Search,
   workbench: PanelsTopLeft,
 };
 

--- a/packages/workbench-app/src/lib/features/onboarding/components/GuidedTourOverlay.svelte
+++ b/packages/workbench-app/src/lib/features/onboarding/components/GuidedTourOverlay.svelte
@@ -48,7 +48,9 @@ let viewportHeight = $state(
 
 const modal = $derived(variant === "modal");
 const last = $derived(index === count - 1);
-const centered = $derived("introducedIn" in step && step.id === "finish");
+const centered = $derived(
+  ("introducedIn" in step && step.id === "finish") || (last && !targetRect),
+);
 const placement = $derived(
   calloutPlacement({
     target: targetRect,

--- a/packages/workbench-app/src/lib/features/onboarding/guide-catalog-policy.test.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/guide-catalog-policy.test.ts
@@ -15,6 +15,7 @@ const noSignals = {
   "project-open": false,
   "provider-ready": false,
   "voice-ready": false,
+  "web-search-ready": false,
 };
 
 describe("guide catalog policy", () => {
@@ -50,6 +51,7 @@ describe("guide catalog policy", () => {
         "project-open": true,
         "provider-ready": true,
         "voice-ready": true,
+        "web-search-ready": true,
       },
     );
     assert.equal(
@@ -64,6 +66,19 @@ describe("guide catalog policy", () => {
       guides.find((guide) => guide.id === "workbench")?.completed,
       false,
     );
+  });
+
+  it("auto-completes the optional web-search guide when Tavily is ready", () => {
+    const guides = resolveGuides(
+      guideCatalog,
+      {},
+      { ...noSignals, "web-search-ready": true },
+    );
+    const webSearch = guides.find((guide) => guide.id === "web-search");
+    assert.equal(webSearch?.priority, "optional");
+    assert.equal(webSearch?.ready, true);
+    assert.equal(webSearch?.completed, true);
+    assert.deepEqual(autoCompletedGuideIds(guides, {}), ["web-search"]);
   });
 
   it("excludes upcoming guides from incomplete counts", () => {

--- a/packages/workbench-app/src/lib/features/onboarding/guide-catalog.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/guide-catalog.ts
@@ -6,6 +6,7 @@ export type GuideId =
   | "voice"
   | "scoped-models"
   | "agent-defaults"
+  | "web-search"
   | "workbench";
 
 export type GuidePriority = "must-do" | "highly-recommended" | "optional";
@@ -13,7 +14,8 @@ export type GuideLifecycle = "available" | "new" | "upcoming";
 export type GuideCompletionSignal =
   | "project-open"
   | "provider-ready"
-  | "voice-ready";
+  | "voice-ready"
+  | "web-search-ready";
 
 export type GuideRun =
   | { kind: "setup-coach"; area: SetupGuideArea }
@@ -89,6 +91,18 @@ export const guideCatalog: readonly GuideDefinition[] = [
     lifecycle: "available",
     actionLabel: "Start guide",
     run: { kind: "setup-coach", area: "agent-defaults" },
+  },
+  {
+    id: "web-search",
+    version: 1,
+    title: "Set up web search",
+    description:
+      "Add a Tavily API key to let agents use the web_search tool for current information.",
+    priority: "optional",
+    lifecycle: "available",
+    actionLabel: "Start guide",
+    run: { kind: "setup-coach", area: "web-search" },
+    completionSignal: "web-search-ready",
   },
   {
     id: "workbench",

--- a/packages/workbench-app/src/lib/features/onboarding/guide-completion.test.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/guide-completion.test.ts
@@ -29,9 +29,13 @@ function memoryStorage(values: Record<string, string> = {}): TestStorage {
 describe("guide completion storage", () => {
   it("reads and writes validated per-guide versions", () => {
     const storage = memoryStorage();
-    writeGuideCompletionVersions({ provider: 1, workbench: 2 }, storage);
+    writeGuideCompletionVersions(
+      { provider: 1, "web-search": 1, workbench: 2 },
+      storage,
+    );
     assert.deepEqual(readGuideCompletionVersions(storage), {
       provider: 1,
+      "web-search": 1,
       workbench: 2,
     });
   });

--- a/packages/workbench-app/src/lib/features/onboarding/guide-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/guide-state.svelte.ts
@@ -85,6 +85,15 @@ export function voiceConfigured(): boolean {
   return hasChatGptAudioAuth(settingsState.authProviders);
 }
 
+export function webSearchConfigured(): boolean {
+  return settingsState.authProviders.some(
+    (provider) =>
+      provider.provider === "tavily" &&
+      provider.configured &&
+      provider.credentialType === "api_key",
+  );
+}
+
 export function scopedModelSummary(): string {
   const count = settingsState.settingsDraft?.scopedModels.length ?? 0;
   if (count === 0) return "All authenticated models are currently available";
@@ -102,6 +111,7 @@ function guideSignals(): GuideSignals {
     "project-open": Boolean(workspaceSelectors.activeProject),
     "provider-ready": providerConfigured(),
     "voice-ready": voiceConfigured(),
+    "web-search-ready": webSearchConfigured(),
   };
 }
 
@@ -139,6 +149,11 @@ export function guideSummary(id: GuideId): string | undefined {
   }
   if (id === "scoped-models") return scopedModelSummary();
   if (id === "agent-defaults") return agentDefaultsSummary().text;
+  if (id === "web-search") {
+    return webSearchConfigured()
+      ? "Web search is ready with Tavily."
+      : "A Tavily API key is not configured yet.";
+  }
   if (id === "workbench") {
     return "Covers conversations, composer controls, panels, Git, tasks, and settings.";
   }

--- a/packages/workbench-app/src/lib/features/onboarding/setup-guide-content.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/setup-guide-content.ts
@@ -3,7 +3,8 @@ export type SetupGuideArea =
   | "provider"
   | "voice"
   | "scoped-models"
-  | "agent-defaults";
+  | "agent-defaults"
+  | "web-search";
 
 export type SetupGuidePreparation =
   | { kind: "auth"; pageId: string; sectionId: string }
@@ -133,6 +134,50 @@ export const setupGuideSteps: Record<
       targetId: "setup-scoped-models-save",
       fallback: "In the Add models dialog, choose Save selection when ready.",
       preparation: { kind: "settings", pageId: "models", sectionId: "models" },
+    },
+  ],
+  "web-search": [
+    {
+      id: "web-search-configure",
+      title: "Configure Tavily",
+      description:
+        "Tavily powers the web_search tool. Open its configuration to add your API key.",
+      targetId: "setup-tavily-configure",
+      fallback:
+        "Open Settings → Tools → Integrations and choose Configure beside Tavily.",
+      preparation: {
+        kind: "settings",
+        pageId: "tools",
+        sectionId: "integrations",
+      },
+      advanceByClickingTarget: true,
+    },
+    {
+      id: "web-search-api-key",
+      title: "Enter your Tavily API key",
+      description:
+        "Paste an API key from your Tavily account. Nerve encrypts the key before sending it to the daemon.",
+      targetId: "setup-tavily-api-key",
+      fallback:
+        "Choose Configure beside Tavily, then paste your API key into the dialog.",
+      preparation: {
+        kind: "settings",
+        pageId: "tools",
+        sectionId: "integrations",
+      },
+    },
+    {
+      id: "web-search-save",
+      title: "Save the API key",
+      description:
+        "Save the key to enable web search for subsequent agent runs.",
+      targetId: "setup-tavily-save",
+      fallback: "In the Tavily configuration dialog, choose Save key.",
+      preparation: {
+        kind: "settings",
+        pageId: "tools",
+        sectionId: "integrations",
+      },
     },
   ],
   "agent-defaults": [

--- a/packages/workbench-app/src/lib/features/onboarding/setup-guide-policy.test.ts
+++ b/packages/workbench-app/src/lib/features/onboarding/setup-guide-policy.test.ts
@@ -45,6 +45,22 @@ describe("setup guide policy", () => {
     assert.equal(steps[0]?.targetId, "setup-auth-openai-codex-connected");
   });
 
+  it("guides web-search setup through Tavily configuration and saving", () => {
+    const steps = setupStepsForArea("web-search", {
+      codexConnected: false,
+    });
+    assert.deepEqual(
+      steps.map((step) => step.targetId),
+      ["setup-tavily-configure", "setup-tavily-api-key", "setup-tavily-save"],
+    );
+    assert.deepEqual(steps[0]?.preparation, {
+      kind: "settings",
+      pageId: "tools",
+      sectionId: "integrations",
+    });
+    assert.equal(steps[0]?.advanceByClickingTarget, true);
+  });
+
   it("opens required dialogs when advancing to dialog-backed steps", () => {
     assert.equal(
       setupStepsForArea("voice", { codexConnected: false })[0]
@@ -53,6 +69,11 @@ describe("setup guide policy", () => {
     );
     assert.equal(
       setupStepsForArea("scoped-models", { codexConnected: false })[0]
+        ?.advanceByClickingTarget,
+      true,
+    );
+    assert.equal(
+      setupStepsForArea("web-search", { codexConnected: false })[0]
         ?.advanceByClickingTarget,
       true,
     );

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/IntegrationsSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/IntegrationsSection.svelte
@@ -67,6 +67,7 @@ const manualPythonPath = $derived(
         <Button
           size="xs"
           variant="outline"
+          data-tour-id="setup-tavily-configure"
           onclick={() => (tavilyDialogOpen = true)}>Configure</Button
         >
       {/snippet}

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/TavilyKeyDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/TavilyKeyDialog.svelte
@@ -111,6 +111,7 @@ async function removeKey(): Promise<void> {
       </Label>
       <Input
         id="tools-tavily-key"
+        data-tour-id="setup-tavily-api-key"
         type="password"
         autocomplete="off"
         placeholder={configured
@@ -152,6 +153,7 @@ async function removeKey(): Promise<void> {
     {/if}
     <Button
       size="sm"
+      data-tour-id="setup-tavily-save"
       disabled={busy || apiKey.trim().length === 0}
       onclick={() => void saveKey()}
     >


### PR DESCRIPTION
## Summary
- add an optional three-step Tavily setup guide for the web search tool
- open Tools integrations and coach users through configuring and saving an API key
- auto-complete the guide when Tavily is configured and cover the flow with onboarding tests

## Validation
- pnpm fix && pnpm check && pnpm test