### PR TITLE
Sign automated release version commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,21 +56,68 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           RELEASE_AUTHOR_ID: ${{ github.actor_id }}
           RELEASE_AUTHOR_NAME: ${{ github.actor }}
+          RELEASE_GPG_FINGERPRINT: ${{ secrets.RELEASE_GPG_FINGERPRINT }}
+          RELEASE_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
+          RELEASE_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           release_tag="v${RELEASE_VERSION}"
           node scripts/verify-release-tag.mjs "${release_tag}"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          export GNUPGHOME="${RUNNER_TEMP}/release-gnupg"
+          gpg_wrapper="${RUNNER_TEMP}/release-gpg-sign"
+          cleanup_signing_material() {
+            rm -rf "${GNUPGHOME}" "${gpg_wrapper}"
+          }
+          trap cleanup_signing_material EXIT
+          mkdir -m 700 "${GNUPGHOME}"
+
+          if [ -z "${RELEASE_GPG_PRIVATE_KEY}" ] ||
+             [ -z "${RELEASE_GPG_PASSPHRASE}" ] ||
+             [ -z "${RELEASE_GPG_FINGERPRINT}" ]; then
+            echo "Release signing secrets are not configured" >&2
+            exit 1
+          fi
+
+          printf '%s' "${RELEASE_GPG_PRIVATE_KEY}" | gpg --batch --import >/dev/null 2>&1
+          expected_fingerprint="$(printf '%s' "${RELEASE_GPG_FINGERPRINT}" | tr -d '[:space:]')"
+          mapfile -t imported_fingerprints < <(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "sec" { primary = 1; next } primary && $1 == "fpr" { print $10; primary = 0 }'
+          )
+          if [ "${#imported_fingerprints[@]}" -ne 1 ] ||
+             [ "${imported_fingerprints[0]}" != "${expected_fingerprint}" ]; then
+            echo "Imported release key does not match RELEASE_GPG_FINGERPRINT" >&2
+            exit 1
+          fi
+
+          cat >"${gpg_wrapper}" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exec gpg --batch --yes --pinentry-mode loopback \
+            --passphrase "${RELEASE_GPG_PASSPHRASE}" "$@"
+          EOF
+          chmod 700 "${gpg_wrapper}"
+
+          git config user.name "Nerve Release Bot"
+          git config user.email "41065538+ThilinaTLM@users.noreply.github.com"
+          git config user.signingkey "${expected_fingerprint}"
+          git config gpg.program "${gpg_wrapper}"
+          git config commit.gpgsign true
           git add package.json packages/*/package.json
           if ! git diff --cached --quiet; then
-            git commit \
+            git commit -S \
               --author="${RELEASE_AUTHOR_NAME} <${RELEASE_AUTHOR_ID}+${RELEASE_AUTHOR_NAME}@users.noreply.github.com>" \
               -m "chore(release): bump version to ${release_tag}"
           else
             echo "Workspace is already at ${release_tag}; reusing the current commit"
+          fi
+
+          if ! verification="$(git verify-commit --raw HEAD 2>&1)" ||
+             ! grep -Fq "[GNUPG:] VALIDSIG ${expected_fingerprint} " <<<"${verification}"; then
+            echo "Release commit is not signed by the configured release key" >&2
+            exit 1
           fi
 
           if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,6 +45,20 @@ Stop all Nerve processes first, then remove the complete `NERVE_HOME` (default `
 
 The deterministic workbench error is `Incompatible Nerve state at <path>...`, ending with `Reset this directory before starting Nerve Protocol v1.` The headless workbench has no general migration reader. The desktop has one narrow upgrade path for an unversioned legacy workbench home: after confirmation it retains a timestamped whole-home backup, initializes version 2, and restores only portable user state—validated settings, the custom provider/model catalog, and re-encrypted provider credentials. Malformed settings or catalog data aborts the migration and restores the original home; an undecryptable credential store is reported as a nonfatal failure because the backup retains it. Conversations, agents, projects, logs, plans, run history, SQLite, and daemon/session state remain only in the backup. Nerve never downgrades or automatically resets malformed, unknown, or future versioned stores.
 
+## Release commit signing
+
+The manual release workflow creates its version-bump commit on protected `main`, so it must use the dedicated `Nerve Release Bot` GPG key registered on the `ThilinaTLM` GitHub account. The initiating maintainer remains the commit author; `Nerve Release Bot <41065538+ThilinaTLM@users.noreply.github.com>` is the signing committer.
+
+Configure these repository Actions secrets together:
+
+- `RELEASE_GPG_PRIVATE_KEY`: the passphrase-protected armored private key
+- `RELEASE_GPG_PASSPHRASE`: the private-key passphrase
+- `RELEASE_GPG_FINGERPRINT`: the full primary-key fingerprint
+
+The matching public key must remain registered with GitHub. The workflow imports the private key into an ephemeral keyring and fails before its atomic push if a secret is missing, the fingerprint differs, the key cannot be unlocked, or the release commit does not verify against that fingerprint.
+
+The current automation key expires on 2028-08-10. Rotate it before expiry by generating and registering a replacement key, replacing all three secrets together, validating a release, and then removing the old public key. If the key may be compromised, remove it from GitHub and replace the secrets before another release.
+
 ## npm publication and OIDC
 
 Tagged releases use GitHub OIDC trusted publishing with provenance and no stored npm token. The trusted publisher for `@nervekit/desktop` uses `.github/workflows/release.yml` in `ThilinaTLM/nerve`. The workflow must not publish until its configured checks, tools/desktop host tests, package verification, desktop packaging, and built-artifact smokes pass on Linux, Windows, and macOS. Workbench-server native host coverage is owned by the separate native-host workflow. An already-published matching version may be skipped only after the expected local tarball is verified.


### PR DESCRIPTION
## Summary
- import and validate the dedicated release GPG key in the release workflow
- sign and verify version-bump commits before the atomic branch/tag push
- document signing secrets, key expiry, and rotation

## Validation
- disposable GPG signing validation, including fingerprint and passphrase failure cases
- `pnpm fix && pnpm check && pnpm test`