### PR TITLE
Tone down launchpad conversation-signal heading size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - Before completing code changes, run `pnpm fix && pnpm check && pnpm test` in one Bash tool call, fix any failures, then rerun the full chain.
 - Keep the automated test suite limited to only the important parts. Not everything needs to have automated tests.
 - Use `NERVE_API_TARGET=http://127.0.0.1:3747 pnpm dev:ui` if you need to run the UI locally and connect to existing nerve daemon server.
+- Use `gh` cli to interact with GitHub.

--- a/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/conversation-signal.svelte
@@ -59,7 +59,7 @@ const launchpad = $derived(variant === "launchpad");
       </p>
     {/if}
     <h2
-      class={`${launchpad ? "mt-2 text-xl @sm:text-2xl" : "mt-4 text-lg @sm:text-xl"} font-normal tracking-tight text-foreground`}
+      class={`${launchpad ? "mt-2 text-lg @sm:text-xl" : "mt-4 text-lg @sm:text-xl"} font-normal tracking-tight text-foreground`}
     >
       {title}
     </h2>


### PR DESCRIPTION
Reduce the launchpad variant's heading size in `conversation-signal` from `text-xl` to `text-lg` so it matches the non-launchpad sizing and avoids an overly large title in the launchpad context.