### PR TITLE
fix(deps): bump dompurify to 3.4.13 and js-yaml to 4.3.1

### DIFF
--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -42,7 +42,7 @@
     "@tanstack/svelte-virtual": "^3.13.29",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",
-    "dompurify": "3.4.0",
+    "dompurify": "3.4.13",
     "mermaid": "11.16.1",
     "mode-watcher": "^1.1.0",
     "paneforge": "^1.0.2",

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
@@ -6,6 +6,7 @@ import type {
   PlanReviewRecord,
   PlanReviewResolveOptions,
 } from "../../../state/tool-types";
+import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import * as DropdownMenu from "@nervekit/ui-kit/components/ui/dropdown-menu";
 import { SplitButton } from "@nervekit/ui-kit/components/ui/split-button";
@@ -49,6 +50,7 @@ let {
   planReviewModelKey = "",
   planReviewThinkingLevel = "off",
   detailsAction,
+  onOpenFile,
   onAcceptPlanReview,
   onAcceptPlanReviewInNewChat,
   onRejectPlanReview,
@@ -256,11 +258,17 @@ async function rejectPlan() {
 {#if showPlanCard && displayedReview}
   <div class="grid gap-2" aria-label="Plan review">
     {#if preview.trim()}
-      <div
-        class="whitespace-pre-wrap rounded-sm border bg-sidebar p-2.5 font-mono text-xs leading-relaxed text-foreground [overflow-wrap:anywhere]"
-      >
-        {preview}
-      </div>
+      {#if expanded}
+        <div class="min-w-0 rounded-sm border bg-sidebar p-3">
+          <Markdown text={preview} {onOpenFile} />
+        </div>
+      {:else}
+        <div
+          class="whitespace-pre-wrap rounded-sm border bg-sidebar p-2.5 font-mono text-xs leading-relaxed text-foreground [overflow-wrap:anywhere]"
+        >
+          {preview}
+        </div>
+      {/if}
     {/if}
 
     <ToolFooter meta={statusMeta} {detailsAction}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml: 4.3.1
+
 importers:
 
   .:
@@ -192,8 +195,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       dompurify:
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 3.4.13
+        version: 3.4.13
       mermaid:
         specifier: 11.16.1
         version: 11.16.1
@@ -3847,8 +3850,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4706,8 +4709,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -6956,7 +6959,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.1.0
@@ -6967,7 +6970,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.1.0
@@ -7091,7 +7094,7 @@ snapshots:
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 26.3.6(typescript@5.9.3)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       klona: 2.0.6
       magic-string: 0.30.21
       mdast-util-directive: 3.1.0(supports-color@7.2.0)
@@ -10062,7 +10065,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -10146,7 +10149,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 1.1.0
       magicast: 0.5.3
@@ -10336,7 +10339,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2(supports-color@7.2.0)
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -10806,7 +10809,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
       builder-util: 26.15.3(supports-color@7.2.0)
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -10823,7 +10826,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.0:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11988,7 +11991,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -12393,7 +12396,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.0
+      dompurify: 3.4.13
       es-toolkit: 1.50.0
       katex: 0.16.47
       khroma: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages:
   - "packages/*"
+overrides:
+  js-yaml: 4.3.1
 allowBuilds:
   "@google/genai": true
   electron: true


### PR DESCRIPTION
## Summary

Closes 11 open Dependabot alerts:

- **dompurify `3.4.0` → `3.4.13`** — resolves 10 GHSAs (medium/low XSS and sanitizer-bypass issues, most recent `GHSA-55q2-fjhq-7xh7`). Bumped the direct pin in `packages/ui-kit/package.json`; the second copy pulled in transitively by `mermaid@11.16.1` (`^3.3.3`) is updated via the lockfile too. Usage in `mermaid-render.ts` (`USE_PROFILES`, `FORBID_TAGS`, `FORBID_ATTR`) is unchanged and compatible.
- **js-yaml `4.3.0` → `4.3.1`** — resolves `GHSA-5p4m-2wfm-xmqj` (high: quadratic CPU consumption in `!!omap` resolution). js-yaml is a purely transitive dependency (astro/starlight docs tooling + electron-builder). Since all parents declare ranges that already allow `4.3.1`, it's pinned via a root `pnpm.overrides` entry in `pnpm-workspace.yaml` (pnpm 11 reads settings there, not from `package.json`).

## Validation

- `pnpm fix && pnpm check && pnpm test` all pass (eslint/boundaries clean, svelte-check 0 errors in ui-kit & workbench-app, astro check clean, 51/51 desktop-shell tests).
- Lockfile diff scoped strictly to the two packages.

> Note: this PR also carries an unrelated in-progress UI change (`PlanModeToolView.svelte` — render expanded plan review as markdown) committed separately so the dependency fix stays isolated in its own commit.