### PR TITLE
feat(workbench): polish conversation rows and switcher activity badges

### DIFF
--- a/packages/workbench-app/src/lib/features/projects/components/ProjectAgentTreeNode.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectAgentTreeNode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { type ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
-import { PanelRow } from "$lib/presentation/panel";
+import { PanelRow, PanelRowCard } from "$lib/presentation/panel";
 import type { ConversationActivityState } from "$lib/features/conversations/state/conversation-activity";
 import { conversationActivityForRecord } from "$lib/features/conversations/state/conversation-activity";
 import type { ConversationRow } from "$lib/core/utils/project-tree";
@@ -52,14 +52,17 @@ const tooltip = $derived(
 );
 </script>
 
-<PanelRow
-  label={row.conversation.title}
-  title={tooltip}
-  status={dotActivity.tone}
-  statusVariant={isOpen ? "solid" : "outline"}
-  pulse={dotActivity.pulse}
-  class="px-2"
-  active={isActive}
-  {menuItems}
-  onclick={() => onOpenConversation?.(row.conversation.id)}
-/>
+<PanelRowCard>
+  <PanelRow
+    label={row.conversation.title}
+    labelLines={2}
+    title={tooltip}
+    status={dotActivity.tone}
+    statusVariant={isOpen ? "solid" : "outline"}
+    pulse={dotActivity.pulse}
+    class="px-2"
+    active={isActive}
+    {menuItems}
+    onclick={() => onOpenConversation?.(row.conversation.id)}
+  />
+</PanelRowCard>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
@@ -133,7 +133,7 @@ const menuContext = $derived<ProjectTreeMenuContext>({
         bind:this={listRegion}
         class="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
-        <PanelList ariaLabel="Conversations" class="shrink-0 py-1">
+        <PanelList ariaLabel="Conversations" class="shrink-0 gap-1 pt-1 pb-0">
           {#each visibleRows as row (row.conversation.id)}
             {@const rowProject =
               projects.find(
@@ -154,11 +154,14 @@ const menuContext = $derived<ProjectTreeMenuContext>({
           {/each}
         </PanelList>
         {#if hasHiddenRows}
-          <div bind:this={listFooter} class="mt-auto shrink-0 p-1">
+          <div
+            bind:this={listFooter}
+            class="flex shrink-0 items-center px-1 pt-1"
+          >
             <Button
               variant="ghost"
               size="xs"
-              class="w-full text-muted-foreground"
+              class="h-4 w-full text-muted-foreground"
               onclick={() => (allConversationsOpen = true)}>See More</Button
             >
           </div>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationsDialog.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationsDialog.svelte
@@ -100,19 +100,21 @@ function openAndClose(conversationId: string) {
           <VirtualScroller
             items={rows}
             getKey={(row) => row.conversation.id}
-            estimateSize={() => 32}
+            estimateSize={() => 48}
             viewportClass="h-full px-0.5"
           >
             {#snippet row({ item })}
-              <ProjectAgentTreeNode
-                row={item}
-                isOpen={openConversationTabIds?.has(item.conversation.id) ??
-                  false}
-                isActive={item.conversation.id === selectedConversationId}
-                activity={conversationActivityById[item.conversation.id]}
-                menuItems={buildMenu?.(item.conversation) ?? []}
-                onOpenConversation={openAndClose}
-              />
+              <div class="py-0.5">
+                <ProjectAgentTreeNode
+                  row={item}
+                  isOpen={openConversationTabIds?.has(item.conversation.id) ??
+                    false}
+                  isActive={item.conversation.id === selectedConversationId}
+                  activity={conversationActivityById[item.conversation.id]}
+                  menuItems={buildMenu?.(item.conversation) ?? []}
+                  onOpenConversation={openAndClose}
+                />
+              </div>
             {/snippet}
           </VirtualScroller>
         {/if}

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -38,14 +38,6 @@ function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
   if (tone === "danger") return "border-destructive/60 text-destructive";
   return "border-info/60 text-info";
 }
-
-function conversationSignalTintClass(
-  tone: ProjectActivitySignal["tone"],
-): string {
-  if (tone === "warn") return "bg-warning/25";
-  if (tone === "danger") return "bg-destructive/25";
-  return "bg-info/25";
-}
 </script>
 
 <nav
@@ -68,6 +60,8 @@ function conversationSignalTintClass(
       {@const signal = projectActivitySignal(item.activity, item.tasks)}
       {@const conversationActivityCount =
         item.activity.needsUser + item.activity.failed + item.activity.running}
+      {@const combinedSignals =
+        conversationActivityCount > 0 && item.tasks.running > 0}
       {@const active = item.key === activeKey}
       <ContextMenu
         items={buildMenuItems?.(item) ?? []}
@@ -85,27 +79,23 @@ function conversationSignalTintClass(
         >
           {#if signal}
             <span
-              class="isolate inline-flex flex-none items-center -space-x-1"
+              class={combinedSignals
+                ? "relative isolate h-5 w-6 flex-none"
+                : "inline-flex size-4 flex-none items-center"}
               aria-hidden="true"
             >
               {#if conversationActivityCount}
                 <span
-                  class={`relative z-10 inline-flex size-4 items-center justify-center rounded-full border bg-popover text-xs leading-none tabular-nums ${conversationSignalClass(signal.tone)}`}
+                  class={`${combinedSignals ? "absolute top-0 left-0" : "relative"} z-10 inline-flex size-4 items-center justify-center rounded-full border-[1.5px] text-xs leading-none tabular-nums ${active ? "bg-muted" : "bg-popover"} ${conversationSignalClass(signal.tone)}`}
                 >
-                  <span
-                    class={`absolute inset-0 rounded-full ${conversationSignalTintClass(signal.tone)}`}
-                  ></span>
-                  <span class="relative z-10">{conversationActivityCount}</span>
+                  <span class="scale-90">{conversationActivityCount}</span>
                 </span>
               {/if}
               {#if item.tasks.running}
                 <span
-                  class="relative z-0 inline-flex size-4 items-center justify-center rounded-full border border-info/60 bg-popover text-info"
+                  class={`${combinedSignals ? "absolute right-0 bottom-0" : "relative"} z-0 inline-flex size-4 items-center justify-center rounded-full border-[1.5px] border-info/60 text-xs leading-none text-info tabular-nums`}
                 >
-                  <span class="absolute inset-0 rounded-full bg-info/25"></span>
-                  <span class="relative z-10 text-xs leading-none tabular-nums"
-                    >{item.tasks.running}</span
-                  >
+                  <span class="scale-90">{item.tasks.running}</span>
                 </span>
               {/if}
             </span>

--- a/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
@@ -16,6 +16,7 @@ let {
   statusVariant = "solid",
   pulse = false,
   label,
+  labelLines = 1,
   description,
   meta,
   metaMono = false,
@@ -57,6 +58,8 @@ let {
   statusVariant?: StatusDotVariant;
   pulse?: boolean;
   label: string;
+  /** Maximum visible lines for the primary label. */
+  labelLines?: 1 | 2;
   description?: string;
   /** Third line under the description; stacked rows only. */
   meta?: string;
@@ -116,6 +119,12 @@ const rowStyle = $derived(
     .join(";") || undefined,
 );
 
+const labelLayoutClass = $derived(
+  labelLines === 2
+    ? "line-clamp-2 break-words whitespace-normal leading-snug"
+    : "truncate",
+);
+
 const toneClass = $derived(
   tone === "destructive"
     ? "text-destructive"
@@ -139,9 +148,11 @@ const toneClass = $derived(
       hoverable && "panel-row-hoverable",
       stacked
         ? "min-h-11 gap-2 py-2.5 pr-3 text-xs"
-        : dense
-          ? "h-5 gap-1 pr-1 text-xs"
-          : "h-7 gap-1.5 pr-1.5 text-xs",
+        : labelLines === 2
+          ? "h-10 gap-2 py-0.5 pr-3 text-xs"
+          : dense
+            ? "h-5 gap-1 pr-1 text-xs"
+            : "h-7 gap-1.5 pr-1.5 text-xs",
       selected && "bg-accent text-accent-foreground",
       tabindex !== undefined &&
         "focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none",
@@ -167,8 +178,8 @@ const toneClass = $derived(
       aria-current={active ? "true" : undefined}
       title={title ?? description ?? label}
       class={cn(
-        "flex min-w-0 flex-1 items-center rounded-sm text-left focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none disabled:opacity-50",
-        stacked ? "gap-2" : dense ? "gap-1" : "gap-1.5",
+        "flex min-w-0 flex-1 cursor-pointer items-center rounded-sm text-left focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none disabled:cursor-default disabled:opacity-50",
+        stacked || labelLines === 2 ? "gap-2" : dense ? "gap-1" : "gap-1.5",
       )}
       {onclick}
       {ondblclick}
@@ -196,7 +207,7 @@ const toneClass = $derived(
           <span class="flex min-w-0 items-center gap-1.5">
             <span
               class={cn(
-                "truncate",
+                labelLayoutClass,
                 toneClass,
                 mono && "font-mono",
                 active && "font-medium",
@@ -223,7 +234,7 @@ const toneClass = $derived(
       {:else}
         <span
           class={cn(
-            "truncate",
+            labelLayoutClass,
             toneClass,
             mono && "font-mono",
             active && "font-medium",

--- a/packages/workbench-app/src/lib/presentation/panel/panel-row-fit.svelte.ts
+++ b/packages/workbench-app/src/lib/presentation/panel/panel-row-fit.svelte.ts
@@ -74,6 +74,7 @@ export function createPanelRowFit(options: PanelRowFitOptions): PanelRowFit {
 
   $effect(() => {
     options.total();
+    options.footer?.();
     queueMicrotask(schedule);
   });
 


### PR DESCRIPTION
## Summary

Workbench UI polish for project/conversation rows and the project switcher activity indicators.

### Conversation rows as two-line cards
- **PanelRow**: new `labelLines` prop (1|2) enabling a two-line clamped label layout with matching row height; adds `cursor-pointer`/`cursor-default` refinements.
- **ProjectAgentTreeNode**: renders conversation rows as two-line card rows via `PanelRowCard`.
- **ProjectConversationsDialog**: bumps the virtual scroller row estimate (32 → 48) and adds padding for the taller card rows.
- **ProjectConversationNavigator**: tightens list gap/spacing and compacts the "See More" footer button.
- **panel-row-fit**: includes the footer element in the fit-recalculation effect so list height accounts for the footer.

### Stacked activity badges in the switcher
- **ProjectSwitcher**: when both a conversation-activity count and running-tasks count are present, the two badges now overlap into a single stacked indicator instead of sitting side by side; replaced translucent tint overlays with border-color styling for AA-visible contrast.

## Validation
- [ ] `pnpm fix && pnpm check && pnpm test` run before merge