### PR TITLE
refactor(workbench): extract panel scroll region and simplify cards

### DIFF
--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
@@ -8,6 +8,7 @@ import {
   PanelEmpty,
   PanelHeader,
   PanelList,
+  PanelScrollRegion,
   PanelToolbarButton,
   PanelView,
 } from "$lib/presentation/panel";
@@ -46,9 +47,6 @@ const MAX_LISTED_CONVERSATIONS = 100;
 
 let pendingDelete = $state<DeleteTarget | undefined>();
 let allConversationsOpen = $state(false);
-let listRegion = $state<HTMLDivElement | null>(null);
-let canScrollUp = $state(false);
-let canScrollDown = $state(false);
 
 const activeProject = $derived(
   projects.find((project) => project.id === selectedProjectId) ?? projects[0],
@@ -69,29 +67,6 @@ $effect(() => {
   if (searchFocusToken === lastSearchFocusToken) return;
   lastSearchFocusToken = searchFocusToken;
   allConversationsOpen = true;
-});
-
-function updateScrollShadows(): void {
-  const region = listRegion;
-  if (!region) return;
-  canScrollUp = region.scrollTop > 2;
-  canScrollDown =
-    region.scrollTop + region.clientHeight < region.scrollHeight - 2;
-}
-
-$effect(() => {
-  const region = listRegion;
-  if (!region) return;
-  updateScrollShadows();
-  region.addEventListener("scroll", updateScrollShadows, { passive: true });
-  const observer = new ResizeObserver(updateScrollShadows);
-  observer.observe(region);
-  const content = region.firstElementChild;
-  if (content) observer.observe(content); // row count changes resize the list
-  return () => {
-    region.removeEventListener("scroll", updateScrollShadows);
-    observer.disconnect();
-  };
 });
 
 const menuContext = $derived<ProjectTreeMenuContext>({
@@ -148,43 +123,28 @@ const menuContext = $derived<ProjectTreeMenuContext>({
         {/snippet}
       </PanelEmpty>
     {:else}
-      <div class="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div
-          bind:this={listRegion}
-          class="conversation-list-scroller min-h-0 flex-1 overflow-y-auto"
-          onscroll={updateScrollShadows}
-        >
-          <PanelList ariaLabel="Conversations" class="shrink-0 gap-1 pt-1 pb-0">
-            {#each displayedRows as row (row.conversation.id)}
-              {@const rowProject =
-                projects.find(
-                  (project) => project.id === row.conversation.projectId,
-                ) ?? activeProject}
-              <ProjectAgentTreeNode
-                {row}
-                isOpen={openConversationTabIds?.has(row.conversation.id) ??
-                  false}
-                isActive={row.conversation.id === selectedConversationId}
-                activity={conversationActivityById[row.conversation.id]}
-                menuItems={buildConversationMenu(
-                  rowProject,
-                  row.conversation,
-                  menuContext,
-                )}
-                {onOpenConversation}
-              />
-            {/each}
-          </PanelList>
-        </div>
-        <div
-          class="conversation-list-shadow conversation-list-shadow-top pointer-events-none absolute inset-x-0 top-0 h-6 opacity-0 transition-opacity duration-150"
-          class:opacity-100={canScrollUp}
-        ></div>
-        <div
-          class="conversation-list-shadow conversation-list-shadow-bottom pointer-events-none absolute inset-x-0 bottom-0 h-6 opacity-0 transition-opacity duration-150"
-          class:opacity-100={canScrollDown}
-        ></div>
-      </div>
+      <PanelScrollRegion ariaLabel="Conversations">
+        <PanelList ariaLabel="Conversations" class="shrink-0 gap-1 pt-1 pb-0">
+          {#each displayedRows as row (row.conversation.id)}
+            {@const rowProject =
+              projects.find(
+                (project) => project.id === row.conversation.projectId,
+              ) ?? activeProject}
+            <ProjectAgentTreeNode
+              {row}
+              isOpen={openConversationTabIds?.has(row.conversation.id) ?? false}
+              isActive={row.conversation.id === selectedConversationId}
+              activity={conversationActivityById[row.conversation.id]}
+              menuItems={buildConversationMenu(
+                rowProject,
+                row.conversation,
+                menuContext,
+              )}
+              {onOpenConversation}
+            />
+          {/each}
+        </PanelList>
+      </PanelScrollRegion>
     {/if}
   </PanelView>
 </Tooltip.Provider>
@@ -227,36 +187,3 @@ const menuContext = $derived<ProjectTreeMenuContext>({
     onOpenChange={(open) => (allConversationsOpen = open)}
   />
 {/if}
-
-<style>
-/* Escape-hatch reason 2: the native scrollbar is hidden; the edge shadows
-   * below are the scroll affordance. */
-.conversation-list-scroller {
-  scrollbar-width: none;
-}
-
-.conversation-list-scroller::-webkit-scrollbar {
-  display: none;
-}
-
-/* Edge shadows are gradients (not expressible as utilities). They blend the
-   * list into the panel's own background color, so rows appear to slide
-   * under the panel surface where more content is waiting. */
-.conversation-list-shadow-bottom {
-  background: linear-gradient(
-    to top,
-    var(--card) 0%,
-    var(--card) 22%,
-    transparent 72%
-  );
-}
-
-.conversation-list-shadow-top {
-  background: linear-gradient(
-    to bottom,
-    var(--card) 0%,
-    var(--card) 22%,
-    transparent 72%
-  );
-}
-</style>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -72,7 +72,7 @@ function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
         <Button
           variant="ghost"
           size="sm"
-          class={`w-full min-w-0 gap-1.5 rounded-xl px-2 ${active ? "border-border bg-muted/80 text-foreground hover:bg-muted" : "border-border/60 bg-muted/30 text-muted-foreground hover:border-border hover:bg-muted/70 hover:text-foreground"}`}
+          class={`w-full min-w-0 gap-1.5 rounded-md bg-accent/35 px-2 ${active ? "text-foreground hover:bg-accent/40" : "text-muted-foreground hover:bg-accent/40 hover:text-foreground"}`}
           pressed={active}
           aria-current={active ? "page" : undefined}
           ariaLabel={tabLabel(item)}

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -167,10 +167,8 @@ function projectMenu(item: ProjectSwitcherItem): ContextMenuItem[] {
               <ContextMenu items={projectMenu(item)} triggerClass="contents">
                 <div
                   id={`recent:${encodeURIComponent(item.key)}`}
-                  class={`group flex w-full cursor-pointer items-center gap-2.5 rounded-md border px-2.5 py-1.5 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
-                    selected
-                      ? "border-primary/50 bg-accent/80"
-                      : "border-border bg-accent/40 hover:bg-accent/70"
+                  class={`group flex w-full cursor-pointer items-center gap-2.5 rounded-md border border-transparent bg-accent/35 px-2.5 py-1.5 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
+                    selected ? "bg-accent/80" : "hover:bg-accent/70"
                   }`}
                   role="option"
                   aria-selected={selected}

--- a/packages/workbench-app/src/lib/features/scratch-notes/components/NotesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/scratch-notes/components/NotesPanelView.svelte
@@ -8,6 +8,7 @@ import {
   PanelBanner,
   PanelEmpty,
   PanelHeader,
+  PanelScrollRegion,
   PanelToolbarButton,
   PanelView,
 } from "$lib/presentation/panel";
@@ -40,7 +41,7 @@ $effect(() => {
 });
 </script>
 
-<PanelView padded={false}>
+<PanelView padded={false} scroll={false}>
   {#snippet banner()}
     <PanelHeader title="Notes" count={project?.notes.length}>
       {#snippet trailing()}
@@ -93,15 +94,21 @@ $effect(() => {
         {/snippet}
       </PanelEmpty>
     {:else}
-      <div class="flex min-w-0 flex-col gap-1.5 py-1">
+      <PanelScrollRegion
+        ariaLabel="Scratch notes"
+        contentClass="flex min-w-0 shrink-0 flex-col gap-1.5 py-1"
+      >
         {#each project.notes as note (note.id)}
           <ScratchNoteCard
             {projectId}
             {note}
-            onDelete={() => (noteToDelete = note)}
+            onDelete={() => {
+              if (note.draftContent.trim()) noteToDelete = note;
+              else void removeScratchNote(projectId, note.id);
+            }}
           />
         {/each}
-      </div>
+      </PanelScrollRegion>
     {/if}
   {/if}
 </PanelView>

--- a/packages/workbench-app/src/lib/features/scratch-notes/components/ScratchNoteCard.svelte
+++ b/packages/workbench-app/src/lib/features/scratch-notes/components/ScratchNoteCard.svelte
@@ -8,7 +8,6 @@ import {
   flushScratchNote,
   renameScratchNote,
   setScratchNoteContent,
-  toggleScratchNoteCollapsed,
   type ScratchNoteEntry,
 } from "../state/scratch-notes-state.svelte";
 
@@ -39,11 +38,9 @@ const status = $derived.by(() => {
 
 <PanelCard
   title={note.title}
-  collapsed={note.collapsed}
   titleHint={`${note.title} — double-click to rename`}
   titleEditing={renaming}
   titleMaxLength={SCRATCH_NOTE_TITLE_MAX_LENGTH}
-  onToggleCollapsed={() => toggleScratchNoteCollapsed(projectId, note.id)}
   onTitleDblClick={() => (renaming = true)}
   onTitleCommit={(title) => {
     renaming = false;
@@ -56,6 +53,7 @@ const status = $derived.by(() => {
       icon={Pencil}
       label={`Rename ${note.title}`}
       dense
+      class="opacity-0 transition-opacity group-hover/title:opacity-100 group-focus-within/title:opacity-100"
       disabled={note.deleting}
       onclick={() => (renaming = true)}
     />
@@ -88,6 +86,6 @@ const status = $derived.by(() => {
     spellcheck={false}
     disabled={note.deleting}
     placeholder="Jot down notes for this project…"
-    class="min-h-16 resize-none rounded-none border-0 bg-transparent px-3 py-2 text-xs leading-relaxed shadow-none focus-visible:ring-0 [field-sizing:content]"
+    class="min-h-16 resize-none rounded-none border-0 bg-transparent px-3 py-2 text-xs font-normal leading-relaxed shadow-none focus-visible:ring-0 md:text-xs dark:bg-transparent [field-sizing:content]"
   />
 </PanelCard>

--- a/packages/workbench-app/src/lib/features/scratch-notes/state/scratch-notes-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/scratch-notes/state/scratch-notes-state.svelte.ts
@@ -21,8 +21,6 @@ type ScratchNoteEntry = ScratchNote & {
   deleting: boolean;
   contentSaveFailed: boolean;
   saveTimer?: ReturnType<typeof setTimeout>;
-  /** Session-only card state; reset when notes are reloaded from the daemon. */
-  collapsed: boolean;
 };
 
 type ScratchNotesProjectEntry = {
@@ -66,7 +64,6 @@ function toEntry(note: ScratchNote): ScratchNoteEntry {
     deleting: false,
     contentSaveFailed: false,
     saveTimer: undefined,
-    collapsed: false,
   };
 }
 
@@ -210,15 +207,6 @@ export function setScratchNoteContent(
     () => void saveScratchNote(projectId, noteId),
     SAVE_DEBOUNCE_MS,
   );
-}
-
-export function toggleScratchNoteCollapsed(
-  projectId: string,
-  noteId: string,
-): void {
-  const note = findNote(projectId, noteId);
-  if (!note) return;
-  note.collapsed = !note.collapsed;
 }
 
 export function flushScratchNote(

--- a/packages/workbench-app/src/lib/presentation/git/GitPullRequestRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPullRequestRow.svelte
@@ -25,7 +25,7 @@ const hasCheckDetails = $derived(pr.checks.runs.length > 0);
 
 <div
   role="listitem"
-  class="group flex min-w-0 flex-col gap-1 rounded-md bg-accent/35 px-3 py-2.5 text-xs leading-tight ring-1 ring-border transition-colors ring-inset hover:bg-accent/60"
+  class="group flex min-w-0 flex-col gap-1 rounded-md bg-accent/35 px-3 py-2.5 text-xs leading-tight transition-colors hover:bg-accent/60"
 >
   <button
     type="button"

--- a/packages/workbench-app/src/lib/presentation/git/GitPullRequestRowSkeleton.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPullRequestRowSkeleton.svelte
@@ -5,7 +5,7 @@ import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
 <div
   role="status"
   aria-label="Loading pull requests"
-  class="flex min-w-0 flex-col gap-1 rounded-md bg-accent/35 px-3 py-2.5 ring-1 ring-border ring-inset"
+  class="flex min-w-0 flex-col gap-1 rounded-md bg-accent/35 px-3 py-2.5"
 >
   <div class="flex min-w-0 items-center gap-1.5">
     <Skeleton class="h-3.5 w-7 shrink-0" />

--- a/packages/workbench-app/src/lib/presentation/git/GitPullRequestsContent.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPullRequestsContent.svelte
@@ -8,11 +8,11 @@ import type {
   GithubStatusResponse,
   GitRepoSummary,
 } from "@nervekit/contracts";
-import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
 import {
   PanelBanner,
   PanelHeader,
   PanelList,
+  PanelScrollRegion,
   PanelToolbarButton,
 } from "$lib/presentation/panel";
 import GitPullRequestRow from "./GitPullRequestRow.svelte";
@@ -164,7 +164,7 @@ function toggleChecks(pr: GithubPr) {
         : "No open PRs for this repository.",
     )}
   {:else}
-    <ScrollArea class="min-h-0 flex-1" viewportClass="min-w-0">
+    <PanelScrollRegion ariaLabel="Pull requests" contentClass="min-w-0">
       {#if prs.length > displayedPrs.length}
         {@render note(`Showing ${displayedPrs.length} of ${prs.length}`)}
       {/if}
@@ -182,6 +182,6 @@ function toggleChecks(pr: GithubPr) {
           />
         {/each}
       </PanelList>
-    </ScrollArea>
+    </PanelScrollRegion>
   {/if}
 </div>

--- a/packages/workbench-app/src/lib/presentation/panel/PanelCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelCard.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-import ChevronDown from "@lucide/svelte/icons/chevron-down";
-import ChevronRight from "@lucide/svelte/icons/chevron-right";
 import { tick, type Component, type Snippet } from "svelte";
 import { cn } from "@nervekit/ui-kit/core/utils";
-import PanelToolbarButton from "./PanelToolbarButton.svelte";
 
 let {
   title,
   icon: Icon,
-  collapsed = false,
   titleHint,
-  onToggleCollapsed,
   onTitleDblClick,
   titleEditing = false,
   titleMaxLength,
@@ -24,11 +19,8 @@ let {
 }: {
   title: string;
   icon?: Component;
-  /** Controlled collapse state; the body renders only when expanded. */
-  collapsed?: boolean;
   /** Tooltip for the title control. */
   titleHint?: string;
-  onToggleCollapsed?: () => void;
   onTitleDblClick?: () => void;
   /** Swaps the title for an inline editor. */
   titleEditing?: boolean;
@@ -78,13 +70,7 @@ function cancel(): void {
     className,
   )}
 >
-  <div class="flex h-7 min-w-0 items-center gap-1 pr-1 pl-0.5">
-    <PanelToolbarButton
-      icon={collapsed ? ChevronRight : ChevronDown}
-      label={collapsed ? `Expand ${title}` : `Collapse ${title}`}
-      dense
-      onclick={() => onToggleCollapsed?.()}
-    />
+  <div class="flex h-7 min-w-0 items-center gap-1 px-3">
     {#if Icon}
       <Icon class="size-3 shrink-0 text-muted-foreground" aria-hidden="true" />
     {/if}
@@ -95,7 +81,7 @@ function cancel(): void {
         value={title}
         maxlength={titleMaxLength}
         aria-label="Note title"
-        class="h-5 min-w-0 flex-1 rounded-sm border border-input bg-background px-1 text-xs font-medium text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+        class="h-5 min-w-0 flex-1 rounded-sm border border-input bg-background px-1 text-xs font-normal text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
         onkeydown={(event) => {
           if (event.key === "Enter") {
             event.preventDefault();
@@ -108,19 +94,21 @@ function cancel(): void {
         onblur={(event) => commit(event.currentTarget.value)}
       />
     {:else}
-      <button
-        type="button"
-        class="min-w-0 max-w-full truncate rounded-sm text-left text-xs font-medium text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
-        title={titleHint ?? title}
-        ondblclick={() => onTitleDblClick?.()}
-      >
-        {title}
-      </button>
-      {#if titleActions}
-        <div class="flex shrink-0 items-center gap-0.5">
-          {@render titleActions()}
-        </div>
-      {/if}
+      <div class="group/title flex min-w-0 items-center gap-0.5">
+        <button
+          type="button"
+          class="min-w-0 max-w-full truncate rounded-sm text-left text-xs font-normal text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+          title={titleHint ?? title}
+          ondblclick={() => onTitleDblClick?.()}
+        >
+          {title}
+        </button>
+        {#if titleActions}
+          <div class="flex shrink-0 items-center gap-0.5">
+            {@render titleActions()}
+          </div>
+        {/if}
+      </div>
       <div class="flex-1"></div>
     {/if}
     {#if meta}
@@ -134,9 +122,7 @@ function cancel(): void {
       </div>
     {/if}
   </div>
-  {#if !collapsed}
-    <div class="min-w-0 border-t border-border/60">
-      {@render children()}
-    </div>
-  {/if}
+  <div class="min-w-0">
+    {@render children()}
+  </div>
 </section>

--- a/packages/workbench-app/src/lib/presentation/panel/PanelRowCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelRowCard.svelte
@@ -17,7 +17,7 @@ let {
 <div
   {role}
   class={cn(
-    "panel-row-card flex min-w-0 flex-col rounded-md px-1 py-0.5 ring-1 ring-border ring-inset transition-colors",
+    "panel-row-card flex min-w-0 flex-col rounded-md px-1 py-0.5 transition-colors",
     className,
   )}
 >

--- a/packages/workbench-app/src/lib/presentation/panel/PanelScrollRegion.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelScrollRegion.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import { cn } from "@nervekit/ui-kit/core/utils";
+
+let {
+  ariaLabel,
+  contentClass,
+  children,
+}: {
+  ariaLabel?: string;
+  contentClass?: string;
+  children: Snippet;
+} = $props();
+
+let region = $state<HTMLDivElement>();
+let content = $state<HTMLDivElement>();
+let canScrollUp = $state(false);
+let canScrollDown = $state(false);
+
+function updateShadows(): void {
+  if (!region) return;
+  canScrollUp = region.scrollTop > 2;
+  canScrollDown =
+    region.scrollTop + region.clientHeight < region.scrollHeight - 2;
+}
+
+$effect(() => {
+  if (!region || !content) return;
+  updateShadows();
+  const observer = new ResizeObserver(updateShadows);
+  observer.observe(region);
+  observer.observe(content);
+  return () => observer.disconnect();
+});
+</script>
+
+<div class="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+  <div
+    bind:this={region}
+    class="panel-scroll-region min-h-0 flex-1 overflow-y-auto"
+    aria-label={ariaLabel}
+    onscroll={updateShadows}
+  >
+    <div bind:this={content} class={cn("min-w-0", contentClass)}>
+      {@render children()}
+    </div>
+  </div>
+  <div
+    class="panel-scroll-shadow panel-scroll-shadow-top pointer-events-none absolute inset-x-0 top-0 h-6 opacity-0 transition-opacity duration-150"
+    class:opacity-100={canScrollUp}
+  ></div>
+  <div
+    class="panel-scroll-shadow panel-scroll-shadow-bottom pointer-events-none absolute inset-x-0 bottom-0 h-6 opacity-0 transition-opacity duration-150"
+    class:opacity-100={canScrollDown}
+  ></div>
+</div>
+
+<style>
+/* Escape-hatch reason 2: native scrollbars are hidden because edge shadows
+ * provide the scroll affordance. */
+.panel-scroll-region {
+  scrollbar-width: none;
+}
+
+.panel-scroll-region::-webkit-scrollbar {
+  display: none;
+}
+
+/* Gradients blend overflowing content into the panel surface. */
+.panel-scroll-shadow-bottom {
+  background: linear-gradient(
+    to top,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+
+.panel-scroll-shadow-top {
+  background: linear-gradient(
+    to bottom,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+</style>

--- a/packages/workbench-app/src/lib/presentation/panel/index.ts
+++ b/packages/workbench-app/src/lib/presentation/panel/index.ts
@@ -6,6 +6,7 @@ export { default as PanelList } from "./PanelList.svelte";
 export { default as PanelPropertyRow } from "./PanelPropertyRow.svelte";
 export { default as PanelRow } from "./PanelRow.svelte";
 export { default as PanelRowCard } from "./PanelRowCard.svelte";
+export { default as PanelScrollRegion } from "./PanelScrollRegion.svelte";
 export {
   createPanelRowFit,
   type PanelRowFit,


### PR DESCRIPTION
## Summary

Extracts the hidden-scrollbar-with-edge-shadows behavior from the project conversation navigator into a reusable `PanelScrollRegion` component, and applies it to the scratch notes list too.

## Changes

- **`PanelScrollRegion` (new)** — reusable scroll region with hidden native scrollbars and gradient edge shadows as the scroll affordance; exported from `presentation/panel`.
- **`ProjectConversationNavigator`** — replaced the inline scroll/shadow logic with `PanelScrollRegion`.
- **`NotesPanelView`** — now uses `PanelScrollRegion` (`PanelView scroll={false}`); empty scratch notes are deleted immediately, while notes with draft content still confirm.
- **`PanelCard`** — removed the collapse toggle (chevron button, `collapsed`/`onToggleCollapsed` props, and per-note session state) in favor of always-visible content; title and body text normalized to `font-normal`; rename action reveals on hover.
- **`ScratchNoteCard`** — dropped collapse wiring; rename button fades in on hover/focus.
- **`ProjectSwitcher` / `RecentProjectsView`** — restyled rows with the accent tint treatment (no border outlines).
- Removed `toggleScratchNoteCollapsed` and the `collapsed` field from scratch-notes state.

## Validation

- `pnpm fix && pnpm check && pnpm test` — all passing.