### PR TITLE
Fix clipped model picker row border

### DIFF
--- a/packages/workbench-app/src/lib/presentation/components/composer/ComposerModelPicker.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ComposerModelPicker.svelte
@@ -213,6 +213,7 @@ $effect(() => {
               getKey={(entry) => entry.key}
               estimateSize={() => 36}
               gap={6}
+              paddingEnd={4}
               viewportClass="max-h-[min(44vh,18rem)]"
               viewportAriaLabel="Available models"
             >


### PR DESCRIPTION
## Summary
- add end padding to the model picker virtual scroller
- prevent the final model row outline from being clipped

## Validation
- pnpm fix
- pnpm check
- pnpm test