### PR TITLE
feat(workbench): add primary actions and icons to empty states

### DIFF
--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import MessagesSquare from "@lucide/svelte/icons/messages-square";
 import Plus from "@lucide/svelte/icons/plus";
 import type { ProjectRecord } from "$lib/api";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
@@ -112,14 +113,20 @@ const menuContext = $derived<ProjectTreeMenuContext>({
     {#if !activeProject}
       <PanelEmpty title="No project selected." description={emptyStateHint} />
     {:else if rows.length === 0}
-      <PanelEmpty title="No conversations in this project yet.">
+      <PanelEmpty
+        icon={MessagesSquare}
+        title="No conversations yet"
+        description="Conversations are scoped to this project."
+      >
         {#snippet action()}
           <Button
             variant="outline"
-            size="sm"
+            size="xs"
             onclick={() => onNewConversationInProject?.(activeProject.dir)}
-            >New chat</Button
           >
+            <Plus />
+            New chat
+          </Button>
         {/snippet}
       </PanelEmpty>
     {:else}

--- a/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
@@ -158,7 +158,13 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
 
 {#snippet taskList()}
   <div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-    <div class="flex min-w-0 shrink flex-col overflow-y-auto">
+    <div
+      class="flex min-w-0 flex-col overflow-y-auto"
+      class:flex-1={!model.definitionsLoading &&
+        projected.definitions.length === 0}
+      class:shrink={model.definitionsLoading ||
+        projected.definitions.length > 0}
+    >
       {#if model.definitionsLoading && model.definitions.length === 0}
         <p class="py-1 text-xs text-muted-foreground">Loading tasks…</p>
       {:else if projected.definitions.length === 0}
@@ -166,7 +172,19 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
           icon={ListTodo}
           title="No saved tasks"
           description="Create a task to run it anytime."
-        />
+        >
+          {#snippet action()}
+            <Button
+              size="xs"
+              variant="outline"
+              disabled={!model.capabilities.manageDefinitions.enabled}
+              onclick={() => (addOpen = true)}
+            >
+              <Plus />
+              New task
+            </Button>
+          {/snippet}
+        </PanelEmpty>
       {:else}
         <PanelList role="none" class="gap-1">
           {#each projected.definitions as entry (entry.key)}


### PR DESCRIPTION
## Summary

Improves empty-state UX in two workbench panels by surfacing the primary action directly:

### ProjectConversationNavigator
- Added `MessagesSquare` icon and a descriptive subtitle ("Conversations are scoped to this project.") to the empty state.
- "New chat" button now includes a `Plus` icon and uses `size="xs"` to match the other empty-state actions.

### TasksPanelView
- Added a "New task" action button (with `Plus` icon) to the "No saved tasks" empty state.
- Button is disabled when the `manageDefinitions` capability is not enabled, matching the existing add-task affordances.
- Adjusted the scroll region flex classes so the empty state fills the panel while a populated list still shrinks correctly.

## Validation
- Ran `pnpm fix && pnpm check && pnpm test` locally.