### PR TITLE
feat(workbench): show project icons in recent projects

### DIFF
--- a/packages/harness/src/node.ts
+++ b/packages/harness/src/node.ts
@@ -1,2 +1,3 @@
 export { NodeExecutionEnv } from "./harness/environment/nodejs.js";
+export { resizeImage, type ResizedImage } from "./models/image-resize.js";
 export * from "./index.js";

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectDirectoryPicker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { untrack } from "svelte";
-import { MediaQuery, SvelteSet } from "svelte/reactivity";
+import { SvelteSet } from "svelte/reactivity";
 import FolderSearch from "@lucide/svelte/icons/folder-search";
 import { writeClipboardText } from "$lib/core/clipboard";
 import { notify } from "$lib/features/notifications/notify.svelte";
@@ -74,24 +74,13 @@ const gitInFlightProjectKeys = new SvelteSet<string>();
 const openedProjectKeys = $derived.by(
   () => new Set(projects.map((project) => pathKey(project.dir))),
 );
-const phoneViewport =
-  typeof window !== "undefined" && typeof window.matchMedia === "function"
-    ? new MediaQuery("max-width: 639px")
-    : undefined;
-const recentProjects = $derived(switcherItems.slice(0, 24));
-const defaultRecentLimit = $derived(phoneViewport?.current ? 4 : 8);
-const defaultRecentProjects = $derived.by(() =>
-  recentProjects
-    .slice(0, defaultRecentLimit)
-    .sort((a, b) =>
-      a.label.localeCompare(b.label, undefined, { sensitivity: "base" }),
-    ),
-);
+const MAX_RECENT_PROJECTS = 100;
+const recentProjects = $derived(switcherItems.slice(0, MAX_RECENT_PROJECTS));
 const pathQuery = $derived(looksLikePath(query.trim()));
 const filteredRecents = $derived.by(() => {
   if (pathQuery) return [];
   const q = query.trim().toLowerCase();
-  if (!q) return defaultRecentProjects;
+  if (!q) return recentProjects;
   return recentProjects.filter(
     (item) =>
       item.label.toLowerCase().includes(q) ||
@@ -278,12 +267,6 @@ async function loadRecentGit(items: ProjectSwitcherItem[], generation: number) {
 
   await Promise.all(Array.from({ length: 4 }, () => worker()));
 }
-function recentGridColumns(): number {
-  return typeof window !== "undefined" &&
-    window.matchMedia("(min-width: 768px)").matches
-    ? 2
-    : 1;
-}
 function handleRecentKeydown(event: KeyboardEvent) {
   const target = event.target as HTMLElement | null;
   const inInput = target?.tagName === "INPUT";
@@ -295,30 +278,13 @@ function handleRecentKeydown(event: KeyboardEvent) {
         recentSelectedIndex =
           recentSelectedIndex < 0
             ? 0
-            : Math.min(recentSelectedIndex + recentGridColumns(), count - 1);
+            : Math.min(recentSelectedIndex + 1, count - 1);
         scrollRecentIntoView();
       }
       break;
     case "ArrowUp":
       event.preventDefault();
       if (count) {
-        recentSelectedIndex = Math.max(
-          0,
-          recentSelectedIndex - recentGridColumns(),
-        );
-        scrollRecentIntoView();
-      }
-      break;
-    case "ArrowRight":
-      if (!inInput && recentGridColumns() > 1 && count) {
-        event.preventDefault();
-        recentSelectedIndex = Math.min(recentSelectedIndex + 1, count - 1);
-        scrollRecentIntoView();
-      }
-      break;
-    case "ArrowLeft":
-      if (!inInput && recentGridColumns() > 1 && count) {
-        event.preventDefault();
         recentSelectedIndex = Math.max(0, recentSelectedIndex - 1);
         scrollRecentIntoView();
       }
@@ -463,7 +429,6 @@ $effect(() => {
         bind:scrollEl={recentScrollEl}
         items={filteredRecents}
         totalRecentCount={recentProjects.length}
-        defaultProjectCount={defaultRecentLimit}
         bind:query
         {pathQuery}
         selectedIndex={recentSelectedIndex}
@@ -478,7 +443,6 @@ $effect(() => {
         onNewChat={(path) => void onNewChat?.(path)}
         onCopyPath={(path) => void copyPath(path)}
         {onForget}
-        onBrowse={() => enterBrowse()}
         onBrowsePath={() => enterBrowse(expandHome(query, homeDir))}
         onQueryChange={resetRecentSelection}
         onSubmit={handleSubmit}
@@ -525,12 +489,14 @@ $effect(() => {
  * globally on the shell's own element (escape-hatch reason 5). The compound
  * selector keeps it ahead of `.dialog-content`'s default width. */
 :global(.dialog-content.project-picker-dialog) {
-  width: min(820px, calc(100vw - 24px));
-  width: min(820px, calc(100dvw - 1.5rem));
+  width: min(720px, calc(100vw - 24px));
+  width: min(720px, calc(100dvw - 1.5rem));
   height: min(680px, calc(100vh - 48px));
   height: min(680px, calc(100dvh - 3rem));
-  min-height: 0;
-  max-height: none;
+  min-height: min(480px, calc(100vh - 48px));
+  min-height: min(480px, calc(100dvh - 3rem));
+  max-height: min(680px, calc(100vh - 48px));
+  max-height: min(680px, calc(100dvh - 3rem));
 }
 
 :global(.dialog-content.project-picker-dialog.project-picker-dialog-recent) {
@@ -545,6 +511,8 @@ $effect(() => {
     width: calc(100dvw - 0.75rem);
     height: calc(100vh - 12px);
     height: calc(100dvh - 0.75rem);
+    max-height: calc(100vh - 12px);
+    max-height: calc(100dvh - 0.75rem);
   }
 
   :global(.dialog-content.project-picker-dialog.project-picker-dialog-recent) {

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectIcon.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectIcon.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import Layers from "@lucide/svelte/icons/layers";
+import { cn } from "@nervekit/ui-kit/core/utils";
+
+type Props = {
+  projectId: string;
+  class?: string;
+};
+
+let { projectId, class: className }: Props = $props();
+let failed = $state(false);
+const source = $derived(
+  `/api/projects/${encodeURIComponent(projectId)}/icon?v=2`,
+);
+</script>
+
+<span
+  class={cn(
+    "relative grid shrink-0 place-items-center overflow-hidden rounded-md border border-border/60 bg-muted/40 text-muted-foreground",
+    className,
+  )}
+  aria-hidden="true"
+>
+  <Layers class="size-1/2" strokeWidth={1.8} />
+  {#if !failed}
+    <img
+      src={source}
+      alt=""
+      loading="lazy"
+      decoding="async"
+      class="absolute inset-0 size-full bg-muted/40 object-cover"
+      onerror={() => (failed = true)}
+    />
+  {/if}
+</span>

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -2,7 +2,6 @@
 import ArrowRight from "@lucide/svelte/icons/arrow-right";
 import Copy from "@lucide/svelte/icons/copy";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
-import FolderSearch from "@lucide/svelte/icons/folder-search";
 import Plus from "@lucide/svelte/icons/plus";
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
@@ -15,12 +14,12 @@ import { tildePath } from "$lib/core/utils/path";
 import type { ProjectGitOverview } from "$lib/features/projects/state/project-overview";
 import type { ProjectSwitcherItem } from "$lib/features/projects/state/project-switcher";
 import ProjectCardStatus from "./ProjectCardStatus.svelte";
+import ProjectIcon from "./ProjectIcon.svelte";
 
 type Props = {
   scrollEl?: HTMLDivElement;
   items: ProjectSwitcherItem[];
   totalRecentCount: number;
-  defaultProjectCount: number;
   query: string;
   pathQuery: boolean;
   selectedIndex: number;
@@ -35,7 +34,6 @@ type Props = {
   onForget?: (projectId: string) => void;
   onCopyPath: (path: string) => void;
   onNewChat: (path: string) => void;
-  onBrowse: () => void;
   onBrowsePath: () => void;
   onQueryChange?: () => void;
   onSubmit?: (event: Event) => void;
@@ -50,7 +48,6 @@ let {
   scrollEl = $bindable(),
   items,
   totalRecentCount,
-  defaultProjectCount,
   query = $bindable(),
   pathQuery,
   selectedIndex,
@@ -65,16 +62,34 @@ let {
   onForget,
   onCopyPath,
   onNewChat,
-  onBrowse,
   onBrowsePath,
   onQueryChange,
   onSubmit,
   onRowKeydown,
 }: Props = $props();
 
-const placeholderCount = $derived(
-  query.trim() ? 0 : Math.max(0, defaultProjectCount - items.length),
-);
+let listContentEl = $state<HTMLDivElement | undefined>(undefined);
+let canScrollUp = $state(false);
+let canScrollDown = $state(false);
+
+function updateScrollShadows(): void {
+  if (!scrollEl) return;
+  canScrollUp = scrollEl.scrollTop > 2;
+  canScrollDown =
+    scrollEl.scrollTop + scrollEl.clientHeight < scrollEl.scrollHeight - 2;
+}
+
+$effect(() => {
+  const region = scrollEl;
+  const content = listContentEl;
+  if (!region || !content) return;
+
+  updateScrollShadows();
+  const observer = new ResizeObserver(updateScrollShadows);
+  observer.observe(region);
+  observer.observe(content);
+  return () => observer.disconnect();
+});
 
 function projectMenu(item: ProjectSwitcherItem): ContextMenuItem[] {
   const project = item.project;
@@ -107,113 +122,147 @@ function projectMenu(item: ProjectSwitcherItem): ContextMenuItem[] {
   />
 </form>
 
-<div class="min-h-0 overflow-auto p-2" bind:this={scrollEl}>
-  {#if pathQuery}
-    <button
-      type="button"
-      class="group flex w-full items-center gap-2.5 rounded-md border border-transparent bg-transparent px-2.5 py-2 text-left hover:bg-accent/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
-      onclick={onBrowsePath}
-    >
-      <span
-        class="grid size-8 flex-none place-items-center rounded-md border border-border/60 bg-muted/40 text-muted-foreground group-hover:text-foreground"
-      >
-        <FolderOpen class="size-4" aria-hidden="true" />
-      </span>
-      <span class="grid min-w-0 flex-1 gap-0.5">
-        <span class="text-sm font-medium text-foreground">Browse path</span>
-        <span class="truncate font-mono text-xs text-muted-foreground"
-          >{query.trim()}</span
+<div class="relative flex min-h-0 flex-1 overflow-hidden">
+  <div
+    class="recent-projects-scroller min-h-0 flex-1 overflow-y-auto p-2"
+    bind:this={scrollEl}
+    onscroll={updateScrollShadows}
+  >
+    <div bind:this={listContentEl}>
+      {#if pathQuery}
+        <button
+          type="button"
+          class="group flex w-full items-center gap-2.5 rounded-md border border-transparent bg-transparent px-2.5 py-2 text-left hover:bg-accent/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+          onclick={onBrowsePath}
         >
-      </span>
-      <ArrowRight
-        class="size-3.5 flex-none text-muted-foreground group-hover:text-foreground"
-        strokeWidth={2.2}
-        aria-hidden="true"
-      />
-    </button>
-  {:else if items.length || placeholderCount}
-    <Tooltip.Provider delayDuration={300} disableHoverableContent>
-      <div
-        class="grid grid-cols-1 gap-1.5 md:grid-cols-2"
-        role="listbox"
-        aria-label="Recent projects"
-        tabindex={-1}
-        aria-activedescendant={activeDescendant}
-      >
-        {#each items as item, i (item.key)}
-          {@const current = item.key === activeProjectKey}
-          {@const selected = selectedIndex === i}
-          <ContextMenu items={projectMenu(item)} triggerClass="contents">
-            <div
-              id={`recent:${encodeURIComponent(item.key)}`}
-              class={`group grid w-full cursor-pointer gap-2 rounded-md border px-2.5 py-2 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
-                selected
-                  ? "border-primary/50 bg-accent/80"
-                  : "border-border bg-accent/40 hover:bg-accent/70"
-              }`}
-              role="option"
-              aria-selected={selected}
-              tabindex="-1"
-              onclick={() => onOpen(item)}
-              onkeydown={(event) => onRowKeydown(event, i, item)}
+          <span
+            class="grid size-8 flex-none place-items-center rounded-md border border-border/60 bg-muted/40 text-muted-foreground group-hover:text-foreground"
+          >
+            <FolderOpen class="size-4" aria-hidden="true" />
+          </span>
+          <span class="grid min-w-0 flex-1 gap-0.5">
+            <span class="text-sm font-medium text-foreground">Browse path</span>
+            <span class="truncate font-mono text-xs text-muted-foreground"
+              >{query.trim()}</span
             >
-              <span class="grid min-w-0 gap-0.5">
-                <span class="flex min-w-0 items-center gap-1.5">
-                  <strong
-                    class="min-w-0 truncate text-sm font-medium text-foreground"
-                  >
-                    {item.project.name}
-                  </strong>
-                  {#if current}
-                    <Badge tone="accent" size="xs" class="flex-none"
-                      >Current</Badge
-                    >
-                  {/if}
-                </span>
-                <span
-                  class="min-w-0 truncate font-mono text-xs text-muted-foreground"
+          </span>
+          <ArrowRight
+            class="size-3.5 flex-none text-muted-foreground group-hover:text-foreground"
+            strokeWidth={2.2}
+            aria-hidden="true"
+          />
+        </button>
+      {:else if items.length}
+        <Tooltip.Provider delayDuration={300} disableHoverableContent>
+          <div
+            class="grid grid-cols-1 gap-1.5"
+            role="listbox"
+            aria-label="Recent projects"
+            tabindex={-1}
+            aria-activedescendant={activeDescendant}
+          >
+            {#each items as item, i (item.key)}
+              {@const current = item.key === activeProjectKey}
+              {@const selected = selectedIndex === i}
+              <ContextMenu items={projectMenu(item)} triggerClass="contents">
+                <div
+                  id={`recent:${encodeURIComponent(item.key)}`}
+                  class={`group flex w-full cursor-pointer items-center gap-2.5 rounded-md border px-2.5 py-1.5 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
+                    selected
+                      ? "border-primary/50 bg-accent/80"
+                      : "border-border bg-accent/40 hover:bg-accent/70"
+                  }`}
+                  role="option"
+                  aria-selected={selected}
+                  tabindex="-1"
+                  onclick={() => onOpen(item)}
+                  onkeydown={(event) => onRowKeydown(event, i, item)}
                 >
-                  {tildePath(item.project.dir, homeDir)}
-                </span>
-              </span>
-              <ProjectCardStatus
-                {item}
-                git={gitByProjectKey[item.key]}
-                gitLoading={gitLoadingByProjectKey[item.key] ?? false}
-                gitError={gitErrorByProjectKey[item.key] ?? false}
-              />
-            </div>
-          </ContextMenu>
-        {/each}
-        {#each Array.from(Array(placeholderCount).keys()) as i (i)}
-          <div role="option" aria-selected="false" class="contents">
-            <button
-              type="button"
-              class="group grid min-h-22 w-full place-content-center justify-items-center gap-1 rounded-md border border-dashed border-border bg-accent/20 px-2.5 py-2 text-center text-muted-foreground hover:bg-accent/60 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
-              aria-label="Browse for a project folder"
-              onclick={onBrowse}
-            >
-              <FolderSearch
-                class="size-4 text-muted-foreground group-hover:text-foreground"
-                aria-hidden="true"
-              />
-              <span class="text-xs font-medium">Browse for a project</span>
-            </button>
+                  <ProjectIcon projectId={item.project.id} class="size-8" />
+                  <span class="grid min-w-0 flex-1 gap-0.5">
+                    <span class="flex min-w-0 items-center gap-1.5">
+                      <strong
+                        class="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
+                      >
+                        {item.project.name}
+                      </strong>
+                      {#if current}
+                        <Badge tone="accent" size="xs" class="flex-none"
+                          >Current</Badge
+                        >
+                      {/if}
+                      <span class="ml-auto min-w-0 flex-none">
+                        <ProjectCardStatus
+                          {item}
+                          git={gitByProjectKey[item.key]}
+                          gitLoading={gitLoadingByProjectKey[item.key] ?? false}
+                          gitError={gitErrorByProjectKey[item.key] ?? false}
+                        />
+                      </span>
+                    </span>
+                    <span
+                      class="min-w-0 truncate font-mono text-xs text-muted-foreground"
+                    >
+                      {tildePath(item.project.dir, homeDir)}
+                    </span>
+                  </span>
+                </div>
+              </ContextMenu>
+            {/each}
           </div>
-        {/each}
-      </div>
-    </Tooltip.Provider>
-  {:else}
-    <div
-      class="grid min-h-40 place-items-center gap-1 p-6 text-center text-muted-foreground"
-    >
-      <FolderOpen size={26} strokeWidth={1.8} aria-hidden="true" />
-      <p class="m-0 mt-1 text-sm text-foreground">
-        {totalRecentCount
-          ? "No recent projects match your search."
-          : "No recent projects yet."}
-      </p>
-      <span class="text-xs">Use Open above to open a project folder.</span>
+        </Tooltip.Provider>
+      {:else}
+        <div
+          class="grid min-h-40 place-items-center gap-1 p-6 text-center text-muted-foreground"
+        >
+          <FolderOpen size={26} strokeWidth={1.8} aria-hidden="true" />
+          <p class="m-0 mt-1 text-sm text-foreground">
+            {totalRecentCount
+              ? "No recent projects match your search."
+              : "No recent projects yet."}
+          </p>
+          <span class="text-xs">Use Browse below to open a project folder.</span
+          >
+        </div>
+      {/if}
     </div>
-  {/if}
+  </div>
+  <div
+    class="recent-projects-shadow recent-projects-shadow-top pointer-events-none absolute inset-x-0 top-0 h-6 opacity-0 transition-opacity duration-150"
+    class:opacity-100={canScrollUp}
+  ></div>
+  <div
+    class="recent-projects-shadow recent-projects-shadow-bottom pointer-events-none absolute inset-x-0 bottom-0 h-6 opacity-0 transition-opacity duration-150"
+    class:opacity-100={canScrollDown}
+  ></div>
 </div>
+
+<style>
+/* Escape-hatch reason 2: native scrollbars are hidden because edge shadows
+ * provide the scroll affordance. */
+.recent-projects-scroller {
+  scrollbar-width: none;
+}
+
+.recent-projects-scroller::-webkit-scrollbar {
+  display: none;
+}
+
+.recent-projects-shadow-bottom {
+  background: linear-gradient(
+    to top,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+
+.recent-projects-shadow-top {
+  background: linear-gradient(
+    to bottom,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+</style>

--- a/packages/workbench-server/src/domains/projects/index.ts
+++ b/packages/workbench-server/src/domains/projects/index.ts
@@ -1,4 +1,8 @@
 export { ProjectRepository } from "./project.repository.js";
 export { ProjectLifecycleService } from "./project.service.js";
 export { ProjectEditorService } from "./project-editor.service.js";
+export {
+  ProjectIconService,
+  type ProjectIcon,
+} from "./project-icon.service.js";
 export { PruneProjectConversationsService } from "./prune-conversations.service.js";

--- a/packages/workbench-server/src/domains/projects/project-icon.service.ts
+++ b/packages/workbench-server/src/domains/projects/project-icon.service.ts
@@ -1,0 +1,481 @@
+import { createHash } from "node:crypto";
+import type { Dirent } from "node:fs";
+import { realpath, readdir, readFile, stat } from "node:fs/promises";
+import { extname, isAbsolute, relative, resolve, sep } from "node:path";
+import type { ProjectRecord } from "@nervekit/contracts";
+import { resizeImage, type ResizedImage } from "@nervekit/harness/node";
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_MAX_CACHE_ENTRIES = 256;
+const MAX_ICON_BYTES = 2 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 256 * 1024;
+const ICON_MAX_DIMENSION = 96;
+const MAX_DISCOVERY_DEPTH = 4;
+const MAX_DISCOVERY_DIRECTORIES = 512;
+const MAX_DISCOVERY_CANDIDATES = 256;
+
+const MANIFEST_PATHS = [
+  "manifest.webmanifest",
+  "manifest.json",
+  "public/manifest.webmanifest",
+  "public/manifest.json",
+  "static/manifest.webmanifest",
+  "static/manifest.json",
+] as const;
+
+const CANDIDATE_DIRECTORIES = [
+  "app",
+  "src/app",
+  "",
+  "public",
+  "static",
+  "assets",
+  "src/assets",
+] as const;
+
+const CANDIDATE_NAMES = [
+  "apple-touch-icon",
+  "favicon",
+  "app-icon",
+  "icon",
+  "logo",
+] as const;
+
+const EXTENSION_PRIORITY = [
+  ".svg",
+  ".png",
+  ".webp",
+  ".jpg",
+  ".jpeg",
+  ".ico",
+] as const;
+
+const MIME_BY_EXTENSION = new Map<string, string>([
+  [".svg", "image/svg+xml"],
+  [".png", "image/png"],
+  [".webp", "image/webp"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".ico", "image/x-icon"],
+]);
+
+const EXCLUDED_SEGMENTS = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  "node_modules",
+  "bower_components",
+  "vendor",
+  "dist",
+  "build",
+  "out",
+  "target",
+  "coverage",
+  ".coverage",
+  ".cache",
+  "cache",
+  ".next",
+  ".nuxt",
+  ".output",
+  ".svelte-kit",
+  ".turbo",
+  ".parcel-cache",
+  ".vite",
+  "test-artifacts",
+  "test-results",
+  "playwright-report",
+]);
+
+export interface ProjectIcon {
+  buffer: Buffer;
+  mimeType: string;
+  etag: string;
+}
+
+type ResizeImage = (
+  source: Buffer,
+  mimeType: string,
+  maxDimension: number,
+) => Promise<ResizedImage>;
+
+type CacheEntry = {
+  expiresAt: number;
+  value: Promise<ProjectIcon | undefined>;
+};
+
+export interface ProjectIconServiceOptions {
+  now?: () => number;
+  resize?: ResizeImage;
+  cacheTtlMs?: number;
+  maxCacheEntries?: number;
+}
+
+interface ManifestIcon {
+  src?: unknown;
+  sizes?: unknown;
+  purpose?: unknown;
+}
+
+interface ManifestDocument {
+  icons?: unknown;
+}
+
+export class ProjectIconService {
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly now: () => number;
+  private readonly resize: ResizeImage;
+  private readonly cacheTtlMs: number;
+  private readonly maxCacheEntries: number;
+
+  constructor(
+    private readonly getProject: (projectId: string) => ProjectRecord,
+    options: ProjectIconServiceOptions = {},
+  ) {
+    this.now = options.now ?? Date.now;
+    this.resize = options.resize ?? resizeImage;
+    this.cacheTtlMs = options.cacheTtlMs ?? CACHE_TTL_MS;
+    this.maxCacheEntries = options.maxCacheEntries ?? DEFAULT_MAX_CACHE_ENTRIES;
+  }
+
+  get(projectId: string): Promise<ProjectIcon | undefined> {
+    // Validate the project even when a stale cache key happens to remain after
+    // project removal.
+    const project = this.getProject(projectId);
+    const now = this.now();
+    const cached = this.cache.get(projectId);
+    if (cached && cached.expiresAt > now) {
+      this.cache.delete(projectId);
+      this.cache.set(projectId, cached);
+      return cached.value;
+    }
+    if (cached) this.cache.delete(projectId);
+
+    const value = this.discover(project.dir).catch((error: unknown) => {
+      this.cache.delete(projectId);
+      throw error;
+    });
+    this.cache.set(projectId, {
+      expiresAt: now + this.cacheTtlMs,
+      value,
+    });
+    this.evictOverflow();
+    return value;
+  }
+
+  private evictOverflow(): void {
+    while (this.cache.size > this.maxCacheEntries) {
+      const oldestKey = this.cache.keys().next().value as string | undefined;
+      if (!oldestKey) return;
+      this.cache.delete(oldestKey);
+    }
+  }
+
+  private async discover(projectDir: string): Promise<ProjectIcon | undefined> {
+    let root: string;
+    try {
+      root = await realpath(projectDir);
+    } catch {
+      return undefined;
+    }
+    const candidates = [
+      ...(await manifestCandidates(root)),
+      ...(await conventionalCandidates(root)),
+      ...(await nestedIconCandidates(root)),
+    ];
+    const seen = new Set<string>();
+
+    for (const candidate of candidates) {
+      const key = candidate.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const loaded = await loadCandidate(root, candidate);
+      if (!loaded) continue;
+
+      let image = loaded;
+      try {
+        const resized = await this.resize(
+          loaded.buffer,
+          loaded.mimeType,
+          ICON_MAX_DIMENSION,
+        );
+        image = { buffer: resized.buffer, mimeType: resized.mimeType };
+      } catch {
+        // ICO and some unusual but browser-supported images may not be
+        // understood by the native normalizer. The capped original is safe to
+        // serve and the browser can decide whether it is renderable.
+      }
+
+      return {
+        ...image,
+        etag: `"${createHash("sha256").update(image.buffer).digest("hex").slice(0, 24)}"`,
+      };
+    }
+    return undefined;
+  }
+}
+
+async function manifestCandidates(root: string): Promise<string[]> {
+  const candidates: string[] = [];
+  for (const manifestPath of MANIFEST_PATHS) {
+    const manifest = await readSmallContainedFile(
+      root,
+      manifestPath,
+      MAX_MANIFEST_BYTES,
+    );
+    if (!manifest) continue;
+    try {
+      const document = JSON.parse(
+        manifest.toString("utf8"),
+      ) as ManifestDocument;
+      if (!Array.isArray(document.icons)) continue;
+      const icons = document.icons
+        .filter(isManifestIcon)
+        .map((icon, index) => ({
+          path: resolveManifestIconPath(manifestPath, icon.src),
+          purposeRank: manifestPurposeRank(icon.purpose),
+          sizeRank: manifestSizeRank(icon.sizes),
+          index,
+        }))
+        .filter(
+          (icon): icon is typeof icon & { path: string } =>
+            icon.path !== undefined,
+        )
+        .sort(
+          (left, right) =>
+            right.purposeRank - left.purposeRank ||
+            right.sizeRank - left.sizeRank ||
+            left.index - right.index,
+        );
+      candidates.push(...icons.map((icon) => icon.path));
+    } catch {
+      // A malformed manifest should not prevent conventional icon discovery.
+    }
+  }
+  return candidates;
+}
+
+function isManifestIcon(
+  value: unknown,
+): value is ManifestIcon & { src: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as ManifestIcon).src === "string"
+  );
+}
+
+function resolveManifestIconPath(
+  manifestPath: string,
+  source: string,
+): string | undefined {
+  const cleanSource = source.split(/[?#]/, 1)[0]?.replaceAll("\\", "/");
+  if (!cleanSource || cleanSource.includes("\0")) return undefined;
+  if (/^[a-z][a-z\d+.-]*:/i.test(cleanSource) || cleanSource.startsWith("//")) {
+    return undefined;
+  }
+
+  const manifestDirectory = manifestPath.includes("/")
+    ? manifestPath.slice(0, manifestPath.lastIndexOf("/"))
+    : "";
+  const webRoot = ["public", "static"].includes(manifestDirectory)
+    ? manifestDirectory
+    : "";
+  const relativeSource = cleanSource.startsWith("/")
+    ? `${webRoot}/${cleanSource.slice(1)}`
+    : `${manifestDirectory}/${cleanSource}`;
+  const normalized = relativeSource.split("/").filter(Boolean).join("/");
+  return isAllowedRelativePath(normalized) &&
+    MIME_BY_EXTENSION.has(extname(normalized).toLowerCase())
+    ? normalized
+    : undefined;
+}
+
+function manifestPurposeRank(purpose: unknown): number {
+  if (typeof purpose !== "string" || purpose.trim() === "") return 2;
+  return purpose.split(/\s+/).includes("any") ? 2 : 1;
+}
+
+function manifestSizeRank(sizes: unknown): number {
+  if (typeof sizes !== "string") return 0;
+  if (sizes.split(/\s+/).includes("any")) return Number.MAX_SAFE_INTEGER;
+  let largest = 0;
+  for (const size of sizes.split(/\s+/)) {
+    const match = /^(\d+)x(\d+)$/i.exec(size);
+    if (!match) continue;
+    const width = Number(match[1]);
+    const height = Number(match[2]);
+    if (width === height) largest = Math.max(largest, width);
+  }
+  return largest;
+}
+
+async function conventionalCandidates(root: string): Promise<string[]> {
+  const candidates: string[] = [];
+  for (const directory of CANDIDATE_DIRECTORIES) {
+    let names: string[];
+    try {
+      names = await readdir(resolve(root, directory));
+    } catch {
+      continue;
+    }
+    const byLowerName = new Map(
+      names.map((name) => [name.toLowerCase(), name]),
+    );
+    for (const baseName of CANDIDATE_NAMES) {
+      for (const extension of EXTENSION_PRIORITY) {
+        const actualName = byLowerName.get(`${baseName}${extension}`);
+        if (actualName) {
+          candidates.push(
+            directory ? `${directory}/${actualName}` : actualName,
+          );
+        }
+      }
+    }
+  }
+  return candidates;
+}
+
+async function nestedIconCandidates(root: string): Promise<string[]> {
+  const candidates: string[] = [];
+  const queue: Array<{ directory: string; depth: number }> = [
+    { directory: "", depth: 0 },
+  ];
+  let visitedDirectories = 0;
+
+  while (
+    queue.length > 0 &&
+    visitedDirectories < MAX_DISCOVERY_DIRECTORIES &&
+    candidates.length < MAX_DISCOVERY_CANDIDATES
+  ) {
+    const current = queue.shift();
+    if (!current) break;
+    visitedDirectories += 1;
+
+    let entries: Dirent<string>[];
+    try {
+      entries = await readdir(resolve(root, current.directory), {
+        withFileTypes: true,
+      });
+    } catch {
+      continue;
+    }
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      const relativePath = current.directory
+        ? `${current.directory}/${entry.name}`
+        : entry.name;
+      if (entry.isFile() && isLikelyIconName(entry.name)) {
+        candidates.push(relativePath);
+        if (candidates.length >= MAX_DISCOVERY_CANDIDATES) break;
+      } else if (
+        entry.isDirectory() &&
+        current.depth < MAX_DISCOVERY_DEPTH &&
+        !EXCLUDED_SEGMENTS.has(entry.name.toLowerCase())
+      ) {
+        queue.push({ directory: relativePath, depth: current.depth + 1 });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function isLikelyIconName(name: string): boolean {
+  const extension = extname(name).toLowerCase();
+  if (!MIME_BY_EXTENSION.has(extension)) return false;
+  const stem = name.slice(0, -extension.length).toLowerCase();
+  return /(?:^|[-_.])(apple-touch-icon|favicon|app-icon|icon|logo|mark)(?:$|[-_.])/.test(
+    stem,
+  );
+}
+
+async function loadCandidate(
+  root: string,
+  candidate: string,
+): Promise<{ buffer: Buffer; mimeType: string } | undefined> {
+  const extension = extname(candidate).toLowerCase();
+  const mimeType = MIME_BY_EXTENSION.get(extension);
+  if (!mimeType || !isAllowedRelativePath(candidate)) return undefined;
+  const buffer = await readSmallContainedFile(root, candidate, MAX_ICON_BYTES);
+  return buffer && isPlausibleImage(buffer, extension)
+    ? { buffer, mimeType }
+    : undefined;
+}
+
+function isPlausibleImage(buffer: Buffer, extension: string): boolean {
+  switch (extension) {
+    case ".png":
+      return buffer
+        .subarray(0, 8)
+        .equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+    case ".jpg":
+    case ".jpeg":
+      return buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8;
+    case ".webp":
+      return (
+        buffer.length >= 12 &&
+        buffer.toString("ascii", 0, 4) === "RIFF" &&
+        buffer.toString("ascii", 8, 12) === "WEBP"
+      );
+    case ".ico":
+      return (
+        buffer.length >= 6 &&
+        buffer[0] === 0 &&
+        buffer[1] === 0 &&
+        buffer[2] === 1 &&
+        buffer[3] === 0
+      );
+    case ".svg": {
+      const source = buffer.subarray(0, 64 * 1024).toString("utf8");
+      return (
+        /<svg(?:\s|>)/i.test(source) &&
+        !/<(?:script|foreignObject)(?:\s|>)/i.test(source) &&
+        !/\son[a-z]+\s*=/i.test(source) &&
+        !/(?:href|src)\s*=\s*["'](?:https?:)?\/\//i.test(source)
+      );
+    }
+    default:
+      return false;
+  }
+}
+
+async function readSmallContainedFile(
+  root: string,
+  candidate: string,
+  maxBytes: number,
+): Promise<Buffer | undefined> {
+  if (!isAllowedRelativePath(candidate)) return undefined;
+  const path = resolve(root, candidate);
+  if (!isInside(root, path)) return undefined;
+  try {
+    const resolvedPath = await realpath(path);
+    if (!isInside(root, resolvedPath)) return undefined;
+    const metadata = await stat(resolvedPath);
+    if (!metadata.isFile() || metadata.size < 1 || metadata.size > maxBytes) {
+      return undefined;
+    }
+    return await readFile(resolvedPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function isAllowedRelativePath(path: string): boolean {
+  if (!path || isAbsolute(path) || path.includes("\0")) return false;
+  const segments = path.replaceAll("\\", "/").split("/");
+  return !segments.some(
+    (segment) =>
+      segment === ".." || EXCLUDED_SEGMENTS.has(segment.toLowerCase()),
+  );
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === "" ||
+    (!pathFromRoot.startsWith(`..${sep}`) &&
+      pathFromRoot !== ".." &&
+      !isAbsolute(pathFromRoot))
+  );
+}

--- a/packages/workbench-server/src/routes/project-routes.ts
+++ b/packages/workbench-server/src/routes/project-routes.ts
@@ -22,6 +22,32 @@ export function createProjectRoutes(state: OrchestratorState): Hono {
   );
   app.get("/", (c) => c.json({ projects: state.registry.listProjects() }));
   app.get(
+    "/:projectId/icon",
+    routeHandler(async (c) => {
+      const icon = await state.registry.projectIcons.get(
+        routeParam(c, "projectId"),
+      );
+      const cacheHeaders = {
+        "Cache-Control": "private, max-age=86400",
+        "X-Content-Type-Options": "nosniff",
+      };
+      if (!icon) {
+        return c.body(null, 404, {
+          ...cacheHeaders,
+          "Cache-Control": "private, no-cache",
+        });
+      }
+      if (c.req.header("if-none-match") === icon.etag) {
+        return c.body(null, 304, { ...cacheHeaders, ETag: icon.etag });
+      }
+      return c.body(new Uint8Array(icon.buffer), 200, {
+        ...cacheHeaders,
+        "Content-Type": icon.mimeType,
+        ETag: icon.etag,
+      });
+    }),
+  );
+  app.get(
     "/:projectId",
     routeHandler((c) =>
       c.json({

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -41,6 +41,7 @@ import {
 } from "../domains/task-definitions/index.js";
 import {
   ProjectEditorService,
+  ProjectIconService,
   ProjectLifecycleService,
   ProjectRepository,
   PruneProjectConversationsService,
@@ -114,6 +115,7 @@ export interface RuntimeServices {
   runQuery: WorkbenchRunQuery;
   workbenchRun: WorkbenchRunService;
   editors: ProjectEditorService;
+  projectIcons: ProjectIconService;
   projectLifecycle: ProjectLifecycleService;
   conversationLifecycle: ConversationLifecycleService;
   conversationQuery: ConversationQueryService;
@@ -315,6 +317,7 @@ export function composeRuntime(
     state,
     removeConversation,
   );
+  services.projectIcons = new ProjectIconService(getProject);
   services.fileCompletions = new FileCompletionService(getProject);
   services.conversationLifecycle = new ConversationLifecycleService(
     storage,

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -118,6 +118,10 @@ export class RuntimeRegistry {
     return this.services.editors;
   }
 
+  get projectIcons() {
+    return this.services.projectIcons;
+  }
+
   private get workbenchRun() {
     return this.services.workbenchRun;
   }

--- a/packages/workbench-server/test/project-icon.service.test.ts
+++ b/packages/workbench-server/test/project-icon.service.test.ts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import type { ProjectRecord } from "@nervekit/contracts";
+import {
+  ProjectIconService,
+  type ProjectIcon,
+} from "../src/domains/projects/project-icon.service.js";
+import { createAuthenticatedApp } from "./helpers/server-routes.js";
+
+const roots: string[] = [];
+const unchangedResize = async (buffer: Buffer, mimeType: string) => ({
+  buffer,
+  mimeType,
+  changed: false,
+});
+
+function png(label: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.from(label),
+  ]);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function projectDirectory(name: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), `nerve-project-icon-${name}-`));
+  roots.push(root);
+  return root;
+}
+
+function project(id: string, dir: string): ProjectRecord {
+  return {
+    id,
+    name: id,
+    dir,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function serviceFor(
+  projects: ProjectRecord[],
+  options: ConstructorParameters<typeof ProjectIconService>[1] = {},
+): ProjectIconService {
+  const byId = new Map(projects.map((candidate) => [candidate.id, candidate]));
+  return new ProjectIconService(
+    (projectId) => {
+      const found = byId.get(projectId);
+      if (!found) throw new Error(`Unknown project ${projectId}`);
+      return found;
+    },
+    { resize: unchangedResize, ...options },
+  );
+}
+
+async function write(path: string, contents: string | Buffer): Promise<void> {
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, contents);
+}
+
+async function icon(
+  service: ProjectIconService,
+  projectId: string,
+): Promise<ProjectIcon> {
+  const result = await service.get(projectId);
+  assert.ok(result);
+  return result;
+}
+
+describe("ProjectIconService", () => {
+  it("prefers the best manifest icon over conventional files", async () => {
+    const dir = await projectDirectory("manifest");
+    await write(
+      join(dir, "public/manifest.webmanifest"),
+      JSON.stringify({
+        icons: [
+          { src: "/icons/mask.png", sizes: "512x512", purpose: "maskable" },
+          { src: "/icons/small.png", sizes: "64x64", purpose: "any" },
+          { src: "/icons/large.png", sizes: "192x192", purpose: "any" },
+        ],
+      }),
+    );
+    await write(join(dir, "public/icons/mask.png"), png("mask"));
+    await write(join(dir, "public/icons/small.png"), png("small"));
+    await write(join(dir, "public/icons/large.png"), png("large"));
+    await write(join(dir, "favicon.svg"), "<svg></svg>");
+
+    const result = await icon(
+      serviceFor([project("proj_manifest", dir)]),
+      "proj_manifest",
+    );
+    assert.ok(result.buffer.equals(png("large")));
+    assert.equal(result.mimeType, "image/png");
+    assert.match(result.etag, /^"[a-f\d]{24}"$/);
+  });
+
+  it("matches conventional filenames case-insensitively and falls through oversized candidates", async () => {
+    const dir = await projectDirectory("conventional");
+    await write(join(dir, "app/apple-touch-icon.svg"), "not-an-image");
+    await write(join(dir, "app/icon.png"), Buffer.alloc(2 * 1024 * 1024 + 1));
+    await write(join(dir, "public/FAVICON.SVG"), "<svg>svg-icon</svg>");
+
+    const result = await icon(
+      serviceFor([project("proj_conventional", dir)]),
+      "proj_conventional",
+    );
+    assert.equal(result.buffer.toString(), "<svg>svg-icon</svg>");
+    assert.equal(result.mimeType, "image/svg+xml");
+  });
+
+  it("finds branded icons in nested workspace apps", async () => {
+    const dir = await projectDirectory("nested-workspace");
+    await write(
+      join(dir, "packages/client/public/acme-logo-dark.svg"),
+      "<svg>nested-logo</svg>",
+    );
+
+    const result = await icon(
+      serviceFor([project("proj_nested", dir)]),
+      "proj_nested",
+    );
+    assert.equal(result.buffer.toString(), "<svg>nested-logo</svg>");
+  });
+
+  it("bounds nested discovery and excludes dependency, build, and test output", async () => {
+    const dir = await projectDirectory("bounded");
+    await write(join(dir, "node_modules/icon.png"), png("dependency"));
+    await write(join(dir, "dist/favicon.png"), png("build"));
+    await write(join(dir, "test-artifacts/logo.png"), png("test-output"));
+    await write(join(dir, "one/two/three/four/five/logo.png"), png("too-deep"));
+
+    assert.equal(
+      await serviceFor([project("proj_bounded", dir)]).get("proj_bounded"),
+      undefined,
+    );
+  });
+
+  it("rejects manifest icons that escape through a symlink", async () => {
+    const dir = await projectDirectory("symlink");
+    const outside = await projectDirectory("outside");
+    await write(join(outside, "icon.png"), png("outside"));
+    await symlink(outside, join(dir, "public"), "dir");
+    await write(
+      join(dir, "manifest.webmanifest"),
+      JSON.stringify({ icons: [{ src: "public/icon.png", sizes: "128x128" }] }),
+    );
+
+    assert.equal(
+      await serviceFor([project("proj_symlink", dir)]).get("proj_symlink"),
+      undefined,
+    );
+  });
+
+  it("caches hits and misses until the TTL expires", async () => {
+    const hitDir = await projectDirectory("hit-cache");
+    const missDir = await projectDirectory("miss-cache");
+    await write(join(hitDir, "icon.png"), png("cached"));
+    let now = 100;
+    const service = serviceFor(
+      [project("proj_hit", hitDir), project("proj_miss", missDir)],
+      { now: () => now, cacheTtlMs: 1_000 },
+    );
+
+    const firstHit = await icon(service, "proj_hit");
+    await rm(join(hitDir, "icon.png"));
+    assert.equal((await icon(service, "proj_hit")).etag, firstHit.etag);
+
+    assert.equal(await service.get("proj_miss"), undefined);
+    await write(join(missDir, "logo.png"), png("appeared"));
+    assert.equal(await service.get("proj_miss"), undefined);
+
+    now += 1_001;
+    assert.equal(await service.get("proj_hit"), undefined);
+    assert.ok(
+      (await icon(service, "proj_miss")).buffer.equals(png("appeared")),
+    );
+  });
+
+  it("deduplicates concurrent normalization and bounds the cache", async () => {
+    const firstDir = await projectDirectory("dedupe-first");
+    const secondDir = await projectDirectory("dedupe-second");
+    await write(join(firstDir, "icon.png"), png("first"));
+    await write(join(secondDir, "icon.png"), png("second"));
+    let resizeCalls = 0;
+    const service = serviceFor(
+      [project("proj_first", firstDir), project("proj_second", secondDir)],
+      {
+        maxCacheEntries: 1,
+        resize: async (buffer, mimeType) => {
+          resizeCalls += 1;
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return { buffer, mimeType, changed: false };
+        },
+      },
+    );
+
+    const [left, right] = await Promise.all([
+      service.get("proj_first"),
+      service.get("proj_first"),
+    ]);
+    assert.equal(left?.etag, right?.etag);
+    assert.equal(resizeCalls, 1);
+
+    await service.get("proj_second");
+    await rm(join(firstDir, "icon.png"));
+    assert.equal(await service.get("proj_first"), undefined);
+  });
+});
+
+describe("project icon route", () => {
+  it("serves cached image responses, conditional requests, and misses", async () => {
+    const dir = await projectDirectory("route");
+    await write(
+      join(dir, "favicon.svg"),
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"></svg>',
+    );
+    const { app, state, headers } = await createAuthenticatedApp();
+    const created = await state.registry.createProject({ dir });
+    const path = `/api/projects/${created.id}/icon`;
+
+    const unauthorized = await app.request(path);
+    assert.equal(unauthorized.status, 401);
+
+    const response = await app.request(path, { headers });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "image/svg+xml");
+    assert.equal(
+      response.headers.get("cache-control"),
+      "private, max-age=86400",
+    );
+    assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+    const etag = response.headers.get("etag");
+    assert.ok(etag);
+
+    const conditional = await app.request(path, {
+      headers: { ...headers, "if-none-match": etag },
+    });
+    assert.equal(conditional.status, 304);
+
+    const missingDir = await projectDirectory("route-missing");
+    const missing = await state.registry.createProject({ dir: missingDir });
+    const notFound = await app.request(`/api/projects/${missing.id}/icon`, {
+      headers,
+    });
+    assert.equal(notFound.status, 404);
+    assert.equal(notFound.headers.get("cache-control"), "private, no-cache");
+  });
+});


### PR DESCRIPTION
## Summary
- discover, normalize, cache, and securely serve project icons from project manifests and conventional icon paths
- display project icons with a fallback in the redesigned searchable recent-project list
- expand recent-project results and cover icon discovery, caching, route authentication, and conditional responses

## Validation
- `pnpm fix && pnpm check && pnpm test`