### PR TITLE
feat(workbench): rework task run management and definition ordering

### DIFF
--- a/packages/website/src/content/docs/guides/background-tasks.md
+++ b/packages/website/src/content/docs/guides/background-tasks.md
@@ -28,7 +28,7 @@ Nerve has no persistent sidecar supervisor. On restart it verifies process ident
 
 Linux uses `/proc` start identity and process groups; macOS uses process-start fingerprints and groups; Windows uses creation time and process-tree termination. Port discovery is best effort.
 
-A normal **Stop** requests graceful process-tree termination and escalates after a bounded wait. Verified recovered or stuck-stopping runs also offer a confirmed **Force kill**. After the run is terminal, remove its history or choose **Run saved task again** to launch the definition's current configuration. Nerve does not force-kill `recovery_unknown` records because their PID identity is unverified.
+A normal **Stop** requests graceful process-tree termination and escalates after a bounded wait. Verified recovered and stuck-stopping runs also offer **Force kill**: immediate for stuck-stopping runs, confirmed for verified recovered runs because you may not have asked to terminate them. After the run is terminal, remove its history or choose **Run saved task again** to launch the definition's current configuration. Nerve does not force-kill `recovery_unknown` records because their PID identity is unverified.
 
 Quitting the desktop app immediately terminates active local task process trees before its owned daemon exits. Closing to the tray leaves tasks running.
 

--- a/packages/website/src/content/docs/troubleshooting/tasks-and-recovery.md
+++ b/packages/website/src/content/docs/troubleshooting/tasks-and-recovery.md
@@ -23,7 +23,7 @@ Check the readiness URL/pattern and task logs. A server listening on a different
 
 ## Stop does not complete
 
-Nerve attempts graceful process-tree termination then bounded escalation. For a verified `recovered` run or one stuck in `stopping`, use **Force kill** and confirm immediate process-tree termination. Force kill can lose buffered output and process cleanup, but the terminal run record can then be removed or its current saved task definition can be run again.
+Nerve attempts graceful process-tree termination then bounded escalation. A run stuck in `stopping` offers **Force kill** immediately, since you already asked to stop it. A verified `recovered` run confirms before killing, because you may not have asked to terminate it. Force kill can lose buffered output and process cleanup, but the terminal run record can then be removed or its current saved task definition can be run again.
 
 Platform security software or child detachment can still interfere. Nerve never offers force kill for `recovery_unknown`; confirm identity before manual OS termination.
 

--- a/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
@@ -13,6 +13,7 @@ import {
 import { ConversationsPanelView } from "$lib/features/projects";
 import {
   cancelSelectedTask,
+  cleanupTaskRuns,
   openTaskTab,
   pruneFinishedTasks,
   removeTask,
@@ -166,6 +167,7 @@ function focusTasks() {
         onCancelTask={(id, request) => void cancelSelectedTask(id, request)}
         onRestartTask={(id) => void restartSelectedTask(id)}
         onRemoveTask={(id) => void removeTask(id)}
+        onCleanupRuns={(ids) => void cleanupTaskRuns(ids)}
         onPruneTasks={() => void pruneFinishedTasks()}
         onRunCommand={(input) => {
           focusTasks();

--- a/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.test.ts
+++ b/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { TaskRecord } from "@nervekit/contracts";
+import type { CenterTabModel } from "$lib/features/workspace";
+import { tabLabel, tabTitle } from "./editor-tab-helpers.js";
+
+function task(patch: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: "task_a",
+    cwd: "/repo",
+    command: "pnpm dev",
+    status: "running",
+    readiness: { outcome: "none" },
+    stdoutPath: "/tmp/out",
+    stderrPath: "/tmp/err",
+    logsPath: "/tmp/logs",
+    startedAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    origin: { kind: "api" },
+    visibility: "background",
+    ...patch,
+  };
+}
+
+function tab(record: TaskRecord): Extract<CenterTabModel, { kind: "task" }> {
+  return {
+    kind: "task",
+    id: "taskdef_a",
+    task: record,
+    active: true,
+    sending: true,
+  };
+}
+
+test("uses a task definition display label for task tabs and titles", () => {
+  const model = tab(
+    task({ displayName: "Workbench UI", name: "legacy", command: "pnpm dev" }),
+  );
+
+  assert.equal(tabLabel(model), "Workbench UI");
+  assert.match(tabTitle(model), /^Workbench UI · running ·/);
+});
+
+test("falls back from blank display names to name and command", () => {
+  assert.equal(tabLabel(tab(task({ displayName: "  ", name: "API" }))), "API");
+  assert.equal(
+    tabLabel(tab(task({ displayName: " ", name: " ", command: "pnpm test" }))),
+    "pnpm test",
+  );
+});

--- a/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.ts
+++ b/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.ts
@@ -14,8 +14,13 @@ export function tabIdentity(tab: CenterTabModel): TabIdentity {
   return { kind: tab.kind, id: tab.id };
 }
 
+function taskLabel(tab: Extract<CenterTabModel, { kind: "task" }>): string {
+  const labels = [tab.task?.displayName, tab.task?.name, tab.task?.command];
+  return labels.find((label) => label?.trim())?.trim() ?? tab.id;
+}
+
 export function tabLabel(tab: CenterTabModel): string {
-  if (tab.kind === "task") return tab.task?.name ?? tab.task?.command ?? tab.id;
+  if (tab.kind === "task") return taskLabel(tab);
   if (tab.kind === "file")
     return (
       tab.file?.name ??
@@ -38,7 +43,7 @@ export function tabLabel(tab: CenterTabModel): string {
 export function tabTitle(tab: CenterTabModel, homeDir?: string): string {
   if (tab.kind === "task") {
     if (!tab.task) return `Missing task · ${tab.id}`;
-    return `${tab.task.name ?? tab.task.command} · ${tab.task.status} · ${shortenPath(tab.task.cwd, homeDir)} · ${tab.task.id}`;
+    return `${taskLabel(tab)} · ${tab.task.status} · ${shortenPath(tab.task.cwd, homeDir)} · ${tab.task.id}`;
   }
   if (tab.kind === "file") return tab.file?.path ?? tab.path ?? tab.id;
   if (tab.kind === "diff")

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -34,9 +34,10 @@ function tabLabel(item: ProjectSwitcherItem): string {
 }
 
 function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
-  if (tone === "warn") return "border-warning/60 text-warning";
-  if (tone === "danger") return "border-destructive/60 text-destructive";
-  return "border-info/60 text-info";
+  if (tone === "warn") return "bg-warning text-warning-foreground";
+  if (tone === "danger")
+    return "bg-destructive-solid text-destructive-solid-foreground";
+  return "bg-info text-info-foreground";
 }
 </script>
 
@@ -80,20 +81,20 @@ function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
           {#if signal}
             <span
               class={combinedSignals
-                ? "relative isolate h-5 w-6 flex-none"
+                ? "relative isolate h-4 w-7 flex-none"
                 : "inline-flex size-4 flex-none items-center"}
               aria-hidden="true"
             >
               {#if conversationActivityCount}
                 <span
-                  class={`${combinedSignals ? "absolute top-0 left-0" : "relative"} z-10 inline-flex size-4 items-center justify-center rounded-full border-[1.5px] text-xs leading-none tabular-nums ${active ? "bg-muted" : "bg-popover"} ${conversationSignalClass(signal.tone)}`}
+                  class={`${combinedSignals ? "absolute top-0 left-0" : "relative"} z-10 inline-flex size-4 items-center justify-center rounded-full border-[1.5px] border-background text-xs leading-none tabular-nums ${conversationSignalClass(signal.tone)}`}
                 >
                   <span class="scale-90">{conversationActivityCount}</span>
                 </span>
               {/if}
               {#if item.tasks.running}
                 <span
-                  class={`${combinedSignals ? "absolute right-0 bottom-0" : "relative"} z-0 inline-flex size-4 items-center justify-center rounded-full border-[1.5px] border-info/60 text-xs leading-none text-info tabular-nums`}
+                  class={`${combinedSignals ? "absolute top-0 right-0" : "relative"} z-0 inline-flex size-4 items-center justify-center rounded-sm border-[1.5px] border-background bg-info text-xs leading-none text-info-foreground tabular-nums`}
                 >
                   <span class="scale-90">{item.tasks.running}</span>
                 </span>

--- a/packages/workbench-app/src/lib/features/tasks/components/TaskShell.svelte
+++ b/packages/workbench-app/src/lib/features/tasks/components/TaskShell.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
 import { TaskOutputPane } from "$lib/presentation/tasks";
 import { loadEarlierTaskLogs } from "$lib/features/tasks/state/task-logs.svelte";
+import {
+  cancelSelectedTask,
+  cleanupTaskRuns,
+  restartSelectedTask,
+} from "$lib/features/tasks/state/tasks.svelte";
 import { taskSelectors } from "$lib/features/tasks/state/task-selectors.svelte";
+import {
+  selectTaskEntryRun,
+  taskEntryKey,
+} from "$lib/features/tasks/state/task-tabs.svelte";
 
 const activeCenterTask = $derived(taskSelectors.activeCenterTask);
+const siblingRuns = $derived(taskSelectors.activeCenterTaskRuns);
 const taskLogs = $derived(
   taskSelectors.taskLogs?.task.id === activeCenterTask?.id
     ? taskSelectors.taskLogs
@@ -14,6 +24,19 @@ const taskLogs = $derived(
 <TaskOutputPane
   task={activeCenterTask}
   {taskLogs}
+  {siblingRuns}
+  onSelectRun={(taskId) =>
+    activeCenterTask
+      ? selectTaskEntryRun(taskEntryKey(activeCenterTask.id), taskId)
+      : Promise.resolve()}
+  onRestartRun={(taskId) => restartSelectedTask(taskId)}
+  onCancelRun={(taskId) => cancelSelectedTask(taskId)}
+  onForceKillRun={(taskId) =>
+    cancelSelectedTask(taskId, {
+      signal: "SIGKILL",
+      reason: "force_kill",
+    })}
+  onCleanupRuns={(taskIds) => cleanupTaskRuns(taskIds)}
   onLoadEarlier={() =>
     activeCenterTask
       ? loadEarlierTaskLogs(activeCenterTask.id)

--- a/packages/workbench-app/src/lib/features/tasks/components/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/tasks/components/TasksPanelView.svelte
@@ -13,6 +13,7 @@ type Props = {
   onCancelTask?: (id: string, request?: CancelTaskRequest) => void;
   onRestartTask?: (id: string) => void;
   onRemoveTask?: (id: string) => void;
+  onCleanupRuns?: (ids: readonly string[]) => void;
   onPruneTasks?: () => void;
   onRunCommand?: (input: {
     projectId: string;
@@ -30,6 +31,7 @@ let {
   onCancelTask,
   onRestartTask,
   onRemoveTask,
+  onCleanupRuns,
   onPruneTasks,
   onRunCommand,
 }: Props = $props();
@@ -43,6 +45,7 @@ const adapter = createWorkbenchTaskPanelAdapter(
     cancelTask: (id, request) => onCancelTask?.(id, request),
     restartTask: (id) => onRestartTask?.(id),
     removeTask: (id) => onRemoveTask?.(id),
+    cleanupRuns: (ids) => onCleanupRuns?.(ids),
     pruneTasks: () => onPruneTasks?.(),
     runCommand: (input) => onRunCommand?.(input),
   },

--- a/packages/workbench-app/src/lib/features/tasks/index.ts
+++ b/packages/workbench-app/src/lib/features/tasks/index.ts
@@ -4,6 +4,7 @@ export { taskState } from "./state/task-state.svelte";
 export { openTaskTab } from "./state/task-tabs.svelte";
 export {
   cancelSelectedTask,
+  cleanupTaskRuns,
   pruneFinishedTasks,
   removeTask,
   restartSelectedTask,

--- a/packages/workbench-app/src/lib/features/tasks/state/task-selectors.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/task-selectors.svelte.ts
@@ -1,6 +1,7 @@
 import { isPathInDirectory } from "$lib/core/utils/path";
 import { workspaceSelectors } from "$lib/features/workspace/state/workspace-selectors.svelte";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import { taskEntryId } from "./task-tabs.svelte";
 import { taskState } from "./task-state.svelte";
 
 export const taskSelectors = {
@@ -21,17 +22,20 @@ export const taskSelectors = {
     const active = workspaceState.activeCenterTab;
     if (active?.kind !== "task") return undefined;
     const candidates = taskState.tasks
-      .filter(
-        (task) =>
-          (task.definitionId ?? task.restartRootTaskId ?? task.id) ===
-          active.id,
-      )
+      .filter((task) => taskEntryId(task) === active.id)
       .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
     return (
       candidates.find(
         (task) => task.id === taskState.selectedRunByEntry[active.id],
       ) ?? candidates[0]
     );
+  },
+  get activeCenterTaskRuns() {
+    const active = workspaceState.activeCenterTab;
+    if (active?.kind !== "task") return [];
+    return taskState.tasks
+      .filter((task) => taskEntryId(task) === active.id)
+      .sort((left, right) => right.startedAt.localeCompare(left.startedAt));
   },
   get taskLogs() {
     return taskState.taskLogs;

--- a/packages/workbench-app/src/lib/features/tasks/state/task-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/task-tabs.svelte.ts
@@ -9,25 +9,41 @@ import {
   setActiveCenterTab,
 } from "$lib/features/workspace/state/center-tabs.svelte";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
+import type { TaskRecord } from "@nervekit/contracts";
+
+export function taskEntryId(task: TaskRecord): string {
+  return task.definitionId ?? task.restartRootTaskId ?? task.id;
+}
 
 export function taskEntryKey(taskId: string): string {
   const task = taskState.tasks.find((candidate) => candidate.id === taskId);
-  return task?.definitionId ?? task?.restartRootTaskId ?? task?.id ?? taskId;
+  return task ? taskEntryId(task) : taskId;
 }
 
 export function runForTaskEntry(entryId: string) {
   const selectedId = taskState.selectedRunByEntry[entryId];
   const candidates = taskState.tasks
-    .filter(
-      (task) =>
-        (task.definitionId ?? task.restartRootTaskId ?? task.id) === entryId,
-    )
+    .filter((task) => taskEntryId(task) === entryId)
     .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
   return candidates.find((task) => task.id === selectedId) ?? candidates[0];
 }
 
 export function setTaskEntryRun(entryId: string, taskId: string): void {
   taskState.selectedRunByEntry[entryId] = taskId;
+}
+
+export async function selectTaskEntryRun(
+  entryId: string,
+  taskId: string,
+): Promise<void> {
+  const task = taskState.tasks.find(
+    (candidate) =>
+      candidate.id === taskId && taskEntryId(candidate) === entryId,
+  );
+  if (!task) return;
+  setTaskEntryRun(entryId, taskId);
+  taskState.selectedTaskId = taskId;
+  await loadTaskLogWindow(taskId);
 }
 
 export async function openTaskTab(taskId: string) {
@@ -56,8 +72,8 @@ export async function selectCenterTaskTab(entryId: string) {
   const task = runForTaskEntry(entryId);
   addCenterTab({ kind: "task", id: entryId });
   setActiveCenterTab({ kind: "task", id: entryId });
-  taskState.selectedTaskId = task?.id;
-  if (task) await loadTaskLogWindow(task.id);
+  if (task) await selectTaskEntryRun(entryId, task.id);
+  else taskState.selectedTaskId = undefined;
 }
 
 export async function closeTaskTab(entryId: string) {

--- a/packages/workbench-app/src/lib/features/tasks/state/tasks.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/tasks.svelte.ts
@@ -89,6 +89,34 @@ export async function removeTask(taskId: string) {
   notify.success("Task removed");
 }
 
+export async function cleanupTaskRuns(taskIds: readonly string[]) {
+  const ids = taskIds.filter((id, index) => taskIds.indexOf(id) === index);
+  if (ids.length === 0) return;
+
+  const results = await Promise.allSettled(ids.map((id) => deleteTask(id)));
+  const removed = ids.filter(
+    (_, index) => results[index]?.status === "fulfilled",
+  );
+  const failed = ids.length - removed.length;
+  for (const id of removed) forgetTask(id);
+  await loadWorkspaceState();
+
+  if (removed.length > 0) {
+    notify.success(
+      removed.length === 1
+        ? "Removed 1 old task run"
+        : `Removed ${removed.length} old task runs`,
+    );
+  }
+  if (failed > 0) {
+    notify.error(
+      failed === 1
+        ? "Could not remove 1 old task run"
+        : `Could not remove ${failed} old task runs`,
+    );
+  }
+}
+
 export async function pruneFinishedTasks() {
   const { removed } = await pruneTasks();
   for (const id of removed) forgetTask(id);

--- a/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
@@ -17,6 +17,10 @@ import {
   launchTaskDefinition,
 } from "$lib/features/tasks/api/tasks.api";
 import { taskState } from "$lib/features/tasks/state/task-state.svelte";
+import {
+  setTaskEntryRun,
+  taskEntryKey,
+} from "$lib/features/tasks/state/task-tabs.svelte";
 import { loadWorkspaceState } from "$lib/features/workspace/state/workspace-actions.svelte";
 import {
   createTaskDefinition,
@@ -44,6 +48,7 @@ export type WorkbenchTaskPanelHostActions = {
   readonly cancelTask?: (id: string, request?: CancelTaskRequest) => void;
   readonly restartTask?: (id: string) => void;
   readonly removeTask?: (id: string) => void;
+  readonly cleanupRuns?: (ids: readonly string[]) => void;
   readonly pruneTasks?: () => void;
   readonly runCommand?: (input: {
     projectId: string;
@@ -126,8 +131,14 @@ export function createWorkbenchTaskPanelAdapter(
   }
 
   const host: TaskPanelActions = {
-    selectTask: (taskId) => {
+    selectTask: async (taskId) => {
       taskState.selectedTaskId = taskId;
+      if (!taskId) {
+        taskState.taskLogs = undefined;
+        return;
+      }
+      setTaskEntryRun(taskEntryKey(taskId), taskId);
+      taskState.taskLogs = await getTaskLogs(taskId);
     },
     openTaskOutput: (taskId) => hostActions.openTaskOutput?.(taskId),
     startTask: (request: StartTaskRequest) => {
@@ -167,6 +178,7 @@ export function createWorkbenchTaskPanelAdapter(
       }),
     restartTask: (id) => hostActions.restartTask?.(id),
     removeTask: (id) => hostActions.removeTask?.(id),
+    cleanupRuns: (ids) => hostActions.cleanupRuns?.(ids),
     pruneTasks: () => hostActions.pruneTasks?.(),
     copyText: async (text) => {
       try {

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
@@ -11,9 +11,9 @@ import Terminal from "@lucide/svelte/icons/terminal";
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
-import { taskPulse, taskTone } from "@nervekit/ui-kit/core/utils/status";
 import { PanelRow, PanelToolbarButton } from "$lib/presentation/panel";
 import { taskDefinitionLabel } from "./task-panel-controller.js";
+import TaskStatusIcon from "./TaskStatusIcon.svelte";
 import type {
   TaskDefinitionEntry,
   TaskEntryCapabilities,
@@ -21,9 +21,7 @@ import type {
 
 let {
   entry,
-  expanded = false,
   capabilities,
-  onToggleExpanded,
   onOpen,
   onRun,
   onCancel,
@@ -31,13 +29,11 @@ let {
   onRestart,
   onEdit,
   onDelete,
+  onCleanupRuns,
   onCopy,
 }: {
   entry: TaskDefinitionEntry;
-  /** Whether the definition's run rows are listed underneath it. */
-  expanded?: boolean;
   capabilities: TaskEntryCapabilities;
-  onToggleExpanded?: () => void;
   onOpen?: (taskId: string) => void;
   onRun?: () => void;
   onCancel?: (taskId: string) => void;
@@ -45,11 +41,11 @@ let {
   onRestart?: (taskId: string) => void;
   onEdit?: () => void;
   onDelete?: () => void;
+  onCleanupRuns?: (taskIds: readonly string[]) => void;
   onCopy?: (text: string) => void;
 } = $props();
 
 const latest = $derived(entry.latestRun);
-const expandable = $derived(entry.runs.length > 0);
 const status = $derived(latest?.status ?? "saved");
 const label = $derived(taskDefinitionLabel(entry));
 const command = $derived(entry.definition.command);
@@ -57,6 +53,9 @@ const cwd = $derived(entry.definition.cwd);
 const concurrent = $derived(entry.definition.runPolicy === "concurrent");
 const canStart = $derived(concurrent || entry.activeRuns.length === 0);
 const active = $derived(entry.activeRuns[0]);
+const cleanableRuns = $derived(
+  entry.runs.filter((run) => run.isRemovable && run.run.id !== latest?.id),
+);
 const recoveryHint = $derived(
   entry.needsRecovery
     ? latest?.status === "recovered"
@@ -80,11 +79,13 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
       disabled: !capabilities.logs,
       onSelect: () => onOpen?.(latest.id),
     });
-  if (expandable)
+  if (cleanableRuns.length > 0)
     items.push({
-      label: expanded ? "Hide runs" : "Show runs",
-      icon: History,
-      onSelect: () => onToggleExpanded?.(),
+      label: "Clean up old runs",
+      icon: Trash2,
+      destructive: true,
+      disabled: !capabilities.remove,
+      onSelect: () => onCleanupRuns?.(cleanableRuns.map((run) => run.run.id)),
     });
   if (canStart)
     items.push({
@@ -157,20 +158,15 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
   title={tooltip}
   mono={label.isCommand}
   tone={label.isCommand ? "muted" : "default"}
-  status={entry.needsRecovery
-    ? "warn"
-    : latest
-      ? taskTone(latest.status)
-      : "neutral"}
-  statusVariant={expanded ? "outline" : "solid"}
-  pulse={latest ? taskPulse(latest.status) : false}
-  disabled={!expandable}
-  ariaExpanded={expandable ? expanded : undefined}
+  disabled={!latest}
   indent={0}
   alwaysShowActions
   {menuItems}
-  onclick={() => expandable && onToggleExpanded?.()}
+  onclick={() => latest && onOpen?.(latest.id)}
 >
+  {#snippet leading()}
+    <TaskStatusIcon {status} />
+  {/snippet}
   {#snippet badges()}
     {#if entry.activeRuns.length > 1}
       <Badge tone="accent" size="xs">{entry.activeRuns.length} running</Badge>
@@ -180,22 +176,28 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
         <History class="mr-1 size-3" />{entry.runs.length}
       </Badge>
     {/if}
-    <Badge tone={latest ? taskTone(latest.status) : "neutral"} size="xs"
-      >{status}</Badge
-    >
   {/snippet}
   {#snippet actions()}
     {#if active?.status === "stopping"}
       <PanelToolbarButton
         icon={Skull}
         label="Force kill task"
+        dense
         disabled={!capabilities.cancel}
         onclick={() => onForceKill?.(active.id)}
       />
     {:else if active}
       <PanelToolbarButton
+        icon={RotateCw}
+        label="Restart task"
+        dense
+        disabled={!capabilities.restart}
+        onclick={() => onRestart?.(active.id)}
+      />
+      <PanelToolbarButton
         icon={Square}
         label="Stop task"
+        dense
         disabled={!capabilities.cancel}
         onclick={() => onCancel?.(active.id)}
       />
@@ -203,6 +205,7 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
       <PanelToolbarButton
         icon={Play}
         label={runLabel}
+        dense
         disabled={!capabilities.start}
         onclick={() => onRun?.()}
       />

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskOutputPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskOutputPane.svelte
@@ -2,14 +2,35 @@
 import Terminal from "@lucide/svelte/icons/terminal";
 import type { TaskLogQueryResponse, TaskRecord } from "@nervekit/contracts";
 import TaskLogTerminal from "./TaskLogTerminal.svelte";
+import TaskRunSwitcher from "./TaskRunSwitcher.svelte";
 
 type Props = {
   task?: Pick<TaskRecord, "id" | "command" | "status" | "error" | "runtime">;
   taskLogs?: TaskLogQueryResponse;
+  siblingRuns?: readonly TaskRecord[];
+  canRestart?: boolean;
+  canCancel?: boolean;
   onLoadEarlier?: () => void | Promise<void>;
+  onSelectRun?: (taskId: string) => void | Promise<void>;
+  onRestartRun?: (taskId: string) => void | Promise<void>;
+  onCancelRun?: (taskId: string) => void | Promise<void>;
+  onForceKillRun?: (taskId: string) => void | Promise<void>;
+  onCleanupRuns?: (taskIds: readonly string[]) => void | Promise<void>;
 };
 
-let { task, taskLogs, onLoadEarlier }: Props = $props();
+let {
+  task,
+  taskLogs,
+  siblingRuns = [],
+  canRestart = true,
+  canCancel = true,
+  onLoadEarlier,
+  onSelectRun,
+  onRestartRun,
+  onCancelRun,
+  onForceKillRun,
+  onCleanupRuns,
+}: Props = $props();
 </script>
 
 <section class="flex h-full min-h-0 flex-col bg-background">
@@ -27,7 +48,7 @@ let { task, taskLogs, onLoadEarlier }: Props = $props();
           >{/if}
       </div>
     {/if}
-    <div class="min-h-0 flex-1">
+    <div class="relative min-h-0 flex-1">
       {#key task.id}
         <TaskLogTerminal
           taskId={task.id}
@@ -36,6 +57,17 @@ let { task, taskLogs, onLoadEarlier }: Props = $props();
           {onLoadEarlier}
         />
       {/key}
+      <TaskRunSwitcher
+        currentTaskId={task.id}
+        runs={siblingRuns}
+        {canRestart}
+        {canCancel}
+        {onSelectRun}
+        {onRestartRun}
+        {onCancelRun}
+        {onForceKillRun}
+        {onCleanupRuns}
+      />
     </div>
   {:else}
     <div

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
@@ -8,11 +8,10 @@ import Square from "@lucide/svelte/icons/square";
 import Terminal from "@lucide/svelte/icons/terminal";
 import X from "@lucide/svelte/icons/x";
 import type { TaskRecord } from "@nervekit/contracts";
-import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
-import { taskPulse, taskTone } from "@nervekit/ui-kit/core/utils/status";
 import { PanelRow, PanelToolbarButton } from "$lib/presentation/panel";
 import { formatTaskRunTime, taskRunLabel } from "./task-panel-controller.js";
+import TaskStatusIcon from "./TaskStatusIcon.svelte";
 import type { TaskEntryCapabilities, TaskRunEntry } from "./task-panel-types";
 
 let {
@@ -138,28 +137,35 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
   title={tooltip}
   mono={!nested && label.isCommand}
   tone={nested || label.isCommand ? "muted" : "default"}
-  status={entry.needsRecovery ? "warn" : taskTone(run.status)}
-  pulse={taskPulse(run.status)}
   indent={nested ? 1 : 0}
   alwaysShowActions
   {menuItems}
   onclick={() => onOpen?.(run.id)}
 >
-  {#snippet badges()}
-    <Badge tone={taskTone(run.status)} size="xs">{run.status}</Badge>
+  {#snippet leading()}
+    <TaskStatusIcon status={run.status} />
   {/snippet}
   {#snippet actions()}
     {#if run.status === "stopping"}
       <PanelToolbarButton
         icon={Skull}
         label={`Force kill ${label.text}`}
+        dense
         disabled={!capabilities.cancel}
         onclick={() => onForceKill?.(run.id)}
       />
     {:else if entry.isActive}
       <PanelToolbarButton
+        icon={RotateCw}
+        label={`Restart ${label.text}`}
+        dense
+        disabled={!capabilities.restart}
+        onclick={() => onRestart?.(run.id)}
+      />
+      <PanelToolbarButton
         icon={Square}
         label={`Stop ${label.text}`}
+        dense
         disabled={!capabilities.cancel}
         onclick={() => onCancel?.(run.id)}
       />
@@ -167,6 +173,7 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
       <PanelToolbarButton
         icon={RotateCw}
         label={`Restart ${label.text}`}
+        dense
         disabled={!capabilities.restart}
         onclick={() => onRestart?.(run.id)}
       />

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunSwitcher.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunSwitcher.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+import Check from "@lucide/svelte/icons/check";
+import ChevronDown from "@lucide/svelte/icons/chevron-down";
+import ChevronUp from "@lucide/svelte/icons/chevron-up";
+import RotateCw from "@lucide/svelte/icons/rotate-cw";
+import Skull from "@lucide/svelte/icons/skull";
+import Square from "@lucide/svelte/icons/square";
+import Trash2 from "@lucide/svelte/icons/trash-2";
+import type { TaskRecord } from "@nervekit/contracts";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import ConfirmDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
+import { slide } from "svelte/transition";
+import { formatTaskRunTime } from "./task-panel-controller.js";
+import TaskStatusIcon from "./TaskStatusIcon.svelte";
+
+let {
+  currentTaskId,
+  runs,
+  canRestart = true,
+  canCancel = true,
+  onSelectRun,
+  onRestartRun,
+  onCancelRun,
+  onForceKillRun,
+  onCleanupRuns,
+}: {
+  currentTaskId: string;
+  runs: readonly TaskRecord[];
+  canRestart?: boolean;
+  canCancel?: boolean;
+  onSelectRun?: (taskId: string) => void | Promise<void>;
+  onRestartRun?: (taskId: string) => void | Promise<void>;
+  onCancelRun?: (taskId: string) => void | Promise<void>;
+  onForceKillRun?: (taskId: string) => void | Promise<void>;
+  onCleanupRuns?: (taskIds: readonly string[]) => void | Promise<void>;
+} = $props();
+
+let expanded = $state(false);
+let cleanupOpen = $state(false);
+const current = $derived(runs.find((run) => run.id === currentTaskId));
+const active = $derived(
+  current &&
+    ["starting", "running", "ready", "recovered"].includes(current.status),
+);
+const sortedRuns = $derived(
+  [...runs].sort((left, right) =>
+    right.startedAt.localeCompare(left.startedAt),
+  ),
+);
+const cleanableRuns = $derived(
+  sortedRuns.filter(
+    (run) =>
+      run.id !== currentTaskId &&
+      [
+        "completed",
+        "failed",
+        "timed_out",
+        "cancelled",
+        "orphaned",
+        "interrupted",
+      ].includes(run.status),
+  ),
+);
+
+function selectRun(taskId: string): void {
+  expanded = false;
+  if (taskId !== currentTaskId) void onSelectRun?.(taskId);
+}
+</script>
+
+{#if runs.length > 1 && current}
+  <div
+    class="absolute top-3 right-4 z-10 w-56 overflow-hidden rounded-md border border-border bg-card text-card-foreground shadow-md"
+  >
+    <div class="flex items-center transition-colors hover:bg-muted">
+      <Button
+        variant="ghost"
+        size="sm"
+        class="min-w-0 flex-1 justify-start rounded-none px-2 text-xs aria-expanded:bg-transparent aria-expanded:text-card-foreground"
+        ariaLabel="Show task run history"
+        aria-expanded={expanded}
+        onclick={() => (expanded = !expanded)}
+      >
+        <TaskStatusIcon status={current.status} />
+        <span class="min-w-0 flex-1 truncate text-left">
+          {formatTaskRunTime(current.startedAt)}
+        </span>
+      </Button>
+      <div
+        class="flex shrink-0 items-center gap-0.5 pr-1"
+        role="group"
+        aria-label="Task actions"
+      >
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          class="size-5 rounded-sm aria-expanded:bg-transparent aria-expanded:text-card-foreground"
+          ariaLabel={expanded
+            ? "Hide task run history"
+            : "Show task run history"}
+          aria-expanded={expanded}
+          onclick={() => (expanded = !expanded)}
+        >
+          {#if expanded}
+            <ChevronUp aria-hidden="true" />
+          {:else}
+            <ChevronDown aria-hidden="true" />
+          {/if}
+        </Button>
+        {#if current.status === "stopping"}
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            class="size-5 rounded-sm"
+            ariaLabel="Force kill task"
+            disabled={!canCancel}
+            onclick={() => void onForceKillRun?.(current.id)}
+          >
+            <Skull aria-hidden="true" />
+          </Button>
+        {:else if active}
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            class="size-5 rounded-sm"
+            ariaLabel="Restart task"
+            disabled={!canRestart}
+            onclick={() => void onRestartRun?.(current.id)}
+          >
+            <RotateCw aria-hidden="true" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            class="size-5 rounded-sm"
+            ariaLabel="Stop task"
+            disabled={!canCancel}
+            onclick={() => void onCancelRun?.(current.id)}
+          >
+            <Square aria-hidden="true" />
+          </Button>
+        {:else}
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            class="size-5 rounded-sm"
+            ariaLabel="Restart task"
+            disabled={!canRestart}
+            onclick={() => void onRestartRun?.(current.id)}
+          >
+            <RotateCw aria-hidden="true" />
+          </Button>
+        {/if}
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          class="size-5 rounded-sm"
+          ariaLabel="Clean up old runs"
+          disabled={cleanableRuns.length === 0 || !onCleanupRuns}
+          onclick={() => (cleanupOpen = true)}
+        >
+          <Trash2 aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+
+    {#if expanded}
+      <div
+        class="max-h-64 overflow-y-auto border-t border-border py-1"
+        transition:slide={{ duration: 140 }}
+        role="list"
+        aria-label="Task run history"
+      >
+        {#each sortedRuns as run (run.id)}
+          <button
+            type="button"
+            class="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            aria-current={run.id === currentTaskId ? "true" : undefined}
+            onclick={() => selectRun(run.id)}
+          >
+            <TaskStatusIcon status={run.status} />
+            <span class="min-w-0 flex-1 truncate">
+              {formatTaskRunTime(run.startedAt)}
+            </span>
+            {#if run.id === currentTaskId}
+              <Check
+                class="size-3.5 shrink-0 text-primary"
+                aria-hidden="true"
+              />
+            {/if}
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<ConfirmDialog
+  bind:open={cleanupOpen}
+  destructive
+  title="Clean up old task runs?"
+  description={`This removes ${cleanableRuns.length} old finished ${cleanableRuns.length === 1 ? "run" : "runs"} and their captured logs. The current run is retained.`}
+  confirmLabel="Clean up"
+  onConfirm={() => void onCleanupRuns?.(cleanableRuns.map((run) => run.id))}
+/>

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskStatusIcon.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskStatusIcon.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+import Ban from "@lucide/svelte/icons/ban";
+import Bookmark from "@lucide/svelte/icons/bookmark";
+import CircleCheck from "@lucide/svelte/icons/circle-check";
+import CircleHelp from "@lucide/svelte/icons/circle-help";
+import CirclePlay from "@lucide/svelte/icons/circle-play";
+import CircleStop from "@lucide/svelte/icons/circle-stop";
+import CircleX from "@lucide/svelte/icons/circle-x";
+import Radio from "@lucide/svelte/icons/radio";
+import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
+import TimerOff from "@lucide/svelte/icons/timer-off";
+import Unplug from "@lucide/svelte/icons/unplug";
+import type { TaskStatus } from "@nervekit/contracts";
+import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import { cn } from "@nervekit/ui-kit/core/utils";
+
+let {
+  status,
+  class: className,
+}: {
+  status: TaskStatus | "saved";
+  class?: string;
+} = $props();
+
+const presentation = $derived.by(() => {
+  switch (status) {
+    case "saved":
+      return { icon: Bookmark, label: "Saved", color: "text-muted-foreground" };
+    case "starting":
+      return { icon: undefined, label: "Starting", color: "text-warning" };
+    case "running":
+      return {
+        icon: CirclePlay,
+        label: "Running",
+        color: "text-success",
+        pulse: true,
+      };
+    case "ready":
+      return {
+        icon: Radio,
+        label: "Ready",
+        color: "text-success",
+        pulse: true,
+      };
+    case "stopping":
+      return { icon: undefined, label: "Stopping", color: "text-warning" };
+    case "completed":
+      return {
+        icon: CircleCheck,
+        label: "Completed",
+        color: "text-muted-foreground",
+      };
+    case "failed":
+      return { icon: CircleX, label: "Failed", color: "text-destructive" };
+    case "timed_out":
+      return { icon: TimerOff, label: "Timed out", color: "text-destructive" };
+    case "cancelled":
+      return { icon: Ban, label: "Cancelled", color: "text-muted-foreground" };
+    case "interrupted":
+      return { icon: CircleStop, label: "Interrupted", color: "text-warning" };
+    case "recovered":
+      return { icon: RotateCcw, label: "Recovered", color: "text-warning" };
+    case "orphaned":
+      return { icon: Unplug, label: "Orphaned", color: "text-destructive" };
+    case "recovery_unknown":
+      return {
+        icon: CircleHelp,
+        label: "Recovery unknown",
+        color: "text-destructive",
+      };
+  }
+});
+
+const Icon = $derived(presentation.icon);
+</script>
+
+<span
+  class={cn(
+    "inline-flex size-4 shrink-0 items-center justify-center",
+    presentation.color,
+    presentation.pulse && "animate-pulse",
+    className,
+  )}
+  title={presentation.label}
+  aria-label={presentation.label}
+  role="img"
+>
+  {#if Icon}
+    <Icon class="size-3.5" strokeWidth={2.2} aria-hidden="true" />
+  {:else}
+    <Spinner class="size-3.5" aria-hidden="true" />
+  {/if}
+</span>

--- a/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
@@ -2,7 +2,6 @@
 import ListTodo from "@lucide/svelte/icons/list-todo";
 import Plus from "@lucide/svelte/icons/plus";
 import Trash2 from "@lucide/svelte/icons/trash-2";
-import { SvelteSet } from "svelte/reactivity";
 import type {
   CreateTaskDefinitionRequest,
   TaskRecord,
@@ -48,23 +47,30 @@ let {
 } = $props();
 
 const projected = $derived(projectTaskPanel(model.definitions, model.tasks));
+const selectedSiblingRuns = $derived.by(() => {
+  const selected = model.selectedTask;
+  if (!selected) return [];
+  const entryId =
+    selected.definitionId ?? selected.restartRootTaskId ?? selected.id;
+  return model.tasks
+    .filter(
+      (task) =>
+        (task.definitionId ?? task.restartRootTaskId ?? task.id) === entryId,
+    )
+    .sort((left, right) => right.startedAt.localeCompare(left.startedAt));
+});
 let addOpen = $state(false);
 let saving = $state(false);
 let confirmPruneOpen = $state(false);
 let forceKillTask = $state<TaskRecord | undefined>();
 let editDefinition = $state<TaskPanelDefinition | undefined>();
 let deleteDefinition = $state<TaskPanelDefinition | undefined>();
+let cleanupRunIds = $state<readonly string[]>([]);
 let saveSourceTask = $state<TaskRecord | undefined>();
 let panelWidth = $state(0);
 let runsRegion = $state<HTMLDivElement | null>(null);
 let runsFooter = $state<HTMLDivElement | null>(null);
 let runsDialogOpen = $state(false);
-const expandedDefinitions = new SvelteSet<string>();
-
-function toggleDefinition(id: string): void {
-  if (!expandedDefinitions.delete(id)) expandedDefinitions.add(id);
-}
-
 // The wide bottom dock can host the run output next to the list.
 const SPLIT_MIN_WIDTH = 720;
 const splitLayout = $derived(panelWidth >= SPLIT_MIN_WIDTH);
@@ -114,6 +120,12 @@ async function updateDefinition(
   }
 }
 
+async function cleanupRuns(): Promise<void> {
+  const ids = cleanupRunIds;
+  cleanupRunIds = [];
+  await panelActions.cleanupRuns(ids);
+}
+
 async function removeDefinition(): Promise<void> {
   if (!deleteDefinition) return;
   await panelActions.deleteDefinition(deleteDefinition);
@@ -125,6 +137,18 @@ async function confirmForceKill(): Promise<void> {
   const taskId = forceKillTask.id;
   forceKillTask = undefined;
   await panelActions.forceKillTask(taskId);
+}
+
+function requestForceKill(taskId: string): void {
+  const task = model.tasks.find((run) => run.id === taskId);
+  if (!task) return;
+  if (task.status === "recovered") {
+    // The user never asked to terminate a recovered run, so confirm first.
+    forceKillTask = task;
+  } else {
+    // Stuck-stopping runs were already stopped once; kill immediately.
+    void panelActions.forceKillTask(taskId);
+  }
 }
 
 function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
@@ -146,46 +170,20 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
       {:else}
         <PanelList role="none" class="gap-1">
           {#each projected.definitions as entry (entry.key)}
-            {@const expanded = expandedDefinitions.has(entry.key)}
             <PanelRowCard>
               <TaskDefinitionRow
                 {entry}
                 {capabilities}
-                {expanded}
-                onToggleExpanded={() => toggleDefinition(entry.key)}
                 onOpen={(id) => void panelActions.openTaskOutput(id)}
                 onRun={() => void panelActions.runDefinition(entry.definition)}
                 onCancel={(id) => void panelActions.cancelTask(id)}
-                onForceKill={(id) =>
-                  (forceKillTask = model.tasks.find((task) => task.id === id))}
+                onForceKill={requestForceKill}
                 onRestart={(id) => void panelActions.restartTask(id)}
                 onEdit={() => (editDefinition = entry.definition)}
                 onDelete={() => (deleteDefinition = entry.definition)}
+                onCleanupRuns={(ids) => (cleanupRunIds = ids)}
                 onCopy={(text) => void panelActions.copyText(text)}
               />
-              {#if expanded}
-                <div
-                  class="flex min-w-0 flex-col border-t border-border/60 pt-0.5"
-                >
-                  {#each entry.runs as runEntry (runEntry.key)}
-                    <TaskRunRow
-                      nested
-                      entry={runEntry}
-                      {capabilities}
-                      onOpen={(id) => void panelActions.openTaskOutput(id)}
-                      onCancel={(id) => void panelActions.cancelTask(id)}
-                      onForceKill={(id) =>
-                        (forceKillTask = model.tasks.find(
-                          (task) => task.id === id,
-                        ))}
-                      onRestart={(id) => void panelActions.restartTask(id)}
-                      onRerunDefinition={() => rerunDefinition(runEntry)}
-                      onRemove={(id) => void panelActions.removeTask(id)}
-                      onCopy={(text) => void panelActions.copyText(text)}
-                    />
-                  {/each}
-                </div>
-              {/if}
             </PanelRowCard>
           {/each}
         </PanelList>
@@ -216,8 +214,7 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
                 {capabilities}
                 onOpen={(id) => void panelActions.openTaskOutput(id)}
                 onCancel={(id) => void panelActions.cancelTask(id)}
-                onForceKill={(id) =>
-                  (forceKillTask = model.tasks.find((task) => task.id === id))}
+                onForceKill={requestForceKill}
                 onRestart={(id) => void panelActions.restartTask(id)}
                 onRemove={(id) => void panelActions.removeTask(id)}
                 onCopy={(text) => void panelActions.copyText(text)}
@@ -281,6 +278,15 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
             <TaskOutputPane
               task={model.selectedTask}
               taskLogs={model.selectedLogs}
+              siblingRuns={selectedSiblingRuns}
+              canRestart={capabilities.restart}
+              canCancel={capabilities.cancel}
+              onSelectRun={(taskId) => void panelActions.selectTask(taskId)}
+              onRestartRun={(taskId) => void panelActions.restartTask(taskId)}
+              onCancelRun={(taskId) => void panelActions.cancelTask(taskId)}
+              onForceKillRun={(taskId) =>
+                void panelActions.forceKillTask(taskId)}
+              onCleanupRuns={(taskIds) => panelActions.cleanupRuns(taskIds)}
             />
           </Pane>
         </PaneGroup>
@@ -297,8 +303,7 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
   {capabilities}
   onOpen={(id) => void panelActions.openTaskOutput(id)}
   onCancel={(id) => void panelActions.cancelTask(id)}
-  onForceKill={(id) =>
-    (forceKillTask = model.tasks.find((task) => task.id === id))}
+  onForceKill={requestForceKill}
   onRestart={(id) => void panelActions.restartTask(id)}
   onRerunDefinition={rerunDefinition}
   onRemove={(id) => void panelActions.removeTask(id)}
@@ -355,6 +360,18 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
   onCancel={() => (forceKillTask = undefined)}
   onOpenChange={(open) => {
     if (!open) forceKillTask = undefined;
+  }}
+/>
+<ConfirmDialog
+  open={cleanupRunIds.length > 0}
+  destructive
+  title="Clean up old task runs?"
+  description={`This removes ${cleanupRunIds.length} old finished ${cleanupRunIds.length === 1 ? "run" : "runs"} and their captured logs. The latest run is retained.`}
+  confirmLabel="Clean up"
+  onConfirm={() => void cleanupRuns()}
+  onCancel={() => (cleanupRunIds = [])}
+  onOpenChange={(open) => {
+    if (!open) cleanupRunIds = [];
   }}
 />
 <ConfirmDialog

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
@@ -56,6 +56,96 @@ test("collapses a definition's concurrent runs into one definition entry while l
   assert.equal(projected.runs.length, 0);
 });
 
+test("blends alphabetical and recency ranks without moving a newly run task to the top", () => {
+  const definitions = [
+    definition({ id: "taskdef_alpha", label: "Alpha" }),
+    definition({ id: "taskdef_bravo", label: "Bravo" }),
+    definition({ id: "taskdef_charlie", label: "Charlie" }),
+    definition({ id: "taskdef_zulu", label: "Zulu" }),
+  ];
+  const projected = projectTaskPanel(definitions, [
+    run("task_zulu", {
+      definitionId: "taskdef_zulu",
+      startedAt: "2026-01-04T00:00:00Z",
+    }),
+    run("task_alpha", {
+      definitionId: "taskdef_alpha",
+      startedAt: "2026-01-03T00:00:00Z",
+    }),
+    run("task_bravo", {
+      definitionId: "taskdef_bravo",
+      startedAt: "2026-01-02T00:00:00Z",
+    }),
+    run("task_charlie", {
+      definitionId: "taskdef_charlie",
+      startedAt: "2026-01-01T00:00:00Z",
+    }),
+  ]);
+
+  assert.deepEqual(
+    projected.definitions.map((entry) => entry.definition.label),
+    ["Alpha", "Bravo", "Zulu", "Charlie"],
+  );
+});
+
+test("lets recency modestly improve nearby alphabetical positions", () => {
+  const projected = projectTaskPanel(
+    [
+      definition({ id: "taskdef_alpha", label: "Alpha" }),
+      definition({ id: "taskdef_bravo", label: "Bravo" }),
+      definition({ id: "taskdef_charlie", label: "Charlie" }),
+      definition({ id: "taskdef_delta", label: "Delta" }),
+    ],
+    [
+      run("task_bravo", {
+        definitionId: "taskdef_bravo",
+        startedAt: "2026-01-04T00:00:00Z",
+      }),
+      run("task_charlie", {
+        definitionId: "taskdef_charlie",
+        startedAt: "2026-01-03T00:00:00Z",
+      }),
+      run("task_delta", {
+        definitionId: "taskdef_delta",
+        startedAt: "2026-01-02T00:00:00Z",
+      }),
+      run("task_alpha", {
+        definitionId: "taskdef_alpha",
+        startedAt: "2026-01-01T00:00:00Z",
+      }),
+    ],
+  );
+
+  assert.deepEqual(
+    projected.definitions.map((entry) => entry.definition.label),
+    ["Bravo", "Alpha", "Charlie", "Delta"],
+  );
+});
+
+test("sorts equally ranked definitions deterministically by label", () => {
+  const timestamp = "2026-01-01T00:00:00Z";
+  const projected = projectTaskPanel(
+    [
+      definition({
+        id: "taskdef_zebra",
+        label: "zebra",
+        updatedAt: timestamp,
+      }),
+      definition({
+        id: "taskdef_alpha",
+        label: "Alpha",
+        updatedAt: timestamp,
+      }),
+    ],
+    [],
+  );
+
+  assert.deepEqual(
+    projected.definitions.map((entry) => entry.definition.id),
+    ["taskdef_alpha", "taskdef_zebra"],
+  );
+});
+
 test("lists only ad-hoc runs at the top level", () => {
   const projected = projectTaskPanel(
     [definition()],

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
@@ -39,6 +39,13 @@ const REMOVABLE_STATUSES = new Set([
   "interrupted",
 ]);
 
+const DEFINITION_ALPHABETICAL_WEIGHT = 0.7;
+const DEFINITION_RECENCY_WEIGHT = 0.3;
+const definitionCollator = new Intl.Collator(undefined, {
+  sensitivity: "base",
+  numeric: true,
+});
+
 export type TaskGroups = {
   running: TaskRecord[];
   orphaned: TaskRecord[];
@@ -133,20 +140,14 @@ export function projectTaskPanel(
     runsByDefinition.set(task.definitionId, runs);
   }
 
-  const definitionEntries = definitions
-    .map((definition) =>
+  const definitionEntries = sortDefinitionEntries(
+    definitions.map((definition) =>
       buildDefinitionEntry(
         definition,
         runsByDefinition.get(definition.id) ?? [],
       ),
-    )
-    .sort(
-      (left, right) =>
-        Number(right.needsRecovery) - Number(left.needsRecovery) ||
-        (
-          right.latestRun?.startedAt ?? right.definition.updatedAt
-        ).localeCompare(left.latestRun?.startedAt ?? left.definition.updatedAt),
-    );
+    ),
+  );
 
   const runEntries = tasks
     .filter((run) => !run.definitionId)
@@ -158,6 +159,55 @@ export function projectTaskPanel(
     );
 
   return { definitions: definitionEntries, runs: runEntries };
+}
+
+function definitionSortLabel(entry: TaskDefinitionEntry): string {
+  const label = entry.definition.label?.trim();
+  return label || entry.definition.command;
+}
+
+function definitionRecency(entry: TaskDefinitionEntry): string {
+  return entry.latestRun?.startedAt ?? entry.definition.updatedAt;
+}
+
+/**
+ * Keeps saved tasks primarily alphabetical while allowing recent activity to
+ * improve their position modestly. Rank blending avoids the distracting jump
+ * to first place caused by a strict newest-first comparison.
+ */
+function sortDefinitionEntries(
+  entries: TaskDefinitionEntry[],
+): TaskDefinitionEntry[] {
+  const alphabetical = [...entries].sort(
+    (left, right) =>
+      definitionCollator.compare(
+        definitionSortLabel(left),
+        definitionSortLabel(right),
+      ) || left.definition.id.localeCompare(right.definition.id),
+  );
+  const recent = [...entries].sort(
+    (left, right) =>
+      definitionRecency(right).localeCompare(definitionRecency(left)) ||
+      left.definition.id.localeCompare(right.definition.id),
+  );
+  const alphabeticalRank = new Map(
+    alphabetical.map((entry, index) => [entry.key, index]),
+  );
+  const recencyRank = new Map(recent.map((entry, index) => [entry.key, index]));
+  const score = (entry: TaskDefinitionEntry) =>
+    (alphabeticalRank.get(entry.key) ?? 0) * DEFINITION_ALPHABETICAL_WEIGHT +
+    (recencyRank.get(entry.key) ?? 0) * DEFINITION_RECENCY_WEIGHT;
+
+  return [...entries].sort(
+    (left, right) =>
+      score(left) - score(right) ||
+      Number(right.needsRecovery) - Number(left.needsRecovery) ||
+      definitionCollator.compare(
+        definitionSortLabel(left),
+        definitionSortLabel(right),
+      ) ||
+      left.definition.id.localeCompare(right.definition.id),
+  );
 }
 
 function toRunEntry(
@@ -228,6 +278,9 @@ export function createTaskPanelActions(
     },
     removeTask: (taskId) => {
       if (enabled("remove")) return host.removeTask(taskId);
+    },
+    cleanupRuns: (taskIds) => {
+      if (enabled("remove")) return host.cleanupRuns(taskIds);
     },
     pruneTasks: () => {
       if (enabled("prune")) return host.pruneTasks();

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-types.ts
@@ -94,6 +94,7 @@ export interface TaskPanelActions {
   readonly forceKillTask: (taskId: string) => void | Promise<void>;
   readonly restartTask: (taskId: string) => void | Promise<void>;
   readonly removeTask: (taskId: string) => void | Promise<void>;
+  readonly cleanupRuns: (taskIds: readonly string[]) => void | Promise<void>;
   readonly pruneTasks: () => void | Promise<void>;
   readonly copyText: (text: string) => void | Promise<void>;
   readonly createDefinition: (


### PR DESCRIPTION
## Summary

Reworks how task runs are presented and managed in the workbench tasks panel, and changes saved-definition ordering.

### Definition list ordering
- Saved task definitions are now sorted **alphabetically**, with recency given modest weight to nudge recently active tasks up a few positions — instead of the previous strict newest-first ordering that jumped a newly run task to the top.
- Deterministic tie-breaking by label/id; recovery-needing entries still surface first.

### Run management
- **Removed expandable run rows** under saved definitions in the list; sibling runs of the selected task are now accessible from a new floating **run switcher** on the task output pane.
- New shared **`TaskStatusIcon`** component replaces the per-row status badges with consistent status icons/spinners across rows, the switcher, and definition rows.
- Added **"Clean up old runs"** (context menu + switcher action) with a destructive confirm dialog that removes finished runs while retaining the latest, then reloads workspace state.
- **Force-kill behavior refined**: verified `recovered` runs confirm before killing (the user never asked to stop them); stuck-`stopping` runs kill immediately. Applies in the list rows, output pane, and runs dialog.
- Added a **restart** action alongside stop/force-kill on active rows.
- Task editor tabs prefer the task definition's `displayName` over `name`/`command`.

### Docs & tests
- Updated force-kill guidance in `background-tasks.md` and `tasks-and-recovery.md`.
- Added tests for the definition ranking blend, tab label fallbacks, and existing controller behavior.

## Validation
- `pnpm fix && pnpm check && pnpm test` passes (0 errors/warnings across all packages).