### PR TITLE
Add Git stash management

### DIFF
--- a/packages/contracts/src/domains/git/git.operations.schema.ts
+++ b/packages/contracts/src/domains/git/git.operations.schema.ts
@@ -9,6 +9,8 @@ import {
   gitOverviewResponseSchema,
   gitProjectFileStatusResponseSchema,
   gitRemoteOpRequestSchema,
+  gitStashCreateRequestSchema,
+  gitStashTargetRequestSchema,
   githubPrCheckoutResponseSchema,
   githubPrChecksResponseSchema,
   githubPrCommitsResponseSchema,
@@ -48,6 +50,12 @@ const gitFileDiffParamsSchema = projectIdParamsSchema.merge(
 );
 const gitRemoteOpParamsSchema = projectIdParamsSchema.merge(
   gitRemoteOpRequestSchema,
+);
+const gitStashCreateParamsSchema = projectIdParamsSchema.merge(
+  gitStashCreateRequestSchema,
+);
+const gitStashTargetParamsSchema = projectIdParamsSchema.merge(
+  gitStashTargetRequestSchema,
 );
 const githubPrListParamsSchema = projectIdParamsSchema.merge(
   githubPrListRequestSchema,
@@ -197,6 +205,33 @@ export const gitOperationDefinitions = [
     "recommended",
     ["workbench_server"] as const,
     "operation.git.switchBaseAndPull",
+  ),
+  defineOperation(
+    "git.stash.create",
+    gitStashCreateParamsSchema,
+    gitMutationResponseSchema,
+    "mutation",
+    "recommended",
+    ["workbench_server"] as const,
+    "operation.git.stash.create",
+  ),
+  defineOperation(
+    "git.stash.apply",
+    gitStashTargetParamsSchema,
+    gitMutationResponseSchema,
+    "mutation",
+    "recommended",
+    ["workbench_server"] as const,
+    "operation.git.stash.apply",
+  ),
+  defineOperation(
+    "git.stash.drop",
+    gitStashTargetParamsSchema,
+    gitMutationResponseSchema,
+    "mutation",
+    "recommended",
+    ["workbench_server"] as const,
+    "operation.git.stash.drop",
   ),
   defineOperation(
     "github.status.get",

--- a/packages/contracts/src/domains/git/git.schema.ts
+++ b/packages/contracts/src/domains/git/git.schema.ts
@@ -93,6 +93,15 @@ export const gitRecentCommitSchema = z.object({
 });
 export type GitRecentCommit = z.infer<typeof gitRecentCommitSchema>;
 
+export const gitStashEntrySchema = z.object({
+  index: z.number().int().nonnegative(),
+  ref: z.string().regex(/^stash@\{\d+\}$/),
+  hash: z.string().min(7).max(128),
+  message: z.string(),
+  relativeDate: z.string(),
+});
+export type GitStashEntry = z.infer<typeof gitStashEntrySchema>;
+
 export const gitOverviewResponseSchema = z.object({
   repo: gitRepoSummarySchema,
   baseBranch: z.string(),
@@ -104,6 +113,7 @@ export const gitOverviewResponseSchema = z.object({
   insertions: z.number().int().nonnegative(),
   deletions: z.number().int().nonnegative(),
   recentCommits: z.array(gitRecentCommitSchema),
+  stashes: z.array(gitStashEntrySchema),
 });
 export type GitOverviewResponse = z.infer<typeof gitOverviewResponseSchema>;
 
@@ -146,6 +156,23 @@ export const gitFileActionRequestSchema = z.object({
   path: z.string().min(1),
 });
 export type GitFileActionRequest = z.infer<typeof gitFileActionRequestSchema>;
+
+export const gitStashAreaSchema = z.enum(["staged", "unstaged"]);
+export type GitStashArea = z.infer<typeof gitStashAreaSchema>;
+
+export const gitStashCreateRequestSchema = z.object({
+  repo: z.string().default("."),
+  area: gitStashAreaSchema,
+  paths: z.array(z.string().min(1)).max(10_000).optional(),
+});
+export type GitStashCreateRequest = z.infer<typeof gitStashCreateRequestSchema>;
+
+export const gitStashTargetRequestSchema = z.object({
+  repo: z.string().default("."),
+  index: z.number().int().nonnegative(),
+  expectedHash: z.string().min(7).max(128),
+});
+export type GitStashTargetRequest = z.infer<typeof gitStashTargetRequestSchema>;
 
 export const gitDiffAreaSchema = z.enum(["staged", "unstaged"]);
 export type GitDiffArea = z.infer<typeof gitDiffAreaSchema>;

--- a/packages/tools/src/git/git-overview.ts
+++ b/packages/tools/src/git/git-overview.ts
@@ -4,6 +4,7 @@ import type {
   GitRepoSummary,
 } from "@nervekit/contracts";
 import type { GitService } from "./git-service.js";
+import { listStashes } from "./git-stash.js";
 import { parsePorcelainV2, parseShortstat } from "./git-status.js";
 
 export async function summarizeRepo(
@@ -76,14 +77,21 @@ export async function overview(
       stdout,
     ),
   );
-  const [repo, { stdout: statusOut }, unstagedResult, stagedResult, recent] =
-    await Promise.all([
-      repoPromise,
-      statusPromise,
-      service.runGit(repoDir, ["diff", "--shortstat"]),
-      service.runGit(repoDir, ["diff", "--staged", "--shortstat"]),
-      service.recentCommits(repoDir),
-    ]);
+  const [
+    repo,
+    { stdout: statusOut },
+    unstagedResult,
+    stagedResult,
+    recent,
+    stashes,
+  ] = await Promise.all([
+    repoPromise,
+    statusPromise,
+    service.runGit(repoDir, ["diff", "--shortstat"]),
+    service.runGit(repoDir, ["diff", "--staged", "--shortstat"]),
+    service.recentCommits(repoDir),
+    listStashes(service, repoDir),
+  ]);
   const { files } = parsePorcelainV2(statusOut);
   const stagedCount = files.filter((file) => file.staged).length;
   const untrackedCount = files.filter((file) => file.untracked).length;
@@ -104,6 +112,7 @@ export async function overview(
     insertions: unstaged.insertions + staged.insertions,
     deletions: unstaged.deletions + staged.deletions,
     recentCommits: recent,
+    stashes,
   };
 }
 

--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -27,6 +27,7 @@ import type {
   GitProjectFileStatusResponse,
   GitRecentCommit,
   GitRepoSummary,
+  GitStashArea,
 } from "@nervekit/contracts";
 import {
   branchExists as branchExistsImpl,
@@ -76,6 +77,11 @@ import {
   GitRepositoryMetadataCache,
   type StableRepoMetadata,
 } from "./git-repository-metadata.js";
+import {
+  createAreaStash,
+  stashApplyArgs,
+  verifyStashTarget,
+} from "./git-stash.js";
 import { parsePorcelainV2 } from "./git-status.js";
 
 const MAX_DISCOVERY_DEPTH = 2;
@@ -662,6 +668,61 @@ export class GitService {
       }
     }
     await this.mapGit(() => this.runGit(repoDir, ["clean", "-f", "--", path]));
+    return {
+      repo: await this.summarizeRepo(
+        repoDir,
+        relativePath,
+        this.repoName(projectId, relativePath),
+      ),
+    };
+  }
+
+  async createStash(
+    projectId: string,
+    relativePath: string,
+    area: GitStashArea,
+    paths?: readonly string[],
+  ): Promise<GitMutationResponse> {
+    const repoDir = this.resolveRepoDir(projectId, relativePath);
+    await this.mapGit(() => createAreaStash(this, repoDir, area, paths));
+    return {
+      repo: await this.summarizeRepo(
+        repoDir,
+        relativePath,
+        this.repoName(projectId, relativePath),
+      ),
+    };
+  }
+
+  async applyStash(
+    projectId: string,
+    relativePath: string,
+    index: number,
+    expectedHash: string,
+  ): Promise<GitMutationResponse> {
+    const repoDir = this.resolveRepoDir(projectId, relativePath);
+    const ref = await verifyStashTarget(this, repoDir, index, expectedHash);
+    await this.mapGit(async () =>
+      this.runGit(repoDir, await stashApplyArgs(this, repoDir, ref)),
+    );
+    return {
+      repo: await this.summarizeRepo(
+        repoDir,
+        relativePath,
+        this.repoName(projectId, relativePath),
+      ),
+    };
+  }
+
+  async dropStash(
+    projectId: string,
+    relativePath: string,
+    index: number,
+    expectedHash: string,
+  ): Promise<GitMutationResponse> {
+    const repoDir = this.resolveRepoDir(projectId, relativePath);
+    const ref = await verifyStashTarget(this, repoDir, index, expectedHash);
+    await this.mapGit(() => this.runGit(repoDir, ["stash", "drop", ref]));
     return {
       repo: await this.summarizeRepo(
         repoDir,

--- a/packages/tools/src/git/git-stash.ts
+++ b/packages/tools/src/git/git-stash.ts
@@ -1,0 +1,200 @@
+import type { GitStashArea, GitStashEntry } from "@nervekit/contracts";
+import { GitWorkflowError } from "./git-errors.js";
+import type { GitService } from "./git-service.js";
+
+const STASH_REF_PATTERN = /^stash@\{(\d+)\}$/;
+
+export function parseStashList(output: string): GitStashEntry[] {
+  return output
+    .split("\n")
+    .filter(Boolean)
+    .flatMap((line) => {
+      const [ref = "", hash = "", message = "", relativeDate = ""] =
+        line.split("\u0000");
+      const match = STASH_REF_PATTERN.exec(ref);
+      if (!match || !hash) return [];
+      return [
+        {
+          index: Number.parseInt(match[1] ?? "", 10),
+          ref,
+          hash,
+          message,
+          relativeDate,
+        },
+      ];
+    });
+}
+
+export async function listStashes(
+  service: GitService,
+  repoDir: string,
+): Promise<GitStashEntry[]> {
+  const { stdout } = await service.runGit(repoDir, [
+    "stash",
+    "list",
+    "--format=%gd%x00%H%x00%gs%x00%cr",
+  ]);
+  return parseStashList(stdout);
+}
+
+export function stashCreateArgs(
+  area: GitStashArea,
+  paths?: readonly string[],
+): string[] {
+  const args =
+    area === "staged"
+      ? ["stash", "push", "--staged"]
+      : ["stash", "push", "--keep-index", "--include-untracked"];
+  const uniquePaths = paths ? [...new Set(paths)] : [];
+  if (uniquePaths.length > 0) args.push("--", ...uniquePaths);
+  return args;
+}
+
+export async function createAreaStash(
+  service: GitService,
+  repoDir: string,
+  area: GitStashArea,
+  paths?: readonly string[],
+): Promise<void> {
+  if (area === "unstaged") {
+    await service.runGit(repoDir, stashCreateArgs(area, paths));
+    return;
+  }
+
+  // Git cannot always remove staged hunks when the same path also has
+  // unstaged hunks. Temporarily stash only paths with an unstaged side, create
+  // the requested staged stash, then restore the temporary entry by its hash.
+  const temporaryPaths = await unstagedPathspecs(service, repoDir, paths);
+  if (temporaryPaths.length === 0) {
+    await service.runGit(repoDir, stashCreateArgs("staged", paths));
+    return;
+  }
+
+  const before = (await listStashes(service, repoDir))[0]?.hash;
+  const temporaryArgs = stashCreateArgs("unstaged", temporaryPaths);
+  temporaryArgs.splice(temporaryArgs.indexOf("--include-untracked"), 1);
+  temporaryArgs.splice(
+    temporaryArgs.indexOf("--"),
+    0,
+    "--message",
+    "Nerve temporary unstaged changes",
+  );
+  await service.runGit(repoDir, temporaryArgs);
+  const temporary = (await listStashes(service, repoDir))[0];
+  const temporaryCreated = temporary && temporary.hash !== before;
+
+  try {
+    await service.runGit(repoDir, stashCreateArgs("staged", paths));
+  } catch (error) {
+    if (temporaryCreated)
+      await restoreTemporaryStash(
+        service,
+        repoDir,
+        temporary.hash,
+        temporaryPaths,
+      );
+    throw error;
+  }
+
+  if (temporaryCreated)
+    await restoreTemporaryStash(
+      service,
+      repoDir,
+      temporary.hash,
+      temporaryPaths,
+    );
+}
+
+async function unstagedPathspecs(
+  service: GitService,
+  repoDir: string,
+  paths?: readonly string[],
+): Promise<string[]> {
+  const suffix = paths && paths.length > 0 ? ["--", ...paths] : [];
+  const { stdout } = await service.runGit(repoDir, [
+    "diff",
+    "--name-only",
+    ...suffix,
+  ]);
+  return [
+    ...new Set(
+      stdout
+        .split("\n")
+        .map((path) => path.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+async function restoreTemporaryStash(
+  service: GitService,
+  repoDir: string,
+  hash: string,
+  paths: readonly string[],
+): Promise<void> {
+  const entry = (await listStashes(service, repoDir)).find(
+    (candidate) => candidate.hash === hash,
+  );
+  if (!entry) {
+    throw new GitWorkflowError(
+      409,
+      "GIT_STASH_CHANGED",
+      "The temporary stash changed before it could be restored.",
+    );
+  }
+  await service.runGit(repoDir, [
+    "restore",
+    `--source=${hash}`,
+    "--worktree",
+    "--",
+    ...paths,
+  ]);
+  await service.runGit(repoDir, ["stash", "drop", entry.ref]);
+}
+
+export async function stashApplyArgs(
+  service: GitService,
+  repoDir: string,
+  ref: string,
+): Promise<string[]> {
+  const { stdout } = await service.runGit(repoDir, [
+    "diff",
+    "--name-only",
+    `${ref}^2`,
+    ref,
+  ]);
+  return stdout.trim().length === 0
+    ? ["stash", "apply", "--index", ref]
+    : ["stash", "apply", ref];
+}
+
+export async function verifyStashTarget(
+  service: GitService,
+  repoDir: string,
+  index: number,
+  expectedHash: string,
+): Promise<string> {
+  const ref = `stash@{${index}}`;
+  let actualHash: string;
+  try {
+    actualHash = (
+      await service.runGit(repoDir, [
+        "rev-parse",
+        "--verify",
+        `${ref}^{commit}`,
+      ])
+    ).stdout.trim();
+  } catch {
+    throw staleStashError();
+  }
+  if (actualHash !== expectedHash) throw staleStashError();
+  return ref;
+}
+
+function staleStashError(): GitWorkflowError {
+  return new GitWorkflowError(
+    409,
+    "GIT_STASH_CHANGED",
+    "The stash list changed. Refresh and try again.",
+  );
+}

--- a/packages/tools/test/git-service-overview.test.ts
+++ b/packages/tools/test/git-service-overview.test.ts
@@ -65,6 +65,9 @@ describe("GitService overview snapshots", () => {
           stderr: "",
         };
       }
+      if (command.startsWith("stash list ")) {
+        return { stdout: "", stderr: "" };
+      }
       if (command.startsWith("rev-parse --verify --quiet")) {
         return { stdout: "abcdef\n", stderr: "" };
       }
@@ -87,6 +90,7 @@ describe("GitService overview snapshots", () => {
     assert.equal(overview.untrackedCount, 1);
     assert.equal(overview.insertions, 2);
     assert.equal(overview.recentCommits.length, 1);
+    assert.deepEqual(overview.stashes, []);
 
     now += 30_001;
     await service.overview("proj_test", ".");

--- a/packages/tools/test/git-service-stash.test.ts
+++ b/packages/tools/test/git-service-stash.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, it } from "node:test";
+import { GitService } from "../src/git/git-service.js";
+import { listStashes, parseStashList } from "../src/git/git-stash.js";
+
+const execFileAsync = promisify(execFile);
+
+async function git(root: string, ...args: string[]): Promise<string> {
+  return (await execFileAsync("git", args, { cwd: root })).stdout.trim();
+}
+
+async function repository(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "nerve-git-stash-"));
+  await git(root, "init");
+  await git(root, "config", "user.email", "nerve@example.test");
+  await git(root, "config", "user.name", "Nerve Tests");
+  await writeFile(join(root, "staged.txt"), "base\n");
+  await writeFile(join(root, "unstaged.txt"), "base\n");
+  await git(root, "add", ".");
+  await git(root, "commit", "-m", "initial");
+  return root;
+}
+
+function service(root: string): GitService {
+  return GitService.forWorkspace(root, "stash-test");
+}
+
+describe("Git stash workflow", () => {
+  it("parses machine-readable stash rows and ignores malformed rows", () => {
+    assert.deepEqual(
+      parseStashList(
+        "stash@{0}\u0000abc1234\u0000WIP on main\u00002 minutes ago\ninvalid\n",
+      ),
+      [
+        {
+          index: 0,
+          ref: "stash@{0}",
+          hash: "abc1234",
+          message: "WIP on main",
+          relativeDate: "2 minutes ago",
+        },
+      ],
+    );
+  });
+
+  it("stashes staged and unstaged areas independently", async () => {
+    const root = await repository();
+    try {
+      const instance = service(root);
+      await writeFile(join(root, "staged.txt"), "staged\n");
+      await git(root, "add", "staged.txt");
+      await writeFile(join(root, "unstaged.txt"), "unstaged\n");
+      await writeFile(join(root, "untracked.txt"), "untracked\n");
+
+      await instance.createStash("proj_test", ".", "staged");
+      assert.equal(
+        await git(root, "status", "--short"),
+        "M unstaged.txt\n?? untracked.txt",
+      );
+      assert.equal(await readFile(join(root, "staged.txt"), "utf8"), "base\n");
+
+      await instance.createStash("proj_test", ".", "unstaged");
+      assert.equal(await git(root, "status", "--short"), "");
+      assert.equal((await listStashes(instance, root)).length, 2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves unstaged worktree content when the same file is also staged", async () => {
+    const root = await repository();
+    try {
+      const instance = service(root);
+      await writeFile(join(root, "staged.txt"), "base\nstaged\n");
+      await git(root, "add", "staged.txt");
+      await writeFile(join(root, "staged.txt"), "base\nstaged\nunstaged\n");
+
+      await instance.createStash("proj_test", ".", "staged", ["staged.txt"]);
+
+      assert.equal(
+        await readFile(join(root, "staged.txt"), "utf8"),
+        "base\nstaged\nunstaged\n",
+      );
+      assert.equal(await git(root, "diff", "--cached", "--name-only"), "");
+      assert.equal((await listStashes(instance, root)).length, 1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scopes creation, applies with index state, and retains the stash", async () => {
+    const root = await repository();
+    try {
+      const instance = service(root);
+      await writeFile(join(root, "staged.txt"), "selected\n");
+      await writeFile(join(root, "unstaged.txt"), "sibling\n");
+
+      await instance.createStash("proj_test", ".", "unstaged", ["staged.txt"]);
+      assert.equal(await readFile(join(root, "staged.txt"), "utf8"), "base\n");
+      assert.equal(
+        await readFile(join(root, "unstaged.txt"), "utf8"),
+        "sibling\n",
+      );
+
+      await git(root, "restore", "unstaged.txt");
+      const [entry] = await listStashes(instance, root);
+      assert.ok(entry);
+      await instance.applyStash("proj_test", ".", entry.index, entry.hash);
+      assert.equal(
+        await readFile(join(root, "staged.txt"), "utf8"),
+        "selected\n",
+      );
+      assert.equal((await listStashes(instance, root)).length, 1);
+      assert.equal(await git(root, "status", "--short"), "M staged.txt");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("applies staged and unstaged area stashes with the right index state", async () => {
+    const root = await repository();
+    try {
+      const instance = service(root);
+      await writeFile(join(root, "staged.txt"), "staged\n");
+      await git(root, "add", "staged.txt");
+      await writeFile(join(root, "unstaged.txt"), "unstaged\n");
+      await instance.createStash("proj_test", ".", "unstaged");
+      await git(root, "commit", "-m", "commit staged side");
+
+      let [entry] = await listStashes(instance, root);
+      assert.ok(entry);
+      await instance.applyStash("proj_test", ".", entry.index, entry.hash);
+      assert.equal(await git(root, "status", "--short"), "M unstaged.txt");
+      await git(root, "restore", "unstaged.txt");
+      await instance.dropStash("proj_test", ".", entry.index, entry.hash);
+
+      await writeFile(join(root, "staged.txt"), "staged again\n");
+      await git(root, "add", "staged.txt");
+      await instance.createStash("proj_test", ".", "staged");
+      [entry] = await listStashes(instance, root);
+      assert.ok(entry);
+      await instance.applyStash("proj_test", ".", entry.index, entry.hash);
+      assert.equal(
+        await git(root, "diff", "--cached", "--name-only"),
+        "staged.txt",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("drops only a verified target and rejects a shifted stash index", async () => {
+    const root = await repository();
+    try {
+      const instance = service(root);
+      await writeFile(join(root, "unstaged.txt"), "first\n");
+      await instance.createStash("proj_test", ".", "unstaged");
+      await writeFile(join(root, "unstaged.txt"), "second\n");
+      await instance.createStash("proj_test", ".", "unstaged");
+      const entries = await listStashes(instance, root);
+      const newest = entries[0];
+      const oldest = entries[1];
+      assert.ok(newest && oldest);
+
+      await instance.dropStash("proj_test", ".", newest.index, newest.hash);
+      await assert.rejects(
+        instance.dropStash("proj_test", ".", oldest.index, oldest.hash),
+        (error: unknown) =>
+          error instanceof Error &&
+          error.message.includes("stash list changed"),
+      );
+      assert.equal((await listStashes(instance, root)).length, 1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/website/src/content/docs/guides/git-and-pull-requests.md
+++ b/packages/website/src/content/docs/guides/git-and-pull-requests.md
@@ -7,7 +7,9 @@ sidebar:
 
 ## Git panel
 
-Nerve discovers repositories in the project and shows branch, working-tree changes, and recent commits. Available UI operations include branch creation and switching, stage/unstage, discard, fetch, pull, push, and sync. Destructive discard asks for confirmation.
+Nerve discovers repositories in the project and shows branch, working-tree changes, and recent commits. Available UI operations include branch creation and switching, stage/unstage, stash, discard, fetch, pull, push, and sync. The Staged and Unstaged headings expose visible whole-group actions; right-click a group, folder, or file for scoped actions. Destructive discard asks for confirmation. Folder expansion is remembered locally per repository and change area.
+
+Stash actions preserve the area where you invoke them: stashing from **Staged** saves staged changes, while stashing from **Unstaged** saves unstaged and untracked changes without changing the index. File and directory actions limit the stash to that path. When a repository has saved stashes, **Stashes (N)** opens a manager where you can apply a stash without removing it or permanently drop it after confirmation.
 
 These Workbench operations are server routes, not agent tools. An agent uses Git indirectly through finite Bash commands, subject to its mode and permission policy.
 

--- a/packages/workbench-app/src/lib/api.ts
+++ b/packages/workbench-app/src/lib/api.ts
@@ -58,6 +58,8 @@ export type {
   GitOverviewResponse,
   GitRecentCommit,
   GitRepoSummary,
+  GitStashArea,
+  GitStashEntry,
   ModelCost,
   ModelDefinition,
   ModelInfo,

--- a/packages/workbench-app/src/lib/features/git/api/git.api.ts
+++ b/packages/workbench-app/src/lib/features/git/api/git.api.ts
@@ -21,6 +21,7 @@ import type {
   GitMutationResponse,
   GitOverviewResponse,
   GitProjectFileStatusResponse,
+  GitStashArea,
 } from "@nervekit/contracts";
 import { protocolRequest } from "@nervekit/protocol";
 
@@ -129,6 +130,54 @@ export async function switchBaseAndPullGit(
     await protocolRequest("git.switchBaseAndPull", {
       projectId,
       repo,
+    })
+  ).result;
+}
+
+export async function createGitStash(
+  projectId: string,
+  repo: string,
+  area: GitStashArea,
+  paths?: readonly string[],
+): Promise<GitMutationResponse> {
+  return (
+    await protocolRequest("git.stash.create", {
+      projectId,
+      repo,
+      area,
+      ...(paths ? { paths: [...paths] } : {}),
+    })
+  ).result;
+}
+
+export async function applyGitStash(
+  projectId: string,
+  repo: string,
+  index: number,
+  expectedHash: string,
+): Promise<GitMutationResponse> {
+  return (
+    await protocolRequest("git.stash.apply", {
+      projectId,
+      repo,
+      index,
+      expectedHash,
+    })
+  ).result;
+}
+
+export async function dropGitStash(
+  projectId: string,
+  repo: string,
+  index: number,
+  expectedHash: string,
+): Promise<GitMutationResponse> {
+  return (
+    await protocolRequest("git.stash.drop", {
+      projectId,
+      repo,
+      index,
+      expectedHash,
     })
   ).result;
 }

--- a/packages/workbench-app/src/lib/features/git/state/git-change-tree-expansion.test.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-change-tree-expansion.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  gitChangeTreeExpansionStorageKey,
+  loadCollapsedGitFolders,
+  sanitizeCollapsedGitFolders,
+  saveCollapsedGitFolders,
+} from "./git-change-tree-expansion.js";
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+test("sanitizes, deduplicates, and bounds collapsed folder keys", () => {
+  const values = Array.from({ length: 2_100 }, (_, index) => `folder:${index}`);
+  assert.equal(sanitizeCollapsedGitFolders([...values, "", 4]).length, 2_000);
+  assert.deepEqual(sanitizeCollapsedGitFolders(["one", "one", "two"]), [
+    "one",
+    "two",
+  ]);
+  assert.deepEqual(sanitizeCollapsedGitFolders({}), []);
+});
+
+test("round-trips per project and repository and removes empty state", () => {
+  const storage = new MemoryStorage();
+  saveCollapsedGitFolders("proj_one", ".", ["unstaged:src"], storage);
+  saveCollapsedGitFolders("proj_one", "nested", ["staged:lib"], storage);
+
+  assert.deepEqual(loadCollapsedGitFolders("proj_one", ".", storage), [
+    "unstaged:src",
+  ]);
+  assert.deepEqual(loadCollapsedGitFolders("proj_one", "nested", storage), [
+    "staged:lib",
+  ]);
+  assert.notEqual(
+    gitChangeTreeExpansionStorageKey("proj_one", "."),
+    gitChangeTreeExpansionStorageKey("proj_one", "nested"),
+  );
+
+  saveCollapsedGitFolders("proj_one", ".", [], storage);
+  assert.equal(
+    storage.getItem(gitChangeTreeExpansionStorageKey("proj_one", ".")),
+    null,
+  );
+});
+
+test("falls back safely for corrupt persisted state", () => {
+  const storage = new MemoryStorage();
+  storage.setItem(
+    gitChangeTreeExpansionStorageKey("proj_one", "."),
+    "not-json",
+  );
+  assert.deepEqual(loadCollapsedGitFolders("proj_one", ".", storage), []);
+});

--- a/packages/workbench-app/src/lib/features/git/state/git-change-tree-expansion.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-change-tree-expansion.ts
@@ -1,0 +1,61 @@
+const STORAGE_PREFIX = "nerve.git.changeTreeCollapsed.v1";
+const MAX_COLLAPSED_FOLDERS = 2_000;
+
+type ExpansionStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function browserStorage(): ExpansionStorage | undefined {
+  if (typeof localStorage === "undefined") return undefined;
+  return localStorage;
+}
+
+export function gitChangeTreeExpansionStorageKey(
+  projectId: string,
+  repo: string,
+): string {
+  return `${STORAGE_PREFIX}:${encodeURIComponent(projectId)}:${encodeURIComponent(repo)}`;
+}
+
+export function sanitizeCollapsedGitFolders(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.filter(
+        (entry): entry is string =>
+          typeof entry === "string" && entry.trim().length > 0,
+      ),
+    ),
+  ].slice(0, MAX_COLLAPSED_FOLDERS);
+}
+
+export function loadCollapsedGitFolders(
+  projectId: string,
+  repo: string,
+  storage: ExpansionStorage | undefined = browserStorage(),
+): string[] {
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(
+      gitChangeTreeExpansionStorageKey(projectId, repo),
+    );
+    return raw ? sanitizeCollapsedGitFolders(JSON.parse(raw)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveCollapsedGitFolders(
+  projectId: string,
+  repo: string,
+  collapsed: Iterable<string>,
+  storage: ExpansionStorage | undefined = browserStorage(),
+): void {
+  if (!storage) return;
+  const values = sanitizeCollapsedGitFolders([...collapsed]);
+  const key = gitChangeTreeExpansionStorageKey(projectId, repo);
+  try {
+    if (values.length === 0) storage.removeItem(key);
+    else storage.setItem(key, JSON.stringify(values));
+  } catch {
+    // Persistence is best-effort; the live expansion state still applies.
+  }
+}

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-mutations.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-mutations.svelte.ts
@@ -1,7 +1,15 @@
-import type { GitBranchSummary, GitFileChange } from "$lib/api";
+import type {
+  GitBranchSummary,
+  GitFileChange,
+  GitStashArea,
+  GitStashEntry,
+} from "$lib/api";
 import {
+  applyGitStash,
   createGitBranch,
+  createGitStash,
   discardGitFile,
+  dropGitStash,
   fetchGit,
   pullGit,
   pushGit,
@@ -12,6 +20,7 @@ import {
   unstageGitFile,
 } from "$lib/api";
 import { notify } from "$lib/features/notifications/notify.svelte";
+import { gitFilesInScope, gitPathspecs } from "$lib/presentation";
 import {
   refreshGitOverview,
   scheduleAutomaticGitRefresh,
@@ -188,42 +197,123 @@ export async function mutateGitFile(
           : discardGitFile;
     const result = await fn(projectId, repo, file.path);
     mergeRepoSummary(projectId, result.repo);
-    await refreshGitOverview(projectId, repo);
   } catch (error) {
     notifyGitFailure(
       `${action[0].toUpperCase()}${action.slice(1)} failed`,
       error,
     );
   } finally {
+    await refreshGitOverview(projectId, repo, { force: true });
     state.operations.fileMutation = undefined;
   }
 }
 
-export async function bulkStageGitFiles(
+export async function mutateGitFileScope(
   projectId: string,
   repo: string,
-  action: "stage-all" | "unstage-all",
+  area: GitStashArea,
+  action: "stage" | "unstage" | "discard",
+  path?: string,
 ): Promise<void> {
   const state = ensureGitRepoState(projectId, repo);
-  const files = state.changes?.files ?? [];
-  const targets =
-    action === "stage-all"
-      ? files.filter((file) => file.untracked || file.worktree !== " ")
-      : files.filter((file) => file.staged);
+  const targets = gitFilesInScope(state.changes?.files ?? [], area, path);
   if (targets.length === 0) return;
-  const fn = action === "stage-all" ? stageGitFile : unstageGitFile;
-  state.operations.bulkMutation = action;
+  const fn =
+    action === "stage"
+      ? stageGitFile
+      : action === "unstage"
+        ? unstageGitFile
+        : discardGitFile;
+  state.operations.bulkMutation = {
+    action,
+    area,
+    ...(path ? { path } : {}),
+  };
   try {
-    for (const file of targets) {
-      await fn(projectId, repo, file.path);
-    }
-    await refreshGitOverview(projectId, repo);
+    for (const file of targets) await fn(projectId, repo, file.path);
   } catch (error) {
     notifyGitFailure(
-      `${action === "stage-all" ? "Stage all" : "Unstage all"} failed`,
+      `${action[0]?.toUpperCase()}${action.slice(1)} changes failed`,
       error,
     );
   } finally {
+    await refreshGitOverview(projectId, repo, { force: true });
     state.operations.bulkMutation = undefined;
+  }
+}
+
+export async function createGitRepoStash(
+  projectId: string,
+  repo: string,
+  area: GitStashArea,
+  path?: string,
+): Promise<void> {
+  const state = ensureGitRepoState(projectId, repo);
+  const scopedFiles = path
+    ? gitFilesInScope(state.changes?.files ?? [], area, path)
+    : undefined;
+  if (path && scopedFiles?.length === 0) return;
+  state.operations.stashMutation = {
+    action: "create",
+    area,
+    ...(path ? { path } : {}),
+  };
+  try {
+    const result = await createGitStash(
+      projectId,
+      repo,
+      area,
+      scopedFiles ? gitPathspecs(scopedFiles) : undefined,
+    );
+    mergeRepoSummary(projectId, result.repo);
+    notify.success("Changes stashed");
+  } catch (error) {
+    notifyGitFailure("Stash failed", error);
+  } finally {
+    await refreshGitOverview(projectId, repo, { force: true });
+    state.operations.stashMutation = undefined;
+  }
+}
+
+export async function applyGitRepoStash(
+  projectId: string,
+  repo: string,
+  stash: GitStashEntry,
+): Promise<void> {
+  const state = ensureGitRepoState(projectId, repo);
+  state.operations.stashMutation = { action: "apply", hash: stash.hash };
+  try {
+    const result = await applyGitStash(
+      projectId,
+      repo,
+      stash.index,
+      stash.hash,
+    );
+    mergeRepoSummary(projectId, result.repo);
+    notify.success("Stash applied");
+  } catch (error) {
+    notifyGitFailure("Apply stash failed", error);
+  } finally {
+    await refreshGitOverview(projectId, repo, { force: true });
+    state.operations.stashMutation = undefined;
+  }
+}
+
+export async function dropGitRepoStash(
+  projectId: string,
+  repo: string,
+  stash: GitStashEntry,
+): Promise<void> {
+  const state = ensureGitRepoState(projectId, repo);
+  state.operations.stashMutation = { action: "drop", hash: stash.hash };
+  try {
+    const result = await dropGitStash(projectId, repo, stash.index, stash.hash);
+    mergeRepoSummary(projectId, result.repo);
+    notify.success("Stash dropped");
+  } catch (error) {
+    notifyGitFailure("Drop stash failed", error);
+  } finally {
+    await refreshGitOverview(projectId, repo, { force: true });
+    state.operations.stashMutation = undefined;
   }
 }

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
@@ -283,6 +283,7 @@ export async function refreshGitOverview(
           () =>
             void refreshGitOverview(projectId, repo, {
               silent: true,
+              force: true,
               onlyIfChanged: true,
             }),
         );

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-slices.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-slices.ts
@@ -6,6 +6,7 @@ import type {
   GitOverviewResponse,
   GitRecentCommit,
   GitRepoSummary,
+  GitStashEntry,
 } from "$lib/api";
 
 export type GitChangesState = Pick<
@@ -81,6 +82,18 @@ export function recentCommitsFingerprint(commits: GitRecentCommit[]): string {
   );
 }
 
+export function stashesFingerprint(stashes: readonly GitStashEntry[]): string {
+  return JSON.stringify(
+    stashes.map((stash) => ({
+      index: stash.index,
+      ref: stash.ref,
+      hash: stash.hash,
+      message: stash.message,
+      relativeDate: stash.relativeDate,
+    })),
+  );
+}
+
 export function branchesFingerprint(branches: GitBranchSummary[]): string {
   return JSON.stringify(
     branches.map((branch) => ({
@@ -117,5 +130,6 @@ export function overviewFingerprint(next: GitOverviewResponse): string {
     repo: repoSummaryFingerprint(next.repo),
     changes: changesFingerprint(changesFromOverview(next)),
     recentCommits: recentCommitsFingerprint(next.recentCommits),
+    stashes: stashesFingerprint(next.stashes),
   });
 }

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
@@ -8,6 +8,7 @@ import type {
   GitOverviewResponse,
   GitRecentCommit,
   GitRepoSummary,
+  GitStashEntry,
   ProjectRecord,
 } from "$lib/api";
 import {
@@ -19,9 +20,15 @@ import {
   defaultGitPrFilterConfig,
   normalizeGitPrFilterConfig,
   type GitPrFilterConfig,
+  type ScopedFileMutation,
+  type StashMutation,
 } from "$lib/presentation";
 import { gitState } from "$lib/features/git/state/git-state.svelte";
 import { gitContextFingerprint } from "./git-context-helpers";
+import {
+  loadCollapsedGitFolders,
+  saveCollapsedGitFolders,
+} from "./git-change-tree-expansion";
 import { prSummariesEqual } from "./pr-sync";
 import {
   branchesFingerprint,
@@ -32,6 +39,7 @@ import {
   prsFingerprint,
   recentCommitsFingerprint,
   repoSummaryFingerprint,
+  stashesFingerprint,
   reposFingerprint,
 } from "./git-panel-slices";
 
@@ -49,7 +57,8 @@ export type GitPanelOperationsState = {
   switchingBranch?: string;
   creatingBranch: boolean;
   fileMutation?: FileMutation;
-  bulkMutation?: "stage-all" | "unstage-all";
+  bulkMutation?: ScopedFileMutation;
+  stashMutation?: StashMutation;
 };
 
 export type GitPanelLoadStatus = "idle" | "loading" | "refreshing" | "error";
@@ -58,10 +67,12 @@ export type GitPanelRepoState = {
   repoSummary?: GitRepoSummary;
   changes?: GitChangesState;
   recentCommits: GitRecentCommit[];
+  stashes: GitStashEntry[];
   github?: GithubStatusResponse;
   prs: GithubPr[];
   prFilters: GitPrFilterConfig;
   branches: GitBranchSummary[];
+  collapsedChangeTreeFolders: SvelteSet<string>;
   operations: GitPanelOperationsState;
   loadingOverview: boolean;
   loadingPrs: boolean;
@@ -77,6 +88,7 @@ export type GitPanelRepoState = {
   lastRepoSummaryFingerprint?: string;
   lastChangesFingerprint?: string;
   lastRecentCommitsFingerprint?: string;
+  lastStashesFingerprint?: string;
   lastBranchesFingerprint?: string;
   lastPrsFingerprint?: string;
   lastGithubFingerprint?: string;
@@ -112,6 +124,7 @@ export type GitOverviewPatchResult = {
   repoChanged: boolean;
   changesChanged: boolean;
   recentCommitsChanged: boolean;
+  stashesChanged: boolean;
 };
 
 export const gitPanelState = $state({
@@ -158,6 +171,7 @@ function createOperationsState(): GitPanelOperationsState {
     creatingBranch: false,
     fileMutation: undefined,
     bulkMutation: undefined,
+    stashMutation: undefined,
   };
 }
 
@@ -166,6 +180,7 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     repoSummary: undefined,
     changes: undefined,
     recentCommits: [],
+    stashes: [],
     github: undefined,
     prs: [],
     prFilters:
@@ -173,6 +188,9 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
         ? storedPrFilters(projectId, repo)
         : defaultGitPrFilterConfig,
     branches: [],
+    collapsedChangeTreeFolders: new SvelteSet(
+      projectId && repo ? loadCollapsedGitFolders(projectId, repo) : [],
+    ),
     operations: createOperationsState(),
     loadingOverview: false,
     loadingPrs: false,
@@ -188,6 +206,7 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     lastRepoSummaryFingerprint: undefined,
     lastChangesFingerprint: undefined,
     lastRecentCommitsFingerprint: undefined,
+    lastStashesFingerprint: undefined,
     lastBranchesFingerprint: undefined,
     lastPrsFingerprint: undefined,
     lastGithubFingerprint: undefined,
@@ -315,6 +334,18 @@ export function ensureGitRepoState(
   return project.repoStates[key];
 }
 
+export function setGitChangeTreeFolderExpanded(
+  projectId: string,
+  repo: string,
+  key: string,
+  expanded: boolean,
+): void {
+  const state = ensureGitRepoState(projectId, repo);
+  if (expanded) state.collapsedChangeTreeFolders.delete(key);
+  else state.collapsedChangeTreeFolders.add(key);
+  saveCollapsedGitFolders(projectId, repo, state.collapsedChangeTreeFolders);
+}
+
 export function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     try {
@@ -342,7 +373,8 @@ export function repoMutationInProgress(
       operations.creatingBranch ||
       operations.switchingBranch ||
       operations.fileMutation ||
-      operations.bulkMutation),
+      operations.bulkMutation ||
+      operations.stashMutation),
   );
 }
 
@@ -383,6 +415,17 @@ export function patchRecentCommitsState(
   return true;
 }
 
+export function patchStashesState(
+  state: GitPanelRepoState,
+  next: GitStashEntry[],
+): boolean {
+  const fingerprint = stashesFingerprint(next);
+  if (state.lastStashesFingerprint === fingerprint) return false;
+  state.stashes = next;
+  state.lastStashesFingerprint = fingerprint;
+  return true;
+}
+
 export function patchGitOverviewState(
   state: GitPanelRepoState,
   next: GitOverviewResponse,
@@ -393,10 +436,18 @@ export function patchGitOverviewState(
     state,
     next.recentCommits,
   );
-  const changed = repoChanged || changesChanged || recentCommitsChanged;
+  const stashesChanged = patchStashesState(state, next.stashes);
+  const changed =
+    repoChanged || changesChanged || recentCommitsChanged || stashesChanged;
   if (!state.loaded) state.loaded = true;
   state.loadedAt = Date.now();
-  return { changed, repoChanged, changesChanged, recentCommitsChanged };
+  return {
+    changed,
+    repoChanged,
+    changesChanged,
+    recentCommitsChanged,
+    stashesChanged,
+  };
 }
 
 export function setProjectRepos(

--- a/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
@@ -20,13 +20,16 @@ import { pendingPollTargets, PR_PENDING_POLL_MS } from "./git-refresh-policy";
 import { workbenchStartupState } from "$lib/core/startup/workbench-startup-state.svelte";
 import { shouldActivateGitPanel } from "./git-startup-policy";
 import {
+  applyGitRepoStash,
   autoRefreshGitOverview,
   autoRefreshPrsIfStale,
-  bulkStageGitFiles,
   createGitRepoBranch,
+  createGitRepoStash,
   fetchGitRepo,
+  dropGitRepoStash,
   gitPanelState,
   mutateGitFile,
+  mutateGitFileScope,
   savePrFilters,
   pullGitRepo,
   pushGitRepo,
@@ -36,6 +39,7 @@ import {
   refreshGitProject,
   refreshPrs,
   selectGitProject,
+  setGitChangeTreeFolderExpanded,
   setGitOverviewRefreshVisible,
   selectGitRepo,
   switchBaseAndPullGitRepo,
@@ -46,6 +50,7 @@ import {
 const unsupported = disabledCapability(
   "Select a project to use Git operations.",
 );
+const emptyCollapsedFolders: ReadonlySet<string> = new Set();
 
 export function createWorkbenchGitPanelAdapter(
   activeProject: () => ProjectRecord | undefined,
@@ -69,6 +74,7 @@ export function createWorkbenchGitPanelAdapter(
             branches: enabledCapability,
             mutateFiles: enabledCapability,
             bulkMutateFiles: enabledCapability,
+            stashes: enabledCapability,
             remote: {
               fetch: enabledCapability,
               pull: enabledCapability,
@@ -84,6 +90,7 @@ export function createWorkbenchGitPanelAdapter(
             branches: unsupported,
             mutateFiles: unsupported,
             bulkMutateFiles: unsupported,
+            stashes: unsupported,
             remote: {
               fetch: unsupported,
               pull: unsupported,
@@ -107,6 +114,9 @@ export function createWorkbenchGitPanelAdapter(
         repositorySummary: current?.repoSummary,
         changes: current?.changes,
         branches: current?.branches ?? [],
+        collapsedChangeTreeFolders:
+          current?.collapsedChangeTreeFolders ?? emptyCollapsedFolders,
+        stashes: current?.stashes ?? [],
         github: current?.github,
         pullRequests: current?.prs ?? [],
         pullRequestFilters: current?.prFilters ?? defaultGitPrFilterConfig,
@@ -223,9 +233,28 @@ export function createWorkbenchGitPanelAdapter(
       const project = activeProject();
       if (project) return mutateGitFile(project.id, repository, file, action);
     },
-    bulkMutateFiles: (repository, action) => {
+    mutateFileScope: (repository, area, action, path) => {
       const project = activeProject();
-      if (project) return bulkStageGitFiles(project.id, repository, action);
+      if (project)
+        return mutateGitFileScope(project.id, repository, area, action, path);
+    },
+    createStash: (repository, area, path) => {
+      const project = activeProject();
+      if (project)
+        return createGitRepoStash(project.id, repository, area, path);
+    },
+    setChangeTreeFolderExpanded: (repository, key, expanded) => {
+      const project = activeProject();
+      if (project)
+        setGitChangeTreeFolderExpanded(project.id, repository, key, expanded);
+    },
+    applyStash: (repository, stash) => {
+      const project = activeProject();
+      if (project) return applyGitRepoStash(project.id, repository, stash);
+    },
+    dropStash: (repository, stash) => {
+      const project = activeProject();
+      if (project) return dropGitRepoStash(project.id, repository, stash);
     },
     runRemoteOperation: (repository, operation) => {
       const project = activeProject();

--- a/packages/workbench-app/src/lib/presentation/git/GitChangesArea.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitChangesArea.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
+import Archive from "@lucide/svelte/icons/archive";
 import ArrowDownToLine from "@lucide/svelte/icons/arrow-down-to-line";
 import ArrowUpFromLine from "@lucide/svelte/icons/arrow-up-from-line";
 import ChevronDown from "@lucide/svelte/icons/chevron-down";
 import ChevronRight from "@lucide/svelte/icons/chevron-right";
+import Eye from "@lucide/svelte/icons/eye";
 import X from "@lucide/svelte/icons/x";
-import type { GitDiffArea, GitFileChange } from "@nervekit/contracts";
+import type {
+  GitDiffArea,
+  GitFileChange,
+  GitStashArea,
+} from "@nervekit/contracts";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
 import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
 import { cn } from "@nervekit/ui-kit/core/utils";
 import {
@@ -14,7 +21,16 @@ import {
   PanelToolbarButton,
   PanelTree,
 } from "$lib/presentation/panel";
-import type { FileMutation, GitPanelCapabilities } from "./git-panel-types";
+import {
+  gitChangeTreeFolderKey,
+  gitExpandedGroupIds,
+} from "./git-panel-controller";
+import type {
+  FileMutation,
+  GitPanelCapabilities,
+  ScopedFileMutation,
+  StashMutation,
+} from "./git-panel-types";
 import { fileStatusLabel, fileTone, statusLetter } from "./git-change-format";
 
 type ChangesState = {
@@ -29,7 +45,9 @@ type Props = {
   stagedFiles: GitFileChange[];
   unstagedFiles: GitFileChange[];
   fileMutation?: FileMutation;
-  bulkMutation?: string;
+  bulkMutation?: ScopedFileMutation;
+  stashMutation?: StashMutation;
+  collapsedFolders: ReadonlySet<string>;
   selectedRepo: string;
   capabilities: GitPanelCapabilities;
   onOpenDiff: (repo: string, file: GitFileChange, area: GitDiffArea) => void;
@@ -38,8 +56,20 @@ type Props = {
     file: GitFileChange,
     action: "stage" | "unstage" | "discard",
   ) => void;
-  onBulkStage: (repo: string, action: "stage-all" | "unstage-all") => void;
+  onMutateScope: (
+    repo: string,
+    area: GitStashArea,
+    action: ScopedFileMutation["action"],
+    path?: string,
+  ) => void;
+  onCreateStash: (repo: string, area: GitStashArea, path?: string) => void;
+  onFolderExpansionChange: (
+    repo: string,
+    key: string,
+    expanded: boolean,
+  ) => void;
   onRequestDiscard: (file: GitFileChange) => void;
+  onRequestDiscardScope: (area: GitStashArea, path?: string) => void;
 };
 
 let {
@@ -48,28 +78,255 @@ let {
   unstagedFiles,
   fileMutation,
   bulkMutation,
+  stashMutation,
+  collapsedFolders,
   selectedRepo,
   capabilities,
   onOpenDiff,
   onMutateFile,
-  onBulkStage,
+  onMutateScope,
+  onCreateStash,
+  onFolderExpansionChange,
   onRequestDiscard,
+  onRequestDiscardScope,
 }: Props = $props();
 
 let stagedExpanded = $state(true);
 let unstagedExpanded = $state(true);
+
+const anyMutation = $derived(
+  Boolean(fileMutation || bulkMutation || stashMutation),
+);
+const stagedNodes = $derived(
+  buildPanelTree(stagedFiles, {
+    getPath: (file) => file.path.split("/"),
+    getKey: (file) => `staged:${file.path}`,
+  }),
+);
+const unstagedNodes = $derived(
+  buildPanelTree(unstagedFiles, {
+    getPath: (file) => file.path.split("/"),
+    getKey: (file) => `unstaged:${file.path}`,
+  }),
+);
+const stagedExpandedIds = $derived(
+  gitExpandedGroupIds(stagedNodes, "staged", collapsedFolders),
+);
+const unstagedExpandedIds = $derived(
+  gitExpandedGroupIds(unstagedNodes, "unstaged", collapsedFolders),
+);
+
+function scopeBusy(
+  mutation: ScopedFileMutation | undefined,
+  action: ScopedFileMutation["action"],
+  area: GitStashArea,
+  path?: string,
+): boolean {
+  return (
+    mutation?.action === action &&
+    mutation.area === area &&
+    mutation.path === path
+  );
+}
+
+function stashScopeBusy(area: GitStashArea, path?: string): boolean {
+  return (
+    stashMutation?.action === "create" &&
+    stashMutation.area === area &&
+    stashMutation.path === path
+  );
+}
+
+function scopeMenu(area: GitStashArea, path?: string): ContextMenuItem[] {
+  const stageAction = area === "staged" ? "unstage" : "stage";
+  return [
+    {
+      label: area === "staged" ? "Unstage" : "Stage",
+      icon: area === "staged" ? ArrowDownToLine : ArrowUpFromLine,
+      disabled: !capabilities.bulkMutateFiles.enabled || anyMutation,
+      onSelect: () => onMutateScope(selectedRepo, area, stageAction, path),
+    },
+    {
+      label: "Stash",
+      icon: Archive,
+      disabled: !capabilities.stashes.enabled || anyMutation,
+      onSelect: () => onCreateStash(selectedRepo, area, path),
+    },
+    { type: "separator" },
+    {
+      label: "Discard",
+      icon: X,
+      destructive: true,
+      disabled: !capabilities.bulkMutateFiles.enabled || anyMutation,
+      onSelect: () => onRequestDiscardScope(area, path),
+    },
+  ];
+}
+
+function fileMenu(area: GitStashArea, file: GitFileChange): ContextMenuItem[] {
+  const stageAction = area === "staged" ? "unstage" : "stage";
+  return [
+    {
+      label: "View",
+      icon: Eye,
+      onSelect: () => onOpenDiff(selectedRepo, file, area),
+    },
+    {
+      label: area === "staged" ? "Unstage" : "Stage",
+      icon: area === "staged" ? ArrowDownToLine : ArrowUpFromLine,
+      disabled: !capabilities.mutateFiles.enabled || anyMutation,
+      onSelect: () => onMutateFile(selectedRepo, file, stageAction),
+    },
+    {
+      label: "Stash",
+      icon: Archive,
+      disabled: !capabilities.stashes.enabled || anyMutation,
+      onSelect: () => onCreateStash(selectedRepo, area, file.path),
+    },
+    { type: "separator" },
+    {
+      label: "Discard",
+      icon: X,
+      destructive: true,
+      disabled: !capabilities.mutateFiles.enabled || anyMutation,
+      onSelect: () => onRequestDiscard(file),
+    },
+  ];
+}
 </script>
+
+{#snippet groupActions(area: GitStashArea)}
+  {@const stageAction = area === "staged" ? "unstage" : "stage"}
+  <PanelToolbarButton
+    icon={area === "staged" ? ArrowDownToLine : ArrowUpFromLine}
+    label={`${area === "staged" ? "Unstage" : "Stage"} all`}
+    title={`${area === "staged" ? "Unstage" : "Stage"} all`}
+    dense
+    loading={scopeBusy(bulkMutation, stageAction, area)}
+    disabled={!capabilities.bulkMutateFiles.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onMutateScope(selectedRepo, area, stageAction);
+    }}
+  />
+  <PanelToolbarButton
+    icon={Archive}
+    label={`Stash all ${area} changes`}
+    title="Stash all"
+    dense
+    loading={stashScopeBusy(area)}
+    disabled={!capabilities.stashes.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onCreateStash(selectedRepo, area);
+    }}
+  />
+  <PanelToolbarButton
+    icon={X}
+    label={`Discard all ${area} changes`}
+    title="Discard all"
+    dense
+    loading={scopeBusy(bulkMutation, "discard", area)}
+    disabled={!capabilities.bulkMutateFiles.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onRequestDiscardScope(area);
+    }}
+  />
+{/snippet}
+
+{#snippet folderActions(area: GitStashArea, path: string)}
+  {@const stageAction = area === "staged" ? "unstage" : "stage"}
+  <PanelToolbarButton
+    icon={area === "staged" ? ArrowDownToLine : ArrowUpFromLine}
+    label={`${area === "staged" ? "Unstage" : "Stage"} ${path}`}
+    title={area === "staged" ? "Unstage" : "Stage"}
+    dense
+    loading={scopeBusy(bulkMutation, stageAction, area, path)}
+    disabled={!capabilities.bulkMutateFiles.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onMutateScope(selectedRepo, area, stageAction, path);
+    }}
+  />
+  <PanelToolbarButton
+    icon={Archive}
+    label={`Stash ${path}`}
+    title="Stash"
+    dense
+    loading={stashScopeBusy(area, path)}
+    disabled={!capabilities.stashes.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onCreateStash(selectedRepo, area, path);
+    }}
+  />
+  <PanelToolbarButton
+    icon={X}
+    label={`Discard changes in ${path}`}
+    title="Discard"
+    dense
+    loading={scopeBusy(bulkMutation, "discard", area, path)}
+    disabled={!capabilities.bulkMutateFiles.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onRequestDiscardScope(area, path);
+    }}
+  />
+{/snippet}
+
+{#snippet fileActions(area: GitStashArea, file: GitFileChange)}
+  {@const stageAction = area === "staged" ? "unstage" : "stage"}
+  {@const busy = fileMutation?.path === file.path}
+  <PanelToolbarButton
+    icon={area === "staged" ? ArrowDownToLine : ArrowUpFromLine}
+    label={`${area === "staged" ? "Unstage" : "Stage"} ${file.path}`}
+    title={area === "staged" ? "Unstage" : "Stage"}
+    dense
+    loading={busy && fileMutation?.action === stageAction}
+    disabled={!capabilities.mutateFiles.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onMutateFile(selectedRepo, file, stageAction);
+    }}
+  />
+  <PanelToolbarButton
+    icon={Archive}
+    label={`Stash ${file.path}`}
+    title="Stash"
+    dense
+    loading={stashScopeBusy(area, file.path)}
+    disabled={!capabilities.stashes.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onCreateStash(selectedRepo, area, file.path);
+    }}
+  />
+  <PanelToolbarButton
+    icon={X}
+    label={`Discard ${file.path}`}
+    title="Discard"
+    dense
+    loading={busy && fileMutation?.action === "discard"}
+    disabled={!capabilities.mutateFiles.enabled || anyMutation}
+    onclick={(event) => {
+      event.stopPropagation();
+      onRequestDiscard(file);
+    }}
+  />
+{/snippet}
 
 {#snippet changeGroup(
   title: string,
   files: GitFileChange[],
-  group: "staged" | "unstaged",
+  area: GitStashArea,
   expanded: boolean,
   onToggle: () => void,
 )}
   <PanelRow
-    label={title}
+    label={`${title} (${files.length})`}
     title={`${expanded ? "Collapse" : "Expand"} ${title.toLowerCase()} changes`}
+    menuItems={scopeMenu(area)}
     dense
     flush
     hoverable={false}
@@ -86,84 +343,47 @@ let unstagedExpanded = $state(true);
         <ChevronRight class="-mr-1 size-3" aria-hidden="true" />
       {/if}
     {/snippet}
-    {#snippet badges()}
-      <span>{files.length}</span>
-    {/snippet}
     {#snippet actions()}
-      <PanelToolbarButton
-        icon={group === "staged" ? ArrowDownToLine : ArrowUpFromLine}
-        label={group === "staged" ? "Unstage all" : "Stage all"}
-        dense
-        loading={bulkMutation ===
-          (group === "staged" ? "unstage-all" : "stage-all")}
-        disabled={files.length === 0 ||
-          !capabilities.bulkMutateFiles.enabled ||
-          Boolean(bulkMutation) ||
-          Boolean(fileMutation)}
-        onclick={(event) => {
-          event.stopPropagation();
-          onBulkStage(
-            selectedRepo,
-            group === "staged" ? "unstage-all" : "stage-all",
-          );
-        }}
-      />
+      {@render groupActions(area)}
     {/snippet}
   </PanelRow>
 
   {#if expanded}
+    {@const nodes = area === "staged" ? stagedNodes : unstagedNodes}
+    {@const expandedIds =
+      area === "staged" ? stagedExpandedIds : unstagedExpandedIds}
     <PanelTree
-      nodes={buildPanelTree(files, {
-        getPath: (file) => file.path.split("/"),
-        getKey: (file) => `${group}:${file.path}`,
-      })}
+      {nodes}
       ariaLabel={`${title} file tree`}
       baseIndent={0}
+      showGroupDisclosure={false}
+      overlayActions
+      {expandedIds}
+      getGroupMenuItems={(path) => scopeMenu(area, path.join("/"))}
+      getItemMenuItems={(file) => fileMenu(area, file)}
       getItemTitle={(file) =>
-        `${fileStatusLabel(file, group)} · ${file.renamedFrom ? `${file.renamedFrom} → ` : ""}${file.path}`}
-      onItemActivate={(file) => onOpenDiff(selectedRepo, file, group)}
+        `${fileStatusLabel(file, area)} · ${file.renamedFrom ? `${file.renamedFrom} → ` : ""}${file.path}`}
+      onItemActivate={(file) => onOpenDiff(selectedRepo, file, area)}
+      onGroupExpansionChange={(path, open) =>
+        onFolderExpansionChange(
+          selectedRepo,
+          gitChangeTreeFolderKey(area, path),
+          open,
+        )}
     >
+      {#snippet groupActions(path)}
+        {@render folderActions(area, path.join("/"))}
+      {/snippet}
       {#snippet itemLeading(file)}
         <span
           class={cn("font-mono font-semibold", fileTone(file))}
-          title={fileStatusLabel(file, group)}
+          title={fileStatusLabel(file, area)}
         >
-          {statusLetter(file, group)}
+          {statusLetter(file, area)}
         </span>
       {/snippet}
       {#snippet itemActions(file)}
-        {@const busy = fileMutation?.path === file.path}
-        <PanelToolbarButton
-          icon={group === "staged" ? ArrowDownToLine : ArrowUpFromLine}
-          label={group === "staged"
-            ? `Unstage ${file.path}`
-            : `Stage ${file.path}`}
-          title={group === "staged" ? "Unstage" : "Stage"}
-          dense
-          loading={busy &&
-            fileMutation?.action === (group === "staged" ? "unstage" : "stage")}
-          disabled={!capabilities.mutateFiles.enabled || busy}
-          onclick={(event) => {
-            event.stopPropagation();
-            onMutateFile(
-              selectedRepo,
-              file,
-              group === "staged" ? "unstage" : "stage",
-            );
-          }}
-        />
-        <PanelToolbarButton
-          icon={X}
-          label={`Discard ${file.path}`}
-          title="Discard"
-          dense
-          loading={busy && fileMutation?.action === "discard"}
-          disabled={!capabilities.mutateFiles.enabled || busy}
-          onclick={(event) => {
-            event.stopPropagation();
-            onRequestDiscard(file);
-          }}
-        />
+        {@render fileActions(area, file)}
       {/snippet}
     </PanelTree>
   {/if}

--- a/packages/workbench-app/src/lib/presentation/git/GitPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPanelView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import ArrowDown from "@lucide/svelte/icons/arrow-down";
 import ArrowUp from "@lucide/svelte/icons/arrow-up";
+import ArchiveRestore from "@lucide/svelte/icons/archive-restore";
 import CloudDownload from "@lucide/svelte/icons/cloud-download";
 import GitCompareArrows from "@lucide/svelte/icons/git-compare-arrows";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
@@ -14,9 +15,11 @@ import {
 import GitChangesArea from "./GitChangesArea.svelte";
 import GitPanelBanner from "./GitPanelBanner.svelte";
 import GitRepositoryControls from "./GitRepositoryControls.svelte";
+import GitStashDialog from "./GitStashDialog.svelte";
 import {
   filterAndSortBranches,
   gitFileGroups,
+  gitFilesInScope,
 } from "./git-panel-controller.js";
 import type { GitPanelActions, GitPanelModel } from "./git-panel-types.js";
 import {
@@ -38,12 +41,21 @@ let {
 } = $props();
 
 let branchDialogOpen = $state(false);
+let stashDialogOpen = $state(false);
 let branchFilter = $state("");
 let newBranchName = $state("");
 let discardCandidate = $state<
   | {
+      kind: "file";
       repository: string;
       file: NonNullable<GitPanelModel["changes"]>["files"][number];
+    }
+  | {
+      kind: "scope";
+      repository: string;
+      area: "staged" | "unstaged";
+      path?: string;
+      count: number;
     }
   | undefined
 >(undefined);
@@ -150,6 +162,17 @@ function openBranchDialog(): void {
         dense
         class="h-auto flex-wrap border-b-0 bg-transparent py-1.5"
       >
+        {#if model.stashes.length > 0}
+          <PanelToolbarButton
+            icon={ArchiveRestore}
+            label={`Stashes (${model.stashes.length})`}
+            variant="outline"
+            showLabel
+            title="Manage stashes"
+            disabled={!model.capabilities.stashes.enabled}
+            onclick={() => (stashDialogOpen = true)}
+          />
+        {/if}
         <PanelToolbarButton
           icon={CloudDownload}
           label="Fetch"
@@ -238,33 +261,72 @@ function openBranchDialog(): void {
       unstagedFiles={fileGroups.unstaged}
       fileMutation={model.operations.fileMutation}
       bulkMutation={model.operations.bulkMutation}
+      stashMutation={model.operations.stashMutation}
+      collapsedFolders={model.collapsedChangeTreeFolders}
       selectedRepo={model.selectedRepository}
       capabilities={model.capabilities}
       onOpenDiff={(repository, file, area) =>
         void actions.openDiff(repository, file, area)}
       onMutateFile={(repository, file, action) =>
         void actions.mutateFile(repository, file, action)}
-      onBulkStage={(repository, action) =>
-        void actions.bulkMutateFiles(repository, action)}
+      onMutateScope={(repository, area, action, path) =>
+        void actions.mutateFileScope(repository, area, action, path)}
+      onCreateStash={(repository, area, path) =>
+        void actions.createStash(repository, area, path)}
+      onFolderExpansionChange={(repository, key, expanded) =>
+        void actions.setChangeTreeFolderExpanded(repository, key, expanded)}
       onRequestDiscard={(file) =>
-        (discardCandidate = { repository: model.selectedRepository, file })}
+        (discardCandidate = {
+          kind: "file",
+          repository: model.selectedRepository,
+          file,
+        })}
+      onRequestDiscardScope={(area, path) =>
+        (discardCandidate = {
+          kind: "scope",
+          repository: model.selectedRepository,
+          area,
+          ...(path ? { path } : {}),
+          count: gitFilesInScope(model.changes?.files ?? [], area, path).length,
+        })}
     />
   {/if}
 </PanelView>
+
+<GitStashDialog
+  bind:open={stashDialogOpen}
+  repositoryName={model.repositorySummary?.name ?? model.selectedRepository}
+  stashes={model.stashes}
+  mutation={model.operations.stashMutation}
+  onApply={(stash) => void actions.applyStash(model.selectedRepository, stash)}
+  onDrop={(stash) => void actions.dropStash(model.selectedRepository, stash)}
+/>
 
 <ConfirmDialog
   open={Boolean(discardCandidate)}
   title="Discard change?"
   description={discardCandidate
-    ? `This will permanently discard all uncommitted changes for ${discardCandidate.file.path}.`
+    ? discardCandidate.kind === "file"
+      ? `This will permanently discard all uncommitted changes for ${discardCandidate.file.path}.`
+      : discardCandidate.path
+        ? `This will permanently discard ${discardCandidate.count} changed ${discardCandidate.count === 1 ? "file" : "files"} in ${discardCandidate.path}.`
+        : `This will permanently discard all ${discardCandidate.count} ${discardCandidate.area} ${discardCandidate.count === 1 ? "change" : "changes"}.`
     : "This will permanently discard this uncommitted change."}
   confirmLabel="Discard"
   destructive
   onConfirm={() => {
     const candidate = discardCandidate;
     discardCandidate = undefined;
-    if (candidate)
+    if (!candidate) return;
+    if (candidate.kind === "file")
       void actions.mutateFile(candidate.repository, candidate.file, "discard");
+    else
+      void actions.mutateFileScope(
+        candidate.repository,
+        candidate.area,
+        "discard",
+        candidate.path,
+      );
   }}
   onCancel={() => (discardCandidate = undefined)}
   onOpenChange={(open) => {

--- a/packages/workbench-app/src/lib/presentation/git/GitStashDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitStashDialog.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+import ArchiveRestore from "@lucide/svelte/icons/archive-restore";
+import Trash2 from "@lucide/svelte/icons/trash-2";
+import type { GitStashEntry } from "@nervekit/contracts";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import ConfirmDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
+import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
+import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import type { StashMutation } from "./git-panel-types";
+
+type Props = {
+  open?: boolean;
+  repositoryName: string;
+  stashes: readonly GitStashEntry[];
+  mutation?: StashMutation;
+  onApply: (stash: GitStashEntry) => void;
+  onDrop: (stash: GitStashEntry) => void;
+};
+
+let {
+  open = $bindable(false),
+  repositoryName,
+  stashes,
+  mutation,
+  onApply,
+  onDrop,
+}: Props = $props();
+
+let dropCandidate = $state<GitStashEntry>();
+const busy = $derived(Boolean(mutation));
+</script>
+
+<Dialog
+  bind:open
+  title="Stashes"
+  description={`Saved changes for ${repositoryName}`}
+  size="sm"
+>
+  {#if stashes.length === 0}
+    <p class="py-4 text-center text-sm text-muted-foreground">
+      No stashes in this repository.
+    </p>
+  {:else}
+    <div class="max-h-80 overflow-y-auto rounded-md border">
+      {#each stashes as stash (stash.hash)}
+        <div
+          class="flex min-w-0 items-center gap-2 border-b px-3 py-2 last:border-b-0"
+        >
+          <ArchiveRestore
+            class="size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span class="truncate text-xs font-medium text-foreground"
+              >{stash.message}</span
+            >
+            <span class="truncate text-xs text-muted-foreground">
+              <span class="font-mono">{stash.ref}</span>
+              · <span class="font-mono">{stash.hash.slice(0, 8)}</span>
+              · {stash.relativeDate}
+            </span>
+          </div>
+          <Button
+            size="xs"
+            variant="outline"
+            disabled={busy}
+            onclick={() => onApply(stash)}
+          >
+            {#if mutation?.action === "apply" && mutation.hash === stash.hash}
+              <Spinner class="size-3" />
+            {:else}
+              <ArchiveRestore />
+            {/if}
+            Apply
+          </Button>
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            aria-label={`Drop ${stash.ref}`}
+            title="Drop stash"
+            disabled={busy}
+            onclick={() => (dropCandidate = stash)}
+          >
+            {#if mutation?.action === "drop" && mutation.hash === stash.hash}
+              <Spinner class="size-3" />
+            {:else}
+              <Trash2 />
+            {/if}
+          </Button>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  {#snippet footer()}
+    <Button size="sm" variant="ghost" onclick={() => (open = false)}>
+      Close
+    </Button>
+  {/snippet}
+</Dialog>
+
+<ConfirmDialog
+  open={Boolean(dropCandidate)}
+  title="Drop stash?"
+  description={dropCandidate
+    ? `This permanently removes ${dropCandidate.ref}: ${dropCandidate.message}`
+    : "This permanently removes the selected stash."}
+  confirmLabel="Drop stash"
+  destructive
+  onConfirm={() => {
+    const candidate = dropCandidate;
+    dropCandidate = undefined;
+    if (candidate) onDrop(candidate);
+  }}
+  onCancel={() => (dropCandidate = undefined)}
+  onOpenChange={(next) => {
+    if (!next) dropCandidate = undefined;
+  }}
+/>

--- a/packages/workbench-app/src/lib/presentation/git/git-panel-controller.test.ts
+++ b/packages/workbench-app/src/lib/presentation/git/git-panel-controller.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { GitFileChange } from "@nervekit/contracts";
+import { buildPanelTree } from "../panel/panel-tree.js";
+import {
+  gitChangeTreeFolderKey,
+  gitExpandedGroupIds,
+  gitFilesInScope,
+  gitPathspecs,
+} from "./git-panel-controller.js";
+
+function change(
+  path: string,
+  options: Partial<GitFileChange> = {},
+): GitFileChange {
+  return {
+    path,
+    index: " ",
+    worktree: "M",
+    staged: false,
+    untracked: false,
+    ...options,
+  };
+}
+
+test("selects staged and unstaged changes independently", () => {
+  const files = [
+    change("staged.ts", { index: "M", worktree: " ", staged: true }),
+    change("unstaged.ts"),
+    change("both.ts", { index: "M", staged: true }),
+  ];
+  assert.deepEqual(
+    gitFilesInScope(files, "staged").map((file) => file.path),
+    ["staged.ts", "both.ts"],
+  );
+  assert.deepEqual(
+    gitFilesInScope(files, "unstaged").map((file) => file.path),
+    ["unstaged.ts", "both.ts"],
+  );
+});
+
+test("matches directory scopes at segment boundaries", () => {
+  const files = [
+    change("src/a.ts"),
+    change("src/nested/b.ts"),
+    change("src2/c.ts"),
+  ];
+  assert.deepEqual(
+    gitFilesInScope(files, "unstaged", "src").map((file) => file.path),
+    ["src/a.ts", "src/nested/b.ts"],
+  );
+});
+
+test("keeps folder collapse identity separate by change area", () => {
+  assert.notEqual(
+    gitChangeTreeFolderKey("staged", ["src"]),
+    gitChangeTreeFolderKey("unstaged", ["src"]),
+  );
+});
+
+test("expands new folders and honors only current persisted collapse keys", () => {
+  const nodes = buildPanelTree([change("src/nested/a.ts")], {
+    getPath: (file) => file.path.split("/"),
+    getKey: (file) => file.path,
+  });
+  const expanded = gitExpandedGroupIds(nodes, "unstaged", new Set());
+  assert.deepEqual([...expanded], ['group:["src","nested"]']);
+
+  assert.deepEqual(
+    [
+      ...gitExpandedGroupIds(
+        nodes,
+        "unstaged",
+        new Set([
+          gitChangeTreeFolderKey("unstaged", ["src", "nested"]),
+          gitChangeTreeFolderKey("unstaged", ["stale"]),
+          gitChangeTreeFolderKey("staged", ["src", "nested"]),
+        ]),
+      ),
+    ],
+    [],
+  );
+});
+
+test("deduplicates current and previous rename pathspecs", () => {
+  assert.deepEqual(
+    gitPathspecs([
+      change("new/name.ts", { renamedFrom: "old/name.ts" }),
+      change("new/name.ts", { renamedFrom: "old/name.ts" }),
+    ]),
+    ["new/name.ts", "old/name.ts"],
+  );
+});

--- a/packages/workbench-app/src/lib/presentation/git/git-panel-controller.ts
+++ b/packages/workbench-app/src/lib/presentation/git/git-panel-controller.ts
@@ -2,6 +2,7 @@ import type {
   GitBranchSummary,
   GitFileChange,
   GithubPr,
+  GitStashArea,
 } from "@nervekit/contracts";
 import type {
   GitPanelActions,
@@ -9,6 +10,10 @@ import type {
   GitPrFilterConfig,
   GitRemoteOperation,
 } from "./git-panel-types.js";
+import {
+  panelTreeExpandableIds,
+  type PanelTreeNode,
+} from "../panel/panel-tree.js";
 
 export function gitFileGroups(files: readonly GitFileChange[]): {
   staged: GitFileChange[];
@@ -18,6 +23,47 @@ export function gitFileGroups(files: readonly GitFileChange[]): {
     staged: files.filter((file) => file.staged),
     unstaged: files.filter((file) => file.untracked || file.worktree !== " "),
   };
+}
+
+export function gitFilesInScope(
+  files: readonly GitFileChange[],
+  area: GitStashArea,
+  path?: string,
+): GitFileChange[] {
+  const grouped = gitFileGroups(files)[area];
+  if (!path) return grouped;
+  return grouped.filter(
+    (file) => file.path === path || file.path.startsWith(`${path}/`),
+  );
+}
+
+export function gitPathspecs(files: readonly GitFileChange[]): string[] {
+  return [
+    ...new Set(
+      files.flatMap((file) =>
+        file.renamedFrom ? [file.path, file.renamedFrom] : [file.path],
+      ),
+    ),
+  ];
+}
+
+export function gitChangeTreeFolderKey(
+  area: GitStashArea,
+  path: readonly string[],
+): string {
+  return `${area}:group:${JSON.stringify(path)}`;
+}
+
+export function gitExpandedGroupIds<T>(
+  nodes: readonly PanelTreeNode<T>[],
+  area: GitStashArea,
+  collapsed: ReadonlySet<string>,
+): Set<string> {
+  return new Set(
+    [...panelTreeExpandableIds(nodes)].filter(
+      (id) => !collapsed.has(`${area}:${id}`),
+    ),
+  );
 }
 
 export function filterAndSortBranches(
@@ -197,9 +243,25 @@ export function createGitPanelActions(
       if (available() && model().capabilities.mutateFiles.enabled)
         return host.mutateFile(repository, file, action);
     },
-    bulkMutateFiles: (repository, action) => {
+    mutateFileScope: (repository, area, action, path) => {
       if (available() && model().capabilities.bulkMutateFiles.enabled)
-        return host.bulkMutateFiles(repository, action);
+        return host.mutateFileScope(repository, area, action, path);
+    },
+    createStash: (repository, area, path) => {
+      if (available() && model().capabilities.stashes.enabled)
+        return host.createStash(repository, area, path);
+    },
+    setChangeTreeFolderExpanded: (repository, key, expanded) => {
+      if (available())
+        return host.setChangeTreeFolderExpanded(repository, key, expanded);
+    },
+    applyStash: (repository, stash) => {
+      if (available() && model().capabilities.stashes.enabled)
+        return host.applyStash(repository, stash);
+    },
+    dropStash: (repository, stash) => {
+      if (available() && model().capabilities.stashes.enabled)
+        return host.dropStash(repository, stash);
     },
     runRemoteOperation: (repository, operation) => {
       if (enabled(operation))

--- a/packages/workbench-app/src/lib/presentation/git/git-panel-types.ts
+++ b/packages/workbench-app/src/lib/presentation/git/git-panel-types.ts
@@ -5,6 +5,8 @@ import type {
   GithubPr,
   GithubStatusResponse,
   GitRepoSummary,
+  GitStashArea,
+  GitStashEntry,
 } from "@nervekit/contracts";
 
 export type FeatureCapability =
@@ -16,7 +18,23 @@ export type FileMutation = {
   readonly action: "stage" | "unstage" | "discard";
 };
 
-export type BulkFileMutation = "stage-all" | "unstage-all";
+export type ScopedFileMutation = {
+  readonly action: "stage" | "unstage" | "discard";
+  readonly area: GitStashArea;
+  readonly path?: string;
+};
+
+export type StashMutation =
+  | {
+      readonly action: "create";
+      readonly area: GitStashArea;
+      readonly path?: string;
+    }
+  | {
+      readonly action: "apply" | "drop";
+      readonly hash: string;
+    };
+
 export type GitRemoteOperation =
   | "fetch"
   | "pull"
@@ -40,6 +58,7 @@ export interface GitPanelCapabilities {
   readonly branches: FeatureCapability;
   readonly mutateFiles: FeatureCapability;
   readonly bulkMutateFiles: FeatureCapability;
+  readonly stashes: FeatureCapability;
   readonly remote: Readonly<Record<GitRemoteOperation, FeatureCapability>>;
   readonly openPullRequest: FeatureCapability;
 }
@@ -60,7 +79,8 @@ export interface GitPanelOperationState {
   readonly switchingBranch?: string;
   readonly creatingBranch: boolean;
   readonly fileMutation?: FileMutation;
-  readonly bulkMutation?: BulkFileMutation;
+  readonly bulkMutation?: ScopedFileMutation;
+  readonly stashMutation?: StashMutation;
 }
 
 export interface GitPanelModel {
@@ -73,6 +93,8 @@ export interface GitPanelModel {
   readonly repositorySummary?: GitRepoSummary;
   readonly changes?: GitChangesModel;
   readonly branches: readonly GitBranchSummary[];
+  readonly collapsedChangeTreeFolders: ReadonlySet<string>;
+  readonly stashes: readonly GitStashEntry[];
   readonly github?: GithubStatusResponse;
   readonly pullRequests: readonly GithubPr[];
   readonly pullRequestFilters: GitPrFilterConfig;
@@ -117,9 +139,29 @@ export interface GitPanelActions {
     file: GitFileChange,
     action: FileMutation["action"],
   ) => void | Promise<void>;
-  readonly bulkMutateFiles: (
+  readonly mutateFileScope: (
     repository: string,
-    action: BulkFileMutation,
+    area: GitStashArea,
+    action: ScopedFileMutation["action"],
+    path?: string,
+  ) => void | Promise<void>;
+  readonly createStash: (
+    repository: string,
+    area: GitStashArea,
+    path?: string,
+  ) => void | Promise<void>;
+  readonly setChangeTreeFolderExpanded: (
+    repository: string,
+    key: string,
+    expanded: boolean,
+  ) => void | Promise<void>;
+  readonly applyStash: (
+    repository: string,
+    stash: GitStashEntry,
+  ) => void | Promise<void>;
+  readonly dropStash: (
+    repository: string,
+    stash: GitStashEntry,
   ) => void | Promise<void>;
   readonly runRemoteOperation: (
     repository: string,

--- a/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
@@ -32,6 +32,7 @@ let {
   stacked = false,
   hoverable = true,
   alwaysShowActions = false,
+  overlayActions = false,
   ariaLabel,
   ariaExpanded,
   role = "listitem",
@@ -82,6 +83,8 @@ let {
   hoverable?: boolean;
   /** Keeps trailing actions visible instead of revealing them on hover. */
   alwaysShowActions?: boolean;
+  /** Reveals actions over the row so hidden controls reserve no width. */
+  overlayActions?: boolean;
   ariaLabel?: string;
   ariaExpanded?: boolean;
   /** Outer row semantics. Tree rows opt into `treeitem`; list rows keep the default. */
@@ -146,6 +149,7 @@ const toneClass = $derived(
     class={cn(
       "panel-row group/panel-row flex min-w-0 items-center rounded-sm",
       hoverable && "panel-row-hoverable",
+      actions && overlayActions && "relative",
       stacked
         ? "min-h-11 gap-2 py-2.5 pr-3 text-xs"
         : labelLines === 2
@@ -258,6 +262,9 @@ const toneClass = $derived(
           "flex shrink-0 items-center gap-0.5",
           !alwaysShowActions &&
             "panel-hover-actions group-focus-within/panel-row:opacity-100 group-hover/panel-row:opacity-100",
+          !alwaysShowActions &&
+            overlayActions &&
+            "pointer-events-none absolute top-1/2 right-1 z-10 -translate-y-1/2 rounded-sm bg-background/95 pl-1 shadow-sm group-focus-within/panel-row:pointer-events-auto group-hover/panel-row:pointer-events-auto",
         )}
       >
         {@render actions()}

--- a/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
@@ -62,10 +62,14 @@ type Props = {
   /** Uncontrolled initial expansion policy. Existing callers default to all. */
   defaultExpanded?: "all" | "none";
   onItemExpansionChange?: (item: T, expanded: boolean) => void;
+  /** Expansion changes for generated path groups. */
+  onGroupExpansionChange?: (path: readonly string[], expanded: boolean) => void;
   /** Opt into a single fixed-height virtualized viewport for large trees. */
   virtualized?: boolean;
   /** Hide item disclosure arrows when open/closed leading icons carry state. */
   showDisclosure?: boolean;
+  /** Hide generated-directory chevrons when folder icons carry state. */
+  showGroupDisclosure?: boolean;
   itemMono?: boolean;
   /** Renders item descriptions on a second line instead of inline. */
   itemStacked?: boolean;
@@ -79,7 +83,12 @@ type Props = {
   itemLabelTrailing?: Snippet<[T]>;
   itemBadges?: Snippet<[T]>;
   itemActions?: Snippet<[T]>;
+  /** Actions for generated directory groups, receiving the full path. */
+  groupActions?: Snippet<[readonly string[]]>;
+  /** Overlay row actions so hidden controls reserve no horizontal space. */
+  overlayActions?: boolean;
   getItemMenuItems?: (item: T) => ContextMenuItem[];
+  getGroupMenuItems?: (path: readonly string[]) => ContextMenuItem[];
   class?: string;
 };
 
@@ -99,8 +108,10 @@ let {
   expandedIds,
   defaultExpanded = "all",
   onItemExpansionChange,
+  onGroupExpansionChange,
   virtualized = false,
   showDisclosure = true,
+  showGroupDisclosure = true,
   itemMono = false,
   itemStacked = false,
   onItemActivate,
@@ -108,7 +119,10 @@ let {
   itemLabelTrailing,
   itemBadges,
   itemActions,
+  groupActions,
+  overlayActions = false,
   getItemMenuItems,
+  getGroupMenuItems,
   class: className,
 }: Props = $props();
 
@@ -155,9 +169,14 @@ $effect(() => {
   if (!focusedId || !visibleIds.has(focusedId)) focusedId = rows[0]?.node.id;
 });
 
+function notifyExpansionChange(node: PanelTreeNode<T>, open: boolean): void {
+  if (node.kind === "item") onItemExpansionChange?.(node.value, open);
+  else onGroupExpansionChange?.(node.path, open);
+}
+
 function setExpanded(node: PanelTreeNode<T>, open: boolean): void {
   if (expandedIds) {
-    if (node.kind === "item") onItemExpansionChange?.(node.value, open);
+    notifyExpansionChange(node, open);
     return;
   }
   if (defaultExpanded === "all") {
@@ -165,7 +184,7 @@ function setExpanded(node: PanelTreeNode<T>, open: boolean): void {
     else collapsed.add(node.id);
   } else if (open) locallyExpanded.add(node.id);
   else locallyExpanded.delete(node.id);
-  if (node.kind === "item") onItemExpansionChange?.(node.value, open);
+  notifyExpansionChange(node, open);
 }
 
 function isExpandable(node: PanelTreeNode<T>): boolean {
@@ -263,18 +282,29 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
   {#if node.kind === "group"}
     {#snippet groupLeading()}
       {#if open}
-        <ChevronDown class="size-3" aria-hidden="true" />
+        {#if showGroupDisclosure}
+          <ChevronDown class="size-3" aria-hidden="true" />
+        {/if}
         <FolderOpen class="size-3.5" aria-hidden="true" />
       {:else}
-        <ChevronRight class="size-3" aria-hidden="true" />
+        {#if showGroupDisclosure}
+          <ChevronRight class="size-3" aria-hidden="true" />
+        {/if}
         <Folder class="size-3.5" aria-hidden="true" />
       {/if}
+    {/snippet}
+    {#snippet renderedGroupActions()}
+      {#if groupActions}{@render groupActions(node.path)}{/if}
     {/snippet}
     <PanelRow
       label={node.label}
       title={node.path.join("/")}
       leading={groupLeading}
+      actions={groupActions ? renderedGroupActions : undefined}
+      menuItems={getGroupMenuItems?.(node.path)}
       dense
+      alwaysShowActions={!overlayActions}
+      {overlayActions}
       indent={baseIndent + row.depth}
       role="treeitem"
       tabindex={focusedId === node.id ? 0 : -1}
@@ -329,7 +359,8 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       actions={itemActions ? leafActions : undefined}
       menuItems={getItemMenuItems?.(node.value)}
       dense
-      alwaysShowActions
+      alwaysShowActions={!overlayActions}
+      {overlayActions}
       class={cn(cardClass(rowIndex), itemClass)}
       indent={baseIndent + (indentItems ? row.depth : 0)}
       role="treeitem"

--- a/packages/workbench-server/src/domains/tools/git-mutation-publisher.ts
+++ b/packages/workbench-server/src/domains/tools/git-mutation-publisher.ts
@@ -12,6 +12,9 @@ const mutationReasons = {
   push: "remote.pushed",
   pull: "remote.pulled",
   fetch: "remote.fetched",
+  createStash: "stash.created",
+  applyStash: "stash.applied",
+  dropStash: "stash.dropped",
   checkoutPr: "github.pr.checked_out",
 } as const;
 

--- a/packages/workbench-server/src/protocol/method-handlers/git-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/git-method-handlers.ts
@@ -45,6 +45,27 @@ export const gitMethodHandlers = defineWorkbenchMethodHandlers({
     state.registry.git.fetch(params.projectId, repo(params)),
   "git.switchBaseAndPull": (state, params) =>
     state.registry.git.switchBaseAndPull(params.projectId, repo(params)),
+  "git.stash.create": (state, params) =>
+    state.registry.git.createStash(
+      params.projectId,
+      repo(params),
+      params.area,
+      params.paths,
+    ),
+  "git.stash.apply": (state, params) =>
+    state.registry.git.applyStash(
+      params.projectId,
+      repo(params),
+      params.index,
+      params.expectedHash,
+    ),
+  "git.stash.drop": (state, params) =>
+    state.registry.git.dropStash(
+      params.projectId,
+      repo(params),
+      params.index,
+      params.expectedHash,
+    ),
   "github.status.get": (state, params) =>
     state.registry.git.githubStatus(params.projectId, repo(params)),
   "github.pr.list": (state, params) =>


### PR DESCRIPTION
## Summary
- add staged and unstaged stash creation, listing, apply, and drop across contracts, tools, server, and workbench state
- add a stash manager plus scoped group, folder, and file actions with concise context menus and hover overlays
- force post-mutation Git refreshes and persist per-repository folder expansion state
- add integration and state/controller tests and update the Git guide

## Validation
- pnpm fix
- pnpm check
- pnpm test