### PR TITLE
feat(workbench): scrollable conversation list with edge shadows

### DIFF
--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
@@ -10,7 +10,6 @@ import {
   PanelList,
   PanelToolbarButton,
   PanelView,
-  createPanelRowFit,
 } from "$lib/presentation/panel";
 import { buildConversationRows } from "$lib/core/utils/project-tree";
 import ProjectAgentTreeNode from "./ProjectAgentTreeNode.svelte";
@@ -43,10 +42,13 @@ let {
   onPruneProjectConversations,
 }: ProjectAgentTreeProps = $props();
 
+const MAX_LISTED_CONVERSATIONS = 100;
+
 let pendingDelete = $state<DeleteTarget | undefined>();
 let allConversationsOpen = $state(false);
 let listRegion = $state<HTMLDivElement | null>(null);
-let listFooter = $state<HTMLDivElement | null>(null);
+let canScrollUp = $state(false);
+let canScrollDown = $state(false);
 
 const activeProject = $derived(
   projects.find((project) => project.id === selectedProjectId) ?? projects[0],
@@ -55,13 +57,7 @@ const projectIds = $derived(projects.map((project) => project.id));
 const rows = $derived(
   buildConversationRows({ conversations, agents, projectIds }),
 );
-const rowFit = createPanelRowFit({
-  region: () => listRegion,
-  footer: () => listFooter,
-  total: () => rows.length,
-});
-const visibleRows = $derived(rows.slice(0, rowFit.count));
-const hasHiddenRows = $derived(visibleRows.length < rows.length);
+const displayedRows = $derived(rows.slice(0, MAX_LISTED_CONVERSATIONS));
 const newConversationShortcut = getShortcutLabel("conversation.new");
 const switchProjectShortcut = getShortcutLabel("conversation.newFromProject");
 const emptyStateHint = switchProjectShortcut
@@ -73,6 +69,29 @@ $effect(() => {
   if (searchFocusToken === lastSearchFocusToken) return;
   lastSearchFocusToken = searchFocusToken;
   allConversationsOpen = true;
+});
+
+function updateScrollShadows(): void {
+  const region = listRegion;
+  if (!region) return;
+  canScrollUp = region.scrollTop > 2;
+  canScrollDown =
+    region.scrollTop + region.clientHeight < region.scrollHeight - 2;
+}
+
+$effect(() => {
+  const region = listRegion;
+  if (!region) return;
+  updateScrollShadows();
+  region.addEventListener("scroll", updateScrollShadows, { passive: true });
+  const observer = new ResizeObserver(updateScrollShadows);
+  observer.observe(region);
+  const content = region.firstElementChild;
+  if (content) observer.observe(content); // row count changes resize the list
+  return () => {
+    region.removeEventListener("scroll", updateScrollShadows);
+    observer.disconnect();
+  };
 });
 
 const menuContext = $derived<ProjectTreeMenuContext>({
@@ -129,48 +148,46 @@ const menuContext = $derived<ProjectTreeMenuContext>({
         {/snippet}
       </PanelEmpty>
     {:else}
-      <div
-        bind:this={listRegion}
-        class="flex min-h-0 flex-1 flex-col overflow-hidden"
-      >
-        <PanelList ariaLabel="Conversations" class="shrink-0 gap-1 pt-1 pb-0">
-          {#each visibleRows as row (row.conversation.id)}
-            {@const rowProject =
-              projects.find(
-                (project) => project.id === row.conversation.projectId,
-              ) ?? activeProject}
-            <ProjectAgentTreeNode
-              {row}
-              isOpen={openConversationTabIds?.has(row.conversation.id) ?? false}
-              isActive={row.conversation.id === selectedConversationId}
-              activity={conversationActivityById[row.conversation.id]}
-              menuItems={buildConversationMenu(
-                rowProject,
-                row.conversation,
-                menuContext,
-              )}
-              {onOpenConversation}
-            />
-          {/each}
-        </PanelList>
-        {#if hasHiddenRows}
-          <div
-            bind:this={listFooter}
-            class="flex shrink-0 items-center px-1 pt-1"
-          >
-            <Button
-              variant="ghost"
-              size="xs"
-              class="h-4 w-full text-muted-foreground"
-              onclick={() => (allConversationsOpen = true)}>See More</Button
-            >
-          </div>
-        {/if}
+      <div class="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div
+          bind:this={listRegion}
+          class="conversation-list-scroller min-h-0 flex-1 overflow-y-auto"
+          onscroll={updateScrollShadows}
+        >
+          <PanelList ariaLabel="Conversations" class="shrink-0 gap-1 pt-1 pb-0">
+            {#each displayedRows as row (row.conversation.id)}
+              {@const rowProject =
+                projects.find(
+                  (project) => project.id === row.conversation.projectId,
+                ) ?? activeProject}
+              <ProjectAgentTreeNode
+                {row}
+                isOpen={openConversationTabIds?.has(row.conversation.id) ??
+                  false}
+                isActive={row.conversation.id === selectedConversationId}
+                activity={conversationActivityById[row.conversation.id]}
+                menuItems={buildConversationMenu(
+                  rowProject,
+                  row.conversation,
+                  menuContext,
+                )}
+                {onOpenConversation}
+              />
+            {/each}
+          </PanelList>
+        </div>
+        <div
+          class="conversation-list-shadow conversation-list-shadow-top pointer-events-none absolute inset-x-0 top-0 h-6 opacity-0 transition-opacity duration-150"
+          class:opacity-100={canScrollUp}
+        ></div>
+        <div
+          class="conversation-list-shadow conversation-list-shadow-bottom pointer-events-none absolute inset-x-0 bottom-0 h-6 opacity-0 transition-opacity duration-150"
+          class:opacity-100={canScrollDown}
+        ></div>
       </div>
     {/if}
   </PanelView>
 </Tooltip.Provider>
-
 <AlertDialog
   open={pendingDelete?.kind === "conversation"}
   title="Delete conversation?"
@@ -210,3 +227,36 @@ const menuContext = $derived<ProjectTreeMenuContext>({
     onOpenChange={(open) => (allConversationsOpen = open)}
   />
 {/if}
+
+<style>
+/* Escape-hatch reason 2: the native scrollbar is hidden; the edge shadows
+   * below are the scroll affordance. */
+.conversation-list-scroller {
+  scrollbar-width: none;
+}
+
+.conversation-list-scroller::-webkit-scrollbar {
+  display: none;
+}
+
+/* Edge shadows are gradients (not expressible as utilities). They blend the
+   * list into the panel's own background color, so rows appear to slide
+   * under the panel surface where more content is waiting. */
+.conversation-list-shadow-bottom {
+  background: linear-gradient(
+    to top,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+
+.conversation-list-shadow-top {
+  background: linear-gradient(
+    to bottom,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+</style>

--- a/packages/workbench-server/test/filesystem.service.test.ts
+++ b/packages/workbench-server/test/filesystem.service.test.ts
@@ -145,6 +145,8 @@ describe("filesystem application service", () => {
         mkdir(join(root, "node_modules")),
         mkdir(join(root, ".git")),
         mkdir(join(root, "src")),
+      ]);
+      await Promise.all([
         writeFile(join(root, ".env"), "secret"),
         writeFile(join(root, "file10.ts"), ""),
         writeFile(join(root, "file2.ts"), ""),


### PR DESCRIPTION
## Summary

Improves the Conversations dock panel list:

- **Removed the "See More" button** — the list now renders all conversation rows directly, capped at 100 (`MAX_LISTED_CONVERSATIONS`). The panel header count still shows the total.
- **Hidden native scrollbar** — replaced with a scrollable region whose overflow affordance is a soft edge shadow (`scrollbar-width: none` / `::-webkit-scrollbar` hidden, escape-hatch reason 2).
- **Edge shadows** — a bottom shadow appears when there is content to scroll below; a mirrored top shadow appears once the user scrolls down. Shadows fade into the panel's background color (`var(--card)`) with an intense edge and short spread, and toggle opacity with a smooth transition. Overlays are `pointer-events-none` and `aria-hidden`.
- Scroll state is tracked via `onscroll` plus a `ResizeObserver` on the region and list content, so shadows update on scroll, panel resize, and conversation-count changes (same pattern as `EditorTabStrip`).

The searchable "Conversations" dialog (`ProjectConversationsDialog`) is preserved — it remains reachable via the `projectSearch.focus` shortcut; only its "See More" trigger was removed.

## Validation

- `pnpm fix && pnpm check && pnpm test` all pass, including `check:boundaries` and `svelte-check` (0 errors).