### PR TITLE
Automate version bump and tagging for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,30 +7,127 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       # Pre-releases: v1.2.3-rc.1, v1.2.3-beta.2, etc.
       - "v[0-9]+.[0-9]+.[0-9]+-*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact SemVer without v (for example, 1.2.3 or 1.2.3-rc.1)
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  verify-tag:
-    name: Verify release tag
+  prepare-release:
+    name: Bump version and create tag
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      release_tag: ${{ steps.push.outputs.release_tag }}
+      release_sha: ${{ steps.push.outputs.release_sha }}
 
     steps:
-      - name: Check out repository
+      - name: Check out default branch
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
 
+      - name: Bump workspace versions
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: node scripts/bump-release-version.mjs "${RELEASE_VERSION}"
+
+      - name: Verify and push release commit and tag
+        id: push
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_AUTHOR_ID: ${{ github.actor_id }}
+          RELEASE_AUTHOR_NAME: ${{ github.actor }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          release_tag="v${RELEASE_VERSION}"
+          node scripts/verify-release-tag.mjs "${release_tag}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json packages/*/package.json
+          if ! git diff --cached --quiet; then
+            git commit \
+              --author="${RELEASE_AUTHOR_NAME} <${RELEASE_AUTHOR_ID}+${RELEASE_AUTHOR_NAME}@users.noreply.github.com>" \
+              -m "chore(release): bump version to ${release_tag}"
+          else
+            echo "Workspace is already at ${release_tag}; reusing the current commit"
+          fi
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "${release_tag}")"
+            head_sha="$(git rev-parse HEAD)"
+            if [ "${tag_sha}" != "${head_sha}" ]; then
+              echo "Tag ${release_tag} already points to ${tag_sha}, not ${head_sha}" >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already points to the release commit"
+          else
+            git tag -a "${release_tag}" -m "Release ${release_tag}"
+          fi
+
+          git push --atomic origin \
+            "HEAD:refs/heads/${DEFAULT_BRANCH}" \
+            "refs/tags/${release_tag}"
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "release_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+  verify-tag:
+    name: Verify release tag
+    needs: prepare-release
+    if: >-
+      always() &&
+      (needs.prepare-release.result == 'success' ||
+       needs.prepare-release.result == 'skipped')
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.context.outputs.release_tag }}
+      release_sha: ${{ steps.context.outputs.release_sha }}
+
+    steps:
+      - name: Check out release commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha || github.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Resolve release context
+        id: context
+        shell: bash
+        env:
+          PREPARED_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          PREPARED_SHA: ${{ needs.prepare-release.outputs.release_sha }}
+          PUSHED_TAG: ${{ github.ref_name }}
+          PUSHED_SHA: ${{ github.sha }}
+        run: |
+          echo "release_tag=${PREPARED_TAG:-${PUSHED_TAG}}" >> "${GITHUB_OUTPUT}"
+          echo "release_sha=${PREPARED_SHA:-${PUSHED_SHA}}" >> "${GITHUB_OUTPUT}"
+
       - name: Verify release tag
-        run: node scripts/verify-release-tag.mjs "${{ github.ref_name }}"
+        run: node scripts/verify-release-tag.mjs "${{ steps.context.outputs.release_tag }}"
 
   quality-and-package:
     name: Check, test, build, and package (Ubuntu)
@@ -39,8 +136,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Check out repository
+      - name: Check out release commit
         uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.verify-tag.outputs.release_sha }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -96,8 +195,10 @@ jobs:
         os: [windows-latest, macos-latest]
 
     steps:
-      - name: Check out repository
+      - name: Check out release commit
         uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.verify-tag.outputs.release_sha }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -132,6 +233,7 @@ jobs:
     name: Publish to npmjs.com
     runs-on: ubuntu-latest
     needs:
+      - verify-tag
       - quality-and-package
       - native-package-smoke
     permissions:
@@ -172,7 +274,7 @@ jobs:
       - name: Publish npm tarball
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ needs.verify-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
           name="@nervekit/desktop"
@@ -196,7 +298,9 @@ jobs:
   github-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
-    needs: publish-npm
+    needs:
+      - verify-tag
+      - publish-npm
     permissions:
       contents: write
 
@@ -212,7 +316,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ needs.verify-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:ui": "pnpm --filter @nervekit/contracts --filter @nervekit/protocol --filter @nervekit/harness --filter @nervekit/tools build && pnpm --filter @nervekit/workbench-app dev",
     "desktop": "pnpm --filter @nervekit/desktop-shell dev --",
     "desktop:remote-enabled": "pnpm desktop -- --host 0.0.0.0 --allow-remote --mobile-https",
+    "release:bump-version": "node scripts/bump-release-version.mjs",
     "release:verify-tag": "node scripts/verify-release-tag.mjs",
     "release:verify-npm": "node scripts/verify-npm-tarballs.mjs",
     "release:smoke:workbench": "node scripts/smoke-workbench-release.mjs",

--- a/scripts/bump-release-version.mjs
+++ b/scripts/bump-release-version.mjs
@@ -1,0 +1,13 @@
+import { setWorkspaceVersion } from "./lib/release-version.mjs";
+import { repoRoot } from "./lib/workspace-packages.mjs";
+
+const args = process.argv.slice(2).filter((arg) => arg !== "--");
+const version = args[0];
+const changedPaths = await setWorkspaceVersion(repoRoot, version);
+
+if (changedPaths.length === 0) {
+  console.log(`Workspace manifests already use version ${version}.`);
+} else {
+  console.log(`Updated workspace manifests to version ${version}:`);
+  for (const path of changedPaths) console.log(`  ${path}`);
+}

--- a/scripts/lib/release-version.mjs
+++ b/scripts/lib/release-version.mjs
@@ -1,0 +1,81 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+export function assertReleaseVersion(version) {
+  if (typeof version !== "string" || !version) {
+    throw new Error("Release version is required.");
+  }
+
+  const match =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?$/.exec(
+      version,
+    );
+  if (!match) {
+    throw new Error(
+      `Invalid release version ${JSON.stringify(version)}. Expected canonical SemVer without a leading v or build metadata.`,
+    );
+  }
+
+  const prerelease = match[4];
+  if (
+    prerelease
+      ?.split(".")
+      .some(
+        (identifier) =>
+          !identifier ||
+          !/^[0-9A-Za-z-]+$/.test(identifier) ||
+          (/^\d+$/.test(identifier) &&
+            identifier.length > 1 &&
+            identifier.startsWith("0")),
+      )
+  ) {
+    throw new Error(
+      `Invalid release version ${JSON.stringify(version)}. Prerelease identifiers must be canonical SemVer.`,
+    );
+  }
+
+  return version;
+}
+
+export async function workspaceManifestPaths(rootDirectory) {
+  const packagesDirectory = join(rootDirectory, "packages");
+  const entries = await readdir(packagesDirectory, { withFileTypes: true });
+  const packageManifests = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(packagesDirectory, entry.name, "package.json"))
+    .sort();
+
+  if (packageManifests.length === 0) {
+    throw new Error(
+      `No workspace package manifests found in ${packagesDirectory}.`,
+    );
+  }
+
+  return [join(rootDirectory, "package.json"), ...packageManifests];
+}
+
+export async function setWorkspaceVersion(rootDirectory, version) {
+  assertReleaseVersion(version);
+  const manifestPaths = await workspaceManifestPaths(rootDirectory);
+  const manifests = await Promise.all(
+    manifestPaths.map(async (manifestPath) => {
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+      if (typeof manifest.version !== "string" || !manifest.version) {
+        throw new Error(
+          `${relative(rootDirectory, manifestPath)} does not declare a version.`,
+        );
+      }
+      return { manifestPath, manifest };
+    }),
+  );
+
+  const changedPaths = [];
+  for (const { manifestPath, manifest } of manifests) {
+    if (manifest.version === version) continue;
+    manifest.version = version;
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    changedPaths.push(relative(rootDirectory, manifestPath));
+  }
+
+  return changedPaths;
+}

--- a/scripts/lib/release-version.test.mjs
+++ b/scripts/lib/release-version.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  assertReleaseVersion,
+  setWorkspaceVersion,
+} from "./release-version.mjs";
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), "nerve-release-version-"));
+  await mkdir(join(root, "packages", "alpha"), { recursive: true });
+  await mkdir(join(root, "packages", "website"), { recursive: true });
+  await writeFile(
+    join(root, "package.json"),
+    `${JSON.stringify({ name: "root", version: "1.0.0", private: true }, null, 2)}\n`,
+  );
+  await writeFile(
+    join(root, "packages", "alpha", "package.json"),
+    `${JSON.stringify({ name: "alpha", version: "1.0.0", marker: "kept" }, null, 2)}\n`,
+  );
+  await writeFile(
+    join(root, "packages", "website", "package.json"),
+    `${JSON.stringify({ name: "website", version: "0.9.0" }, null, 2)}\n`,
+  );
+  return root;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+test("accepts stable and prerelease versions", () => {
+  for (const version of ["0.23.0", "1.2.3-rc.1", "10.0.0-beta-feature.2"]) {
+    assert.equal(assertReleaseVersion(version), version);
+  }
+});
+
+test("rejects non-canonical or unsupported versions", () => {
+  for (const version of [
+    "v1.2.3",
+    "1.2",
+    "01.2.3",
+    "1.2.3-rc.01",
+    "1.2.3+build.1",
+    "1.2.3-",
+  ]) {
+    assert.throws(
+      () => assertReleaseVersion(version),
+      /Invalid release version/,
+    );
+  }
+});
+
+test("updates the root and every package manifest", async (context) => {
+  const root = await createFixture();
+  context.after(() => rm(root, { recursive: true, force: true }));
+
+  const changedPaths = await setWorkspaceVersion(root, "1.1.0-rc.1");
+  assert.deepEqual(changedPaths, [
+    "package.json",
+    join("packages", "alpha", "package.json"),
+    join("packages", "website", "package.json"),
+  ]);
+
+  const rootManifest = await readJson(join(root, "package.json"));
+  const alphaManifest = await readJson(
+    join(root, "packages", "alpha", "package.json"),
+  );
+  const websiteManifest = await readJson(
+    join(root, "packages", "website", "package.json"),
+  );
+  assert.equal(rootManifest.version, "1.1.0-rc.1");
+  assert.equal(alphaManifest.version, "1.1.0-rc.1");
+  assert.equal(alphaManifest.marker, "kept");
+  assert.equal(websiteManifest.version, "1.1.0-rc.1");
+
+  assert.deepEqual(await setWorkspaceVersion(root, "1.1.0-rc.1"), []);
+});


### PR DESCRIPTION
## Summary
- add a manual release dispatch that updates all workspace package versions
- commit the version bump with the dispatching user as author and atomically create/push the release tag
- preserve tag-triggered releases while pinning packaging and publication to the verified release commit
- add reusable release-version tooling and focused tests

## Validation
- `pnpm fix && pnpm check && pnpm test`
- release workflow YAML parse check
- no-op version bump against the current workspace version