### PR TITLE
fix: stop manufacturing a CI environment for shell tasks

### DIFF
--- a/packages/tools/src/execution/shell/bash.ts
+++ b/packages/tools/src/execution/shell/bash.ts
@@ -16,7 +16,6 @@ function nonInteractiveShellEnv(): NodeJS.ProcessEnv {
     GIT_PAGER: "cat",
     GIT_TERMINAL_PROMPT: "0",
     TERM: "dumb",
-    CI: process.env.CI ?? "1",
   };
 }
 

--- a/packages/tools/test/bash.test.ts
+++ b/packages/tools/test/bash.test.ts
@@ -43,7 +43,7 @@ describe("bash executor", () => {
     const project = await createTempProject();
     const result = await executeBash(
       {
-        command: `${node} -e "process.stdout.write(JSON.stringify({ PAGER: process.env.PAGER, GIT_PAGER: process.env.GIT_PAGER, GIT_TERMINAL_PROMPT: process.env.GIT_TERMINAL_PROMPT, TERM: process.env.TERM, CI: process.env.CI }))"`,
+        command: `${node} -e "process.stdout.write(JSON.stringify({ PAGER: process.env.PAGER, GIT_PAGER: process.env.GIT_PAGER, GIT_TERMINAL_PROMPT: process.env.GIT_TERMINAL_PROMPT, TERM: process.env.TERM }))"`,
       },
       { cwd: project.root },
     );
@@ -53,7 +53,25 @@ describe("bash executor", () => {
     assert.equal(env.GIT_PAGER, "cat");
     assert.equal(env.GIT_TERMINAL_PROMPT, "0");
     assert.equal(env.TERM, "dumb");
-    assert.equal(env.CI, process.env.CI ?? "1");
+  });
+
+  it("does not manufacture a CI environment", async () => {
+    const inheritedCi = process.env.CI;
+    delete process.env.CI;
+    try {
+      const project = await createTempProject();
+      const result = await executeBash(
+        {
+          command: `${node} -e "process.stdout.write(process.env.CI ?? 'unset')"`,
+        },
+        { cwd: project.root },
+      );
+
+      assert.equal(result.stdout, "unset");
+    } finally {
+      if (inheritedCi === undefined) delete process.env.CI;
+      else process.env.CI = inheritedCi;
+    }
   });
 
   it("uses configured shellPath instead of the platform default shell", async (t) => {

--- a/packages/workbench-server/src/domains/tasks/process-runtime/shell.ts
+++ b/packages/workbench-server/src/domains/tasks/process-runtime/shell.ts
@@ -11,7 +11,6 @@ export function processEnvironment(
     GIT_PAGER: "cat",
     GIT_TERMINAL_PROMPT: "0",
     TERM: "dumb",
-    CI: process.env.CI ?? "1",
     ...(overrides ?? {}),
   };
 }

--- a/packages/workbench-server/src/domains/tasks/task-supervisor.ts
+++ b/packages/workbench-server/src/domains/tasks/task-supervisor.ts
@@ -22,7 +22,6 @@ function nonInteractiveShellEnv(
     GIT_PAGER: "cat",
     GIT_TERMINAL_PROMPT: "0",
     TERM: "dumb",
-    CI: process.env.CI ?? "1",
     ...(overrides ?? {}),
   };
 }

--- a/packages/workbench-server/test/process-runtime-driver.test.ts
+++ b/packages/workbench-server/test/process-runtime-driver.test.ts
@@ -5,7 +5,19 @@ import { test } from "node:test";
 import {
   defaultProcessRuntimeDriver,
   observeProcessLifecycle,
+  processEnvironment,
 } from "../src/domains/tasks/process-runtime/index.js";
+
+test("does not manufacture a CI environment for runtime tasks", () => {
+  const inheritedCi = process.env.CI;
+  delete process.env.CI;
+  try {
+    assert.equal(processEnvironment().CI, undefined);
+  } finally {
+    if (inheritedCi === undefined) delete process.env.CI;
+    else process.env.CI = inheritedCi;
+  }
+});
 
 test("replays process exit, close, and error outcomes to late consumers", async () => {
   const closedChild = new EventEmitter() as ChildProcess;

--- a/packages/workbench-server/test/task-supervisor.test.ts
+++ b/packages/workbench-server/test/task-supervisor.test.ts
@@ -78,13 +78,7 @@ function runtime(overrides: Partial<TaskRuntime> = {}): TaskRuntime {
 describe("task supervisor spawn metadata", () => {
   it("spawns with non-interactive pager-safe environment defaults", async () => {
     const output = await collectSpawnedStdout(
-      printEnvCommand([
-        "PAGER",
-        "GIT_PAGER",
-        "GIT_TERMINAL_PROMPT",
-        "TERM",
-        "CI",
-      ]),
+      printEnvCommand(["PAGER", "GIT_PAGER", "GIT_TERMINAL_PROMPT", "TERM"]),
     );
     const env = JSON.parse(output) as Record<string, string>;
 
@@ -92,7 +86,20 @@ describe("task supervisor spawn metadata", () => {
     assert.equal(env.GIT_PAGER, "cat");
     assert.equal(env.GIT_TERMINAL_PROMPT, "0");
     assert.equal(env.TERM, "dumb");
-    assert.equal(env.CI, process.env.CI ?? "1");
+  });
+
+  it("does not manufacture a CI environment for managed tasks", async () => {
+    const inheritedCi = process.env.CI;
+    delete process.env.CI;
+    try {
+      const output = await collectSpawnedStdout(printEnvCommand(["CI"]));
+      const env = JSON.parse(output) as Record<string, string>;
+
+      assert.equal(env.CI, undefined);
+    } finally {
+      if (inheritedCi === undefined) delete process.env.CI;
+      else process.env.CI = inheritedCi;
+    }
   });
 
   it("uses configured shellPath for managed task commands", async () => {


### PR DESCRIPTION
## Summary

Stops forcing `CI=1` into the environment of spawned shell processes. Previously, the bash executor, task supervisor, and process-runtime driver all set `CI` to `"1"` by default when the parent process had no `CI` set. This made tools like `git`, `pnpm`, and test runners behave in CI mode (e.g., progress-suppressed, non-interactive prompts) for what are really local interactive runs.

Now the `CI` variable is left untouched: it is inherited as-is and never manufactured.

## Changes

- `packages/tools/src/execution/shell/bash.ts` — drop the `CI` default from the non-interactive shell env
- `packages/workbench-server/src/domains/tasks/process-runtime/shell.ts` — drop the `CI` default from runtime process env
- `packages/workbench-server/src/domains/tasks/task-supervisor.ts` — drop the `CI` default from managed-task env
- Tests updated to assert `CI` is absent (not defaulted) when it is unset in the parent, in `bash.test.ts`, `process-runtime-driver.test.ts`, and `task-supervisor.test.ts`