### PR TITLE
Add configurable image explanation tool

### DIFF
--- a/packages/contracts/src/domains/conversations/conversation.schema.ts
+++ b/packages/contracts/src/domains/conversations/conversation.schema.ts
@@ -388,6 +388,17 @@ export interface ConversationLiveToolDraftDiscardedData {
   reason: ConversationLiveToolDraftDiscardReason;
 }
 
+export const conversationLiveToolOutputStreamSchema = z.enum([
+  "stdout",
+  "stderr",
+  "combined",
+  "thinking",
+  "text",
+]);
+export type ConversationLiveToolOutputStream = z.infer<
+  typeof conversationLiveToolOutputStreamSchema
+>;
+
 export interface ConversationLiveToolOutputDeltaData {
   conversationId: string;
   agentId: string;
@@ -399,7 +410,7 @@ export interface ConversationLiveToolOutputDeltaData {
   providerToolCallId?: string;
   toolCallId: string;
   toolName: string;
-  stream: "stdout" | "stderr" | "combined";
+  stream: ConversationLiveToolOutputStream;
   offset: number;
   delta: string;
 }
@@ -473,7 +484,7 @@ export interface ConversationLiveTurnSnapshot {
 }
 
 export interface ConversationLiveToolOutputChunkSnapshot {
-  stream: "stdout" | "stderr" | "combined";
+  stream: ConversationLiveToolOutputStream;
   text: string;
   ts: string;
 }
@@ -594,7 +605,7 @@ export const conversationLiveTurnSnapshotSchema = z.object({
 });
 
 export const conversationLiveToolOutputChunkSnapshotSchema = z.object({
-  stream: z.enum(["stdout", "stderr", "combined"]),
+  stream: conversationLiveToolOutputStreamSchema,
   text: z.string(),
   ts: z.string().datetime(),
 });
@@ -933,7 +944,7 @@ const conversationLiveToolOutputDeltaDataSchema = z.object({
   providerToolCallId: z.string().min(1).optional(),
   toolCallId: z.string().startsWith("tool_"),
   toolName: z.string().min(1),
-  stream: z.enum(["stdout", "stderr", "combined"]),
+  stream: conversationLiveToolOutputStreamSchema,
   offset: z.number().int().nonnegative(),
   delta: z.string().max(PUBLIC_EVENT_MAX_STRING_CHARS),
 });

--- a/packages/contracts/src/domains/settings/settings.schema.ts
+++ b/packages/contracts/src/domains/settings/settings.schema.ts
@@ -75,13 +75,18 @@ const bashToolSettingsSchema = z.object({
   }),
 });
 
+const imageExplanationToolSettingsSchema = z.object({
+  model: modelSelectionSchema.optional(),
+});
+
 const toolSettingsSchema = z.object({
-  disabled: z.array(userConfigurableToolNameSchema).default([]),
+  disabled: z.array(userConfigurableToolNameSchema).default(["explain_image"]),
   bash: bashToolSettingsSchema.default({
     autoPromotion: { enabled: true, afterMs: 120_000 },
   }),
   jira: jiraToolSettingsSchema.default({ enabled: false }),
   confluence: confluenceToolSettingsSchema.default({ enabled: false }),
+  imageExplanation: imageExplanationToolSettingsSchema.default({}),
 });
 
 export const compactionProfileSchema = z.enum([
@@ -200,10 +205,11 @@ export const settingsSchema = z.object({
   }),
   runtime: runtimeSettingsSchema.default({}),
   tools: toolSettingsSchema.default({
-    disabled: [],
+    disabled: ["explain_image"],
     bash: { autoPromotion: { enabled: true, afterMs: 120_000 } },
     jira: { enabled: false },
     confluence: { enabled: false },
+    imageExplanation: {},
   }),
   skills: z
     .object({
@@ -272,10 +278,11 @@ export const defaultSettings: Settings = {
   },
   runtime: {},
   tools: {
-    disabled: [],
+    disabled: ["explain_image"],
     bash: { autoPromotion: { enabled: true, afterMs: 120_000 } },
     jira: { enabled: false },
     confluence: { enabled: false },
+    imageExplanation: {},
   },
   skills: { disabled: [], agentBrowser: { enabled: [] } },
   scopedModels: [],
@@ -403,6 +410,11 @@ export const updateSettingsRequestSchema = z.object({
           siteUrl: z.string().trim().url().nullable().optional(),
           email: z.string().trim().email().nullable().optional(),
           defaultSpaceKey: z.string().trim().min(1).nullable().optional(),
+        })
+        .optional(),
+      imageExplanation: z
+        .object({
+          model: modelSelectionSchema.nullable().optional(),
         })
         .optional(),
     })

--- a/packages/contracts/src/domains/settings/settings.schema.ts
+++ b/packages/contracts/src/domains/settings/settings.schema.ts
@@ -77,6 +77,7 @@ const bashToolSettingsSchema = z.object({
 
 const imageExplanationToolSettingsSchema = z.object({
   model: modelSelectionSchema.optional(),
+  thinkingLevel: thinkingLevelSchema.default("off"),
 });
 
 const toolSettingsSchema = z.object({
@@ -86,7 +87,9 @@ const toolSettingsSchema = z.object({
   }),
   jira: jiraToolSettingsSchema.default({ enabled: false }),
   confluence: confluenceToolSettingsSchema.default({ enabled: false }),
-  imageExplanation: imageExplanationToolSettingsSchema.default({}),
+  imageExplanation: imageExplanationToolSettingsSchema.default({
+    thinkingLevel: "off",
+  }),
 });
 
 export const compactionProfileSchema = z.enum([
@@ -209,7 +212,7 @@ export const settingsSchema = z.object({
     bash: { autoPromotion: { enabled: true, afterMs: 120_000 } },
     jira: { enabled: false },
     confluence: { enabled: false },
-    imageExplanation: {},
+    imageExplanation: { thinkingLevel: "off" },
   }),
   skills: z
     .object({
@@ -282,7 +285,7 @@ export const defaultSettings: Settings = {
     bash: { autoPromotion: { enabled: true, afterMs: 120_000 } },
     jira: { enabled: false },
     confluence: { enabled: false },
-    imageExplanation: {},
+    imageExplanation: { thinkingLevel: "off" },
   },
   skills: { disabled: [], agentBrowser: { enabled: [] } },
   scopedModels: [],
@@ -415,6 +418,7 @@ export const updateSettingsRequestSchema = z.object({
       imageExplanation: z
         .object({
           model: modelSelectionSchema.nullable().optional(),
+          thinkingLevel: thinkingLevelSchema.optional(),
         })
         .optional(),
     })

--- a/packages/contracts/src/domains/tools/records.schema.ts
+++ b/packages/contracts/src/domains/tools/records.schema.ts
@@ -31,6 +31,7 @@ export const toolGroupNameSchema = z.enum([
   "shell",
   "python",
   "web",
+  "vision",
   "jira",
   "confluence",
   "input",
@@ -67,6 +68,7 @@ export const coreToolNameSchema = z.enum([
   "todos_get",
   "web_search",
   "web_fetch",
+  "explain_image",
   "jira_search_users",
   "jira_search_issues",
   "jira_get_issue",
@@ -89,6 +91,7 @@ export type CoreToolName = z.infer<typeof coreToolNameSchema>;
 export const userConfigurableToolNameSchema = z.enum([
   "web_search",
   "web_fetch",
+  "explain_image",
   "python_exec",
 ]);
 export type UserConfigurableToolName = z.infer<

--- a/packages/contracts/src/domains/tools/tool-results.schema.ts
+++ b/packages/contracts/src/domains/tools/tool-results.schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { thinkingLevelSchema } from "../models/index.js";
+import { modelSelectionSchema, thinkingLevelSchema } from "../models/index.js";
 import {
   taskListeningPortSchema,
   taskLogQueryResponseSchema,
@@ -323,6 +323,17 @@ export const webSearchResultDetailsSchema = z.object({
 });
 export type WebSearchResultDetails = z.infer<
   typeof webSearchResultDetailsSchema
+>;
+
+export const explainImageResultDetailsSchema = z.object({
+  path: z.string(),
+  mimeType: z.string(),
+  byteSize: z.number().int().nonnegative(),
+  model: modelSelectionSchema,
+  explanation: z.string(),
+});
+export type ExplainImageResultDetails = z.infer<
+  typeof explainImageResultDetailsSchema
 >;
 
 export const webFetchResultDetailsSchema = z.object({

--- a/packages/contracts/test/protocol.schema.test.ts
+++ b/packages/contracts/test/protocol.schema.test.ts
@@ -7,6 +7,7 @@ import {
   boundedPublicJsonSchema,
   boundedPublicObjectSchema,
   canTransition,
+  conversationLiveToolOutputStreamSchema,
   conversationStream,
   eventBatchDataSchema,
   eventBatchMessageSchema,
@@ -32,6 +33,21 @@ import {
 } from "../src/index.js";
 
 const ts = "2026-06-26T12:00:00.000Z";
+
+describe("live tool output streams", () => {
+  it("accepts model thinking and text channels", () => {
+    for (const stream of ["thinking", "text"] as const) {
+      assert.equal(
+        conversationLiveToolOutputStreamSchema.safeParse(stream).success,
+        true,
+      );
+    }
+    assert.equal(
+      conversationLiveToolOutputStreamSchema.safeParse("reasoning").success,
+      false,
+    );
+  });
+});
 
 function message(kind: string, data: unknown) {
   return {

--- a/packages/contracts/test/settings.test.ts
+++ b/packages/contracts/test/settings.test.ts
@@ -68,7 +68,9 @@ describe("settings schema", () => {
     });
     assert.equal(settings.tools.jira.enabled, false);
     assert.equal(settings.tools.confluence.enabled, false);
-    assert.deepEqual(settings.tools.imageExplanation, {});
+    assert.deepEqual(settings.tools.imageExplanation, {
+      thinkingLevel: "off",
+    });
   });
 
   it("backfills event tones for the previous notification settings shape", () => {
@@ -165,6 +167,7 @@ describe("settings schema", () => {
         },
         imageExplanation: {
           model: { provider: "google", modelId: "gemini-2.5-flash" },
+          thinkingLevel: "high",
         },
       },
     });
@@ -241,9 +244,9 @@ describe("settings schema", () => {
     );
     assert.equal(parsed.tools?.confluence?.email, "user@example.com");
     assert.equal(parsed.tools?.confluence?.defaultSpaceKey, "DEV");
-    assert.deepEqual(parsed.tools?.imageExplanation?.model, {
-      provider: "google",
-      modelId: "gemini-2.5-flash",
+    assert.deepEqual(parsed.tools?.imageExplanation, {
+      model: { provider: "google", modelId: "gemini-2.5-flash" },
+      thinkingLevel: "high",
     });
     const cleared = updateSettingsRequestSchema.parse({
       runtime: { pythonExecutablePath: null, shellPath: null },

--- a/packages/contracts/test/settings.test.ts
+++ b/packages/contracts/test/settings.test.ts
@@ -59,7 +59,7 @@ describe("settings schema", () => {
         failed: "alert",
       },
     });
-    assert.deepEqual(settings.tools.disabled, []);
+    assert.deepEqual(settings.tools.disabled, ["explain_image"]);
     assert.deepEqual(settings.skills.disabled, []);
     assert.deepEqual(settings.skills.agentBrowser.enabled, []);
     assert.deepEqual(settings.tools.bash.autoPromotion, {
@@ -68,6 +68,7 @@ describe("settings schema", () => {
     });
     assert.equal(settings.tools.jira.enabled, false);
     assert.equal(settings.tools.confluence.enabled, false);
+    assert.deepEqual(settings.tools.imageExplanation, {});
   });
 
   it("backfills event tones for the previous notification settings shape", () => {
@@ -146,7 +147,7 @@ describe("settings schema", () => {
         agentBrowser: { enabled: ["core", "dogfood"] },
       },
       tools: {
-        disabled: ["web_search", "web_fetch", "python_exec"],
+        disabled: ["web_search", "web_fetch", "explain_image", "python_exec"],
         bash: {
           autoPromotion: { enabled: false, afterMs: 240_000 },
         },
@@ -161,6 +162,9 @@ describe("settings schema", () => {
           siteUrl: "https://example.atlassian.net",
           email: "user@example.com",
           defaultSpaceKey: "DEV",
+        },
+        imageExplanation: {
+          model: { provider: "google", modelId: "gemini-2.5-flash" },
         },
       },
     });
@@ -211,6 +215,7 @@ describe("settings schema", () => {
     assert.deepEqual(parsed.tools?.disabled, [
       "web_search",
       "web_fetch",
+      "explain_image",
       "python_exec",
     ]);
     assert.deepEqual(parsed.skills?.disabled, ["diagram", "imagegen"]);
@@ -236,6 +241,10 @@ describe("settings schema", () => {
     );
     assert.equal(parsed.tools?.confluence?.email, "user@example.com");
     assert.equal(parsed.tools?.confluence?.defaultSpaceKey, "DEV");
+    assert.deepEqual(parsed.tools?.imageExplanation?.model, {
+      provider: "google",
+      modelId: "gemini-2.5-flash",
+    });
     const cleared = updateSettingsRequestSchema.parse({
       runtime: { pythonExecutablePath: null, shellPath: null },
       tools: {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -60,6 +60,7 @@ export * from "./harness/result.js";
 export { registerManagedProvider } from "./models/provider-registry.js";
 export * from "./transport/proxy.js";
 export * from "./models/prompt-stream.js";
+export * from "./models/image-explanation.js";
 export * from "./models/provider-error-classification.js";
 export * from "./models/resolution.js";
 export { registerAgentScriptedProvider } from "./models/scripted-provider.js";

--- a/packages/harness/src/models/image-explanation.ts
+++ b/packages/harness/src/models/image-explanation.ts
@@ -1,0 +1,65 @@
+import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
+import { normalizeImagesForModel } from "./image-normalization.js";
+import { completeSimpleWithModel } from "./provider-registry.js";
+
+const IMAGE_EXPLANATION_PROMPT = `Explain this image comprehensively for another model that cannot see it.
+Be factual and precise. Include all visible text exactly, the layout and spatial relationships, objects and people, UI state, diagrams or charts, colors, and any details that may matter. Clearly distinguish direct observations from uncertain interpretations.`;
+
+export type ImageExplanationAuth = {
+  apiKey?: string;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  env?: Record<string, string>;
+};
+
+export async function explainImageWithModel(input: {
+  model: Model<Api>;
+  image: ImageContent;
+  prompt?: string;
+  auth?: ImageExplanationAuth;
+  signal?: AbortSignal;
+}): Promise<string> {
+  if (!(input.model.input ?? ["text"]).includes("image")) {
+    throw new Error(
+      "The configured image explanation model does not support image input.",
+    );
+  }
+  const requestModel = input.auth?.baseUrl
+    ? { ...input.model, baseUrl: input.auth.baseUrl }
+    : input.model;
+  const focus = input.prompt?.trim();
+  const prompt = focus
+    ? `${IMAGE_EXPLANATION_PROMPT}\n\nFocus on this request:\n${focus}`
+    : IMAGE_EXPLANATION_PROMPT;
+  const messages = await normalizeImagesForModel(
+    [
+      {
+        role: "user",
+        content: [{ type: "text", text: prompt }, input.image],
+        timestamp: Date.now(),
+      },
+    ],
+    requestModel,
+  );
+  const response = await completeSimpleWithModel(
+    requestModel,
+    { messages },
+    {
+      apiKey: input.auth?.apiKey,
+      headers: input.auth?.headers,
+      env: input.auth?.env,
+      signal: input.signal,
+    },
+  );
+  const explanation = response.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+  if (!explanation) {
+    throw new Error(
+      "The configured vision model returned no text explanation.",
+    );
+  }
+  return explanation;
+}

--- a/packages/harness/src/models/image-explanation.ts
+++ b/packages/harness/src/models/image-explanation.ts
@@ -1,7 +1,7 @@
 import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
 import type { ThinkingLevel } from "../agent/types/index.js";
 import { normalizeImagesForModel } from "./image-normalization.js";
-import { completeSimpleWithModel } from "./provider-registry.js";
+import { streamSimpleWithModel } from "./provider-registry.js";
 
 const IMAGE_EXPLANATION_PROMPT = `Explain this image comprehensively for another model that cannot see it.
 Be factual and precise. Include all visible text exactly, the layout and spatial relationships, objects and people, UI state, diagrams or charts, colors, and any details that may matter. Clearly distinguish direct observations from uncertain interpretations.`;
@@ -18,6 +18,10 @@ export async function explainImageWithModel(input: {
   image: ImageContent;
   prompt?: string;
   thinkingLevel?: ThinkingLevel;
+  onDelta?: (update: {
+    kind: "thinking" | "text";
+    delta: string;
+  }) => void | Promise<void>;
   auth?: ImageExplanationAuth;
   signal?: AbortSignal;
 }): Promise<string> {
@@ -49,7 +53,7 @@ export async function explainImageWithModel(input: {
     input.thinkingLevel !== "off"
       ? input.thinkingLevel
       : undefined;
-  const response = await completeSimpleWithModel(
+  const stream = streamSimpleWithModel(
     requestModel,
     { messages },
     {
@@ -60,6 +64,20 @@ export async function explainImageWithModel(input: {
       signal: input.signal,
     },
   );
+  for await (const event of stream) {
+    if (event.type !== "thinking_delta" && event.type !== "text_delta") {
+      continue;
+    }
+    try {
+      await input.onDelta?.({
+        kind: event.type === "thinking_delta" ? "thinking" : "text",
+        delta: event.delta,
+      });
+    } catch {
+      // Live progress is best effort and must never fail image explanation.
+    }
+  }
+  const response = await stream.result();
   const explanation = response.content
     .filter((block) => block.type === "text")
     .map((block) => block.text)

--- a/packages/harness/src/models/image-explanation.ts
+++ b/packages/harness/src/models/image-explanation.ts
@@ -1,4 +1,5 @@
 import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
+import type { ThinkingLevel } from "../agent/types/index.js";
 import { normalizeImagesForModel } from "./image-normalization.js";
 import { completeSimpleWithModel } from "./provider-registry.js";
 
@@ -16,6 +17,7 @@ export async function explainImageWithModel(input: {
   model: Model<Api>;
   image: ImageContent;
   prompt?: string;
+  thinkingLevel?: ThinkingLevel;
   auth?: ImageExplanationAuth;
   signal?: AbortSignal;
 }): Promise<string> {
@@ -41,6 +43,12 @@ export async function explainImageWithModel(input: {
     ],
     requestModel,
   );
+  const reasoning =
+    requestModel.reasoning &&
+    input.thinkingLevel &&
+    input.thinkingLevel !== "off"
+      ? input.thinkingLevel
+      : undefined;
   const response = await completeSimpleWithModel(
     requestModel,
     { messages },
@@ -48,6 +56,7 @@ export async function explainImageWithModel(input: {
       apiKey: input.auth?.apiKey,
       headers: input.auth?.headers,
       env: input.auth?.env,
+      reasoning,
       signal: input.signal,
     },
   );

--- a/packages/harness/test/models/image-explanation.test.ts
+++ b/packages/harness/test/models/image-explanation.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { explainImageWithModel } from "../../src/models/image-explanation.js";
+import { registerManagedFauxProvider } from "../../src/models/provider-registry.js";
+
+describe("explainImageWithModel", () => {
+  it("streams thinking and text separately and returns only final text", async () => {
+    const registration = registerManagedFauxProvider({
+      provider: "nerve-faux-image-explanation",
+      models: [{ id: "vision", name: "Vision" }],
+      tokensPerSecond: 10_000,
+      tokenSize: { min: 2, max: 4 },
+    });
+    registration.setResponses([
+      async () =>
+        fauxAssistantMessage([
+          { type: "thinking", thinking: "Inspecting image details." },
+          { type: "text", text: "## Result\n\nA settings screen." },
+        ]),
+    ]);
+    const model = {
+      ...registration.getModel("vision"),
+      input: ["text", "image"] as const,
+      reasoning: true,
+    };
+    const updates: Array<{ kind: "thinking" | "text"; delta: string }> = [];
+    try {
+      const explanation = await explainImageWithModel({
+        model,
+        image: {
+          type: "image",
+          data: "iVBORw0KGgo=",
+          mimeType: "image/png",
+        },
+        thinkingLevel: "high",
+        onDelta: (update) => updates.push(update),
+      });
+      assert.equal(explanation, "## Result\n\nA settings screen.");
+      assert.equal(
+        updates
+          .filter((update) => update.kind === "thinking")
+          .map((update) => update.delta)
+          .join(""),
+        "Inspecting image details.",
+      );
+      assert.equal(
+        updates
+          .filter((update) => update.kind === "text")
+          .map((update) => update.delta)
+          .join(""),
+        "## Result\n\nA settings screen.",
+      );
+    } finally {
+      registration.unregister();
+    }
+  });
+
+  it("does not fail inference when live progress reporting throws", async () => {
+    const registration = registerManagedFauxProvider({
+      provider: "nerve-faux-image-progress-failure",
+      models: [{ id: "vision", name: "Vision" }],
+      tokensPerSecond: 10_000,
+    });
+    registration.setResponses([
+      async () => fauxAssistantMessage("A complete explanation."),
+    ]);
+    try {
+      const explanation = await explainImageWithModel({
+        model: {
+          ...registration.getModel("vision"),
+          input: ["text", "image"] as const,
+        },
+        image: {
+          type: "image",
+          data: "iVBORw0KGgo=",
+          mimeType: "image/png",
+        },
+        onDelta: () => {
+          throw new Error("subscriber unavailable");
+        },
+      });
+      assert.equal(explanation, "A complete explanation.");
+    } finally {
+      registration.unregister();
+    }
+  });
+});

--- a/packages/tools/src/catalog/core/vision.tools.ts
+++ b/packages/tools/src/catalog/core/vision.tools.ts
@@ -1,0 +1,41 @@
+import { Type } from "typebox";
+import { executeExplainImage } from "../../execution/vision/explain-image.js";
+import type { ToolDefinition } from "../types.js";
+
+const explainImageParameters = Type.Object(
+  {
+    path: Type.String({
+      description: "Absolute or project-relative path to an image file",
+      minLength: 1,
+    }),
+    prompt: Type.Optional(
+      Type.String({
+        description:
+          "Optional question or specific detail the vision model should focus on",
+        minLength: 1,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const visionToolDefinitions = [
+  {
+    name: "explain_image",
+    group: "vision",
+    baseRisk: "network",
+    traits: ["credentialed", "read_only_network"],
+    executionKind: "local",
+    executor: executeExplainImage,
+    label: "Explain Image",
+    description:
+      "Ask the vision model configured in Nerve Settings to explain an image as detailed text.",
+    promptSnippet:
+      "Explain an image path with the configured vision model when you cannot inspect images directly",
+    promptGuidelines: [
+      "Use explain_image for image paths you need to understand. Include a focused prompt when the user asks about a specific visual detail.",
+    ],
+    parameters: explainImageParameters,
+    executionMode: "sequential",
+  },
+] satisfies ToolDefinition[];

--- a/packages/tools/src/catalog/manifest.ts
+++ b/packages/tools/src/catalog/manifest.ts
@@ -12,6 +12,7 @@ import { jiraToolDefinitions } from "./core/jira.tools.js";
 import { pythonToolDefinitions } from "./core/python.tools.js";
 import { shellToolDefinitions } from "./core/shell.tools.js";
 import { webToolDefinitions } from "./core/web.tools.js";
+import { visionToolDefinitions } from "./core/vision.tools.js";
 import { exploreToolDefinitions } from "./orchestration/explore.tools.js";
 import { planModeToolDefinitions } from "./orchestration/plan-mode.tools.js";
 import { taskToolDefinitions } from "./orchestration/task.tools.js";
@@ -33,6 +34,7 @@ export const coreToolDefinitions: readonly ToolDefinition[] = Object.freeze([
   ...remainingFilesystemToolDefinitions,
   ...interactionToolDefinitions,
   ...webToolDefinitions,
+  ...visionToolDefinitions,
   ...jiraToolDefinitions,
   ...confluenceToolDefinitions,
 ]);

--- a/packages/tools/src/execution/filesystem/read.ts
+++ b/packages/tools/src/execution/filesystem/read.ts
@@ -40,7 +40,9 @@ function startsWithAscii(
   return true;
 }
 
-function detectSupportedImageMimeType(buffer: Uint8Array): string | null {
+export function detectSupportedImageMimeType(
+  buffer: Uint8Array,
+): string | null {
   if (startsWith(buffer, [0xff, 0xd8, 0xff])) return "image/jpeg";
   if (startsWith(buffer, PNG_SIGNATURE)) return "image/png";
   if (startsWithAscii(buffer, 0, "GIF")) return "image/gif";

--- a/packages/tools/src/execution/vision/explain-image.ts
+++ b/packages/tools/src/execution/vision/explain-image.ts
@@ -1,0 +1,86 @@
+import { readFile, stat } from "node:fs/promises";
+import type { ToolExecutionContext, ToolExecutionResult } from "../../types.js";
+import { buildProcessTextResult } from "../common/process-result.js";
+import { detectSupportedImageMimeType } from "../filesystem/read.js";
+import {
+  isErrnoException,
+  pathNotFoundMessage,
+  resolveReadPath,
+} from "../filesystem/path.js";
+
+export const EXPLAIN_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
+
+function optionalPrompt(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("prompt must be a non-empty string when provided.");
+  }
+  return value.trim();
+}
+
+export async function executeExplainImage(
+  args: Record<string, unknown>,
+  context: ToolExecutionContext,
+): Promise<ToolExecutionResult> {
+  if (!context.explainImage) {
+    throw new Error(
+      "Image explanation is not configured. Choose a vision model in Nerve Settings → Tools.",
+    );
+  }
+
+  const path = await resolveReadPath(context.cwd, args.path);
+  const fileStat = await stat(path).catch((error: unknown) => {
+    if (isErrnoException(error) && error.code === "ENOENT") {
+      throw new Error(pathNotFoundMessage("explain_image", args.path, path));
+    }
+    throw error;
+  });
+  if (!fileStat.isFile()) {
+    throw new Error(`explain_image requires a regular file: ${path}`);
+  }
+  if (fileStat.size > EXPLAIN_IMAGE_MAX_BYTES) {
+    throw new Error(
+      `Image is too large for explain_image (${fileStat.size} bytes; maximum ${EXPLAIN_IMAGE_MAX_BYTES} bytes).`,
+    );
+  }
+
+  const data = await readFile(path);
+  const mimeType = detectSupportedImageMimeType(data);
+  if (!mimeType) {
+    throw new Error(
+      "Unsupported image format. explain_image supports JPEG, PNG, GIF, and WebP files detected from their contents.",
+    );
+  }
+
+  const response = await context.explainImage({
+    path,
+    data,
+    mimeType,
+    prompt: optionalPrompt(args.prompt),
+    signal: context.signal,
+  });
+  const explanation = response.explanation.trim();
+  if (!explanation) {
+    throw new Error("The configured vision model returned no explanation.");
+  }
+
+  const result = await buildProcessTextResult({
+    text: explanation,
+    outputFilePrefix: "nerve-image-explanation",
+    exitMessagePrefix: "Image explanation",
+    dataDir: context.dataDir,
+    details: {
+      path,
+      mimeType,
+      byteSize: data.byteLength,
+      model: response.model,
+    },
+  });
+  return {
+    ...result,
+    details: {
+      ...(result.details as Record<string, unknown> | undefined),
+      explanation: result.content ?? "",
+    },
+  };
+}

--- a/packages/tools/src/execution/vision/explain-image.ts
+++ b/packages/tools/src/execution/vision/explain-image.ts
@@ -58,6 +58,7 @@ export async function executeExplainImage(
     mimeType,
     prompt: optionalPrompt(args.prompt),
     signal: context.signal,
+    onUpdate: context.onUpdate,
   });
   const explanation = response.explanation.trim();
   if (!explanation) {

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ConversationLiveToolOutputStream,
   ToolContentBlockPayload,
   ToolExecutionResultPayload,
   ToolImageContentPayload,
@@ -8,7 +9,7 @@ import type { PythonRuntime } from "./execution/python/runtime.js";
 
 export type ToolExecutionOutputUpdate = {
   kind: "output";
-  stream: "stdout" | "stderr" | "combined";
+  stream: ConversationLiveToolOutputStream;
   chunk: string;
 };
 
@@ -18,6 +19,7 @@ export type ExplainImageRequest = {
   mimeType: string;
   prompt?: string;
   signal?: AbortSignal;
+  onUpdate?: (update: ToolExecutionOutputUpdate) => void | Promise<void>;
 };
 
 export type ExplainImageResponse = {

--- a/packages/tools/src/types.ts
+++ b/packages/tools/src/types.ts
@@ -12,6 +12,19 @@ export type ToolExecutionOutputUpdate = {
   chunk: string;
 };
 
+export type ExplainImageRequest = {
+  path: string;
+  data: Uint8Array;
+  mimeType: string;
+  prompt?: string;
+  signal?: AbortSignal;
+};
+
+export type ExplainImageResponse = {
+  explanation: string;
+  model: { provider: string; modelId: string };
+};
+
 export type ToolExecutionContext = {
   cwd: string;
   signal?: AbortSignal;
@@ -19,6 +32,9 @@ export type ToolExecutionContext = {
   shellPath?: string;
   getApiKey?: (provider: string) => Promise<string | undefined>;
   getProviderConfig?: (provider: string) => Promise<unknown>;
+  explainImage?: (
+    request: ExplainImageRequest,
+  ) => Promise<ExplainImageResponse>;
   pythonRuntime?: PythonRuntime;
   pythonPolicy?: {
     allowNetwork: boolean;
@@ -101,6 +117,10 @@ export type WebSearchToolArgs = {
 export type WebFetchToolArgs = {
   url?: unknown;
   raw?: unknown;
+};
+
+export type ExplainImageToolArgs = ToolPathArgs & {
+  prompt?: unknown;
 };
 
 export type JiraToolArgs = Record<string, unknown>;

--- a/packages/tools/test/availability.test.ts
+++ b/packages/tools/test/availability.test.ts
@@ -31,6 +31,7 @@ describe("read-only tool availability and permissions", () => {
       "write",
       "web_search",
       "web_fetch",
+      "explain_image",
       "explore",
       "task_start",
       "task_cancel",

--- a/packages/tools/test/dispatch.test.ts
+++ b/packages/tools/test/dispatch.test.ts
@@ -1,6 +1,7 @@
 import type { ToolName } from "@nervekit/contracts";
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
+import { writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { describe, it } from "node:test";
 import { HTML_CONVERSION_MAX_INPUT_BYTES } from "../src/execution/common/isolated-html-to-markdown.js";
@@ -191,6 +192,50 @@ describe("executeTool dispatch", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it("dispatches explain_image through the host vision callback", async () => {
+    const project = await createTempProject();
+    const image = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00,
+    ]);
+    await writeFile(`${project.root}/screen.png`, image);
+    const result = await executeTool(
+      "explain_image",
+      { path: "screen.png", prompt: "Read the error" },
+      {
+        cwd: project.root,
+        explainImage: async (request) => {
+          assert.equal(request.mimeType, "image/png");
+          assert.equal(request.prompt, "Read the error");
+          assert.deepEqual(Buffer.from(request.data), image);
+          return {
+            explanation: "The screenshot shows a build error.",
+            model: { provider: "google", modelId: "gemini" },
+          };
+        },
+      },
+    );
+    assert.equal(result.content, "The screenshot shows a build error.");
+    const details = result.details as Record<string, unknown>;
+    assert.equal(details.mimeType, "image/png");
+    assert.equal(details.byteSize, image.byteLength);
+    assert.equal(
+      JSON.stringify(result).includes(image.toString("base64")),
+      false,
+    );
+  });
+
+  it("rejects explain_image without a configured host callback", async () => {
+    const project = await createTempProject();
+    await assert.rejects(
+      executeTool(
+        "explain_image",
+        { path: "screen.png" },
+        { cwd: project.root },
+      ),
+      /not configured/,
+    );
   });
 
   it("rejects todo tools because they are orchestrator-owned", async () => {

--- a/packages/tools/test/dispatch.test.ts
+++ b/packages/tools/test/dispatch.test.ts
@@ -200,6 +200,7 @@ describe("executeTool dispatch", () => {
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00,
     ]);
     await writeFile(`${project.root}/screen.png`, image);
+    const updates: Array<{ stream: string; chunk: string }> = [];
     const result = await executeTool(
       "explain_image",
       { path: "screen.png", prompt: "Read the error" },
@@ -209,13 +210,32 @@ describe("executeTool dispatch", () => {
           assert.equal(request.mimeType, "image/png");
           assert.equal(request.prompt, "Read the error");
           assert.deepEqual(Buffer.from(request.data), image);
+          await request.onUpdate?.({
+            kind: "output",
+            stream: "thinking",
+            chunk: "Inspecting pixels",
+          });
+          await request.onUpdate?.({
+            kind: "output",
+            stream: "text",
+            chunk: "The screenshot shows a build error.",
+          });
           return {
             explanation: "The screenshot shows a build error.",
             model: { provider: "google", modelId: "gemini" },
           };
         },
+        onUpdate: (update) => updates.push(update),
       },
     );
+    assert.deepEqual(updates, [
+      { kind: "output", stream: "thinking", chunk: "Inspecting pixels" },
+      {
+        kind: "output",
+        stream: "text",
+        chunk: "The screenshot shows a build error.",
+      },
+    ]);
     assert.equal(result.content, "The screenshot shows a build error.");
     const details = result.details as Record<string, unknown>;
     assert.equal(details.mimeType, "image/png");

--- a/packages/website/src/content/docs/developers/tools-policy.md
+++ b/packages/website/src/content/docs/developers/tools-policy.md
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-The contracts and tool manifest define 38 agent-callable names. Definitions declare schemas, risk traits, availability, and parallel/sequential execution. Executors return bounded content plus artifacts/transcripts when needed.
+The contracts and tool manifest define 39 agent-callable names. Definitions declare schemas, risk traits, availability, and parallel/sequential execution. Executors return bounded content plus artifacts/transcripts when needed.
 
 ## Local versus host tools
 

--- a/packages/website/src/content/docs/guides/images-and-voice.md
+++ b/packages/website/src/content/docs/guides/images-and-voice.md
@@ -11,8 +11,10 @@ Copy an image and paste with `Ctrl/Cmd+V` inside the composer. Nerve intercepts 
 
 Accepted MIME families include PNG, JPEG, GIF, WebP, SVG, BMP, TIFF, and AVIF. The path lets the agent's file-reading pipeline send image content to a capable model.
 
+For a text-only model, configure and enable `explain_image` under **Settings → Tools**. The agent can then send the temporary path to the selected vision model and receive a detailed text explanation. The tool is completely hidden from vision-capable models and whenever it is disabled.
+
 :::caution
-The composer does not currently prevent image paste when a text-only model is selected. Choose a model known to support image input. Pasted files are temporary paths, not durable project attachments, and the UI does not promise a file-size or decoded-signature validation boundary.
+Pasted files are temporary paths, not durable project attachments. `explain_image` uploads image bytes when its configured model is remote; use a compatible local vision provider when images must remain local.
 :::
 
 Dropping an image, another file, or a folder onto the desktop composer is different from clipboard image paste: it inserts the item's existing filesystem path without copying, uploading, or creating a durable attachment. See [Use the composer](/guides/composer/#drop-files-and-folders) for the full workflow. In a browser or installed PWA, use `@` completion to reference paths inside the project.

--- a/packages/website/src/content/docs/models/usage-images-voice.md
+++ b/packages/website/src/content/docs/models/usage-images-voice.md
@@ -17,9 +17,11 @@ Nerve currently retrieves subscription usage snapshots only for OAuth Anthropic 
 
 ## Image input
 
-Custom model definitions can declare image input and the harness can pass image content. The public model picker does not currently expose modality and the composer enables clipboard image paste for every selected model. Select a model known to accept images; a text-only model can reject the request.
+Custom model definitions can declare image input and the harness can pass image content. Pasted images become temporary local paths rather than durable attachments.
 
-See [Images and voice](/guides/images-and-voice/) for clipboard behavior. Pasted images become temporary local paths rather than durable attachments.
+For text-only models, choose an image-capable model for `explain_image` under **Settings → Tools**, then enable the tool. The agent can explicitly request a detailed description of a JPEG, PNG, GIF, or WebP path. The tool is not disclosed to the model while disabled and is automatically absent when the primary model already supports images.
+
+The configured vision provider receives the image bytes. A local OpenAI-compatible vision endpoint can keep processing local; cloud-provider usage and billing remain separate from the primary model. See [Images and voice](/guides/images-and-voice/) for clipboard behavior.
 
 ## Voice input
 

--- a/packages/website/src/content/docs/reference/tools.md
+++ b/packages/website/src/content/docs/reference/tools.md
@@ -1,11 +1,11 @@
 ---
 title: Agent tool catalog
-description: The 38 agent-callable tools, availability gates, risks, and important limits.
+description: The 39 agent-callable tools, availability gates, risks, and important limits.
 sidebar:
   order: 3
 ---
 
-Nerve exposes 38 tool names. Availability also depends on mode, permission, runtime discovery, module settings, and user toggles.
+Nerve exposes 39 tool names. Availability also depends on mode, permission, runtime discovery, module settings, and user toggles.
 
 ## Files and execution
 
@@ -21,7 +21,15 @@ Reads are bounded and parallel-capable. `edit`/`write` are serialized mutations.
 - Jira: `jira_search_users`, `jira_search_issues`, `jira_get_issue`, `jira_get_project`, `jira_create_issue`, `jira_update_issue`, `jira_add_comment`, `jira_transition_issue`
 - Confluence: `confluence_search_spaces`, `confluence_search_pages`, `confluence_get_page`, `confluence_download_pages`, `confluence_create_page`, `confluence_update_page`, `confluence_publish_pages`, `confluence_upload_attachment`
 
-Only Web search/fetch and Python are individual global tool toggles. Search requires Tavily. Jira/Confluence require enabled modules and credentials.
+Web search/fetch, image explanation, and Python are individual global tool toggles. Search requires Tavily. Jira/Confluence require enabled modules and credentials.
+
+## Image explanation
+
+- `explain_image`
+
+Choose an image-capable fallback model under **Settings → Tools**, then explicitly enable the tool. It is exposed only when the current agent model is text-only. When disabled, it is absent from the agent's tool schema and system prompt.
+
+The tool accepts an absolute or project-relative JPEG, PNG, GIF, or WebP path and an optional focus prompt. It sends the image to the configured vision model and returns only bounded explanatory text to the primary model. Cloud providers receive the image bytes; a compatible local provider can keep processing local.
 
 ## Interaction and to-dos
 

--- a/packages/website/src/content/docs/reference/tools.md
+++ b/packages/website/src/content/docs/reference/tools.md
@@ -27,7 +27,7 @@ Web search/fetch, image explanation, and Python are individual global tool toggl
 
 - `explain_image`
 
-Choose an image-capable fallback model under **Settings → Tools**, then explicitly enable the tool. It is exposed only when the current agent model is text-only. When disabled, it is absent from the agent's tool schema and system prompt.
+Choose an image-capable fallback model and its thinking level under **Settings → Tools**, then explicitly enable the tool. It is exposed only when the current agent model is text-only. When disabled, it is absent from the agent's tool schema and system prompt.
 
 The tool accepts an absolute or project-relative JPEG, PNG, GIF, or WebP path and an optional focus prompt. It sends the image to the configured vision model and returns only bounded explanatory text to the primary model. Cloud providers receive the image bytes; a compatible local provider can keep processing local.
 

--- a/packages/website/src/content/docs/troubleshooting/providers.md
+++ b/packages/website/src/content/docs/troubleshooting/providers.md
@@ -27,7 +27,9 @@ Voice requires OpenAI Codex/ChatGPT OAuth with account information, not an OpenA
 
 ## Image request fails
 
-The composer allows paste regardless of model modality. Select a model known to support image input; Nerve's picker does not currently enforce it.
+For a text-only primary model, open **Settings → Tools → Image explanation**, choose a currently available image-capable model, then enable `explain_image`. If the configured model or its credentials were removed, the setting is marked unavailable and the tool is hidden until reconfigured.
+
+The tool is intentionally absent when disabled or when the primary model already supports image input. It accepts JPEG, PNG, GIF, and WebP files up to 20 MB, detected from file contents rather than the extension.
 
 ## GitHub PRs are unavailable
 

--- a/packages/workbench-app/src/lib/features/settings/components/SettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/SettingsPage.svelte
@@ -191,6 +191,7 @@ function statusText(): string {
           {settingsDraft}
           {status}
           {authProviders}
+          {models}
           {onSettingsChange}
         />
       {:else if page.id === "skills"}

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/BuiltInToolsSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/BuiltInToolsSection.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 import { SvelteSet } from "svelte/reactivity";
-import type { AuthProviderMetadata, Settings, StatusResponse } from "$lib/api";
+import type {
+  AuthProviderMetadata,
+  ModelInfo,
+  ModelSelection,
+  Settings,
+  StatusResponse,
+} from "$lib/api";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import { Switch } from "@nervekit/ui-kit/components/ui/switch";
 import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
@@ -13,6 +19,14 @@ import {
   SettingsSummaryRow,
   SettingsToggleRow,
 } from "$lib/presentation/components/settings";
+import {
+  modelDisplayName,
+  modelKey,
+  providerDisplayName,
+  supportsImageInput,
+  usableModelOptions,
+} from "$lib/presentation/utils/model";
+import SingleModelSelectionDialog from "../../shared/SingleModelSelectionDialog.svelte";
 import type { SettingsChange } from "../settings-change";
 import PythonRuntimeDialog from "./PythonRuntimeDialog.svelte";
 import TavilyKeyDialog from "./TavilyKeyDialog.svelte";
@@ -28,6 +42,7 @@ type Props = {
   settingsDraft: Settings;
   status?: StatusResponse;
   authProviders?: AuthProviderMetadata[];
+  models?: ModelInfo[];
   onSettingsChange?: SettingsChange;
 };
 
@@ -37,11 +52,13 @@ let {
   settingsDraft,
   status,
   authProviders = [],
+  models = [],
   onSettingsChange,
 }: Props = $props();
 
 let tavilyDialogOpen = $state(false);
 let pythonDialogOpen = $state(false);
+let visionModelDialogOpen = $state(false);
 
 const disabledTools = $derived(new Set(settingsDraft.tools?.disabled ?? []));
 const python = $derived(status?.runtime.python);
@@ -58,9 +75,24 @@ const tavilyConfigured = $derived(
 );
 const tavilyDisplayName = $derived(tavilyProvider?.displayName ?? "Tavily");
 const bashAutoPromotion = $derived(settingsDraft.tools.bash.autoPromotion);
+const usableVisionModels = $derived(
+  usableModelOptions(models, authProviders).filter(supportsImageInput),
+);
+const configuredVisionSelection = $derived(
+  settingsDraft.tools.imageExplanation.model,
+);
+const configuredVisionModel = $derived(
+  configuredVisionSelection
+    ? usableVisionModels.find(
+        (model) => modelKey(model) === modelKey(configuredVisionSelection),
+      )
+    : undefined,
+);
+const visionReady = $derived(Boolean(configuredVisionModel));
 
 function groupEnabled(group: ToolGroupDef): boolean {
   if (group.configurableTools.length === 0) return true;
+  if (group.id === "vision" && !visionReady) return false;
   return group.configurableTools.every((name) => !disabledTools.has(name));
 }
 
@@ -68,6 +100,7 @@ function setToolsEnabled(
   names: ConfigurableToolName[],
   enabled: boolean,
 ): void {
+  if (enabled && names.includes("explain_image") && !visionReady) return;
   const tools = ensureToolsDraft(settingsDraft);
   const next = new SvelteSet(tools.disabled);
   for (const name of names) {
@@ -77,6 +110,16 @@ function setToolsEnabled(
   const disabled = configurableToolOrder.filter((name) => next.has(name));
   tools.disabled = disabled;
   onSettingsChange?.({ tools: { disabled } }, { immediate: true });
+}
+
+function saveVisionModel(selection: { model?: ModelSelection }): void {
+  const model = selection.model;
+  settingsDraft.tools.imageExplanation.model = model;
+  onSettingsChange?.(
+    { tools: { imageExplanation: { model: model ?? null } } },
+    { immediate: true },
+  );
+  if (!model) setToolsEnabled(["explain_image"], false);
 }
 
 function setBashAutoPromotionEnabled(enabled: boolean): void {
@@ -131,6 +174,7 @@ function updateBashAutoPromotionSeconds(value: string): void {
             <Switch
               size="settings"
               checked={enabled}
+              disabled={group.id === "vision" && !visionReady}
               aria-label={`Enable ${group.label} tools`}
               onCheckedChange={(checked) =>
                 setToolsEnabled(group.configurableTools, checked)}
@@ -189,6 +233,40 @@ function updateBashAutoPromotionSeconds(value: string): void {
                 >
               {/snippet}
             </SettingsSummaryRow>
+          {:else if group.id === "vision"}
+            <SettingsSummaryRow
+              class="mt-1"
+              title={configuredVisionModel
+                ? modelDisplayName(configuredVisionModel)
+                : configuredVisionSelection
+                  ? `${configuredVisionSelection.provider}/${configuredVisionSelection.modelId}`
+                  : "Vision model not configured"}
+              status={configuredVisionModel
+                ? "ok"
+                : configuredVisionSelection
+                  ? "warning"
+                  : "muted"}
+            >
+              {#snippet meta()}
+                {#if configuredVisionModel}
+                  {providerDisplayName(configuredVisionModel.provider)} · Image input
+                {:else if configuredVisionSelection}
+                  Configured model is unavailable or does not support images.
+                {:else}
+                  Choose an image-capable model before enabling this tool.
+                {/if}
+              {/snippet}
+              {#snippet actions()}
+                <Button
+                  size="xs"
+                  variant="outline"
+                  onclick={() => (visionModelDialogOpen = true)}
+                  >{configuredVisionSelection
+                    ? "Reconfigure"
+                    : "Choose model"}</Button
+                >
+              {/snippet}
+            </SettingsSummaryRow>
           {:else if group.id === "python"}
             <SettingsSummaryRow
               class="mt-1"
@@ -231,6 +309,19 @@ function updateBashAutoPromotionSeconds(value: string): void {
   bind:open={tavilyDialogOpen}
   configured={tavilyConfigured}
   displayName={tavilyDisplayName}
+/>
+
+<SingleModelSelectionDialog
+  bind:open={visionModelDialogOpen}
+  title="Choose image explanation model"
+  description="Only configured models that accept image input are shown."
+  models={usableVisionModels}
+  selectedModel={configuredVisionSelection}
+  selectedThinkingLevel="off"
+  showThinkingLevel={false}
+  emptyMessage="No configured image-capable models are available."
+  confirmLabel="Save model"
+  onSave={saveVisionModel}
 />
 
 <PythonRuntimeDialog

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/BuiltInToolsSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/BuiltInToolsSection.svelte
@@ -5,6 +5,7 @@ import type {
   ModelInfo,
   ModelSelection,
   Settings,
+  ThinkingLevel,
   StatusResponse,
 } from "$lib/api";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
@@ -112,11 +113,22 @@ function setToolsEnabled(
   onSettingsChange?.({ tools: { disabled } }, { immediate: true });
 }
 
-function saveVisionModel(selection: { model?: ModelSelection }): void {
+function saveVisionModel(selection: {
+  model?: ModelSelection;
+  thinkingLevel: ThinkingLevel;
+}): void {
   const model = selection.model;
   settingsDraft.tools.imageExplanation.model = model;
+  settingsDraft.tools.imageExplanation.thinkingLevel = selection.thinkingLevel;
   onSettingsChange?.(
-    { tools: { imageExplanation: { model: model ?? null } } },
+    {
+      tools: {
+        imageExplanation: {
+          model: model ?? null,
+          thinkingLevel: selection.thinkingLevel,
+        },
+      },
+    },
     { immediate: true },
   );
   if (!model) setToolsEnabled(["explain_image"], false);
@@ -250,6 +262,8 @@ function updateBashAutoPromotionSeconds(value: string): void {
               {#snippet meta()}
                 {#if configuredVisionModel}
                   {providerDisplayName(configuredVisionModel.provider)} · Image input
+                  · Thinking {settingsDraft.tools.imageExplanation
+                    .thinkingLevel}
                 {:else if configuredVisionSelection}
                   Configured model is unavailable or does not support images.
                 {:else}
@@ -317,8 +331,7 @@ function updateBashAutoPromotionSeconds(value: string): void {
   description="Only configured models that accept image input are shown."
   models={usableVisionModels}
   selectedModel={configuredVisionSelection}
-  selectedThinkingLevel="off"
-  showThinkingLevel={false}
+  selectedThinkingLevel={settingsDraft.tools.imageExplanation.thinkingLevel}
   emptyMessage="No configured image-capable models are available."
   confirmLabel="Save model"
   onSave={saveVisionModel}

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/ToolsSettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/ToolsSettingsPage.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-import type { AuthProviderMetadata, Settings, StatusResponse } from "$lib/api";
+import type {
+  AuthProviderMetadata,
+  ModelInfo,
+  Settings,
+  StatusResponse,
+} from "$lib/api";
 import { SettingsSection } from "$lib/presentation/components/settings";
 import type { SettingsChange } from "../settings-change";
 import BuiltInToolsSection from "./BuiltInToolsSection.svelte";
@@ -9,6 +14,7 @@ type Props = {
   settingsDraft: Settings;
   status?: StatusResponse;
   authProviders?: AuthProviderMetadata[];
+  models?: ModelInfo[];
   onSettingsChange?: SettingsChange;
 };
 
@@ -16,6 +22,7 @@ let {
   settingsDraft,
   status,
   authProviders = [],
+  models = [],
   onSettingsChange,
 }: Props = $props();
 </script>
@@ -25,6 +32,7 @@ let {
     {settingsDraft}
     {status}
     {authProviders}
+    {models}
     {onSettingsChange}
   />
 </SettingsSection>

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/tool-catalog.ts
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/tool-catalog.ts
@@ -10,6 +10,7 @@ export type ToolGroupId =
   | "plan-mode"
   | "todos"
   | "web"
+  | "vision"
   | "tasks"
   | "shell"
   | "python";
@@ -26,6 +27,7 @@ export type ToolGroupDef = {
 export const configurableToolOrder: ConfigurableToolName[] = [
   "web_search",
   "web_fetch",
+  "explain_image",
   "python_exec",
 ];
 
@@ -150,6 +152,20 @@ export const toolGroups: ToolGroupDef[] = [
       {
         name: "web_fetch",
         description: "Fetch a URL and convert HTML to readable markdown.",
+      },
+    ],
+  },
+  {
+    id: "vision",
+    label: "Image explanation",
+    description:
+      "Use a separate vision model to explain images to text-only agents.",
+    configurableTools: ["explain_image"],
+    tools: [
+      {
+        name: "explain_image",
+        description:
+          "Return a detailed text explanation from the configured vision model.",
       },
     ],
   },

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/tools-draft.ts
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/tools-draft.ts
@@ -7,7 +7,7 @@ export function ensureToolsDraft(settingsDraft: Settings): Settings["tools"] {
     bash: { autoPromotion: { enabled: true, afterMs: 120_000 } },
     jira: { enabled: false },
     confluence: { enabled: false },
-    imageExplanation: {},
+    imageExplanation: { thinkingLevel: "off" },
   };
   return settingsDraft.tools;
 }

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/tools-draft.ts
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/tools-draft.ts
@@ -3,10 +3,11 @@ import type { Settings } from "$lib/api";
 /** Ensures the optional `tools` branch exists before mutating the draft. */
 export function ensureToolsDraft(settingsDraft: Settings): Settings["tools"] {
   settingsDraft.tools ??= {
-    disabled: [],
+    disabled: ["explain_image"],
     bash: { autoPromotion: { enabled: true, afterMs: 120_000 } },
     jira: { enabled: false },
     confluence: { enabled: false },
+    imageExplanation: {},
   };
   return settingsDraft.tools;
 }

--- a/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/shared/SingleModelSelectionDialog.svelte
@@ -37,6 +37,8 @@ type Props = {
   fallbackThinkingLevels?: ThinkingLevel[];
   confirmLabel?: string;
   onSave?: (selection: SaveSelection) => void;
+  showThinkingLevel?: boolean;
+  emptyMessage?: string;
 };
 
 let {
@@ -50,6 +52,8 @@ let {
   fallbackThinkingLevels = ["off"],
   confirmLabel = "Save selection",
   onSave,
+  showThinkingLevel = true,
+  emptyMessage = "Authenticate a provider before choosing a model.",
 }: Props = $props();
 
 let selectedKey = $state("");
@@ -156,7 +160,7 @@ function useFallback(): void {
       <div class="grid min-h-0 grid-rows-[minmax(0,1fr)] px-3 py-2">
         {#if models.length === 0}
           <p class="py-1 text-sm text-muted-foreground">
-            Authenticate a provider before choosing a model.
+            {emptyMessage}
           </p>
         {:else if filteredModels.length === 0}
           <p class="py-1 text-sm text-muted-foreground">
@@ -193,29 +197,31 @@ function useFallback(): void {
       </div>
     </Tooltip.Provider>
 
-    <div class="grid gap-1 border-t border-border/50 px-3 py-2">
-      <span class="text-xs text-muted-foreground">Thinking level</span>
-      <ToggleGroup.Root
-        type="single"
-        size="xs"
-        spacing={1}
-        variant="outline"
-        value={thinkingLevel}
-        aria-label="Thinking level"
-        class="min-w-0 flex-wrap justify-start"
-        onValueChange={(value) => {
-          if (value) thinkingLevel = value as ThinkingLevel;
-        }}
-      >
-        {#each thinkingLevels as level (level)}
-          <ToggleGroup.Item
-            value={level}
-            class="flex-none rounded-full text-xs capitalize data-[state=on]:text-primary"
-            >{level}</ToggleGroup.Item
-          >
-        {/each}
-      </ToggleGroup.Root>
-    </div>
+    {#if showThinkingLevel}
+      <div class="grid gap-1 border-t border-border/50 px-3 py-2">
+        <span class="text-xs text-muted-foreground">Thinking level</span>
+        <ToggleGroup.Root
+          type="single"
+          size="xs"
+          spacing={1}
+          variant="outline"
+          value={thinkingLevel}
+          aria-label="Thinking level"
+          class="min-w-0 flex-wrap justify-start"
+          onValueChange={(value) => {
+            if (value) thinkingLevel = value as ThinkingLevel;
+          }}
+        >
+          {#each thinkingLevels as level (level)}
+            <ToggleGroup.Item
+              value={level}
+              class="flex-none rounded-full text-xs capitalize data-[state=on]:text-primary"
+              >{level}</ToggleGroup.Item
+            >
+          {/each}
+        </ToggleGroup.Root>
+      </div>
+    {/if}
   </div>
 
   {#snippet footer()}

--- a/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
@@ -183,6 +183,12 @@ function hasMeaningfulDurableBody(view: ParsedToolView | undefined): boolean {
       return Boolean(view.answer || view.results.length);
     case "web_fetch":
       return Boolean(view.content?.length);
+    case "explain_image":
+      return Boolean(
+        view.explanation?.length ||
+        view.thinking?.length ||
+        view.liveExplanation?.length,
+      );
     case "generic":
       return Boolean(view.resultText || view.result.length);
     case "jira":

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExplainImageToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExplainImageToolView.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
+import type {
+  ToolCallDisplayRecord,
+  ToolView,
+} from "../../views/tool-result-view";
+import ToolOutputBlock from "./ToolOutputBlock.svelte";
+
+type Props = {
+  toolCall: ToolCallDisplayRecord;
+  view: Extract<ToolView, { kind: "explain_image" }>;
+  expanded?: boolean;
+  onOpenFile?: (path: string, line?: number) => void;
+};
+
+let { toolCall, view, expanded = false, onOpenFile }: Props = $props();
+
+const liveText = $derived.by(() => {
+  const sections: string[] = [];
+  if (view.thinking?.length) sections.push(`Thinking\n${view.thinking}`);
+  if (view.liveExplanation?.length) {
+    sections.push(`Explanation\n${view.liveExplanation}`);
+  }
+  return sections.join("\n\n");
+});
+</script>
+
+{#if expanded && view.explanation}
+  <div class="min-w-0 rounded-sm border bg-sidebar p-3">
+    <Markdown text={view.explanation} {onOpenFile} />
+  </div>
+{:else if view.live && liveText}
+  <div class="grid gap-1.5" aria-label="Live image explanation generation">
+    <ToolOutputBlock
+      text={liveText}
+      direction="tail"
+      outputLimits={view.outputLimits}
+    />
+  </div>
+{:else if view.explanation}
+  <ToolOutputBlock text={view.explanation} direction="head" />
+{:else if toolCall.status === "completed"}
+  <p class="m-0 text-xs text-muted-foreground">No explanation returned.</p>
+{/if}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolCallDetailsDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolCallDetailsDialog.svelte
@@ -105,7 +105,9 @@ const argsPreview = $derived(
   payloadPreview(payloadValue(displayToolCall, "args", "argsPreview")),
 );
 const resultPreview = $derived(
-  payloadPreview(payloadValue(displayToolCall, "result", "resultPreview")),
+  displayToolCall.toolName === "explain_image"
+    ? undefined
+    : payloadPreview(payloadValue(displayToolCall, "result", "resultPreview")),
 );
 const description = $derived(
   [displayToolCall.status, presentation.primaryArg?.text]

--- a/packages/workbench-app/src/lib/presentation/tools/lifecycle/core-specs.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/lifecycle/core-specs.ts
@@ -540,8 +540,8 @@ export const coreToolLifecycleSpecs = {
   explain_image: defineToolLifecycleSpec({
     name: "explain_image",
     argumentRegion: "none",
-    completedView: "generic",
-    resultPlaceholder: { variant: "text", rows: 4 },
+    completedView: "explain_image",
+    resultPlaceholder: { variant: "text", rows: 6 },
     present: (source, stage, cwd) =>
       argumentPresentation({
         primaryArg: pathArg(source, cwd),

--- a/packages/workbench-app/src/lib/presentation/tools/lifecycle/core-specs.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/lifecycle/core-specs.ts
@@ -537,6 +537,26 @@ export const coreToolLifecycleSpecs = {
         ],
       }),
   }),
+  explain_image: defineToolLifecycleSpec({
+    name: "explain_image",
+    argumentRegion: "none",
+    completedView: "generic",
+    resultPlaceholder: { variant: "text", rows: 4 },
+    present: (source, stage, cwd) =>
+      argumentPresentation({
+        primaryArg: pathArg(source, cwd),
+        body:
+          stage === "approval"
+            ? keyValues([
+                ["Image", source.string("path"), true],
+                ["Focus", source.string("prompt")],
+              ])
+            : undefined,
+        safetyNotes: [
+          "Sends the image to the vision model configured in Nerve Settings.",
+        ],
+      }),
+  }),
   web_fetch: defineToolLifecycleSpec({
     name: "web_fetch",
     argumentRegion: "none",
@@ -579,6 +599,7 @@ export const coreToolLifecycleSpecs = {
     | "todos_get"
     | "web_search"
     | "web_fetch"
+    | "explain_image"
   >,
   ToolLifecycleSpec
 >;

--- a/packages/workbench-app/src/lib/presentation/tools/lifecycle/types.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/lifecycle/types.ts
@@ -91,7 +91,8 @@ export type CompletedViewFamily =
   | "jira"
   | "confluence"
   | "web_search"
-  | "web_fetch";
+  | "web_fetch"
+  | "explain_image";
 
 export type ToolLifecycleSpec<Name extends ToolName = ToolName> = {
   name: Name;

--- a/packages/workbench-app/src/lib/presentation/tools/lifecycle/types.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/lifecycle/types.ts
@@ -72,6 +72,7 @@ export type ToolResultPlaceholder = {
 };
 
 export type CompletedViewFamily =
+  | "generic"
   | "read"
   | "bash"
   | "python"

--- a/packages/workbench-app/src/lib/presentation/tools/views/registry.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/registry.ts
@@ -4,6 +4,7 @@ import BashToolView from "../components/tool-call/BashToolView.svelte";
 import ConfluenceToolView from "../components/tool-call/ConfluenceToolView.svelte";
 import EditToolView from "../components/tool-call/EditToolView.svelte";
 import ExploreToolView from "../components/tool-call/ExploreToolView.svelte";
+import ExplainImageToolView from "../components/tool-call/ExplainImageToolView.svelte";
 import FindToolView from "../components/tool-call/FindToolView.svelte";
 import GenericToolView from "../components/tool-call/GenericToolView.svelte";
 import GrepToolView from "../components/tool-call/GrepToolView.svelte";
@@ -44,6 +45,7 @@ const viewByKind: Record<ToolView["kind"], ToolViewComponent> = {
   confluence: ConfluenceToolView,
   web_search: WebSearchToolView,
   web_fetch: WebFetchToolView,
+  explain_image: ExplainImageToolView,
   generic: GenericToolView,
 };
 

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation.ts
@@ -481,6 +481,23 @@ export function toolPresentation(
       };
     }
 
+    case "explain_image": {
+      const content = view.live ? view.liveExplanation : view.explanation;
+      const meta: MetaItem[] = view.live
+        ? [{ text: view.thinking ? "thinking" : "generating", tone: "info" }]
+        : [];
+      meta.push(...outputMeta(view));
+      return {
+        ...base,
+        primaryArg: view.path
+          ? { text: view.relPath ?? view.path, openPath: view.path }
+          : base.primaryArg,
+        meta,
+        detailsAction:
+          previewDetailsAction ?? detailsActionFor(lineCount(content), "lines"),
+      };
+    }
+
     case "jira": {
       const meta: MetaItem[] = [];
       if (view.dryRun) meta.push({ text: "preview", tone: "info" });

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-parser.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-parser.ts
@@ -2,6 +2,7 @@ import {
   askUserResultSchema,
   bashResultDetailsSchema,
   editOperationResultDetailsSchema,
+  explainImageResultDetailsSchema,
   exploreResultPreviewSchema,
   pythonResultDetailsSchema,
   todosResultSchema,
@@ -654,6 +655,68 @@ export function parseToolView(
         results,
         outputLimits,
         outputArtifacts,
+      };
+    }
+
+    case "explain_image": {
+      const details = explainImageResultDetailsSchema.safeParse(
+        result?.details,
+      );
+      const data = details.success ? details.data : undefined;
+      const path = resolveToolPath(
+        data?.path ?? result?.path ?? stringField(args.path),
+        cwd,
+      );
+      const live = toolCall.status === "running" && Boolean(liveOutput);
+      const boundedLiveChunks = (() => {
+        if (!liveOutput) return [];
+        let remaining = liveOutput.text.length;
+        const chunks = [] as typeof liveOutput.chunks;
+        for (let index = liveOutput.chunks.length - 1; index >= 0; index -= 1) {
+          if (remaining <= 0) break;
+          const chunk = liveOutput.chunks[index];
+          if (!chunk) continue;
+          const text = chunk.text.slice(
+            Math.max(0, chunk.text.length - remaining),
+          );
+          chunks.unshift({ ...chunk, text });
+          remaining -= text.length;
+        }
+        return chunks;
+      })();
+      const liveText = (stream: "thinking" | "text") =>
+        boundedLiveChunks
+          .filter((chunk) => chunk.stream === stream)
+          .map((chunk) => chunk.text)
+          .join("");
+      return {
+        kind: "explain_image",
+        path,
+        relPath: relativePath(path, cwd),
+        explanation: live
+          ? undefined
+          : (data?.explanation ?? resultOutputText(result, rawResult)) ||
+            undefined,
+        thinking: live ? liveText("thinking") : undefined,
+        liveExplanation: live ? liveText("text") : undefined,
+        live,
+        outputLimits: liveOutput?.outputLimits
+          ? {
+              ...outputLimits,
+              live: {
+                capped: liveOutput.outputLimits.capped,
+                direction: liveOutput.outputLimits.direction,
+                maxChars: liveOutput.outputLimits.maxChars,
+                maxChunks: liveOutput.outputLimits.maxChunks,
+                totalChars: liveOutput.outputLimits.totalChars,
+                displayedChars: liveOutput.outputLimits.displayedChars,
+                omittedChars: liveOutput.outputLimits.omittedChars,
+                totalLines: liveOutput.outputLimits.totalLines,
+                displayedLines: liveOutput.outputLimits.displayedLines,
+                omittedLines: liveOutput.outputLimits.omittedLines,
+              },
+            }
+          : outputLimits,
       };
     }
 

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.explain-image.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.explain-image.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ConversationLiveToolOutputSnapshot } from "@nervekit/contracts";
+import { parseToolView } from "./tool-result-view";
+import { toolCall } from "./tool-result-view.fixtures";
+
+const liveOutput: ConversationLiveToolOutputSnapshot = {
+  toolCallId: "tool_01H00000000000000000000000",
+  chunks: [
+    {
+      stream: "thinking",
+      text: "Inspecting the layout. ",
+      ts: "2026-01-01T00:00:01.000Z",
+    },
+    {
+      stream: "thinking",
+      text: "Reading labels.",
+      ts: "2026-01-01T00:00:02.000Z",
+    },
+    {
+      stream: "text",
+      text: "## Screenshot\n",
+      ts: "2026-01-01T00:00:03.000Z",
+    },
+    {
+      stream: "text",
+      text: "A settings page.",
+      ts: "2026-01-01T00:00:04.000Z",
+    },
+  ],
+  text: "Inspecting the layout. Reading labels.## Screenshot\nA settings page.",
+  updatedAt: "2026-01-01T00:00:04.000Z",
+};
+
+describe("parseToolView explain_image", () => {
+  it("keeps live thinking and explanation channels separate", () => {
+    const view = parseToolView(
+      toolCall("explain_image", { path: "screen.png" }, undefined, {
+        status: "running",
+      }),
+      liveOutput,
+    );
+    assert.equal(view.kind, "explain_image");
+    if (view.kind !== "explain_image") return;
+    assert.equal(view.live, true);
+    assert.equal(view.thinking, "Inspecting the layout. Reading labels.");
+    assert.equal(view.liveExplanation, "## Screenshot\nA settings page.");
+    assert.equal(view.explanation, undefined);
+  });
+
+  it("replaces transient progress with the durable completed explanation", () => {
+    const explanation = "## Screenshot\n\n- A settings page";
+    const view = parseToolView(
+      toolCall(
+        "explain_image",
+        { path: "screen.png" },
+        {
+          content: explanation,
+          details: {
+            path: "/tmp/project/screen.png",
+            mimeType: "image/png",
+            byteSize: 128,
+            model: { provider: "google", modelId: "gemini" },
+            explanation,
+          },
+        },
+      ),
+      liveOutput,
+    );
+    assert.equal(view.kind, "explain_image");
+    if (view.kind !== "explain_image") return;
+    assert.equal(view.live, false);
+    assert.equal(view.explanation, explanation);
+    assert.equal(view.thinking, undefined);
+    assert.equal(view.liveExplanation, undefined);
+  });
+
+  it("falls back to legacy text results", () => {
+    const view = parseToolView(
+      toolCall(
+        "explain_image",
+        { path: "screen.png" },
+        { content: "A legacy explanation." },
+      ),
+    );
+    assert.equal(view.kind, "explain_image");
+    if (view.kind !== "explain_image") return;
+    assert.equal(view.explanation, "A legacy explanation.");
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
@@ -394,6 +394,16 @@ export type ToolView =
       outputArtifacts?: ToolOutputArtifactPayload[];
     }
   | {
+      kind: "explain_image";
+      path?: string;
+      relPath?: string;
+      explanation?: string;
+      thinking?: string;
+      liveExplanation?: string;
+      live: boolean;
+      outputLimits?: ToolOutputLimitsPayload;
+    }
+  | {
       kind: "generic";
       toolName: string;
       args: RedactedStructuredEntry[];

--- a/packages/workbench-server/src/domains/agents/run/explore-tool-summary.ts
+++ b/packages/workbench-server/src/domains/agents/run/explore-tool-summary.ts
@@ -31,6 +31,8 @@ export function summarizeExploreToolCall(
       return activity("Searching the web", stringValue(args.query));
     case "web_fetch":
       return activity("Fetching web page", safeUrl(args.url));
+    case "explain_image":
+      return activity("Explaining image", pathDetail(args));
     case "ask_user":
       return "Requesting user input";
     case "todos_set":

--- a/packages/workbench-server/src/domains/agents/run/workbench-agent-mechanics.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-agent-mechanics.ts
@@ -6,6 +6,7 @@ import {
   deriveAutoCompactionPolicy,
   getModelContextWindow,
   isContextOverflowAssistantMessage,
+  resolveAgentModel,
 } from "@nervekit/harness";
 import type { ToolExecutionResult } from "@nervekit/tools";
 import type {
@@ -111,11 +112,34 @@ export class WorkbenchAgentMechanics {
     const pythonAvailable = await this.deps.pythonRuntime.isAvailableForProject(
       agent.projectDir,
     );
+    const primaryModel = resolveAgentModel(agent.model);
+    const imageExplanationSelection =
+      this.deps.storage.settings.tools.imageExplanation.model;
+    const imageExplanationModel = imageExplanationSelection
+      ? resolveAgentModel(imageExplanationSelection)
+      : undefined;
+    const imageExplanationModelValid = Boolean(
+      imageExplanationSelection &&
+      imageExplanationModel?.provider === imageExplanationSelection.provider &&
+      imageExplanationModel.id === imageExplanationSelection.modelId &&
+      (imageExplanationModel.input ?? ["text"]).includes("image"),
+    );
+    const imageExplanationAvailable = Boolean(
+      imageExplanationModelValid &&
+      imageExplanationModel &&
+      (await this.deps.auth
+        .requestAuthForPiModel(imageExplanationModel)
+        .catch(() => undefined)),
+    );
     return activeToolNamesForAgent(agent, {
       pythonAvailable,
       disabledToolNames: this.deps.storage.settings.tools.disabled,
       jiraEnabled: this.deps.storage.settings.tools.jira.enabled,
       confluenceEnabled: this.deps.storage.settings.tools.confluence.enabled,
+      imageExplanationAvailable,
+      primaryModelSupportsImages: (primaryModel.input ?? ["text"]).includes(
+        "image",
+      ),
     });
   }
 

--- a/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
@@ -24,7 +24,6 @@ import type {
 import { toolNameSchema } from "@nervekit/contracts";
 import { planDirForStorageHome } from "../../plans/plan-paths.js";
 import {
-  activeToolNamesForAgent,
   createAgentToolsForAgent,
   toolPromptMetadata,
 } from "../../tools/agent-tool-adapter.js";
@@ -139,12 +138,7 @@ export async function executeWorkbenchHarness(
     const latestAgent = () => this.deps.state.agents.get(agent.id) ?? agent;
     const composeLatestSystemPrompt = () => {
       const currentAgent = latestAgent();
-      const currentActiveToolNames = activeToolNamesForAgent(currentAgent, {
-        pythonAvailable: activeToolNames.includes("python_exec"),
-        disabledToolNames: this.deps.storage.settings.tools.disabled,
-        jiraEnabled: this.deps.storage.settings.tools.jira.enabled,
-        confluenceEnabled: this.deps.storage.settings.tools.confluence.enabled,
-      });
+      const currentActiveToolNames = activeToolNames;
       return composeAgentSystemPrompt(
         currentAgent,
         currentActiveToolNames,

--- a/packages/workbench-server/src/domains/runs/runtime/conversation-runtime.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/conversation-runtime.ts
@@ -22,6 +22,7 @@ import {
   type ConversationLiveToolDraftStartedData,
   type ConversationLiveToolOutputDeltaData,
   type ConversationLiveToolOutputSnapshot,
+  type ConversationLiveToolOutputStream,
   type ConversationLiveTurnSnapshot,
   type ConversationRunRetrySnapshot,
   type LiveMessageStatus,
@@ -536,7 +537,7 @@ export class ConversationRuntime {
     providerToolCallId?: string;
     toolCallId: string;
     toolName: string;
-    stream: "stdout" | "stderr" | "combined";
+    stream: ConversationLiveToolOutputStream;
     delta: string;
   }): ConversationLiveToolOutputDeltaData {
     const run = input.runId ? this.runsByRunId.get(input.runId) : undefined;

--- a/packages/workbench-server/src/domains/tasks/task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-service.ts
@@ -6,7 +6,10 @@ import type {
   TaskLogQueryResponse,
   TaskRecord,
 } from "@nervekit/contracts";
-import { splitLiveOutputChunks } from "@nervekit/tools";
+import {
+  splitLiveOutputChunks,
+  type ToolExecutionOutputUpdate,
+} from "@nervekit/tools";
 import type {
   ClockPort,
   DiagnosticPort,
@@ -154,11 +157,9 @@ export type TaskStartInput = StartTaskRequest & {
   readonly restartedFromTaskId?: string;
   readonly restartRootTaskId?: string;
   readonly restartGeneration?: number;
-  readonly onOutput?: (update: {
-    kind: "output";
-    stream: "stdout" | "stderr" | "combined";
-    chunk: string;
-  }) => void | Promise<void>;
+  readonly onOutput?: (
+    update: ToolExecutionOutputUpdate,
+  ) => void | Promise<void>;
 };
 
 const terminalStatuses = new Set<TaskRecord["status"]>([

--- a/packages/workbench-server/src/domains/tools/agent-tool-adapter.ts
+++ b/packages/workbench-server/src/domains/tools/agent-tool-adapter.ts
@@ -90,6 +90,8 @@ export function activeToolNamesForAgent(
     disabledToolNames?: readonly UserConfigurableToolName[];
     jiraEnabled?: boolean;
     confluenceEnabled?: boolean;
+    imageExplanationAvailable?: boolean;
+    primaryModelSupportsImages?: boolean;
   } = {},
 ): ToolName[] {
   const unavailable: ToolName[] = [];
@@ -103,6 +105,12 @@ export function activeToolNamesForAgent(
     unavailable.push(
       ...toolDefinitionsByGroup("confluence").map((tool) => tool.name),
     );
+  }
+  if (
+    options.imageExplanationAvailable !== true ||
+    options.primaryModelSupportsImages === true
+  ) {
+    unavailable.push("explain_image");
   }
 
   const disabled = new Set<ToolName>(options.disabledToolNames ?? []);

--- a/packages/workbench-server/src/domains/tools/orchestration-tool-dispatcher.ts
+++ b/packages/workbench-server/src/domains/tools/orchestration-tool-dispatcher.ts
@@ -7,6 +7,8 @@ import {
   resolveCommandCwd,
   createTaskHandlers,
   createTodoHandlers,
+  type ExplainImageRequest,
+  type ExplainImageResponse,
   type ToolExecutionContext,
   type ToolExecutionOutputUpdate,
   type ToolExecutionResult,
@@ -80,6 +82,7 @@ export interface OrchestrationToolDispatcherDeps {
   getAgent(agentId: string): AgentRecord;
   runExplore: ExploreRunner;
   getApiKey(provider: string): Promise<string | undefined>;
+  explainImage(request: ExplainImageRequest): Promise<ExplainImageResponse>;
   plans: PlanService;
   setAgentMode(
     agentId: string,
@@ -243,6 +246,7 @@ export class OrchestrationToolDispatcher {
       dataDir: this.deps.storage.paths.home,
       shellPath: this.deps.storage.settings.runtime.shellPath,
       getApiKey: this.deps.getApiKey,
+      explainImage: this.deps.explainImage,
       getProviderConfig: async (provider) => {
         if (provider === "jira") return this.deps.storage.settings.tools.jira;
         if (provider === "confluence") {

--- a/packages/workbench-server/src/domains/tools/tool-call-transcript-preview.ts
+++ b/packages/workbench-server/src/domains/tools/tool-call-transcript-preview.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- bounded tool-specific transcript projections share one overflow budget. */
 import {
   toolCallTranscriptRecordSchema,
   type GrepMatch,
@@ -666,6 +667,23 @@ export function toToolCallTranscriptRecord(
       break;
     }
 
+    case "explain_image": {
+      const details = record(resultRecord.details);
+      const explanation = firstLines(
+        stringField(details.explanation) ?? outputText(resultRecord),
+      );
+      resultPreview = {
+        ...withTextContent(resultRecord, explanation.value),
+        details: {
+          ...details,
+          explanation: explanation.value ?? "",
+        },
+      };
+      ({ hidden, noun } = textOverflowStats([explanation]));
+      direction = "head";
+      break;
+    }
+
     case "explore": {
       const reports = firstItems(
         arrayField<Record<string, unknown>>(resultRecord.reports),
@@ -750,6 +768,7 @@ export function toToolCallTranscriptRecord(
   const resultFirst =
     taskToolName !== undefined ||
     toolCall.toolName === "explore" ||
+    toolCall.toolName === "explain_image" ||
     toolCall.toolName === "web_search" ||
     toolCall.toolName === "web_fetch";
   const finalized = finalizePublicPreview(

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -1,5 +1,10 @@
 import { resolve } from "node:path";
-import { allToolDescriptors, toolRiskForName } from "@nervekit/tools";
+import {
+  allToolDescriptors,
+  type ExplainImageRequest,
+  type ExplainImageResponse,
+  toolRiskForName,
+} from "@nervekit/tools";
 import {
   type AgentRecord,
   type ApprovalRecord,
@@ -173,6 +178,9 @@ export class ToolService {
     private readonly getApiKey: (
       provider: string,
     ) => Promise<string | undefined>,
+    private readonly explainImage: (
+      request: ExplainImageRequest,
+    ) => Promise<ExplainImageResponse>,
     private readonly plans: PlanService,
     private readonly setAgentMode: (
       agentId: string,
@@ -204,6 +212,7 @@ export class ToolService {
       getAgent: this.getAgent,
       runExplore: this.runExplore,
       getApiKey: this.getApiKey,
+      explainImage: this.explainImage,
       plans: this.plans,
       setAgentMode: this.setAgentMode,
       conversationRuntime: this.conversationRuntime,

--- a/packages/workbench-server/src/infrastructure/storage/initialize.ts
+++ b/packages/workbench-server/src/infrastructure/storage/initialize.ts
@@ -68,6 +68,38 @@ function migrateLegacyToolNames(value: unknown): {
   };
 }
 
+function migrateImageExplanationTool(value: unknown): {
+  value: unknown;
+  changed: boolean;
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { value, changed: false };
+  }
+  const settings = value as Record<string, unknown>;
+  const tools = settings.tools;
+  if (!tools || typeof tools !== "object" || Array.isArray(tools)) {
+    return { value, changed: false };
+  }
+  const toolSettings = tools as Record<string, unknown>;
+  if ("imageExplanation" in toolSettings) {
+    return { value, changed: false };
+  }
+  const disabled = Array.isArray(toolSettings.disabled)
+    ? toolSettings.disabled
+    : [];
+  return {
+    value: {
+      ...settings,
+      tools: {
+        ...toolSettings,
+        disabled: [...new Set([...disabled, "explain_image"])],
+        imageExplanation: {},
+      },
+    },
+    changed: true,
+  };
+}
+
 const removedNotificationToneIds = new Set([
   "kenney-click-1",
   "kenney-click-2",
@@ -149,8 +181,11 @@ export async function initializeStorage(
   const rawSettings = await readJsonFile<unknown>(paths.configPath);
   const normalizedAppearance = migrateLegacyAppearanceSettings(rawSettings);
   const normalizedTools = migrateLegacyToolNames(normalizedAppearance.value);
-  const normalizedTones = migrateRemovedNotificationTones(
+  const normalizedImageExplanation = migrateImageExplanationTool(
     normalizedTools.value,
+  );
+  const normalizedTones = migrateRemovedNotificationTones(
+    normalizedImageExplanation.value,
   );
   const settings = settingsSchema.parse({
     ...defaultSettings,
@@ -159,6 +194,7 @@ export async function initializeStorage(
   if (
     normalizedAppearance.changed ||
     normalizedTools.changed ||
+    normalizedImageExplanation.changed ||
     normalizedTones.changed
   ) {
     await atomicWriteJson(paths.configPath, settings, 0o600);
@@ -246,6 +282,14 @@ export async function writeSettings(
           : {}),
       }
     : undefined;
+  const imageExplanationPatch = patch.tools?.imageExplanation
+    ? {
+        ...patch.tools.imageExplanation,
+        ...(patch.tools.imageExplanation.model === null
+          ? { model: undefined }
+          : {}),
+      }
+    : undefined;
   const confluencePatch = patch.tools?.confluence
     ? {
         ...patch.tools.confluence,
@@ -272,6 +316,14 @@ export async function writeSettings(
               confluence: {
                 ...storage.settings.tools.confluence,
                 ...confluencePatch,
+              },
+            }
+          : {}),
+        ...(imageExplanationPatch
+          ? {
+              imageExplanation: {
+                ...storage.settings.tools.imageExplanation,
+                ...imageExplanationPatch,
               },
             }
           : {}),

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -1,4 +1,5 @@
 import {
+  clampAgentThinkingLevel,
   explainImageWithModel,
   generateSummary,
   resolveAgentModel,
@@ -480,6 +481,10 @@ export function composeRuntime(
           mimeType: request.mimeType,
         },
         prompt: request.prompt,
+        thinkingLevel: clampAgentThinkingLevel(
+          selection,
+          storage.settings.tools.imageExplanation.thinkingLevel,
+        ),
         auth: requestAuth,
         signal: request.signal,
       });

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -1,4 +1,8 @@
-import { generateSummary, resolveAgentModel } from "@nervekit/harness";
+import {
+  explainImageWithModel,
+  generateSummary,
+  resolveAgentModel,
+} from "@nervekit/harness";
 import { withGitMutationEvents } from "../domains/tools/git-mutation-publisher.js";
 import { GitRepositoryWatcher } from "../domains/tools/git-repository-watcher.js";
 import { withGitRepositoryWatching } from "../domains/tools/git-repository-watching.js";
@@ -440,6 +444,47 @@ export function composeRuntime(
     (parent, args, options) =>
       services.workbenchRun.runExplore(parent, args, options),
     (provider) => auth.getApiKey(provider),
+    async (request) => {
+      const selection = storage.settings.tools.imageExplanation.model;
+      if (!selection) {
+        throw new Error(
+          "Image explanation is not configured. Choose a vision model in Settings → Tools.",
+        );
+      }
+      const model = resolveAgentModel(selection);
+      if (
+        model.provider !== selection.provider ||
+        model.id !== selection.modelId
+      ) {
+        throw new Error(
+          `The configured image explanation model is unavailable: ${selection.provider}/${selection.modelId}.`,
+        );
+      }
+      if (!(model.input ?? ["text"]).includes("image")) {
+        throw new Error(
+          "The configured image explanation model does not support image input.",
+        );
+      }
+      const requestAuth = await auth.requestAuthForPiModel(model);
+      if (!requestAuth) {
+        throw new Error(
+          `Credentials are not configured for the image explanation model provider: ${model.provider}.`,
+        );
+      }
+      subscriptionUsage.touchProvider(model.provider);
+      const explanation = await explainImageWithModel({
+        model,
+        image: {
+          type: "image",
+          data: Buffer.from(request.data).toString("base64"),
+          mimeType: request.mimeType,
+        },
+        prompt: request.prompt,
+        auth: requestAuth,
+        signal: request.signal,
+      });
+      return { explanation, model: selection };
+    },
     services.plans,
     (agentId, mode, reason) =>
       services.agentLifecycle.setAgentModeInternal(agentId, mode, reason),

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -487,6 +487,14 @@ export function composeRuntime(
         ),
         auth: requestAuth,
         signal: request.signal,
+        onDelta: async ({ kind, delta }) => {
+          if (request.signal?.aborted || !delta) return;
+          await request.onUpdate?.({
+            kind: "output",
+            stream: kind,
+            chunk: delta,
+          });
+        },
       });
       return { explanation, model: selection };
     },

--- a/packages/workbench-server/test/explain-image-tool-availability.test.ts
+++ b/packages/workbench-server/test/explain-image-tool-availability.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AgentRecord } from "@nervekit/contracts";
+import {
+  activeToolNamesForAgent,
+  toolPromptMetadata,
+} from "../src/domains/tools/agent-tool-adapter.js";
+
+function agent(): AgentRecord {
+  return {
+    id: "agent_01HN0000000000000000000000",
+    conversationId: "conv_01HN0000000000000000000000",
+    projectId: "proj_01HN0000000000000000000000",
+    projectDir: "/tmp/project",
+    workerId: "worker_01HN0000000000000000000000",
+    rootAgentId: "agent_01HN0000000000000000000000",
+    mode: "coding",
+    permissionLevel: "autonomous",
+    approvalPolicy: { autoApproveReadOnly: true },
+    workspaceScope: { roots: ["/tmp/project"] },
+    budget: { depth: 0, maxDepth: 3 },
+    status: "idle",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function active(options: {
+  disabled?: boolean;
+  fallbackReady?: boolean;
+  primaryVision?: boolean;
+}) {
+  return activeToolNamesForAgent(agent(), {
+    pythonAvailable: true,
+    jiraEnabled: true,
+    confluenceEnabled: true,
+    disabledToolNames: options.disabled ? ["explain_image"] : [],
+    imageExplanationAvailable: options.fallbackReady,
+    primaryModelSupportsImages: options.primaryVision,
+  });
+}
+
+describe("explain_image availability", () => {
+  it("is exposed only for enabled, configured text-only agents", () => {
+    assert.equal(
+      active({ fallbackReady: true, primaryVision: false }).includes(
+        "explain_image",
+      ),
+      true,
+    );
+    assert.equal(
+      active({ disabled: true, fallbackReady: true }).includes("explain_image"),
+      false,
+    );
+    assert.equal(
+      active({ fallbackReady: false }).includes("explain_image"),
+      false,
+    );
+    assert.equal(
+      active({ fallbackReady: true, primaryVision: true }).includes(
+        "explain_image",
+      ),
+      false,
+    );
+  });
+
+  it("leaves no prompt metadata when disabled", () => {
+    const names = active({ disabled: true, fallbackReady: true });
+    const metadata = toolPromptMetadata(names);
+    assert.equal(names.includes("explain_image"), false);
+    assert.equal(metadata.activeToolNames.includes("explain_image"), false);
+    assert.equal("explain_image" in metadata.snippets, false);
+    assert.equal(JSON.stringify(metadata).includes("explain_image"), false);
+  });
+});

--- a/packages/workbench-server/test/storage-settings-migration.test.ts
+++ b/packages/workbench-server/test/storage-settings-migration.test.ts
@@ -180,7 +180,9 @@ describe("settings migrations", () => {
       "web_search",
       "explain_image",
     ]);
-    assert.deepEqual(storage.settings.tools.imageExplanation, {});
+    assert.deepEqual(storage.settings.tools.imageExplanation, {
+      thinkingLevel: "off",
+    });
   });
 
   it("migrates and deduplicates the legacy python disabled tool name", async () => {

--- a/packages/workbench-server/test/storage-settings-migration.test.ts
+++ b/packages/workbench-server/test/storage-settings-migration.test.ts
@@ -152,6 +152,37 @@ describe("settings migrations", () => {
     });
   });
 
+  it("adds the image explanation tool as disabled to older settings", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-settings-migration-"));
+    roots.push(root);
+    const configPath = join(root, "config.json");
+    await initializeStorage(root);
+    const legacyTools: Partial<typeof defaultSettings.tools> = {
+      ...defaultSettings.tools,
+    };
+    delete legacyTools.imageExplanation;
+    await writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          ...defaultSettings,
+          tools: { ...legacyTools, disabled: ["web_search"] },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const storage = await initializeStorage(root);
+
+    assert.deepEqual(storage.settings.tools.disabled, [
+      "web_search",
+      "explain_image",
+    ]);
+    assert.deepEqual(storage.settings.tools.imageExplanation, {});
+  });
+
   it("migrates and deduplicates the legacy python disabled tool name", async () => {
     const root = await mkdtemp(join(tmpdir(), "nerve-settings-migration-"));
     roots.push(root);

--- a/packages/workbench-server/test/tool-call-transcript-preview.test.ts
+++ b/packages/workbench-server/test/tool-call-transcript-preview.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ToolCallRecord } from "@nervekit/contracts";
+import { toToolCallTranscriptRecord } from "../src/domains/tools/tool-call-transcript-preview.js";
+
+function explainImageToolCall(explanation: string): ToolCallRecord {
+  return {
+    id: "tool_01H00000000000000000000000",
+    agentId: "agent_01H00000000000000000000000",
+    conversationId: "conv_01H00000000000000000000000",
+    projectId: "proj_01H0000000000000000000000",
+    toolName: "explain_image",
+    risk: "read",
+    args: { path: "/tmp/screen.png", prompt: "Read labels" },
+    cwd: "/tmp/project",
+    status: "completed",
+    result: {
+      content: explanation,
+      contentBlocks: [{ type: "text", text: explanation }],
+      details: {
+        path: "/tmp/screen.png",
+        mimeType: "image/png",
+        byteSize: 1024,
+        model: { provider: "google", modelId: "gemini" },
+        explanation,
+      },
+    },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+  };
+}
+
+describe("explain_image transcript preview", () => {
+  it("keeps a bounded explanation preview without duplicate content blocks", () => {
+    const explanation = Array.from(
+      { length: 20 },
+      (_, index) => `Line ${index + 1}: image detail`,
+    ).join("\n");
+    const preview = toToolCallTranscriptRecord(
+      explainImageToolCall(explanation),
+    );
+    const result = preview.resultPreview as Record<string, unknown>;
+    const details = result.details as Record<string, unknown>;
+
+    assert.equal(typeof details.explanation, "string");
+    assert.ok(String(details.explanation).length < explanation.length);
+    assert.equal("contentBlocks" in result, false);
+    assert.deepEqual(preview.previewOverflow, {
+      hidden: 10,
+      noun: "lines",
+      direction: "head",
+    });
+    assert.equal(JSON.stringify(preview).includes("thinking"), false);
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit `explain_image` tool backed by a globally configured vision-capable model and thinking level
- expose the tool only to text-only primary models, and keep it entirely absent from model-visible schemas and prompts while disabled
- add Settings → Tools configuration, migration-safe defaults, bounded image handling, result presentation, tests, and documentation

## Validation
- `pnpm fix && pnpm check && pnpm test`