### PR TITLE
feat(workbench): enrich project picker with activity and git overview

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/ProjectDialogs.svelte
+++ b/packages/workbench-app/src/lib/app/shell/ProjectDialogs.svelte
@@ -19,7 +19,6 @@ import {
 
 const status = $derived(workspaceSelectors.status);
 const projects = $derived(workspaceSelectors.projects);
-const conversations = $derived(workspaceSelectors.conversations);
 const projectItems = $derived(workspaceSelectors.projectSwitcherItems);
 const activeConversation = $derived(conversationSelectors.activeConversation);
 const treeNodes = $derived(conversationSelectors.treeNodes);
@@ -43,7 +42,6 @@ async function editConversationEntry(entry: {
 <ProjectDirectoryPicker
   bind:open={workspaceState.projectPickerOpen}
   {projects}
-  {conversations}
   switcherItems={projectItems}
   activeProjectKey={workspaceState.selectedProjectKey}
   homeDir={status?.storage.userHome}

--- a/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
+++ b/packages/workbench-app/src/lib/app/shell/Titlebar.svelte
@@ -92,7 +92,6 @@ let {
     <span class="inline-flex items-center gap-1.5 text-foreground">
       <span class="brand-mark"><NerveMark compact /></span>
     </span>
-    <span class="h-5 w-px bg-border" aria-hidden="true"></span>
     <ProjectSwitcher
       items={projects}
       activeKey={activeProjectKey}

--- a/packages/workbench-app/src/lib/features/git/index.ts
+++ b/packages/workbench-app/src/lib/features/git/index.ts
@@ -1,4 +1,5 @@
 export * from "./api/git.api";
+export { GIT_STALE_MS } from "./state/git-refresh-policy";
 export {
   clearGitContext,
   refreshGitContext,

--- a/packages/workbench-app/src/lib/features/projects/components/DirectoryPickerList.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/DirectoryPickerList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import CheckCircle2 from "@lucide/svelte/icons/check-circle-2";
-import ChevronRight from "@lucide/svelte/icons/chevron-right";
 import Folder from "@lucide/svelte/icons/folder";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
@@ -45,18 +44,8 @@ let {
 }: Props = $props();
 </script>
 
-<div class="min-h-0 overflow-auto p-2" bind:this={listEl}>
+<div class="min-h-0 overflow-x-hidden overflow-y-auto p-2" bind:this={listEl}>
   <section>
-    <header
-      class="flex items-center gap-2 px-1 pt-1 pb-1.5 font-mono text-xs tracking-wide text-muted-foreground uppercase"
-    >
-      <span>Folders</span>
-      {#if !loading && filteredEntries.length}<span
-          class="ml-auto text-muted-foreground tabular-nums"
-          >{filteredEntries.length}</span
-        >{/if}
-    </header>
-
     {#if loading}
       <div class="grid gap-0.5" aria-label="Loading directories">
         {#each [0, 1, 2, 3, 4, 5, 6] as index (index)}<span class="skeleton-row"
@@ -74,6 +63,7 @@ let {
       >
         {#each filteredEntries as entry, fi (entry.path)}
           {@const idx = fi}
+          {@const signals = uniqueSignals(entry.signals)}
           <div
             id={`folder:${entry.path}`}
             class="row"
@@ -98,39 +88,30 @@ let {
               aria-hidden="true"
               class="flex-none text-muted-foreground"
             />
-            <span class="grid min-w-0 gap-px"
+            <span class="grid min-w-0 flex-1 gap-px"
               ><strong
                 class="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap"
                 >{entry.name}</strong
               ></span
             >
-            <span class="flex items-center justify-end gap-1.5">
-              {#if isOpened(entry.path)}<Badge tone="good" size="xs"
-                  ><CheckCircle2 size={11} />Opened</Badge
-                >{/if}
-              {#each uniqueSignals(entry.signals) as signal (signal)}
-                {@const meta = signalMeta[signal]}
-                {@const Icon = meta.icon}
-                <Badge
-                  tone={meta.tone ?? "neutral"}
-                  size="xs"
-                  title={meta.title}
-                  ><Icon size={11} strokeWidth={2.2} />{meta.label}</Badge
-                >
-              {/each}
-              <button
-                class="row-drill"
-                type="button"
-                title="Open folder"
-                aria-label="Open folder"
-                onclick={(e) => {
-                  e.stopPropagation();
-                  void load(entry.path);
-                }}
-              >
-                <ChevronRight size={15} strokeWidth={2.2} aria-hidden="true" />
-              </button>
-            </span>
+            {#if isOpened(entry.path) || signals.length}
+              <span class="flex items-center justify-end gap-1.5">
+                {#if isOpened(entry.path)}<Badge tone="good" size="xs"
+                    ><CheckCircle2 size={11} />Opened</Badge
+                  >{/if}
+                {#each signals as signal (signal)}
+                  {@const meta = signalMeta[signal]}
+                  {@const Icon = meta.icon}
+                  <Badge
+                    tone={meta.tone ?? "neutral"}
+                    size="xs"
+                    title={meta.title}
+                    class="max-[520px]:hidden"
+                    ><Icon size={11} strokeWidth={2.2} />{meta.label}</Badge
+                  >
+                {/each}
+              </span>
+            {/if}
           </div>
         {/each}
       </div>
@@ -157,8 +138,7 @@ let {
 <style>
 .row {
   position: relative;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  display: flex;
   align-items: center;
   gap: 0.6rem;
   width: 100%;
@@ -196,34 +176,6 @@ let {
   width: 2px;
   border-radius: 999px;
   background: var(--primary);
-}
-
-/* The drill affordance is revealed by the row's own hover/selection state. */
-.row-drill {
-  display: inline-grid;
-  place-items: center;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  padding: 0.15rem;
-  color: var(--muted-foreground);
-  cursor: pointer;
-  opacity: 0;
-  transition:
-    opacity 120ms ease,
-    background 120ms ease,
-    color 120ms ease;
-}
-
-.row-drill:hover {
-  background: var(--accent);
-  color: var(--foreground);
-}
-
-.row:hover .row-drill,
-.row.selected .row-drill,
-.row-drill:focus-visible {
-  opacity: 1;
 }
 
 /* Loading placeholder binds the shared picker-sheen keyframe

--- a/packages/workbench-app/src/lib/features/projects/components/DirectoryPickerSearch.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/DirectoryPickerSearch.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
 import ArrowLeft from "@lucide/svelte/icons/arrow-left";
-import ChevronRight from "@lucide/svelte/icons/chevron-right";
 import MoveUp from "@lucide/svelte/icons/move-up";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
 import Switch from "@nervekit/ui-kit/components/ui/switch-field";
-import type { PathCrumb } from "$lib/core/utils/path";
-
 type Props = {
-  crumbs: PathCrumb[];
   loading: boolean;
   parent?: string;
   query: string;
@@ -22,7 +18,6 @@ type Props = {
 };
 
 let {
-  crumbs,
   loading,
   parent,
   query = $bindable(),
@@ -36,50 +31,39 @@ let {
 </script>
 
 <div
-  class="flex items-center gap-2 border-b border-b-border/60 py-1.5 pr-2.5 pl-3 max-[520px]:gap-1 max-[520px]:pr-1.5 max-[520px]:pl-2"
+  class="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1.5 border-b border-border/50 p-2"
 >
-  {#if onBack}
-    <Button
-      variant="ghost"
-      size="icon-sm"
-      title="Back to recents"
-      ariaLabel="Back to recents"
-      onclick={onBack}
-    >
-      <ArrowLeft size={15} strokeWidth={2.2} />
-    </Button>
-    <span class="h-4.5 w-px bg-border/70" aria-hidden="true"></span>
-  {/if}
-  <nav
-    class="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden font-mono text-xs"
-    aria-label="Current location"
+  <span class="flex size-8 items-center justify-center">
+    {#if onBack}
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        title="Back to projects"
+        ariaLabel="Back to projects"
+        onclick={onBack}
+      >
+        <ArrowLeft size={15} strokeWidth={2.2} />
+      </Button>
+    {/if}
+  </span>
+
+  <form
+    class="col-span-3 row-start-2 min-w-0 sm:col-span-1 sm:col-start-2 sm:row-start-1"
+    onsubmit={onSubmit}
   >
-    {#each crumbs as crumb, i (crumb.path)}
-      {#if i > 0}<ChevronRight
-          class="flex-none text-muted-foreground/55 max-[520px]:hidden"
-          size={13}
-          strokeWidth={2.2}
-          aria-hidden="true"
-        />{/if}
-      {#if i === crumbs.length - 1}
-        <span
-          class="max-w-48 cursor-default overflow-hidden px-1 py-0.5 font-medium text-ellipsis whitespace-nowrap text-foreground max-[560px]:max-w-28"
-          title={crumb.path}>{crumb.label}</span
-        >
-      {:else}
-        <button
-          class="max-w-48 cursor-pointer overflow-hidden rounded-sm border-0 bg-transparent px-1 py-0.5 text-ellipsis whitespace-nowrap text-muted-foreground transition-[color,background-color,border-color,box-shadow] duration-120 not-disabled:hover:bg-accent not-disabled:hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground focus-visible:outline-none max-[560px]:max-w-28 max-[520px]:hidden"
-          type="button"
-          title={crumb.path}
-          disabled={loading}
-          onclick={() => onLoad?.(crumb.path)}
-        >
-          {crumb.label}
-        </button>
-      {/if}
-    {/each}
-  </nav>
-  <div class="flex flex-none items-center gap-1">
+    <SearchInput
+      bind:value={query}
+      onValueChange={() => onQueryChange?.(query)}
+      placeholder="Filter folders or paste a path"
+      disabled={loading}
+      inputClass="font-mono"
+      ariaLabel="Filter folders or enter a path"
+    />
+  </form>
+
+  <div
+    class="col-start-3 row-start-1 flex flex-none items-center justify-end gap-0.5"
+  >
     <Button
       variant="ghost"
       size="icon-sm"
@@ -100,24 +84,10 @@ let {
     >
       <RefreshCw size={14} strokeWidth={2.2} />
     </Button>
-    <span class="h-4.5 w-px bg-border/70" aria-hidden="true"></span>
     <Switch
       bind:checked={showHidden}
       label="Hidden"
-      class="h-7 gap-1.5 rounded-sm border border-border/60 bg-input px-1.5 text-xs max-[520px]:gap-1 max-[520px]:px-1"
+      class="h-7 gap-1.5 px-1 text-xs"
     />
   </div>
 </div>
-<form
-  class="grid items-center border-b border-b-border/60 px-3 py-2.5"
-  onsubmit={onSubmit}
->
-  <SearchInput
-    bind:value={query}
-    onValueChange={() => onQueryChange?.(query)}
-    placeholder="Filter folders or paste a path"
-    disabled={loading}
-    inputClass="font-mono"
-    ariaLabel="Filter folders or enter a path"
-  />
-</form>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectCardStatus.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectCardStatus.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+import GitBranch from "@lucide/svelte/icons/git-branch";
+import ListTodo from "@lucide/svelte/icons/list-todo";
+import MessageCircleMore from "@lucide/svelte/icons/message-circle-more";
+import MessageCircleQuestion from "@lucide/svelte/icons/message-circle-question";
+import MessageCircleX from "@lucide/svelte/icons/message-circle-x";
+import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
+import type { ProjectGitOverview } from "$lib/features/projects/state/project-overview";
+import type { ProjectSwitcherItem } from "$lib/features/projects/state/project-switcher";
+
+type Props = {
+  item: ProjectSwitcherItem;
+  git?: ProjectGitOverview;
+  gitLoading?: boolean;
+  gitError?: boolean;
+};
+
+let { item, git, gitLoading = false, gitError = false }: Props = $props();
+
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+const runningLabel = $derived(
+  `${countLabel(item.activity.running, "conversation")} running`,
+);
+const waitingLabel = $derived(
+  `${countLabel(item.activity.needsUser, "conversation")} waiting for you`,
+);
+const failedLabel = $derived(
+  `${countLabel(item.activity.failed, "conversation")} failed`,
+);
+const taskLabel = $derived(
+  `${countLabel(item.tasks.running, "background task")} running`,
+);
+const gitLabel = $derived.by(() => {
+  if (gitLoading && !git) return "Loading Git status";
+  if (gitError) return "Git status unavailable";
+  if (!git || git.repositoryCount === 0) return "No Git repository";
+
+  const repository =
+    git.repositoryCount > 1
+      ? `${git.repositoryCount} repositories`
+      : git.detached
+        ? "Detached HEAD"
+        : (git.branch ?? "Unknown branch");
+  const workingTree = git.changeCount
+    ? countLabel(git.changeCount, "working tree change")
+    : "Clean working tree";
+  const unpublished = git.aheadCount
+    ? countLabel(git.aheadCount, "unpublished commit")
+    : git.upstreamKnown
+      ? "No unpublished commits"
+      : "Unpublished commits unknown";
+  return `${repository}. ${workingTree}. ${unpublished}.`;
+});
+const gitValue = $derived(
+  gitError || !git || git.repositoryCount === 0 ? "—" : git.changeCount,
+);
+const hasActivity = $derived(
+  item.activity.running > 0 ||
+    item.activity.needsUser > 0 ||
+    item.activity.failed > 0 ||
+    item.tasks.running > 0,
+);
+</script>
+
+<div
+  class="flex min-w-0 items-center justify-between gap-3 text-xs tabular-nums"
+  aria-label="Project status summary"
+>
+  <span class="flex min-w-0 items-center gap-1.5">
+    {#if item.activity.needsUser}
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              class="inline-flex cursor-help items-center gap-1 rounded-sm border-0 bg-warning/10 px-1.5 py-0.5 text-warning"
+              aria-label={waitingLabel}
+              onclick={(event) => event.stopPropagation()}
+              onkeydown={(event) => event.stopPropagation()}
+            >
+              <MessageCircleQuestion class="size-3.5" aria-hidden="true" />
+              <span>{item.activity.needsUser}</span>
+            </button>
+          {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content sideOffset={5}>{waitingLabel}</Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+
+    {#if item.activity.failed}
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              class="inline-flex cursor-help items-center gap-1 rounded-sm border-0 bg-destructive/10 px-1.5 py-0.5 text-destructive"
+              aria-label={failedLabel}
+              onclick={(event) => event.stopPropagation()}
+              onkeydown={(event) => event.stopPropagation()}
+            >
+              <MessageCircleX class="size-3.5" aria-hidden="true" />
+              <span>{item.activity.failed}</span>
+            </button>
+          {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content sideOffset={5}>{failedLabel}</Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+
+    {#if item.activity.running}
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              class="inline-flex cursor-help items-center gap-1 rounded-sm border-0 bg-info/10 px-1.5 py-0.5 text-info"
+              aria-label={runningLabel}
+              onclick={(event) => event.stopPropagation()}
+              onkeydown={(event) => event.stopPropagation()}
+            >
+              <MessageCircleMore class="size-3.5" aria-hidden="true" />
+              <span>{item.activity.running}</span>
+            </button>
+          {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content sideOffset={5}>{runningLabel}</Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+
+    {#if item.tasks.running}
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              class="inline-flex cursor-help items-center gap-1 rounded-sm border-0 bg-info/10 px-1.5 py-0.5 text-info"
+              aria-label={taskLabel}
+              onclick={(event) => event.stopPropagation()}
+              onkeydown={(event) => event.stopPropagation()}
+            >
+              <ListTodo class="size-3.5" aria-hidden="true" />
+              <span>{item.tasks.running}</span>
+            </button>
+          {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content sideOffset={5}>{taskLabel}</Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+
+    {#if !hasActivity}
+      <span class="text-muted-foreground">No active work</span>
+    {/if}
+  </span>
+
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        <button
+          {...props}
+          type="button"
+          class={`inline-flex flex-none cursor-help items-center gap-1 rounded-sm border-0 px-1.5 py-0.5 ${git && git.repositoryCount > 0 ? (git.changeCount ? "bg-warning/10 text-warning" : "bg-success/10 text-success") : "bg-transparent text-muted-foreground"}`}
+          aria-label={gitLabel}
+          onclick={(event) => event.stopPropagation()}
+          onkeydown={(event) => event.stopPropagation()}
+        >
+          <GitBranch class="size-3.5" aria-hidden="true" />
+          {#if gitLoading && !git}
+            <Skeleton class="h-3 w-4" aria-label="Loading Git status" />
+          {:else}
+            <span>{gitValue}</span>
+          {/if}
+        </button>
+      {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content sideOffset={5} class="max-w-72">
+      {gitLabel}
+    </Tooltip.Content>
+  </Tooltip.Root>
+</div>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { SvelteMap, SvelteSet } from "svelte/reactivity";
+import { untrack } from "svelte";
+import { MediaQuery, SvelteSet } from "svelte/reactivity";
 import FolderSearch from "@lucide/svelte/icons/folder-search";
 import { writeClipboardText } from "$lib/core/clipboard";
 import { notify } from "$lib/features/notifications/notify.svelte";
@@ -9,9 +10,10 @@ import {
   listDirectories,
   type FilesystemDirectoryResponse,
   type ProjectRecord,
-  type ConversationRecord,
 } from "$lib/api";
-import { looksLikePath, pathBreadcrumbs, pathKey } from "$lib/core/utils/path";
+import { queryClient, queryKeys } from "$lib/core/query";
+import { discoverGitRepos, GIT_STALE_MS } from "$lib/features/git";
+import { looksLikePath, pathKey } from "$lib/core/utils/path";
 import DirectoryPickerFooter from "./DirectoryPickerFooter.svelte";
 import DirectoryPickerList from "./DirectoryPickerList.svelte";
 import DirectoryPickerSearch from "./DirectoryPickerSearch.svelte";
@@ -22,14 +24,14 @@ import {
   uniqueSignals,
 } from "./directory-picker-helpers";
 import type { FilesystemEntry, NavItem } from "./directory-picker-types";
-import type {
-  ProjectActivitySummary,
-  ProjectSwitcherItem,
-} from "$lib/features/projects/state/project-switcher";
+import type { ProjectSwitcherItem } from "$lib/features/projects/state/project-switcher";
+import {
+  summarizeProjectGit,
+  type ProjectGitOverview,
+} from "$lib/features/projects/state/project-overview";
 type Props = {
   open?: boolean;
   projects?: ProjectRecord[];
-  conversations?: ConversationRecord[];
   switcherItems?: ProjectSwitcherItem[];
   activeProjectKey?: string;
   homeDir?: string;
@@ -42,7 +44,6 @@ type Props = {
 let {
   open = $bindable(false),
   projects = [],
-  conversations = [],
   switcherItems = [],
   activeProjectKey,
   homeDir,
@@ -65,69 +66,42 @@ let wasOpen = $state(false);
 let previousShowHidden = $state(false);
 let listEl = $state<HTMLDivElement | undefined>(undefined);
 let recentScrollEl = $state<HTMLDivElement | undefined>(undefined);
+let gitByProjectKey = $state<Record<string, ProjectGitOverview>>({});
+let gitLoadingByProjectKey = $state<Record<string, boolean>>({});
+let gitErrorByProjectKey = $state<Record<string, boolean>>({});
+let gitLoadGeneration = 0;
+const gitInFlightProjectKeys = new SvelteSet<string>();
 const openedProjectKeys = $derived.by(
   () => new Set(projects.map((project) => pathKey(project.dir))),
 );
-const activityByProjectId = $derived.by(() => {
-  const map = new SvelteMap<string, ProjectActivitySummary>();
-  for (const item of switcherItems) {
-    for (const id of item.projectIds) map.set(id, item.activity);
-  }
-  return map;
-});
-const currentProjectIds = $derived.by(() => {
-  const active = switcherItems.find((item) => item.key === activeProjectKey);
-  return new SvelteSet(active?.projectIds ?? []);
-});
-const lastAccessedByProjectId = $derived.by(() => {
-  const map = new SvelteMap<string, number>();
-  for (const item of switcherItems) {
-    if (item.lastAccessedAt === undefined) continue;
-    for (const id of item.projectIds) map.set(id, item.lastAccessedAt);
-  }
-  return map;
-});
-const conversationCounts = $derived.by(() => {
-  const counts = new SvelteMap<string, number>();
-  for (const conversation of conversations) {
-    counts.set(
-      conversation.projectId,
-      (counts.get(conversation.projectId) ?? 0) + 1,
-    );
-  }
-  return counts;
-});
-const recentProjects = $derived.by(() => {
-  const seen = new SvelteSet<string>();
-  return [...projects]
-    .sort(
-      (a, b) =>
-        (lastAccessedByProjectId.get(b.id) ?? 0) -
-          (lastAccessedByProjectId.get(a.id) ?? 0) ||
-        b.updatedAt.localeCompare(a.updatedAt),
-    )
-    .filter((project) => {
-      const key = pathKey(project.dir);
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    })
-    .slice(0, 24);
-});
+const phoneViewport =
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? new MediaQuery("max-width: 639px")
+    : undefined;
+const recentProjects = $derived(switcherItems.slice(0, 24));
+const defaultRecentLimit = $derived(phoneViewport?.current ? 4 : 8);
+const defaultRecentProjects = $derived.by(() =>
+  recentProjects
+    .slice(0, defaultRecentLimit)
+    .sort((a, b) =>
+      a.label.localeCompare(b.label, undefined, { sensitivity: "base" }),
+    ),
+);
 const pathQuery = $derived(looksLikePath(query.trim()));
 const filteredRecents = $derived.by(() => {
   if (pathQuery) return [];
   const q = query.trim().toLowerCase();
-  if (!q) return recentProjects;
+  if (!q) return defaultRecentProjects;
   return recentProjects.filter(
-    (project) =>
-      project.name.toLowerCase().includes(q) ||
-      project.dir.toLowerCase().includes(q),
+    (item) =>
+      item.label.toLowerCase().includes(q) ||
+      item.project.name.toLowerCase().includes(q) ||
+      item.project.dir.toLowerCase().includes(q),
   );
 });
 const recentActiveDescendant = $derived(
-  recentSelectedIndex >= 0
-    ? `recent:${filteredRecents[recentSelectedIndex]?.id}`
+  recentSelectedIndex >= 0 && filteredRecents[recentSelectedIndex]
+    ? `recent:${encodeURIComponent(filteredRecents[recentSelectedIndex].key)}`
     : undefined,
 );
 const filteredEntries = $derived.by(() => {
@@ -158,12 +132,8 @@ const openTargetSignals = $derived(
   ),
 );
 const activeDescendant = $derived(selectedItem?.id);
-const crumbs = $derived(pathBreadcrumbs(listing?.path, homeDir));
 function isOpened(path: string): boolean {
   return openedProjectKeys.has(pathKey(path));
-}
-function conversationCountFor(project: ProjectRecord): number {
-  return conversationCounts.get(project.id) ?? 0;
 }
 async function load(path?: string) {
   loading = true;
@@ -194,6 +164,9 @@ function scrollRecentIntoView() {
       ?.querySelector('[role="option"][aria-selected="true"]')
       ?.scrollIntoView({ block: "nearest" });
   });
+}
+function resetRecentSelection() {
+  recentSelectedIndex = -1;
 }
 function enterBrowse(path?: string) {
   mode = "browse";
@@ -227,7 +200,7 @@ function handleSubmit(event: Event) {
   if (mode === "recent") {
     const target =
       filteredRecents[recentSelectedIndex >= 0 ? recentSelectedIndex : 0];
-    if (target) void chooseProject(target.id);
+    if (target) void chooseProject(target.project.id);
     return;
   }
   const first = navItems[0];
@@ -254,13 +227,13 @@ function handleFolderRowKeydown(
 function handleRecentRowKeydown(
   event: KeyboardEvent,
   index: number,
-  project: ProjectRecord,
+  item: ProjectSwitcherItem,
 ) {
   if (event.key === "Enter" || event.key === " ") {
     event.preventDefault();
     event.stopPropagation();
     recentSelectedIndex = index;
-    void chooseProject(project.id);
+    void chooseProject(item.project.id);
   }
 }
 async function copyPath(path: string) {
@@ -270,6 +243,46 @@ async function copyPath(path: string) {
   } catch {
     notify.error("Could not copy to clipboard");
   }
+}
+async function loadRecentGit(items: ProjectSwitcherItem[], generation: number) {
+  let nextIndex = 0;
+  async function worker() {
+    while (generation === gitLoadGeneration && open && mode === "recent") {
+      const item = items[nextIndex++];
+      if (!item) return;
+      if (
+        gitByProjectKey[item.key] ||
+        gitErrorByProjectKey[item.key] ||
+        gitInFlightProjectKeys.has(item.key)
+      ) {
+        continue;
+      }
+
+      gitInFlightProjectKeys.add(item.key);
+      gitLoadingByProjectKey[item.key] = true;
+      try {
+        const discovery = await queryClient.fetchQuery({
+          queryKey: queryKeys.git.repos(item.project.id),
+          queryFn: () => discoverGitRepos(item.project.id),
+          staleTime: GIT_STALE_MS,
+        });
+        gitByProjectKey[item.key] = summarizeProjectGit(discovery);
+      } catch {
+        if (!gitByProjectKey[item.key]) gitErrorByProjectKey[item.key] = true;
+      } finally {
+        gitInFlightProjectKeys.delete(item.key);
+        gitLoadingByProjectKey[item.key] = false;
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: 4 }, () => worker()));
+}
+function recentGridColumns(): number {
+  return typeof window !== "undefined" &&
+    window.matchMedia("(min-width: 768px)").matches
+    ? 2
+    : 1;
 }
 function handleRecentKeydown(event: KeyboardEvent) {
   const target = event.target as HTMLElement | null;
@@ -282,15 +295,31 @@ function handleRecentKeydown(event: KeyboardEvent) {
         recentSelectedIndex =
           recentSelectedIndex < 0
             ? 0
-            : Math.min(recentSelectedIndex + 1, count - 1);
+            : Math.min(recentSelectedIndex + recentGridColumns(), count - 1);
         scrollRecentIntoView();
       }
       break;
     case "ArrowUp":
       event.preventDefault();
       if (count) {
-        recentSelectedIndex =
-          recentSelectedIndex <= 0 ? 0 : recentSelectedIndex - 1;
+        recentSelectedIndex = Math.max(
+          0,
+          recentSelectedIndex - recentGridColumns(),
+        );
+        scrollRecentIntoView();
+      }
+      break;
+    case "ArrowRight":
+      if (!inInput && recentGridColumns() > 1 && count) {
+        event.preventDefault();
+        recentSelectedIndex = Math.min(recentSelectedIndex + 1, count - 1);
+        scrollRecentIntoView();
+      }
+      break;
+    case "ArrowLeft":
+      if (!inInput && recentGridColumns() > 1 && count) {
+        event.preventDefault();
+        recentSelectedIndex = Math.max(0, recentSelectedIndex - 1);
         scrollRecentIntoView();
       }
       break;
@@ -304,7 +333,7 @@ function handleRecentKeydown(event: KeyboardEvent) {
       {
         const target2 =
           filteredRecents[recentSelectedIndex >= 0 ? recentSelectedIndex : 0];
-        if (target2) void chooseProject(target2.id);
+        if (target2) void chooseProject(target2.project.id);
       }
       break;
   }
@@ -363,11 +392,19 @@ function handleKeydown(event: KeyboardEvent) {
   else handleBrowseKeydown(event);
 }
 $effect(() => {
+  const items = open && mode === "recent" ? filteredRecents : [];
+  const generation = ++gitLoadGeneration;
+  if (!items.length || typeof window === "undefined") return;
+  untrack(() => void loadRecentGit(items, generation));
+});
+$effect(() => {
   if (open && !wasOpen) {
     mode = recentProjects.length ? "recent" : "browse";
     recentSelectedIndex = -1;
     selectedIndex = -1;
     query = "";
+    gitByProjectKey = {};
+    gitErrorByProjectKey = {};
     void load(listing?.path || undefined);
   }
   wasOpen = open;
@@ -377,30 +414,44 @@ $effect(() => {
   previousShowHidden = showHidden;
 });
 </script>
+
+{#snippet recentFooter()}
+  <Button
+    variant="outline"
+    size="sm"
+    data-tour-id="guide-project-browse"
+    onclick={() => enterBrowse()}
+  >
+    <FolderSearch size={14} strokeWidth={2.2} />
+    Browse
+  </Button>
+{/snippet}
+
+{#snippet browseFooter()}
+  <DirectoryPickerFooter
+    path={openTargetPath}
+    {homeDir}
+    signals={openTargetSignals}
+    {signalMeta}
+    {loading}
+    onOpen={() => void openTarget()}
+  />
+{/snippet}
+
 <Dialog
   flush
   bind:open
-  title="Projects"
-  description="Choose a recent project or browse for a folder."
-  class="project-picker-dialog"
+  title={mode === "recent" ? "Projects" : "Open Project"}
+  description={mode === "recent"
+    ? "Choose a recent project or browse for a folder."
+    : "Choose a folder to open as a project."}
+  class={`project-picker-dialog ${mode === "recent" ? "project-picker-dialog-recent" : ""}`}
+  footer={mode === "recent" ? recentFooter : browseFooter}
   onOpenChange={handleOpenChange}
 >
-  {#snippet headerActions()}
-    {#if mode === "recent"}
-      <Button
-        variant="outline"
-        size="sm"
-        data-tour-id="guide-project-browse"
-        onclick={() => enterBrowse()}
-      >
-        <FolderSearch size={14} strokeWidth={2.2} />
-        Open
-      </Button>
-    {/if}
-  {/snippet}
   <div
     class={`grid h-full min-h-0 ${
-      mode === "recent"
+      mode === "recent" || !error
         ? "grid-rows-[auto_minmax(0,1fr)]"
         : "grid-rows-[auto_auto_minmax(0,1fr)]"
     }`}
@@ -410,30 +461,31 @@ $effect(() => {
     {#if mode === "recent"}
       <RecentProjectsView
         bind:scrollEl={recentScrollEl}
-        recentProjects={filteredRecents}
+        items={filteredRecents}
         totalRecentCount={recentProjects.length}
+        defaultProjectCount={defaultRecentLimit}
         bind:query
         {pathQuery}
         selectedIndex={recentSelectedIndex}
         activeDescendant={recentActiveDescendant}
+        {activeProjectKey}
         {homeDir}
         {loading}
-        {conversationCountFor}
-        activityFor={(project) => activityByProjectId.get(project.id)}
-        lastAccessedFor={(project) => lastAccessedByProjectId.get(project.id)}
-        isCurrent={(project) => currentProjectIds.has(project.id)}
-        onOpen={(project) => void chooseProject(project.id)}
+        {gitByProjectKey}
+        {gitLoadingByProjectKey}
+        {gitErrorByProjectKey}
+        onOpen={(item) => void chooseProject(item.project.id)}
         onNewChat={(path) => void onNewChat?.(path)}
         onCopyPath={(path) => void copyPath(path)}
         {onForget}
+        onBrowse={() => enterBrowse()}
         onBrowsePath={() => enterBrowse(expandHome(query, homeDir))}
-        onQueryChange={() => (recentSelectedIndex = -1)}
+        onQueryChange={resetRecentSelection}
         onSubmit={handleSubmit}
         onRowKeydown={handleRecentRowKeydown}
       />
     {:else}
       <DirectoryPickerSearch
-        {crumbs}
         {loading}
         parent={listing?.parent}
         bind:query
@@ -445,9 +497,7 @@ $effect(() => {
         onBack={recentProjects.length ? enterRecent : undefined}
       />
       {#if error}
-        <p
-          class="m-0 border-b border-b-border/60 px-3 py-2 text-xs text-destructive"
-        >
+        <p class="m-0 px-3 py-2 text-xs text-destructive">
           {error}
         </p>
       {/if}
@@ -468,24 +518,6 @@ $effect(() => {
       />
     {/if}
   </div>
-  {#snippet footer()}
-    {#if mode === "recent"}
-      <span class="flex-1 text-xs text-muted-foreground">
-        {recentProjects.length} recent project{recentProjects.length === 1
-          ? ""
-          : "s"}
-      </span>
-    {:else}
-      <DirectoryPickerFooter
-        path={openTargetPath}
-        {homeDir}
-        signals={openTargetSignals}
-        {signalMeta}
-        {loading}
-        onOpen={() => void openTarget()}
-      />
-    {/if}
-  {/snippet}
 </Dialog>
 
 <style>
@@ -493,18 +525,30 @@ $effect(() => {
  * globally on the shell's own element (escape-hatch reason 5). The compound
  * selector keeps it ahead of `.dialog-content`'s default width. */
 :global(.dialog-content.project-picker-dialog) {
-  width: min(680px, calc(100vw - 24px));
-  width: min(680px, calc(100dvw - 1.5rem));
-  min-height: min(82vh, 520px);
-  min-height: min(82dvh, 520px);
-  max-height: min(82vh, 720px);
-  max-height: min(82dvh, 720px);
+  width: min(820px, calc(100vw - 24px));
+  width: min(820px, calc(100dvw - 1.5rem));
+  height: min(680px, calc(100vh - 48px));
+  height: min(680px, calc(100dvh - 3rem));
+  min-height: 0;
+  max-height: none;
+}
+
+:global(.dialog-content.project-picker-dialog.project-picker-dialog-recent) {
+  height: auto;
+  max-height: min(640px, calc(100vh - 48px));
+  max-height: min(640px, calc(100dvh - 3rem));
 }
 
 @media (max-width: 560px) {
   :global(.dialog-content.project-picker-dialog) {
     width: calc(100vw - 12px);
     width: calc(100dvw - 0.75rem);
+    height: calc(100vh - 12px);
+    height: calc(100dvh - 0.75rem);
+  }
+
+  :global(.dialog-content.project-picker-dialog.project-picker-dialog-recent) {
+    height: auto;
     max-height: calc(100vh - 12px);
     max-height: calc(100dvh - 0.75rem);
   }

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -4,13 +4,10 @@ import { Button } from "@nervekit/ui-kit/components/ui/button";
 import ContextMenu, {
   type ContextMenuItem,
 } from "@nervekit/ui-kit/components/ui/context-menu-list";
-import { StatusDot } from "@nervekit/ui-kit/components/ui/status-dot";
+import { getShortcutAriaLabel } from "$lib/core/shortcuts/registry";
 import {
-  getShortcutAriaLabel,
-  getShortcutLabel,
-} from "$lib/core/shortcuts/registry";
-import {
-  projectActivityIndicator,
+  projectActivitySignal,
+  type ProjectActivitySignal,
   type ProjectSwitcherItem,
 } from "$lib/features/projects/state/project-switcher";
 
@@ -30,15 +27,24 @@ let {
   onOpenPicker,
 }: Props = $props();
 
-const switchShortcut = getShortcutLabel("conversation.newFromProject");
-const switchTitle = switchShortcut
-  ? `Switch project (${switchShortcut})`
-  : "Switch project";
 const switchAria = getShortcutAriaLabel("conversation.newFromProject");
-
 function tabLabel(item: ProjectSwitcherItem): string {
-  const indicator = projectActivityIndicator(item.activity);
-  return indicator ? `${item.label}: ${indicator.summary}` : item.label;
+  const signal = projectActivitySignal(item.activity, item.tasks);
+  return signal ? `${item.label}: ${signal.summary}` : item.label;
+}
+
+function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
+  if (tone === "warn") return "border-warning/60 text-warning";
+  if (tone === "danger") return "border-destructive/60 text-destructive";
+  return "border-info/60 text-info";
+}
+
+function conversationSignalTintClass(
+  tone: ProjectActivitySignal["tone"],
+): string {
+  if (tone === "warn") return "bg-warning/25";
+  if (tone === "danger") return "bg-destructive/25";
+  return "bg-info/25";
 }
 </script>
 
@@ -51,7 +57,6 @@ function tabLabel(item: ProjectSwitcherItem): string {
     size="icon-sm"
     class="shrink-0 [-webkit-app-region:no-drag]"
     ariaLabel="Switch project"
-    title={switchTitle}
     data-tour-id="guide-project-open"
     aria-keyshortcuts={switchAria}
     onclick={() => onOpenPicker?.()}
@@ -60,7 +65,9 @@ function tabLabel(item: ProjectSwitcherItem): string {
   </Button>
   <div class="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
     {#each items as item (item.key)}
-      {@const indicator = projectActivityIndicator(item.activity)}
+      {@const signal = projectActivitySignal(item.activity, item.tasks)}
+      {@const conversationActivityCount =
+        item.activity.needsUser + item.activity.failed + item.activity.running}
       {@const active = item.key === activeKey}
       <ContextMenu
         items={buildMenuItems?.(item) ?? []}
@@ -70,20 +77,38 @@ function tabLabel(item: ProjectSwitcherItem): string {
         <Button
           variant="ghost"
           size="sm"
-          class={`w-full min-w-0 gap-1.5 px-2 ${active ? "" : "text-muted-foreground"}`}
-          {active}
+          class={`w-full min-w-0 gap-1.5 rounded-xl px-2 ${active ? "border-border bg-muted/80 text-foreground hover:bg-muted" : "border-border/60 bg-muted/30 text-muted-foreground hover:border-border hover:bg-muted/70 hover:text-foreground"}`}
           pressed={active}
           aria-current={active ? "page" : undefined}
           ariaLabel={tabLabel(item)}
-          title={`${item.project.dir}${indicator ? ` — ${indicator.summary}` : ""}`}
           onclick={() => onSelect?.(item.project.id)}
         >
-          {#if indicator}
-            <StatusDot
-              tone={indicator.tone}
-              size="xs"
-              pulse={indicator.pulse}
-            />
+          {#if signal}
+            <span
+              class="isolate inline-flex flex-none items-center -space-x-1"
+              aria-hidden="true"
+            >
+              {#if conversationActivityCount}
+                <span
+                  class={`relative z-10 inline-flex size-4 items-center justify-center rounded-full border bg-popover text-xs leading-none tabular-nums ${conversationSignalClass(signal.tone)}`}
+                >
+                  <span
+                    class={`absolute inset-0 rounded-full ${conversationSignalTintClass(signal.tone)}`}
+                  ></span>
+                  <span class="relative z-10">{conversationActivityCount}</span>
+                </span>
+              {/if}
+              {#if item.tasks.running}
+                <span
+                  class="relative z-0 inline-flex size-4 items-center justify-center rounded-full border border-info/60 bg-popover text-info"
+                >
+                  <span class="absolute inset-0 rounded-full bg-info/25"></span>
+                  <span class="relative z-10 text-xs leading-none tabular-nums"
+                    >{item.tasks.running}</span
+                  >
+                </span>
+              {/if}
+            </span>
           {/if}
           <span class="truncate">{item.label}</span>
         </Button>

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -2,108 +2,102 @@
 import ArrowRight from "@lucide/svelte/icons/arrow-right";
 import Copy from "@lucide/svelte/icons/copy";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
-import LayoutPanelLeft from "@lucide/svelte/icons/layout-panel-left";
+import FolderSearch from "@lucide/svelte/icons/folder-search";
 import Plus from "@lucide/svelte/icons/plus";
 import Trash2 from "@lucide/svelte/icons/trash-2";
-import type { ProjectRecord } from "$lib/api";
+import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import ContextMenu, {
   type ContextMenuItem,
 } from "@nervekit/ui-kit/components/ui/context-menu-list";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
-import { StatusDot } from "@nervekit/ui-kit/components/ui/status-dot";
-import { dateTimeLabel, relativeTimeLabel } from "$lib/core/utils/time";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 import { tildePath } from "$lib/core/utils/path";
-import {
-  projectActivityIndicator,
-  type ProjectActivitySummary,
-} from "$lib/features/projects/state/project-switcher";
+import type { ProjectGitOverview } from "$lib/features/projects/state/project-overview";
+import type { ProjectSwitcherItem } from "$lib/features/projects/state/project-switcher";
+import ProjectCardStatus from "./ProjectCardStatus.svelte";
 
 type Props = {
   scrollEl?: HTMLDivElement;
-  recentProjects: ProjectRecord[];
+  items: ProjectSwitcherItem[];
   totalRecentCount: number;
+  defaultProjectCount: number;
   query: string;
   pathQuery: boolean;
   selectedIndex: number;
   activeDescendant?: string;
+  activeProjectKey?: string;
   homeDir?: string;
   loading: boolean;
-  conversationCountFor: (project: ProjectRecord) => number;
-  activityFor?: (project: ProjectRecord) => ProjectActivitySummary | undefined;
-  lastAccessedFor?: (project: ProjectRecord) => number | undefined;
-  isCurrent?: (project: ProjectRecord) => boolean;
-  onOpen: (project: ProjectRecord) => void;
+  gitByProjectKey: Record<string, ProjectGitOverview>;
+  gitLoadingByProjectKey: Record<string, boolean>;
+  gitErrorByProjectKey: Record<string, boolean>;
+  onOpen: (item: ProjectSwitcherItem) => void;
   onForget?: (projectId: string) => void;
   onCopyPath: (path: string) => void;
   onNewChat: (path: string) => void;
+  onBrowse: () => void;
   onBrowsePath: () => void;
   onQueryChange?: () => void;
   onSubmit?: (event: Event) => void;
   onRowKeydown: (
     event: KeyboardEvent,
     index: number,
-    project: ProjectRecord,
+    item: ProjectSwitcherItem,
   ) => void;
 };
 
 let {
   scrollEl = $bindable(),
-  recentProjects,
+  items,
   totalRecentCount,
+  defaultProjectCount,
   query = $bindable(),
   pathQuery,
   selectedIndex,
   activeDescendant,
+  activeProjectKey,
   homeDir,
   loading,
-  conversationCountFor,
-  activityFor,
-  lastAccessedFor,
-  isCurrent,
+  gitByProjectKey,
+  gitLoadingByProjectKey,
+  gitErrorByProjectKey,
   onOpen,
   onForget,
   onCopyPath,
   onNewChat,
+  onBrowse,
   onBrowsePath,
   onQueryChange,
   onSubmit,
   onRowKeydown,
 }: Props = $props();
 
-function lastAccessLabel(timestamp: number | undefined): string {
-  if (timestamp === undefined) return "—";
-  return relativeTimeLabel(new Date(timestamp).toISOString());
-}
+const placeholderCount = $derived(
+  query.trim() ? 0 : Math.max(0, defaultProjectCount - items.length),
+);
 
-function lastAccessTitle(timestamp: number | undefined): string {
-  if (timestamp === undefined) return "Last access not recorded";
-  return `Last accessed ${dateTimeLabel(new Date(timestamp).toISOString())}`;
-}
-
-function projectMenu(project: ProjectRecord): ContextMenuItem[] {
-  const items: ContextMenuItem[] = [
+function projectMenu(item: ProjectSwitcherItem): ContextMenuItem[] {
+  const project = item.project;
+  const menuItems: ContextMenuItem[] = [
     { label: "New chat", icon: Plus, onSelect: () => onNewChat(project.dir) },
     { label: "Copy path", icon: Copy, onSelect: () => onCopyPath(project.dir) },
   ];
   if (onForget) {
-    items.push(
+    menuItems.push(
       { type: "separator" },
       {
         label: "Forget project",
         icon: Trash2,
         destructive: true,
-        onSelect: () => onForget?.(project.id),
+        onSelect: () => onForget(project.id),
       },
     );
   }
-  return items;
+  return menuItems;
 }
 </script>
 
-<form
-  class="grid items-center border-b border-b-border/60 px-3 py-2.5"
-  onsubmit={onSubmit}
->
+<form class="grid items-center px-3 py-2.5" onsubmit={onSubmit}>
   <SearchInput
     bind:value={query}
     onValueChange={() => onQueryChange?.()}
@@ -137,92 +131,78 @@ function projectMenu(project: ProjectRecord): ContextMenuItem[] {
         aria-hidden="true"
       />
     </button>
-  {:else if recentProjects.length}
-    <div
-      class="grid gap-px"
-      role="listbox"
-      aria-label="Recent projects"
-      tabindex={-1}
-      aria-activedescendant={activeDescendant}
-    >
-      {#each recentProjects as project, i (project.id)}
-        {@const chats = conversationCountFor(project)}
-        {@const summary = activityFor?.(project)}
-        {@const indicator = summary
-          ? projectActivityIndicator(summary)
-          : undefined}
-        {@const current = isCurrent?.(project) ?? false}
-        {@const lastAccessedAt = lastAccessedFor?.(project)}
-        {@const selected = selectedIndex === i}
-        <ContextMenu items={projectMenu(project)} triggerClass="contents">
-          <div
-            id={`recent:${project.id}`}
-            class={`group flex w-full cursor-pointer items-center gap-2 rounded-md border px-2 py-1.5 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
-              selected
-                ? "border-border bg-accent"
-                : "border-transparent hover:bg-accent/60"
-            }`}
-            role="option"
-            aria-selected={selected}
-            tabindex="-1"
-            title={`${project.dir}\n${lastAccessTitle(lastAccessedAt)}${indicator ? `\n${indicator.summary}` : ""}`}
-            onclick={() => onOpen(project)}
-            onkeydown={(e) => onRowKeydown(e, i, project)}
-          >
-            <span
-              class={`grid size-7 flex-none place-items-center rounded-md border ${
-                current
-                  ? "border-primary/40 bg-primary/10 text-primary"
-                  : `border-border/60 bg-muted/40 ${
-                      selected
-                        ? "text-foreground"
-                        : "text-muted-foreground group-hover:text-foreground"
-                    }`
+  {:else if items.length || placeholderCount}
+    <Tooltip.Provider delayDuration={300} disableHoverableContent>
+      <div
+        class="grid grid-cols-1 gap-1.5 md:grid-cols-2"
+        role="listbox"
+        aria-label="Recent projects"
+        tabindex={-1}
+        aria-activedescendant={activeDescendant}
+      >
+        {#each items as item, i (item.key)}
+          {@const current = item.key === activeProjectKey}
+          {@const selected = selectedIndex === i}
+          <ContextMenu items={projectMenu(item)} triggerClass="contents">
+            <div
+              id={`recent:${encodeURIComponent(item.key)}`}
+              class={`group grid w-full cursor-pointer gap-2 rounded-md border px-2.5 py-2 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
+                selected
+                  ? "border-primary/50 bg-accent/80"
+                  : "border-border bg-accent/40 hover:bg-accent/70"
               }`}
-              title={current ? "Current project" : undefined}
+              role="option"
+              aria-selected={selected}
+              tabindex="-1"
+              onclick={() => onOpen(item)}
+              onkeydown={(event) => onRowKeydown(event, i, item)}
             >
-              <LayoutPanelLeft class="size-3.5" aria-hidden="true" />
-              {#if current}
-                <span class="sr-only">Current project</span>
-              {/if}
-            </span>
-            <span class="grid min-w-0 flex-1 gap-px">
-              <span class="flex min-w-0 items-center gap-1.5">
-                <strong
-                  class="min-w-0 truncate text-sm font-normal text-foreground"
-                  >{project.name}</strong
+              <span class="grid min-w-0 gap-0.5">
+                <span class="flex min-w-0 items-center gap-1.5">
+                  <strong
+                    class="min-w-0 truncate text-sm font-medium text-foreground"
+                  >
+                    {item.project.name}
+                  </strong>
+                  {#if current}
+                    <Badge tone="accent" size="xs" class="flex-none"
+                      >Current</Badge
+                    >
+                  {/if}
+                </span>
+                <span
+                  class="min-w-0 truncate font-mono text-xs text-muted-foreground"
                 >
-                {#if indicator}
-                  <StatusDot
-                    tone={indicator.tone}
-                    size="xs"
-                    pulse={indicator.pulse}
-                    label={indicator.summary}
-                  />
-                {/if}
+                  {tildePath(item.project.dir, homeDir)}
+                </span>
               </span>
-              <span
-                class="min-w-0 truncate font-mono text-xs text-muted-foreground"
-                >{tildePath(project.dir, homeDir)}</span
-              >
-            </span>
-            <span
-              class="flex-none pl-2 text-xs whitespace-nowrap text-muted-foreground tabular-nums"
+              <ProjectCardStatus
+                {item}
+                git={gitByProjectKey[item.key]}
+                gitLoading={gitLoadingByProjectKey[item.key] ?? false}
+                gitError={gitErrorByProjectKey[item.key] ?? false}
+              />
+            </div>
+          </ContextMenu>
+        {/each}
+        {#each Array.from(Array(placeholderCount).keys()) as i (i)}
+          <div role="option" aria-selected="false" class="contents">
+            <button
+              type="button"
+              class="group grid min-h-22 w-full place-content-center justify-items-center gap-1 rounded-md border border-dashed border-border bg-accent/20 px-2.5 py-2 text-center text-muted-foreground hover:bg-accent/60 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+              aria-label="Browse for a project folder"
+              onclick={onBrowse}
             >
-              {chats} chat{chats === 1 ? "" : "s"}
-              <span class="max-[520px]:hidden">
-                <span class="px-1 text-muted-foreground/50" aria-hidden="true"
-                  >·</span
-                >
-                {lastAccessedAt === undefined
-                  ? "Not accessed"
-                  : `Accessed ${lastAccessLabel(lastAccessedAt)}`}
-              </span>
-            </span>
+              <FolderSearch
+                class="size-4 text-muted-foreground group-hover:text-foreground"
+                aria-hidden="true"
+              />
+              <span class="text-xs font-medium">Browse for a project</span>
+            </button>
           </div>
-        </ContextMenu>
-      {/each}
-    </div>
+        {/each}
+      </div>
+    </Tooltip.Provider>
   {:else}
     <div
       class="grid min-h-40 place-items-center gap-1 p-6 text-center text-muted-foreground"

--- a/packages/workbench-app/src/lib/features/projects/index.ts
+++ b/packages/workbench-app/src/lib/features/projects/index.ts
@@ -3,14 +3,15 @@ export { default as ConversationsPanelView } from "./components/ConversationsPan
 export { default as ProjectSwitcher } from "./components/ProjectSwitcher.svelte";
 export {
   buildProjectSwitcherItems,
-  projectActivityIndicator,
+  projectActivitySignal,
   quickProjectItems,
   summarizeProjectActivity,
 } from "./state/project-switcher";
 export type {
-  ProjectActivityIndicator,
+  ProjectActivitySignal,
   ProjectActivitySummary,
   ProjectSwitcherItem,
+  ProjectTaskSummary,
 } from "./state/project-switcher";
 export {
   focusProjectSearch,

--- a/packages/workbench-app/src/lib/features/projects/state/project-overview.test.ts
+++ b/packages/workbench-app/src/lib/features/projects/state/project-overview.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { GitDiscoveryResponse, GitRepoSummary } from "$lib/api";
+import { summarizeProjectGit } from "./project-overview";
+
+function repo(patch: Partial<GitRepoSummary> = {}): GitRepoSummary {
+  return {
+    relativePath: ".",
+    absDir: "/work/app",
+    name: "app",
+    isRepo: true,
+    currentBranch: "main",
+    detached: false,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+    hasRemote: true,
+    hasGithubRemote: true,
+    baseBranch: "main",
+    onBaseBranch: true,
+    mergedToBase: true,
+    dirty: false,
+    changeCount: 0,
+    ...patch,
+  };
+}
+
+function discovery(repos: GitRepoSummary[]): GitDiscoveryResponse {
+  return { projectIsRepo: repos.length === 1, repos };
+}
+
+test("summarizes an empty Git project", () => {
+  assert.deepEqual(summarizeProjectGit(discovery([])), {
+    repositoryCount: 0,
+    branch: undefined,
+    detached: false,
+    changeCount: 0,
+    aheadCount: 0,
+    upstreamKnown: false,
+  });
+});
+
+test("shows branch and status totals for one repository", () => {
+  assert.deepEqual(
+    summarizeProjectGit(discovery([repo({ changeCount: 4, ahead: 2 })])),
+    {
+      repositoryCount: 1,
+      branch: "main",
+      detached: false,
+      changeCount: 4,
+      aheadCount: 2,
+      upstreamKnown: true,
+    },
+  );
+});
+
+test("represents detached HEAD and ignores unknown upstream counts", () => {
+  const result = summarizeProjectGit(
+    discovery([repo({ currentBranch: null, detached: true, ahead: null })]),
+  );
+  assert.equal(result.branch, undefined);
+  assert.equal(result.detached, true);
+  assert.equal(result.aheadCount, 0);
+  assert.equal(result.upstreamKnown, true);
+});
+
+test("aggregates multiple repositories without choosing a branch", () => {
+  assert.deepEqual(
+    summarizeProjectGit(
+      discovery([
+        repo({ changeCount: 2, ahead: 1 }),
+        repo({
+          relativePath: "packages/api",
+          currentBranch: "feature/api",
+          changeCount: 3,
+          ahead: 4,
+        }),
+      ]),
+    ),
+    {
+      repositoryCount: 2,
+      branch: undefined,
+      detached: false,
+      changeCount: 5,
+      aheadCount: 5,
+      upstreamKnown: true,
+    },
+  );
+});

--- a/packages/workbench-app/src/lib/features/projects/state/project-overview.ts
+++ b/packages/workbench-app/src/lib/features/projects/state/project-overview.ts
@@ -1,0 +1,33 @@
+import type { GitDiscoveryResponse } from "$lib/api";
+
+export type ProjectGitOverview = {
+  repositoryCount: number;
+  branch?: string;
+  detached: boolean;
+  changeCount: number;
+  aheadCount: number;
+  upstreamKnown: boolean;
+};
+
+export function summarizeProjectGit(
+  discovery: GitDiscoveryResponse,
+): ProjectGitOverview {
+  const soleRepo =
+    discovery.repos.length === 1 ? discovery.repos[0] : undefined;
+  return {
+    repositoryCount: discovery.repos.length,
+    branch: soleRepo?.currentBranch ?? undefined,
+    detached: soleRepo?.detached ?? false,
+    changeCount: discovery.repos.reduce(
+      (total, repo) => total + repo.changeCount,
+      0,
+    ),
+    aheadCount: discovery.repos.reduce(
+      (total, repo) => total + Math.max(0, repo.ahead ?? 0),
+      0,
+    ),
+    upstreamKnown:
+      discovery.repos.length > 0 &&
+      discovery.repos.every((repo) => repo.hasUpstream),
+  };
+}

--- a/packages/workbench-app/src/lib/features/projects/state/project-switcher.test.ts
+++ b/packages/workbench-app/src/lib/features/projects/state/project-switcher.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { ConversationRecord, ProjectRecord } from "$lib/api";
+import type { ConversationRecord, ProjectRecord, TaskRecord } from "$lib/api";
 import type { ConversationActivityState } from "$lib/features/conversations/state/conversation-activity";
 import {
   buildProjectSwitcherItems,
-  projectActivityIndicator,
+  projectActivitySignal,
   quickProjectItems,
   summarizeProjectActivity,
 } from "./project-switcher";
@@ -33,6 +33,21 @@ function conversation(
   } as ConversationRecord;
 }
 
+function task(
+  id: string,
+  cwd: string,
+  patch: Partial<TaskRecord> = {},
+): TaskRecord {
+  return {
+    id,
+    cwd,
+    command: "pnpm dev",
+    status: "running",
+    visibility: "background",
+    ...patch,
+  } as TaskRecord;
+}
+
 function activity(
   input: Partial<ConversationActivityState>,
 ): ConversationActivityState {
@@ -46,7 +61,7 @@ function activity(
   };
 }
 
-test("summarizes only current actionable project activity", () => {
+test("summarizes current waiting, failed, and running conversations", () => {
   const conversations = [
     conversation("error", "p", "2026-01-01"),
     conversation("waiting", "p", "2026-01-02"),
@@ -58,37 +73,55 @@ test("summarizes only current actionable project activity", () => {
       waiting: activity({ tone: "warn", needsUser: true }),
       running: activity({ tone: "running", busy: true }),
     }),
-    { needsUser: 1, running: 1 },
+    { needsUser: 1, failed: 1, running: 1 },
   );
 });
 
-test("omits project indicators for terminal errors", () => {
-  const summary = summarizeProjectActivity(
-    [conversation("error", "p", "2026-01-01")],
-    { error: activity({ tone: "danger" }) },
-  );
-  assert.deepEqual(summary, { needsUser: 0, running: 0 });
-  assert.equal(projectActivityIndicator(summary), undefined);
-});
-
-test("collapses actionable project activity into one indicator", () => {
+test("combines project activity and background tasks into one priority signal", () => {
   assert.equal(
-    projectActivityIndicator({ needsUser: 0, running: 0 }),
+    projectActivitySignal(
+      { needsUser: 0, failed: 0, running: 0 },
+      { running: 0 },
+    ),
     undefined,
   );
-  assert.deepEqual(projectActivityIndicator({ needsUser: 1, running: 2 }), {
-    tone: "warn",
-    pulse: false,
-    summary: "1 waiting for you, 2 running",
-  });
-  assert.deepEqual(projectActivityIndicator({ needsUser: 0, running: 1 }), {
-    tone: "running",
-    pulse: true,
-    summary: "1 running",
-  });
+  assert.deepEqual(
+    projectActivitySignal(
+      { needsUser: 1, failed: 2, running: 3 },
+      { running: 4 },
+    ),
+    {
+      tone: "warn",
+      count: 10,
+      summary:
+        "1 waiting for you, 2 failed, 3 conversations running, 4 background tasks running",
+    },
+  );
+  assert.deepEqual(
+    projectActivitySignal(
+      { needsUser: 0, failed: 1, running: 2 },
+      { running: 0 },
+    ),
+    {
+      tone: "danger",
+      count: 3,
+      summary: "1 failed, 2 conversations running",
+    },
+  );
+  assert.deepEqual(
+    projectActivitySignal(
+      { needsUser: 0, failed: 0, running: 1 },
+      { running: 1 },
+    ),
+    {
+      tone: "running",
+      count: 2,
+      summary: "1 conversation running, 1 background task running",
+    },
+  );
 });
 
-test("groups directory aliases and disambiguates duplicate folder names", () => {
+test("groups aliases and aggregates their conversations", () => {
   const projects = [
     project("p1", "app", "/work/one/app", "2026-01-01"),
     project("p2", "app alias", "/work/one/app/", "2026-01-02"),
@@ -96,29 +129,45 @@ test("groups directory aliases and disambiguates duplicate folder names", () => 
   ];
   const items = buildProjectSwitcherItems({
     projects,
-    conversations: [conversation("c1", "p1", "2026-01-04")],
+    conversations: [
+      conversation("c1", "p1", "2026-01-04"),
+      conversation("c2", "p2", "2026-01-05"),
+    ],
+    tasks: [],
     activityById: {},
   });
   assert.equal(items.length, 2);
-  assert.deepEqual(
-    items.find((item) => item.key === "/work/one/app")?.projectIds,
-    ["p1", "p2"],
-  );
+  const aliased = items.find((item) => item.key === "/work/one/app");
+  assert.deepEqual(aliased?.projectIds, ["p1", "p2"]);
+  assert.equal(aliased?.conversationCount, 2);
   assert.ok(items.every((item) => item.label !== "app"));
 });
 
-test("exposes the persisted project access time", () => {
+test("counts only active background tasks and resolves legacy cwd by longest path", () => {
   const items = buildProjectSwitcherItems({
-    projects: [project("p1", "app", "/work/app", "2026-01-01")],
+    projects: [
+      project("outer", "work", "/work", "2026-01-01"),
+      project("inner", "app", "/work/app", "2026-01-02"),
+      project("inner-alias", "app alias", "/work/app/", "2026-01-03"),
+    ],
     conversations: [],
+    tasks: [
+      task("task_owned", "/elsewhere", { projectId: "inner" }),
+      task("task_legacy", "/work/app/packages/api"),
+      task("task_foreground", "/work/app", { visibility: "foreground" }),
+      task("task_done", "/work/app", { status: "completed" }),
+    ],
     activityById: {},
-    recency: { "/work/app": 1_786_249_800_000 },
   });
 
-  assert.equal(items[0]?.lastAccessedAt, 1_786_249_800_000);
+  assert.equal(
+    items.find((item) => item.key === "/work/app")?.tasks.running,
+    2,
+  );
+  assert.equal(items.find((item) => item.key === "/work")?.tasks.running, 0);
 });
 
-test("sorts the chosen recent projects alphabetically", () => {
+test("exposes access time and preserves quick-project selection and alphabetization", () => {
   const items = buildProjectSwitcherItems({
     projects: [
       project("z", "Zulu", "/zulu", "2026-01-03"),
@@ -126,30 +175,20 @@ test("sorts the chosen recent projects alphabetically", () => {
       project("m", "Mike", "/mike", "2026-01-01"),
     ],
     conversations: [],
+    tasks: [],
     activityById: {},
+    recency: { "/alpha": 1_786_249_800_000 },
   });
+  assert.equal(
+    items.find((item) => item.key === "/alpha")?.lastAccessedAt,
+    1_786_249_800_000,
+  );
   assert.deepEqual(
     quickProjectItems(items, undefined, 2).map((item) => item.label),
     ["alpha", "zulu"],
   );
-});
-
-test("quick projects always retain the active project", () => {
-  const items = buildProjectSwitcherItems({
-    projects: [
-      project("a", "a", "/a", "2026-01-01"),
-      project("b", "b", "/b", "2026-01-02"),
-      project("c", "c", "/c", "2026-01-03"),
-    ],
-    conversations: [],
-    activityById: {},
-  });
   assert.deepEqual(
-    quickProjectItems(items, "/a", 1).map((item) => item.key),
-    ["/a"],
-  );
-  assert.deepEqual(
-    quickProjectItems(items, "/a", 2).map((item) => item.key),
-    ["/a", "/c"],
+    quickProjectItems(items, "/mike", 2).map((item) => item.key),
+    ["/alpha", "/mike"],
   );
 });

--- a/packages/workbench-app/src/lib/features/projects/state/project-switcher.ts
+++ b/packages/workbench-app/src/lib/features/projects/state/project-switcher.ts
@@ -1,5 +1,6 @@
 import type { StatusTone } from "@nervekit/ui-kit/core/utils/status";
-import type { ConversationRecord, ProjectRecord } from "$lib/api";
+import type { ConversationRecord, ProjectRecord, TaskRecord } from "$lib/api";
+import { isPathInDirectory } from "$lib/core/utils/path";
 import {
   conversationLastUserSortAt,
   projectFolderName,
@@ -10,6 +11,11 @@ import type { ConversationActivityState } from "$lib/features/conversations/stat
 
 export type ProjectActivitySummary = {
   needsUser: number;
+  failed: number;
+  running: number;
+};
+
+export type ProjectTaskSummary = {
   running: number;
 };
 
@@ -20,7 +26,9 @@ export type ProjectSwitcherItem = {
   label: string;
   sortAt: string;
   lastAccessedAt?: number;
+  conversationCount: number;
   activity: ProjectActivitySummary;
+  tasks: ProjectTaskSummary;
 };
 
 export function summarizeProjectActivity(
@@ -29,39 +37,58 @@ export function summarizeProjectActivity(
 ): ProjectActivitySummary {
   const summary: ProjectActivitySummary = {
     needsUser: 0,
+    failed: 0,
     running: 0,
   };
   for (const conversation of conversations) {
     const activity = activityById[conversation.id];
     if (!activity) continue;
     if (activity.needsUser) summary.needsUser += 1;
-    else if (activity.busy && activity.tone !== "danger") summary.running += 1;
+    else if (activity.tone === "danger") summary.failed += 1;
+    else if (activity.busy) summary.running += 1;
   }
   return summary;
 }
 
-export type ProjectActivityIndicator = {
-  tone: StatusTone;
-  pulse: boolean;
+export type ProjectActivitySignal = {
+  tone: Extract<StatusTone, "warn" | "danger" | "running">;
+  count: number;
   /** Human-readable breakdown of current actionable activity. */
   summary: string;
 };
 
-export function projectActivityIndicator(
+export function projectActivitySignal(
   activity: ProjectActivitySummary,
-): ProjectActivityIndicator | undefined {
+  tasks: ProjectTaskSummary,
+): ProjectActivitySignal | undefined {
   const parts = [
     activity.needsUser ? `${activity.needsUser} waiting for you` : "",
-    activity.running ? `${activity.running} running` : "",
+    activity.failed ? `${activity.failed} failed` : "",
+    activity.running
+      ? `${activity.running} conversation${activity.running === 1 ? "" : "s"} running`
+      : "",
+    tasks.running
+      ? `${tasks.running} background task${tasks.running === 1 ? "" : "s"} running`
+      : "",
   ].filter(Boolean);
   if (!parts.length) return undefined;
-  const tone: StatusTone = activity.needsUser ? "warn" : "running";
-  return { tone, pulse: tone === "running", summary: parts.join(", ") };
+  const tone: ProjectActivitySignal["tone"] = activity.needsUser
+    ? "warn"
+    : activity.failed
+      ? "danger"
+      : "running";
+  return {
+    tone,
+    count:
+      activity.needsUser + activity.failed + activity.running + tasks.running,
+    summary: parts.join(", "),
+  };
 }
 
 export function buildProjectSwitcherItems(input: {
   projects: ProjectRecord[];
   conversations: ConversationRecord[];
+  tasks: TaskRecord[];
   activityById: Record<string, ConversationActivityState>;
   homeDir?: string;
   recency?: Record<string, number>;
@@ -70,6 +97,46 @@ export function buildProjectSwitcherItems(input: {
   for (const project of input.projects) {
     const key = projectKey(project);
     byKey.set(key, [...(byKey.get(key) ?? []), project]);
+  }
+
+  const projectKeyById = new Map<string, string>();
+  for (const [key, projects] of byKey) {
+    for (const project of projects) projectKeyById.set(project.id, key);
+  }
+
+  const runningTasksByKey = new Map<string, number>();
+  const activeTaskStatuses = new Set<TaskRecord["status"]>([
+    "starting",
+    "running",
+    "ready",
+    "stopping",
+  ]);
+  for (const task of input.tasks) {
+    if (
+      task.visibility !== "background" ||
+      !activeTaskStatuses.has(task.status)
+    ) {
+      continue;
+    }
+
+    let key = task.projectId ? projectKeyById.get(task.projectId) : undefined;
+    if (!key) {
+      let longestMatch = -1;
+      for (const [candidateKey, projects] of byKey) {
+        const dir = projects[0]?.dir;
+        if (
+          dir &&
+          dir.length > longestMatch &&
+          isPathInDirectory(task.cwd, dir)
+        ) {
+          key = candidateKey;
+          longestMatch = dir.length;
+        }
+      }
+    }
+    if (key) {
+      runningTasksByKey.set(key, (runningTasksByKey.get(key) ?? 0) + 1);
+    }
   }
 
   const folderCounts = new Map<string, number>();
@@ -104,7 +171,9 @@ export function buildProjectSwitcherItems(input: {
           ? latestConversation
           : project.updatedAt,
       lastAccessedAt: input.recency?.[key],
+      conversationCount: conversations.length,
       activity: summarizeProjectActivity(conversations, input.activityById),
+      tasks: { running: runningTasksByKey.get(key) ?? 0 },
     };
   });
 

--- a/packages/workbench-app/src/lib/features/workspace/state/workspace-selectors.svelte.ts
+++ b/packages/workbench-app/src/lib/features/workspace/state/workspace-selectors.svelte.ts
@@ -157,6 +157,7 @@ export const workspaceSelectors = {
     return buildProjectSwitcherItems({
       projects: workspaceState.projects,
       conversations: workspaceState.conversations,
+      tasks: taskState.tasks,
       activityById: this.conversationActivityById,
       homeDir: workspaceState.status?.storage.userHome,
       recency: workspaceState.projectRecency,

--- a/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
@@ -30,19 +30,8 @@ const launchpad = $derived(variant === "launchpad");
 </script>
 
 <div
-  class="relative flex h-full min-h-full items-center justify-center overflow-hidden p-6 text-center"
+  class="@container relative flex h-full min-h-full items-center justify-center overflow-hidden p-6 text-center"
 >
-  {#if launchpad}
-    <div
-      class="pointer-events-none absolute inset-x-8 top-1/2 h-px max-w-5xl -translate-y-32 bg-gradient-to-r from-transparent via-border to-transparent"
-      aria-hidden="true"
-    ></div>
-    <div
-      class="pointer-events-none absolute left-1/2 top-1/2 size-80 -translate-x-1/2 -translate-y-1/2 rounded-full border border-dashed border-border/60"
-      aria-hidden="true"
-    ></div>
-  {/if}
-
   <div
     class={`brand-signal-enter relative flex w-full flex-col items-center ${launchpad ? "max-w-3xl" : "max-w-2xl"}`}
   >
@@ -70,11 +59,13 @@ const launchpad = $derived(variant === "launchpad");
       </p>
     {/if}
     <h2
-      class={`${launchpad ? "mt-2 text-2xl" : "mt-4 text-xl"} font-semibold tracking-tight text-foreground`}
+      class={`${launchpad ? "mt-2 text-xl @sm:text-2xl" : "mt-4 text-lg @sm:text-xl"} font-normal tracking-tight text-foreground`}
     >
       {title}
     </h2>
-    <p class="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground">
+    <p
+      class="mt-2 max-w-sm text-xs leading-relaxed text-muted-foreground @sm:text-sm"
+    >
       {message}
     </p>
 
@@ -88,7 +79,7 @@ const launchpad = $derived(variant === "launchpad");
           {@const Icon = starter.icon}
           <button
             type="button"
-            class="group inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border bg-card px-4 text-sm font-medium text-foreground shadow-sm transition-colors hover:border-primary/40 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50"
+            class="group inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border bg-card px-4 text-xs font-medium text-foreground shadow-sm transition-colors hover:border-primary/40 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50 @sm:text-sm"
             disabled={startersDisabled}
             onclick={() => onSelectStarter?.(starter)}
           >


### PR DESCRIPTION
## Summary

Overhauls the project switcher and recent-projects picker so each project surfaces a live snapshot of what's happening: conversation activity, background tasks, and Git status.

### Project switcher tabs
- Replaces the single status dot with count badges: waiting-for-you, failed, and running conversations, plus a separate badge for running background tasks (with hover titles).
- `projectActivityIndicator` becomes `projectActivitySignal`, returning a priority tone (`warn` > `danger` > `running`), a total count, and a human-readable summary.

### Recent projects picker
- Redesigned as a responsive two-column card grid (1 column on phones via `MediaQuery`), with keyboard navigation that follows the grid (up/down/left/right).
- New `ProjectCardStatus` component shows per-project activity chips (waiting / failed / running / background tasks) with tooltips, and a Git overview card: repository/branch, working tree change count, and unpublished commits.
- Git discovery is lazy-loaded per project through the query client (`GIT_STALE_MS` refresh policy) with loading/error states; new `summarizeProjectGit` helper aggregates multi-repo projects.
- "Browse for a project" placeholder cards fill the default grid when there are few recents.
- Dialog footer moved actions (Browse/Open) into the dialog footer; browse mode merged the search field into the toolbar and removed the drill-chevron folder rows.

### Task attribution
- `buildProjectSwitcherItems` now takes tasks and counts active background tasks per project, resolving by owner `projectId` first, then by longest-path `cwd` match for legacy tasks.

### Misc
- Removed the titlebar divider and the launchpad decorative rings; conversation-signal typography is now container-query responsive.
- Tests updated/extended for the new signal shape and task attribution; new tests for `summarizeProjectGit`.

## Validation
- `pnpm fix`, `pnpm check`, and `pnpm test` all pass.