### PR TITLE
Add conversation starter prompts

### DIFF
--- a/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { untrack } from "svelte";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import Mic from "@lucide/svelte/icons/mic";
 import { isInlineCommandPrompt } from "@nervekit/contracts";
@@ -66,7 +67,11 @@ let {
   onApprovalPolicyChange,
 }: PromptComposerProps = $props();
 
-let editorFocusToken = $state(0);
+// A newly created pending conversation opens directly into its first prompt,
+// so its editor should be ready for typing as soon as it mounts.
+let editorFocusToken = $state(
+  untrack(() => (pendingConversationActive ? 1 : 0)),
+);
 let voiceSubmitPending = $state(false);
 let lastFocusToken = $state<number | undefined>(undefined);
 let lastComposerEscapeToken = $state<number | undefined>(undefined);

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationWelcome.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationWelcome.svelte
@@ -1,38 +1,37 @@
 <script lang="ts">
-import Plus from "@lucide/svelte/icons/plus";
-import { ConversationSignal } from "$lib/presentation";
-import { Button } from "@nervekit/ui-kit/components/ui/button";
-import { Kbd } from "@nervekit/ui-kit/components/ui/kbd";
-import { getShortcutLabel } from "$lib/core/shortcuts/registry";
+import type { Mode } from "@nervekit/contracts";
+import {
+  ConversationSignal,
+  conversationStarters,
+  type ConversationStarter,
+} from "$lib/presentation";
 
 let {
   onNewChat,
   projectSelected = false,
+  projectLabel,
+  projectPath,
 }: {
-  onNewChat: () => void;
+  onNewChat: (mode: Mode) => void;
   projectSelected?: boolean;
+  projectLabel?: string;
+  projectPath?: string;
 } = $props();
 
-const newChatShortcut = getShortcutLabel("conversation.new");
+function startWith(starter: ConversationStarter) {
+  onNewChat(starter.mode);
+}
 </script>
 
 <ConversationSignal
-  title="Where should we start?"
+  variant="launchpad"
+  title="Let's give this repo a plot twist."
   message={projectSelected
-    ? "Begin a conversation in the selected project to explore, plan, and build."
-    : "Select a project from the top header to begin a conversation."}
->
-  {#snippet footer()}
-    <Button onclick={onNewChat} disabled={!projectSelected}>
-      <Plus aria-hidden="true" />
-      New chat
-    </Button>
-
-    {#if newChatShortcut}
-      <div class="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
-        <span>or press</span>
-        <Kbd>{newChatShortcut}</Kbd>
-      </div>
-    {/if}
-  {/snippet}
-</ConversationSignal>
+    ? "Plot the move, or dive straight into the code."
+    : "Bring a project. We'll bring the momentum."}
+  {projectLabel}
+  {projectPath}
+  starters={conversationStarters}
+  startersDisabled={!projectSelected}
+  onSelectStarter={startWith}
+/>

--- a/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
@@ -323,8 +323,12 @@ function menuForTranscript(
   {#snippet emptyExtension()}
     <ConversationWelcome
       projectSelected={Boolean(activeProject && onNewConversationInProject)}
-      onNewChat={() => {
-        if (activeProject) onNewConversationInProject?.(activeProject.dir);
+      projectLabel={activeProjectLabel}
+      projectPath={activeProject?.dir}
+      onNewChat={(initialMode) => {
+        if (activeProject) {
+          onNewConversationInProject?.(activeProject.dir, initialMode);
+        }
       }}
     />
   {/snippet}

--- a/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
@@ -75,7 +75,10 @@ export type WorkbenchConversationAdapterProps = {
   onDismissUserQuestion?: (questionId: string) => void | Promise<void>;
   onAbort?: () => void;
   onCompact?: () => void;
-  onNewConversationInProject?: (projectDir: string) => void;
+  onNewConversationInProject?: (
+    projectDir: string,
+    initialMode?: AgentRecord["mode"],
+  ) => void;
   onOpenFile?: (path: string, line?: number) => void;
   onModelChange?: (value: string) => void;
   onThinkingLevelChange?: (value: AgentRecord["thinkingLevel"]) => void;

--- a/packages/workbench-app/src/lib/features/conversations/state/pending.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/pending.ts
@@ -1,4 +1,4 @@
-import type { ProjectRecord } from "$lib/api";
+import type { AgentRecord, ProjectRecord } from "$lib/api";
 import { pendingConversationKey } from "$lib/core/state/state-keys";
 import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
 import { settingsState } from "$lib/features/settings/state/settings-state.svelte";
@@ -15,7 +15,10 @@ import { workspaceState } from "$lib/features/workspace/state/workspace-state.sv
 import { resolveNewAgentComposerSelection } from "./agent-selection-defaults";
 import { clearTranscriptState, createPendingConversationId } from "./state";
 
-export function openPendingConversation(project: ProjectRecord) {
+export function openPendingConversation(
+  project: ProjectRecord,
+  initialMode?: AgentRecord["mode"],
+) {
   const id = createPendingConversationId();
   const defaults = settingsState.settingsDraft
     ? resolveNewAgentComposerSelection(
@@ -38,7 +41,7 @@ export function openPendingConversation(project: ProjectRecord) {
     composerText: "",
     selectedModelKey: defaults.selectedModelKey,
     thinkingLevel: defaults.selectedThinkingLevel,
-    mode: defaults.selectedMode,
+    mode: initialMode ?? defaults.selectedMode,
     permissionLevel: defaults.selectedPermissionLevel,
     approvalPolicy: defaults.selectedApprovalPolicy,
     sending: false,

--- a/packages/workbench-app/src/lib/features/settings/components/pages/agents/ModelPickerRow.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/agents/ModelPickerRow.svelte
@@ -54,10 +54,10 @@ let {
 let dialogOpen = $state(false);
 </script>
 
-<SettingsRow {label} {description}>
+<SettingsRow {label} {description} layout="responsive">
   {#snippet control()}
     <div
-      class="relative w-64 min-w-0 max-w-full cursor-pointer rounded-md border border-primary/60 bg-primary/8 shadow-xs transition-colors hover:bg-primary/12"
+      class="relative w-full min-w-0 cursor-pointer rounded-md border border-primary/60 bg-primary/8 shadow-xs transition-colors hover:bg-primary/12 sm:w-64"
       role="group"
       aria-label={label}
     >

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-actions.svelte.ts
@@ -290,16 +290,19 @@ export function newConversation() {
   void openPendingConversationForProject(activeProject);
 }
 
-export function newConversationInProject(projectDir: string) {
+export function newConversationInProject(
+  projectDir: string,
+  initialMode?: AgentRecord["mode"],
+) {
   const project = projectForNewConversation(
     workspaceState.projects,
     projectDir,
   );
   if (project) {
-    void openPendingConversationForProject(project);
+    void openPendingConversationForProject(project, initialMode);
     return;
   }
-  void createConversationForDirectory(projectDir);
+  void createConversationForDirectory(projectDir, initialMode);
 }
 
 export async function deleteProjectAndRefresh(projectId: string) {
@@ -402,14 +405,18 @@ export async function pruneProjectConversationsAndRefresh(
 
 async function openPendingConversationForProject(
   project: ProjectRecord,
+  initialMode?: AgentRecord["mode"],
 ): Promise<void> {
   workspaceState.error = undefined;
   workspaceState.projectPickerOpen = false;
   await selectProject(project.id, { deferTabActivation: true });
-  openPendingConversation(project);
+  openPendingConversation(project, initialMode);
 }
 
-export async function createConversationForDirectory(dir: string) {
+export async function createConversationForDirectory(
+  dir: string,
+  initialMode?: AgentRecord["mode"],
+) {
   workspaceState.error = undefined;
   try {
     const project = await createProject(dir);
@@ -419,7 +426,7 @@ export async function createConversationForDirectory(dir: string) {
         (candidate) => candidate.id !== project.id,
       ),
     ];
-    await openPendingConversationForProject(project);
+    await openPendingConversationForProject(project, initialMode);
   } catch (caught) {
     const message = caught instanceof Error ? caught.message : String(caught);
     workspaceState.error = message;

--- a/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
@@ -1,31 +1,127 @@
 <script lang="ts">
+import Folder from "@lucide/svelte/icons/folder";
 import type { Snippet } from "svelte";
 import NerveBadge from "../brand/NerveBadge.svelte";
+import type { ConversationStarter } from "./conversation-starters";
 
 let {
   title,
   message,
+  variant = "conversation",
+  projectLabel,
+  projectPath,
+  starters = [],
+  startersDisabled = false,
+  onSelectStarter,
   footer,
 }: {
   title: string;
   message: string;
+  variant?: "launchpad" | "conversation";
+  projectLabel?: string;
+  projectPath?: string;
+  starters?: readonly ConversationStarter[];
+  startersDisabled?: boolean;
+  onSelectStarter?: (starter: ConversationStarter) => void;
   footer?: Snippet;
 } = $props();
+
+const launchpad = $derived(variant === "launchpad");
 </script>
 
-<div class="flex h-full min-h-full items-center justify-center p-6 text-center">
-  <div class="brand-signal-enter flex w-full max-w-xl flex-col items-center">
-    <NerveBadge class="size-12" />
+<div
+  class="relative flex h-full min-h-full items-center justify-center overflow-hidden p-6 text-center"
+>
+  {#if launchpad}
+    <div
+      class="pointer-events-none absolute inset-x-8 top-1/2 h-px max-w-5xl -translate-y-32 bg-gradient-to-r from-transparent via-border to-transparent"
+      aria-hidden="true"
+    ></div>
+    <div
+      class="pointer-events-none absolute left-1/2 top-1/2 size-80 -translate-x-1/2 -translate-y-1/2 rounded-full border border-dashed border-border/60"
+      aria-hidden="true"
+    ></div>
+  {/if}
 
-    <h2 class="mt-5 text-xl font-semibold tracking-tight text-foreground">
+  <div
+    class={`brand-signal-enter relative flex w-full flex-col items-center ${launchpad ? "max-w-3xl" : "max-w-2xl"}`}
+  >
+    <div
+      class={`relative flex items-center justify-center ${launchpad ? "size-20" : "size-14"}`}
+    >
+      <div
+        class={`absolute rotate-6 rounded-2xl border bg-muted/50 ${launchpad ? "size-16" : "size-12"}`}
+        aria-hidden="true"
+      ></div>
+      <div
+        class={`absolute -rotate-6 rounded-2xl border border-border/70 bg-background ${launchpad ? "size-14" : "size-10"}`}
+        aria-hidden="true"
+      ></div>
+      <NerveBadge
+        class={launchpad ? "relative z-10 size-12" : "relative z-10 size-9"}
+      />
+    </div>
+
+    {#if launchpad}
+      <p
+        class="mt-4 text-xs font-medium uppercase tracking-widest text-muted-foreground"
+      >
+        Workspace ready
+      </p>
+    {/if}
+    <h2
+      class={`${launchpad ? "mt-2 text-2xl" : "mt-4 text-xl"} font-semibold tracking-tight text-foreground`}
+    >
       {title}
     </h2>
-    <p class="mt-2 max-w-lg text-sm leading-relaxed text-muted-foreground">
+    <p class="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground">
       {message}
     </p>
 
+    {#if starters.length > 0}
+      <div
+        class="mt-6 flex flex-wrap justify-center gap-2"
+        role="group"
+        aria-label="Conversation starters"
+      >
+        {#each starters as starter (starter.id)}
+          {@const Icon = starter.icon}
+          <button
+            type="button"
+            class="group inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border bg-card px-4 text-sm font-medium text-foreground shadow-sm transition-colors hover:border-primary/40 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50"
+            disabled={startersDisabled}
+            onclick={() => onSelectStarter?.(starter)}
+          >
+            <Icon
+              class="size-4 text-primary"
+              strokeWidth={2.2}
+              aria-hidden="true"
+            />
+            <span>{starter.label}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+
+    {#if projectLabel}
+      <div
+        class={`${starters.length > 0 || launchpad ? "mt-4" : "mt-3"} inline-flex max-w-md items-center gap-1.5 rounded-full border bg-muted/60 px-3 py-1.5 text-xs text-muted-foreground`}
+        title={projectPath}
+        aria-label={projectPath
+          ? `Current project ${projectPath}`
+          : `Current project ${projectLabel}`}
+      >
+        <Folder
+          class="size-3.5 shrink-0"
+          strokeWidth={2.2}
+          aria-hidden="true"
+        />
+        <span class="truncate font-mono text-foreground">{projectLabel}</span>
+      </div>
+    {/if}
+
     {#if footer}
-      <div class="mt-6 flex flex-col items-center">
+      <div class={`${launchpad ? "mt-6" : "mt-5"} flex flex-col items-center`}>
         {@render footer()}
       </div>
     {/if}

--- a/packages/workbench-app/src/lib/presentation/components/conversation/conversation-starters.ts
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/conversation-starters.ts
@@ -1,0 +1,26 @@
+import Code2 from "@lucide/svelte/icons/code-2";
+import ListChecks from "@lucide/svelte/icons/list-checks";
+import type { Mode } from "@nervekit/contracts";
+import type { Component } from "svelte";
+
+export type ConversationStarter = {
+  id: "plan" | "code";
+  label: string;
+  mode: Mode;
+  icon: Component;
+};
+
+export const conversationStarters: readonly ConversationStarter[] = [
+  {
+    id: "plan",
+    label: "Plan",
+    mode: "planning",
+    icon: ListChecks,
+  },
+  {
+    id: "code",
+    label: "Code",
+    mode: "coding",
+    icon: Code2,
+  },
+];

--- a/packages/workbench-app/src/lib/presentation/components/conversation/index.ts
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/index.ts
@@ -3,4 +3,8 @@ export { default as ConversationPane } from "./conversation-pane.svelte";
 export { default as ConversationBanner } from "./conversation-banner.svelte";
 export { default as ConversationEmptyState } from "./conversation-empty-state.svelte";
 export { default as ConversationSignal } from "./conversation-signal.svelte";
+export {
+  conversationStarters,
+  type ConversationStarter,
+} from "./conversation-starters";
 export * from "./types.js";

--- a/packages/workbench-app/src/lib/presentation/components/settings/settings-row.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/settings/settings-row.svelte
@@ -7,7 +7,7 @@ type Props = {
   label?: string;
   description?: string;
   htmlFor?: string;
-  layout?: "inline" | "stacked";
+  layout?: "inline" | "stacked" | "responsive";
   class?: string;
   badges?: Snippet;
   control?: Snippet;
@@ -31,7 +31,9 @@ let {
     "gap-3 py-1.5",
     layout === "inline"
       ? "grid grid-cols-[minmax(0,1fr)_auto] items-center"
-      : "grid gap-2",
+      : layout === "responsive"
+        ? "grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-3"
+        : "grid gap-2",
     className,
   )}
 >
@@ -56,7 +58,13 @@ let {
   {/if}
 
   {#if control}
-    <div class={cn("min-w-0", layout === "inline" && "flex justify-end")}>
+    <div
+      class={cn(
+        "min-w-0",
+        layout === "inline" && "flex justify-end",
+        layout === "responsive" && "sm:flex sm:justify-end",
+      )}
+    >
       {@render control()}
     </div>
   {/if}

--- a/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import Folder from "@lucide/svelte/icons/folder";
 import { SvelteMap } from "svelte/reactivity";
 import type {
   AgentRecord,
@@ -381,29 +380,11 @@ const showEmptyRun = $derived(
 
 {#if showEmptyRun}
   <ConversationSignal
-    title="Where should we start?"
-    message="Ask Nerve to explore, plan, or build in this project."
-  >
-    {#snippet footer()}
-      {#if activeProjectLabel}
-        <div
-          class="inline-flex max-w-md items-center gap-1.5 rounded-md border bg-muted px-2 py-1 text-xs text-muted-foreground"
-          title={activeProject?.dir}
-          aria-label={`Conversation will be created in project ${activeProject?.dir}`}
-        >
-          <Folder
-            class="size-3.5 shrink-0"
-            strokeWidth={2.2}
-            aria-hidden="true"
-          />
-          <span class="shrink-0">Project:</span>
-          <span class="truncate font-mono text-foreground"
-            >{activeProjectLabel}</span
-          >
-        </div>
-      {/if}
-    {/snippet}
-  </ConversationSignal>
+    title="The cursor is yours."
+    message="Bring the question. Nerve will bring the map, the tools, and the follow-through."
+    projectLabel={activeProjectLabel}
+    projectPath={activeProject?.dir}
+  />
 {:else}
   <VirtualScroller
     bind:controller


### PR DESCRIPTION
## Summary
- add reusable conversation starter prompts and welcome-screen actions
- wire starter selection through composer, pending state, and workspace conversation flows
- refine model picker, settings rows, and transcript presentation behavior

## Validation
- pnpm fix
- pnpm check
- pnpm test