### PR TITLE
Add animated active item outlines

### DIFF
--- a/packages/workbench-app/src/lib/features/projects/components/ProjectAgentTreeNode.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectAgentTreeNode.svelte
@@ -52,7 +52,7 @@ const tooltip = $derived(
 );
 </script>
 
-<PanelRowCard>
+<PanelRowCard itemKey={row.conversation.id} {menuItems}>
   <PanelRow
     label={row.conversation.title}
     labelLines={2}
@@ -62,7 +62,6 @@ const tooltip = $derived(
     pulse={dotActivity.pulse}
     class="px-2"
     active={isActive}
-    {menuItems}
     onclick={() => onOpenConversation?.(row.conversation.id)}
   />
 </PanelRowCard>

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectConversationNavigator.svelte
@@ -130,7 +130,10 @@ const menuContext = $derived<ProjectTreeMenuContext>({
         {/snippet}
       </PanelEmpty>
     {:else}
-      <PanelScrollRegion ariaLabel="Conversations">
+      <PanelScrollRegion
+        ariaLabel="Conversations"
+        activeKey={selectedConversationId}
+      >
         <PanelList ariaLabel="Conversations" class="shrink-0 gap-1 pt-1 pb-0">
           {#each displayedRows as row (row.conversation.id)}
             {@const rowProject =

--- a/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectSwitcher.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import LayoutGrid from "@lucide/svelte/icons/layout-grid";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
-import ContextMenu, {
-  type ContextMenuItem,
-} from "@nervekit/ui-kit/components/ui/context-menu-list";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
+import { ItemCollection, ItemSurface } from "$lib/presentation";
 import { getShortcutAriaLabel } from "$lib/core/shortcuts/registry";
 import {
   projectActivitySignal,
@@ -56,7 +55,10 @@ function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
   >
     <LayoutGrid class="size-4" aria-hidden="true" />
   </Button>
-  <div class="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
+  <ItemCollection
+    {activeKey}
+    class="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden"
+  >
     {#each items as item (item.key)}
       {@const signal = projectActivitySignal(item.activity, item.tasks)}
       {@const conversationActivityCount =
@@ -64,15 +66,17 @@ function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
       {@const combinedSignals =
         conversationActivityCount > 0 && item.tasks.running > 0}
       {@const active = item.key === activeKey}
-      <ContextMenu
-        items={buildMenuItems?.(item) ?? []}
-        disabled={!buildMenuItems}
-        triggerClass="block min-w-0 max-w-56 overflow-hidden [-webkit-app-region:no-drag]"
+      <ItemSurface
+        itemKey={item.key}
+        menuItems={buildMenuItems?.(item) ?? []}
+        menuDisabled={!buildMenuItems}
+        hover="soft"
+        class="min-w-0 max-w-56 overflow-hidden [-webkit-app-region:no-drag]"
       >
         <Button
           variant="ghost"
           size="sm"
-          class={`w-full min-w-0 gap-1.5 rounded-md bg-accent/35 px-2 ${active ? "text-foreground hover:bg-accent/40" : "text-muted-foreground hover:bg-accent/40 hover:text-foreground"}`}
+          class={`w-full min-w-0 gap-1.5 rounded-md bg-transparent px-2 hover:bg-transparent dark:hover:bg-transparent ${active ? "text-foreground data-[active]:bg-transparent" : "text-muted-foreground hover:text-foreground"}`}
           pressed={active}
           aria-current={active ? "page" : undefined}
           ariaLabel={tabLabel(item)}
@@ -103,7 +107,7 @@ function conversationSignalClass(tone: ProjectActivitySignal["tone"]): string {
           {/if}
           <span class="truncate">{item.label}</span>
         </Button>
-      </ContextMenu>
+      </ItemSurface>
     {/each}
-  </div>
+  </ItemCollection>
 </nav>

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -5,12 +5,11 @@ import FolderOpen from "@lucide/svelte/icons/folder-open";
 import Plus from "@lucide/svelte/icons/plus";
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
-import ContextMenu, {
-  type ContextMenuItem,
-} from "@nervekit/ui-kit/components/ui/context-menu-list";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
 import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 import { tildePath } from "$lib/core/utils/path";
+import { ItemScrollRegion, ItemSurface } from "$lib/presentation";
 import type { ProjectGitOverview } from "$lib/features/projects/state/project-overview";
 import type { ProjectSwitcherItem } from "$lib/features/projects/state/project-switcher";
 import ProjectCardStatus from "./ProjectCardStatus.svelte";
@@ -68,29 +67,6 @@ let {
   onRowKeydown,
 }: Props = $props();
 
-let listContentEl = $state<HTMLDivElement | undefined>(undefined);
-let canScrollUp = $state(false);
-let canScrollDown = $state(false);
-
-function updateScrollShadows(): void {
-  if (!scrollEl) return;
-  canScrollUp = scrollEl.scrollTop > 2;
-  canScrollDown =
-    scrollEl.scrollTop + scrollEl.clientHeight < scrollEl.scrollHeight - 2;
-}
-
-$effect(() => {
-  const region = scrollEl;
-  const content = listContentEl;
-  if (!region || !content) return;
-
-  updateScrollShadows();
-  const observer = new ResizeObserver(updateScrollShadows);
-  observer.observe(region);
-  observer.observe(content);
-  return () => observer.disconnect();
-});
-
 function projectMenu(item: ProjectSwitcherItem): ContextMenuItem[] {
   const project = item.project;
   const menuItems: ContextMenuItem[] = [
@@ -122,145 +98,105 @@ function projectMenu(item: ProjectSwitcherItem): ContextMenuItem[] {
   />
 </form>
 
-<div class="relative flex min-h-0 flex-1 overflow-hidden">
-  <div
-    class="recent-projects-scroller min-h-0 flex-1 overflow-y-auto p-2"
-    bind:this={scrollEl}
-    onscroll={updateScrollShadows}
-  >
-    <div bind:this={listContentEl}>
-      {#if pathQuery}
-        <button
-          type="button"
-          class="group flex w-full items-center gap-2.5 rounded-md border border-transparent bg-transparent px-2.5 py-2 text-left hover:bg-accent/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
-          onclick={onBrowsePath}
+<ItemScrollRegion
+  bind:viewport={scrollEl}
+  activeKey={activeProjectKey}
+  contentClass="p-2"
+>
+  {#if pathQuery}
+    <button
+      type="button"
+      class="group flex w-full items-center gap-2.5 rounded-md border border-transparent bg-transparent px-2.5 py-2 text-left hover:bg-accent/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+      onclick={onBrowsePath}
+    >
+      <span
+        class="grid size-8 flex-none place-items-center rounded-md border border-border/60 bg-muted/40 text-muted-foreground group-hover:text-foreground"
+      >
+        <FolderOpen class="size-4" aria-hidden="true" />
+      </span>
+      <span class="grid min-w-0 flex-1 gap-0.5">
+        <span class="text-sm font-medium text-foreground">Browse path</span>
+        <span class="truncate font-mono text-xs text-muted-foreground"
+          >{query.trim()}</span
         >
-          <span
-            class="grid size-8 flex-none place-items-center rounded-md border border-border/60 bg-muted/40 text-muted-foreground group-hover:text-foreground"
-          >
-            <FolderOpen class="size-4" aria-hidden="true" />
-          </span>
-          <span class="grid min-w-0 flex-1 gap-0.5">
-            <span class="text-sm font-medium text-foreground">Browse path</span>
-            <span class="truncate font-mono text-xs text-muted-foreground"
-              >{query.trim()}</span
-            >
-          </span>
-          <ArrowRight
-            class="size-3.5 flex-none text-muted-foreground group-hover:text-foreground"
-            strokeWidth={2.2}
-            aria-hidden="true"
-          />
-        </button>
-      {:else if items.length}
-        <Tooltip.Provider delayDuration={300} disableHoverableContent>
-          <div
-            class="grid grid-cols-1 gap-1.5"
-            role="listbox"
-            aria-label="Recent projects"
+      </span>
+      <ArrowRight
+        class="size-3.5 flex-none text-muted-foreground group-hover:text-foreground"
+        strokeWidth={2.2}
+        aria-hidden="true"
+      />
+    </button>
+  {:else if items.length}
+    <Tooltip.Provider delayDuration={300} disableHoverableContent>
+      <div
+        class="grid grid-cols-1 gap-1.5"
+        role="listbox"
+        aria-label="Recent projects"
+        tabindex={-1}
+        aria-activedescendant={activeDescendant}
+      >
+        {#each items as item, i (item.key)}
+          {@const current = item.key === activeProjectKey}
+          {@const selected = selectedIndex === i}
+          <ItemSurface
+            id={`recent:${encodeURIComponent(item.key)}`}
+            role="option"
+            ariaSelected={selected}
             tabindex={-1}
-            aria-activedescendant={activeDescendant}
+            itemKey={item.key}
+            menuItems={projectMenu(item)}
+            hover="default"
+            class={`group w-full cursor-pointer items-center gap-2.5 border border-transparent px-2.5 py-1.5 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
+              selected
+                ? "bg-accent/90 hover:bg-accent dark:bg-accent/80 dark:hover:bg-accent/80"
+                : "hover:bg-accent/90 dark:hover:bg-accent/70"
+            }`}
+            onclick={() => onOpen(item)}
+            onkeydown={(event) => onRowKeydown(event, i, item)}
           >
-            {#each items as item, i (item.key)}
-              {@const current = item.key === activeProjectKey}
-              {@const selected = selectedIndex === i}
-              <ContextMenu items={projectMenu(item)} triggerClass="contents">
-                <div
-                  id={`recent:${encodeURIComponent(item.key)}`}
-                  class={`group flex w-full cursor-pointer items-center gap-2.5 rounded-md border border-transparent bg-accent/35 px-2.5 py-1.5 text-left focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none ${
-                    selected ? "bg-accent/80" : "hover:bg-accent/70"
-                  }`}
-                  role="option"
-                  aria-selected={selected}
-                  tabindex="-1"
-                  onclick={() => onOpen(item)}
-                  onkeydown={(event) => onRowKeydown(event, i, item)}
+            <ProjectIcon projectId={item.project.id} class="size-8" />
+            <span class="grid min-w-0 flex-1 gap-0.5">
+              <span class="flex min-w-0 items-center gap-1.5">
+                <strong
+                  class="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
                 >
-                  <ProjectIcon projectId={item.project.id} class="size-8" />
-                  <span class="grid min-w-0 flex-1 gap-0.5">
-                    <span class="flex min-w-0 items-center gap-1.5">
-                      <strong
-                        class="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
-                      >
-                        {item.project.name}
-                      </strong>
-                      {#if current}
-                        <Badge tone="accent" size="xs" class="flex-none"
-                          >Current</Badge
-                        >
-                      {/if}
-                      <span class="ml-auto min-w-0 flex-none">
-                        <ProjectCardStatus
-                          {item}
-                          git={gitByProjectKey[item.key]}
-                          gitLoading={gitLoadingByProjectKey[item.key] ?? false}
-                          gitError={gitErrorByProjectKey[item.key] ?? false}
-                        />
-                      </span>
-                    </span>
-                    <span
-                      class="min-w-0 truncate font-mono text-xs text-muted-foreground"
-                    >
-                      {tildePath(item.project.dir, homeDir)}
-                    </span>
-                  </span>
-                </div>
-              </ContextMenu>
-            {/each}
-          </div>
-        </Tooltip.Provider>
-      {:else}
-        <div
-          class="grid min-h-40 place-items-center gap-1 p-6 text-center text-muted-foreground"
-        >
-          <FolderOpen size={26} strokeWidth={1.8} aria-hidden="true" />
-          <p class="m-0 mt-1 text-sm text-foreground">
-            {totalRecentCount
-              ? "No recent projects match your search."
-              : "No recent projects yet."}
-          </p>
-          <span class="text-xs">Use Browse below to open a project folder.</span
-          >
-        </div>
-      {/if}
+                  {item.project.name}
+                </strong>
+                {#if current}
+                  <Badge tone="accent" size="xs" class="flex-none"
+                    >Current</Badge
+                  >
+                {/if}
+                <span class="ml-auto min-w-0 flex-none">
+                  <ProjectCardStatus
+                    {item}
+                    git={gitByProjectKey[item.key]}
+                    gitLoading={gitLoadingByProjectKey[item.key] ?? false}
+                    gitError={gitErrorByProjectKey[item.key] ?? false}
+                  />
+                </span>
+              </span>
+              <span
+                class="min-w-0 truncate font-mono text-xs text-muted-foreground"
+              >
+                {tildePath(item.project.dir, homeDir)}
+              </span>
+            </span>
+          </ItemSurface>
+        {/each}
+      </div>
+    </Tooltip.Provider>
+  {:else}
+    <div
+      class="grid min-h-40 place-items-center gap-1 p-6 text-center text-muted-foreground"
+    >
+      <FolderOpen size={26} strokeWidth={1.8} aria-hidden="true" />
+      <p class="m-0 mt-1 text-sm text-foreground">
+        {totalRecentCount
+          ? "No recent projects match your search."
+          : "No recent projects yet."}
+      </p>
+      <span class="text-xs">Use Browse below to open a project folder.</span>
     </div>
-  </div>
-  <div
-    class="recent-projects-shadow recent-projects-shadow-top pointer-events-none absolute inset-x-0 top-0 h-6 opacity-0 transition-opacity duration-150"
-    class:opacity-100={canScrollUp}
-  ></div>
-  <div
-    class="recent-projects-shadow recent-projects-shadow-bottom pointer-events-none absolute inset-x-0 bottom-0 h-6 opacity-0 transition-opacity duration-150"
-    class:opacity-100={canScrollDown}
-  ></div>
-</div>
-
-<style>
-/* Escape-hatch reason 2: native scrollbars are hidden because edge shadows
- * provide the scroll affordance. */
-.recent-projects-scroller {
-  scrollbar-width: none;
-}
-
-.recent-projects-scroller::-webkit-scrollbar {
-  display: none;
-}
-
-.recent-projects-shadow-bottom {
-  background: linear-gradient(
-    to top,
-    var(--card) 0%,
-    var(--card) 22%,
-    transparent 72%
-  );
-}
-
-.recent-projects-shadow-top {
-  background: linear-gradient(
-    to bottom,
-    var(--card) 0%,
-    var(--card) 22%,
-    transparent 72%
-  );
-}
-</style>
+  {/if}
+</ItemScrollRegion>

--- a/packages/workbench-app/src/lib/presentation/git/GitPullRequestRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPullRequestRow.svelte
@@ -5,6 +5,7 @@ import X from "@lucide/svelte/icons/x";
 import type { GithubPr } from "@nervekit/contracts";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import { ItemSurface } from "$lib/presentation/items";
 import { checksTone } from "./git-change-format";
 import { githubCheckRunOutcome } from "./github-pr-checks";
 
@@ -23,9 +24,10 @@ let { pr, expanded, disabled, disabledReason, onOpen, onToggleChecks }: Props =
 const hasCheckDetails = $derived(pr.checks.runs.length > 0);
 </script>
 
-<div
+<ItemSurface
   role="listitem"
-  class="group flex min-w-0 flex-col gap-1 rounded-md bg-accent/35 px-3 py-2.5 text-xs leading-tight transition-colors hover:bg-accent/60"
+  hover="default"
+  class="group flex-col gap-1 px-3 py-2.5 text-xs leading-tight"
 >
   <button
     type="button"
@@ -110,4 +112,4 @@ const hasCheckDetails = $derived(pr.checks.runs.length > 0);
       {/each}
     </div>
   {/if}
-</div>
+</ItemSurface>

--- a/packages/workbench-app/src/lib/presentation/git/GitPullRequestRowSkeleton.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitPullRequestRowSkeleton.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
+import { ItemSurface } from "$lib/presentation/items";
 </script>
 
-<div
+<ItemSurface
   role="status"
-  aria-label="Loading pull requests"
-  class="flex min-w-0 flex-col gap-1 rounded-md bg-accent/35 px-3 py-2.5"
+  ariaLabel="Loading pull requests"
+  class="flex-col gap-1 px-3 py-2.5"
 >
   <div class="flex min-w-0 items-center gap-1.5">
     <Skeleton class="h-3.5 w-7 shrink-0" />
@@ -16,4 +17,4 @@ import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
     <Skeleton class="ml-auto size-6 rounded-sm" />
   </div>
   <span class="sr-only">Loading pull requests</span>
-</div>
+</ItemSurface>

--- a/packages/workbench-app/src/lib/presentation/index.ts
+++ b/packages/workbench-app/src/lib/presentation/index.ts
@@ -13,6 +13,7 @@ export type { ScrollFollowDecisionInput } from "./components/transcript/conversa
 export { shouldDisableFollowForScroll } from "./components/transcript/conversation-scroll-intent.js";
 export { default as TranscriptList } from "./components/transcript/TranscriptList.svelte";
 export { default as TranscriptRow } from "./components/transcript/TranscriptRow.svelte";
+export * from "./items/index.js";
 export * from "./panel/index.js";
 export * from "./shell/index.js";
 export * from "./context.svelte.js";

--- a/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
+++ b/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+import { tick, type Snippet } from "svelte";
+import { cn } from "@nervekit/ui-kit/core/utils";
+import { relativeItemRectangle } from "./item-collection.js";
+
+let {
+  activeKey,
+  class: className,
+  children,
+}: {
+  activeKey?: string;
+  class?: string;
+  children: Snippet;
+} = $props();
+
+let collection = $state<HTMLDivElement>();
+let x = $state(0);
+let y = $state(0);
+let width = $state(0);
+let height = $state(0);
+let visible = $state(false);
+let measureFrame: number | undefined;
+let showFrame: number | undefined;
+
+function candidates(): HTMLElement[] {
+  if (!collection) return [];
+  return [
+    ...collection.querySelectorAll<HTMLElement>("[data-active-outline-key]"),
+  ].filter(
+    (candidate) =>
+      candidate.closest<HTMLElement>("[data-item-collection]") === collection,
+  );
+}
+
+function activeTarget(): HTMLElement | undefined {
+  if (!activeKey) return undefined;
+  return candidates().find(
+    (candidate) => candidate.dataset.activeOutlineKey === activeKey,
+  );
+}
+
+function measure(): void {
+  measureFrame = undefined;
+  if (!collection) return;
+  const target = activeTarget();
+  if (!target) {
+    visible = false;
+    return;
+  }
+
+  const geometry = relativeItemRectangle(
+    collection.getBoundingClientRect(),
+    target.getBoundingClientRect(),
+  );
+  x = geometry.x;
+  y = geometry.y;
+  width = geometry.width;
+  height = geometry.height;
+
+  if (!visible) {
+    if (showFrame !== undefined) cancelAnimationFrame(showFrame);
+    showFrame = requestAnimationFrame(() => {
+      showFrame = undefined;
+      if (activeTarget()) visible = true;
+    });
+  }
+}
+
+function scheduleMeasure(): void {
+  if (measureFrame !== undefined) return;
+  measureFrame = requestAnimationFrame(measure);
+}
+
+$effect(() => {
+  const key = activeKey;
+  const host = collection;
+  void tick().then(() => {
+    if (activeKey === key && collection === host) scheduleMeasure();
+  });
+});
+
+$effect(() => {
+  const host = collection;
+  if (!host) return;
+
+  const resizeObserver = new ResizeObserver(scheduleMeasure);
+  const observeCandidates = () => {
+    resizeObserver.disconnect();
+    resizeObserver.observe(host);
+    for (const candidate of candidates()) resizeObserver.observe(candidate);
+  };
+  observeCandidates();
+
+  const mutationObserver = new MutationObserver(() => {
+    observeCandidates();
+    scheduleMeasure();
+  });
+  mutationObserver.observe(host, { childList: true, subtree: true });
+
+  host.addEventListener("scroll", scheduleMeasure, true);
+  window.addEventListener("resize", scheduleMeasure);
+  scheduleMeasure();
+
+  return () => {
+    resizeObserver.disconnect();
+    mutationObserver.disconnect();
+    host.removeEventListener("scroll", scheduleMeasure, true);
+    window.removeEventListener("resize", scheduleMeasure);
+    if (measureFrame !== undefined) cancelAnimationFrame(measureFrame);
+    if (showFrame !== undefined) cancelAnimationFrame(showFrame);
+    measureFrame = undefined;
+    showFrame = undefined;
+  };
+});
+</script>
+
+<div
+  bind:this={collection}
+  data-item-collection=""
+  class={cn("relative min-w-0", className)}
+>
+  {@render children()}
+  <div
+    aria-hidden="true"
+    class="pointer-events-none absolute top-0 left-0 z-20 rounded-md border border-primary opacity-0 transition-[transform,width,height,opacity] duration-200 ease-out will-change-transform"
+    class:opacity-100={visible}
+    style:transform={`translate3d(${x}px, ${y}px, 0)`}
+    style:width={`${width}px`}
+    style:height={`${height}px`}
+  ></div>
+</div>

--- a/packages/workbench-app/src/lib/presentation/items/ItemScrollRegion.svelte
+++ b/packages/workbench-app/src/lib/presentation/items/ItemScrollRegion.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import { cn } from "@nervekit/ui-kit/core/utils";
+import ItemCollection from "./ItemCollection.svelte";
+
+let {
+  viewport = $bindable(),
+  activeKey,
+  ariaLabel,
+  class: className,
+  viewportClass,
+  contentClass,
+  children,
+}: {
+  viewport?: HTMLDivElement;
+  activeKey?: string;
+  ariaLabel?: string;
+  class?: string;
+  viewportClass?: string;
+  contentClass?: string;
+  children: Snippet;
+} = $props();
+
+let content = $state<HTMLDivElement>();
+let canScrollUp = $state(false);
+let canScrollDown = $state(false);
+
+function updateShadows(): void {
+  if (!viewport) return;
+  canScrollUp = viewport.scrollTop > 2;
+  canScrollDown =
+    viewport.scrollTop + viewport.clientHeight < viewport.scrollHeight - 2;
+}
+
+$effect(() => {
+  if (!viewport || !content) return;
+  updateShadows();
+  const observer = new ResizeObserver(updateShadows);
+  observer.observe(viewport);
+  observer.observe(content);
+  return () => observer.disconnect();
+});
+</script>
+
+<div
+  class={cn("relative flex min-h-0 flex-1 flex-col overflow-hidden", className)}
+>
+  <div
+    bind:this={viewport}
+    class={cn(
+      "item-scroll-region min-h-0 flex-1 overflow-y-auto",
+      viewportClass,
+    )}
+    aria-label={ariaLabel}
+    onscroll={updateShadows}
+  >
+    <div bind:this={content} class="min-w-0">
+      <ItemCollection {activeKey} class={contentClass}>
+        {@render children()}
+      </ItemCollection>
+    </div>
+  </div>
+  <div
+    class="item-scroll-shadow item-scroll-shadow-top pointer-events-none absolute inset-x-0 top-0 h-6 opacity-0 transition-opacity duration-150"
+    class:opacity-100={canScrollUp}
+  ></div>
+  <div
+    class="item-scroll-shadow item-scroll-shadow-bottom pointer-events-none absolute inset-x-0 bottom-0 h-6 opacity-0 transition-opacity duration-150"
+    class:opacity-100={canScrollDown}
+  ></div>
+</div>
+
+<style>
+/* Native scrollbars are hidden because edge shadows provide the affordance. */
+.item-scroll-region {
+  scrollbar-width: none;
+}
+
+.item-scroll-region::-webkit-scrollbar {
+  display: none;
+}
+
+.item-scroll-shadow-bottom {
+  background: linear-gradient(
+    to top,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+
+.item-scroll-shadow-top {
+  background: linear-gradient(
+    to bottom,
+    var(--card) 0%,
+    var(--card) 22%,
+    transparent 72%
+  );
+}
+</style>

--- a/packages/workbench-app/src/lib/presentation/items/ItemSurface.svelte
+++ b/packages/workbench-app/src/lib/presentation/items/ItemSurface.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
+import ContextMenuList from "@nervekit/ui-kit/components/ui/context-menu-list";
+import { cn } from "@nervekit/ui-kit/core/utils";
+
+type SurfaceElement = "div" | "section";
+type SurfaceHover = "none" | "soft" | "default";
+
+let {
+  element = "div",
+  role,
+  id,
+  tabindex,
+  ariaLabel,
+  ariaSelected,
+  itemKey,
+  hover = "none",
+  focusWithin = false,
+  menuItems,
+  menuDisabled = false,
+  menuTriggerClass = "contents",
+  onMenuOpenChange,
+  class: className,
+  onclick,
+  onkeydown,
+  onfocus,
+  ondblclick,
+  children,
+}: {
+  element?: SurfaceElement;
+  role?: string;
+  id?: string;
+  tabindex?: number;
+  ariaLabel?: string;
+  ariaSelected?: boolean;
+  itemKey?: string;
+  hover?: SurfaceHover;
+  focusWithin?: boolean;
+  menuItems?: ContextMenuItem[];
+  menuDisabled?: boolean;
+  menuTriggerClass?: string;
+  onMenuOpenChange?: (open: boolean) => void;
+  class?: string;
+  onclick?: (event: MouseEvent) => void;
+  onkeydown?: (event: KeyboardEvent) => void;
+  onfocus?: (event: FocusEvent) => void;
+  ondblclick?: (event: MouseEvent) => void;
+  children: Snippet;
+} = $props();
+
+const surfaceClass = $derived(
+  cn(
+    "flex min-w-0 rounded-md bg-accent/60 transition-colors dark:bg-accent/35",
+    hover === "soft" && "hover:bg-accent/80 dark:hover:bg-accent/40",
+    hover === "default" && "hover:bg-accent/90 dark:hover:bg-accent/60",
+    focusWithin && "focus-within:bg-accent/90 dark:focus-within:bg-accent/60",
+    className,
+  ),
+);
+</script>
+
+{#snippet surface()}
+  <svelte:element
+    this={element}
+    {id}
+    {role}
+    {tabindex}
+    aria-label={ariaLabel}
+    aria-selected={ariaSelected}
+    data-active-outline-key={itemKey}
+    class={surfaceClass}
+    {onclick}
+    {onkeydown}
+    {onfocus}
+    {ondblclick}
+  >
+    {@render children()}
+  </svelte:element>
+{/snippet}
+
+{#if menuItems && menuItems.length > 0}
+  <ContextMenuList
+    items={menuItems}
+    disabled={menuDisabled}
+    triggerClass={menuTriggerClass}
+    onOpenChange={onMenuOpenChange}
+  >
+    {@render surface()}
+  </ContextMenuList>
+{:else}
+  {@render surface()}
+{/if}

--- a/packages/workbench-app/src/lib/presentation/items/index.ts
+++ b/packages/workbench-app/src/lib/presentation/items/index.ts
@@ -1,0 +1,8 @@
+export { default as ItemCollection } from "./ItemCollection.svelte";
+export { default as ItemScrollRegion } from "./ItemScrollRegion.svelte";
+export { default as ItemSurface } from "./ItemSurface.svelte";
+export { relativeItemRectangle } from "./item-collection.js";
+export type {
+  ItemRectangle,
+  RelativeItemRectangle,
+} from "./item-collection.js";

--- a/packages/workbench-app/src/lib/presentation/items/item-collection.test.ts
+++ b/packages/workbench-app/src/lib/presentation/items/item-collection.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { relativeItemRectangle } from "./item-collection.js";
+
+test("relativeItemRectangle projects a target into collection coordinates", () => {
+  assert.deepEqual(
+    relativeItemRectangle(
+      { left: 40, top: 20, width: 400, height: 300 },
+      { left: 64, top: 72, width: 180, height: 36 },
+    ),
+    { x: 24, y: 52, width: 180, height: 36 },
+  );
+});
+
+test("relativeItemRectangle retains targets above or left of a scrolled viewport", () => {
+  assert.deepEqual(
+    relativeItemRectangle(
+      { left: 20, top: 30, width: 240, height: 180 },
+      { left: 8, top: -10, width: 200, height: 28 },
+    ),
+    { x: -12, y: -40, width: 200, height: 28 },
+  );
+});

--- a/packages/workbench-app/src/lib/presentation/items/item-collection.ts
+++ b/packages/workbench-app/src/lib/presentation/items/item-collection.ts
@@ -1,0 +1,26 @@
+export type ItemRectangle = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
+export type RelativeItemRectangle = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/** Returns target geometry in the collection's local coordinate space. */
+export function relativeItemRectangle(
+  collection: ItemRectangle,
+  target: ItemRectangle,
+): RelativeItemRectangle {
+  return {
+    x: target.left - collection.left,
+    y: target.top - collection.top,
+    width: target.width,
+    height: target.height,
+  };
+}

--- a/packages/workbench-app/src/lib/presentation/panel/PanelCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { tick, type Component, type Snippet } from "svelte";
-import { cn } from "@nervekit/ui-kit/core/utils";
+import { ItemSurface } from "$lib/presentation/items";
 
 let {
   title,
@@ -64,11 +64,10 @@ function cancel(): void {
 }
 </script>
 
-<section
-  class={cn(
-    "flex min-w-0 flex-col rounded-md bg-accent/35 transition-colors focus-within:bg-accent/60",
-    className,
-  )}
+<ItemSurface
+  element="section"
+  focusWithin
+  class={`flex-col ${className ?? ""}`}
 >
   <div class="flex h-7 min-w-0 items-center gap-1 px-3">
     {#if Icon}
@@ -125,4 +124,4 @@ function cancel(): void {
   <div class="min-w-0">
     {@render children()}
   </div>
-</section>
+</ItemSurface>

--- a/packages/workbench-app/src/lib/presentation/panel/PanelRowCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelRowCard.svelte
@@ -1,25 +1,32 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
-import { cn } from "@nervekit/ui-kit/core/utils";
+import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
+import { ItemSurface } from "$lib/presentation/items";
 
 let {
   role = "none",
+  itemKey,
+  menuItems,
+  menuDisabled = false,
   class: className,
   children,
 }: {
   /** Outer semantics; rows inside already carry `listitem` where needed. */
   role?: "listitem" | "none";
+  itemKey?: string;
+  menuItems?: ContextMenuItem[];
+  menuDisabled?: boolean;
   class?: string;
   children: Snippet;
 } = $props();
 </script>
 
-<div
+<ItemSurface
   {role}
-  class={cn(
-    "panel-row-card flex min-w-0 flex-col rounded-md px-1 py-0.5 transition-colors",
-    className,
-  )}
+  {itemKey}
+  {menuItems}
+  {menuDisabled}
+  class={`panel-row-card flex-col px-1 py-0.5 ${className ?? ""}`}
 >
   {@render children()}
-</div>
+</ItemSurface>

--- a/packages/workbench-app/src/lib/presentation/panel/PanelScrollRegion.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelScrollRegion.svelte
@@ -1,87 +1,22 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
-import { cn } from "@nervekit/ui-kit/core/utils";
+import { ItemScrollRegion } from "$lib/presentation/items";
 
 let {
+  viewport = $bindable(),
+  activeKey,
   ariaLabel,
   contentClass,
   children,
 }: {
+  viewport?: HTMLDivElement;
+  activeKey?: string;
   ariaLabel?: string;
   contentClass?: string;
   children: Snippet;
 } = $props();
-
-let region = $state<HTMLDivElement>();
-let content = $state<HTMLDivElement>();
-let canScrollUp = $state(false);
-let canScrollDown = $state(false);
-
-function updateShadows(): void {
-  if (!region) return;
-  canScrollUp = region.scrollTop > 2;
-  canScrollDown =
-    region.scrollTop + region.clientHeight < region.scrollHeight - 2;
-}
-
-$effect(() => {
-  if (!region || !content) return;
-  updateShadows();
-  const observer = new ResizeObserver(updateShadows);
-  observer.observe(region);
-  observer.observe(content);
-  return () => observer.disconnect();
-});
 </script>
 
-<div class="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-  <div
-    bind:this={region}
-    class="panel-scroll-region min-h-0 flex-1 overflow-y-auto"
-    aria-label={ariaLabel}
-    onscroll={updateShadows}
-  >
-    <div bind:this={content} class={cn("min-w-0", contentClass)}>
-      {@render children()}
-    </div>
-  </div>
-  <div
-    class="panel-scroll-shadow panel-scroll-shadow-top pointer-events-none absolute inset-x-0 top-0 h-6 opacity-0 transition-opacity duration-150"
-    class:opacity-100={canScrollUp}
-  ></div>
-  <div
-    class="panel-scroll-shadow panel-scroll-shadow-bottom pointer-events-none absolute inset-x-0 bottom-0 h-6 opacity-0 transition-opacity duration-150"
-    class:opacity-100={canScrollDown}
-  ></div>
-</div>
-
-<style>
-/* Escape-hatch reason 2: native scrollbars are hidden because edge shadows
- * provide the scroll affordance. */
-.panel-scroll-region {
-  scrollbar-width: none;
-}
-
-.panel-scroll-region::-webkit-scrollbar {
-  display: none;
-}
-
-/* Gradients blend overflowing content into the panel surface. */
-.panel-scroll-shadow-bottom {
-  background: linear-gradient(
-    to top,
-    var(--card) 0%,
-    var(--card) 22%,
-    transparent 72%
-  );
-}
-
-.panel-scroll-shadow-top {
-  background: linear-gradient(
-    to bottom,
-    var(--card) 0%,
-    var(--card) 22%,
-    transparent 72%
-  );
-}
-</style>
+<ItemScrollRegion bind:viewport {activeKey} {ariaLabel} {contentClass}>
+  {@render children()}
+</ItemScrollRegion>

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
@@ -11,7 +11,11 @@ import Terminal from "@lucide/svelte/icons/terminal";
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
-import { PanelRow, PanelToolbarButton } from "$lib/presentation/panel";
+import {
+  PanelRow,
+  PanelRowCard,
+  PanelToolbarButton,
+} from "$lib/presentation/panel";
 import { taskDefinitionLabel } from "./task-panel-controller.js";
 import TaskStatusIcon from "./TaskStatusIcon.svelte";
 import type {
@@ -22,6 +26,7 @@ import type {
 let {
   entry,
   capabilities,
+  active = false,
   onOpen,
   onRun,
   onCancel,
@@ -34,6 +39,7 @@ let {
 }: {
   entry: TaskDefinitionEntry;
   capabilities: TaskEntryCapabilities;
+  active?: boolean;
   onOpen?: (taskId: string) => void;
   onRun?: () => void;
   onCancel?: (taskId: string) => void;
@@ -52,7 +58,7 @@ const command = $derived(entry.definition.command);
 const cwd = $derived(entry.definition.cwd);
 const concurrent = $derived(entry.definition.runPolicy === "concurrent");
 const canStart = $derived(concurrent || entry.activeRuns.length === 0);
-const active = $derived(entry.activeRuns[0]);
+const activeRun = $derived(entry.activeRuns[0]);
 const cleanableRuns = $derived(
   entry.runs.filter((run) => run.isRemovable && run.run.id !== latest?.id),
 );
@@ -67,7 +73,7 @@ const tooltip = $derived(
   [command, cwd, recoveryHint].filter(Boolean).join("\n"),
 );
 const runLabel = $derived(
-  concurrent && active ? "Start another run" : "Run task",
+  concurrent && activeRun ? "Start another run" : "Run task",
 );
 
 const menuItems = $derived.by<ContextMenuItem[]>(() => {
@@ -94,27 +100,27 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
       disabled: !capabilities.start,
       onSelect: () => onRun?.(),
     });
-  if (active) {
+  if (activeRun) {
     items.push({
       label: "Restart",
       icon: RotateCw,
       disabled: !capabilities.restart,
-      onSelect: () => onRestart?.(active.id),
+      onSelect: () => onRestart?.(activeRun.id),
     });
-    if (active.status !== "stopping")
+    if (activeRun.status !== "stopping")
       items.push({
         label: "Stop",
         icon: Square,
         disabled: !capabilities.cancel,
-        onSelect: () => onCancel?.(active.id),
+        onSelect: () => onCancel?.(activeRun.id),
       });
-    if (active.status === "recovered" || active.status === "stopping")
+    if (activeRun.status === "recovered" || activeRun.status === "stopping")
       items.push({
         label: "Force kill",
         icon: Skull,
         destructive: true,
         disabled: !capabilities.cancel,
-        onSelect: () => onForceKill?.(active.id),
+        onSelect: () => onForceKill?.(activeRun.id),
       });
   }
 
@@ -153,62 +159,64 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
 });
 </script>
 
-<PanelRow
-  label={label.text}
-  title={tooltip}
-  mono={label.isCommand}
-  tone={label.isCommand ? "muted" : "default"}
-  disabled={!latest}
-  indent={0}
-  alwaysShowActions
-  {menuItems}
-  onclick={() => latest && onOpen?.(latest.id)}
->
-  {#snippet leading()}
-    <TaskStatusIcon {status} />
-  {/snippet}
-  {#snippet badges()}
-    {#if entry.activeRuns.length > 1}
-      <Badge tone="accent" size="xs">{entry.activeRuns.length} running</Badge>
-    {/if}
-    {#if entry.runs.length > 1}
-      <Badge tone="neutral" size="xs">
-        <History class="mr-1 size-3" />{entry.runs.length}
-      </Badge>
-    {/if}
-  {/snippet}
-  {#snippet actions()}
-    {#if active?.status === "stopping"}
-      <PanelToolbarButton
-        icon={Skull}
-        label="Force kill task"
-        dense
-        disabled={!capabilities.cancel}
-        onclick={() => onForceKill?.(active.id)}
-      />
-    {:else if active}
-      <PanelToolbarButton
-        icon={RotateCw}
-        label="Restart task"
-        dense
-        disabled={!capabilities.restart}
-        onclick={() => onRestart?.(active.id)}
-      />
-      <PanelToolbarButton
-        icon={Square}
-        label="Stop task"
-        dense
-        disabled={!capabilities.cancel}
-        onclick={() => onCancel?.(active.id)}
-      />
-    {:else if canStart}
-      <PanelToolbarButton
-        icon={Play}
-        label={runLabel}
-        dense
-        disabled={!capabilities.start}
-        onclick={() => onRun?.()}
-      />
-    {/if}
-  {/snippet}
-</PanelRow>
+<PanelRowCard itemKey={entry.key} {menuItems}>
+  <PanelRow
+    label={label.text}
+    title={tooltip}
+    mono={label.isCommand}
+    tone={label.isCommand ? "muted" : "default"}
+    disabled={!latest}
+    indent={0}
+    alwaysShowActions
+    {active}
+    onclick={() => latest && onOpen?.(latest.id)}
+  >
+    {#snippet leading()}
+      <TaskStatusIcon {status} />
+    {/snippet}
+    {#snippet badges()}
+      {#if entry.activeRuns.length > 1}
+        <Badge tone="accent" size="xs">{entry.activeRuns.length} running</Badge>
+      {/if}
+      {#if entry.runs.length > 1}
+        <Badge tone="neutral" size="xs">
+          <History class="mr-1 size-3" />{entry.runs.length}
+        </Badge>
+      {/if}
+    {/snippet}
+    {#snippet actions()}
+      {#if activeRun?.status === "stopping"}
+        <PanelToolbarButton
+          icon={Skull}
+          label="Force kill task"
+          dense
+          disabled={!capabilities.cancel}
+          onclick={() => onForceKill?.(activeRun.id)}
+        />
+      {:else if activeRun}
+        <PanelToolbarButton
+          icon={RotateCw}
+          label="Restart task"
+          dense
+          disabled={!capabilities.restart}
+          onclick={() => onRestart?.(activeRun.id)}
+        />
+        <PanelToolbarButton
+          icon={Square}
+          label="Stop task"
+          dense
+          disabled={!capabilities.cancel}
+          onclick={() => onCancel?.(activeRun.id)}
+        />
+      {:else if canStart}
+        <PanelToolbarButton
+          icon={Play}
+          label={runLabel}
+          dense
+          disabled={!capabilities.start}
+          onclick={() => onRun?.()}
+        />
+      {/if}
+    {/snippet}
+  </PanelRow>
+</PanelRowCard>

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
@@ -9,7 +9,11 @@ import Terminal from "@lucide/svelte/icons/terminal";
 import X from "@lucide/svelte/icons/x";
 import type { TaskRecord } from "@nervekit/contracts";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
-import { PanelRow, PanelToolbarButton } from "$lib/presentation/panel";
+import {
+  PanelRow,
+  PanelRowCard,
+  PanelToolbarButton,
+} from "$lib/presentation/panel";
 import { formatTaskRunTime, taskRunLabel } from "./task-panel-controller.js";
 import TaskStatusIcon from "./TaskStatusIcon.svelte";
 import type { TaskEntryCapabilities, TaskRunEntry } from "./task-panel-types";
@@ -18,6 +22,7 @@ let {
   entry,
   nested = false,
   capabilities,
+  active = false,
   onOpen,
   onCancel,
   onForceKill,
@@ -31,6 +36,7 @@ let {
   /** Renders the run as a child of its definition row: time-first label, deeper indent. */
   nested?: boolean;
   capabilities: TaskEntryCapabilities;
+  active?: boolean;
   onOpen?: (taskId: string) => void;
   onCancel?: (taskId: string) => void;
   onForceKill?: (taskId: string) => void;
@@ -131,52 +137,54 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
 });
 </script>
 
-<PanelRow
-  label={nested ? startedAt : label.text}
-  description={nested ? undefined : startedAt}
-  title={tooltip}
-  mono={!nested && label.isCommand}
-  tone={nested || label.isCommand ? "muted" : "default"}
-  indent={nested ? 1 : 0}
-  alwaysShowActions
-  {menuItems}
-  onclick={() => onOpen?.(run.id)}
->
-  {#snippet leading()}
-    <TaskStatusIcon status={run.status} />
-  {/snippet}
-  {#snippet actions()}
-    {#if run.status === "stopping"}
-      <PanelToolbarButton
-        icon={Skull}
-        label={`Force kill ${label.text}`}
-        dense
-        disabled={!capabilities.cancel}
-        onclick={() => onForceKill?.(run.id)}
-      />
-    {:else if entry.isActive}
-      <PanelToolbarButton
-        icon={RotateCw}
-        label={`Restart ${label.text}`}
-        dense
-        disabled={!capabilities.restart}
-        onclick={() => onRestart?.(run.id)}
-      />
-      <PanelToolbarButton
-        icon={Square}
-        label={`Stop ${label.text}`}
-        dense
-        disabled={!capabilities.cancel}
-        onclick={() => onCancel?.(run.id)}
-      />
-    {:else}
-      <PanelToolbarButton
-        icon={RotateCw}
-        label={`Restart ${label.text}`}
-        dense
-        disabled={!capabilities.restart}
-        onclick={() => onRestart?.(run.id)}
-      />
-    {/if}
-  {/snippet}
-</PanelRow>
+<PanelRowCard itemKey={entry.key} {menuItems}>
+  <PanelRow
+    label={nested ? startedAt : label.text}
+    description={nested ? undefined : startedAt}
+    title={tooltip}
+    mono={!nested && label.isCommand}
+    tone={nested || label.isCommand ? "muted" : "default"}
+    indent={nested ? 1 : 0}
+    alwaysShowActions
+    {active}
+    onclick={() => onOpen?.(run.id)}
+  >
+    {#snippet leading()}
+      <TaskStatusIcon status={run.status} />
+    {/snippet}
+    {#snippet actions()}
+      {#if run.status === "stopping"}
+        <PanelToolbarButton
+          icon={Skull}
+          label={`Force kill ${label.text}`}
+          dense
+          disabled={!capabilities.cancel}
+          onclick={() => onForceKill?.(run.id)}
+        />
+      {:else if entry.isActive}
+        <PanelToolbarButton
+          icon={RotateCw}
+          label={`Restart ${label.text}`}
+          dense
+          disabled={!capabilities.restart}
+          onclick={() => onRestart?.(run.id)}
+        />
+        <PanelToolbarButton
+          icon={Square}
+          label={`Stop ${label.text}`}
+          dense
+          disabled={!capabilities.cancel}
+          onclick={() => onCancel?.(run.id)}
+        />
+      {:else}
+        <PanelToolbarButton
+          icon={RotateCw}
+          label={`Restart ${label.text}`}
+          dense
+          disabled={!capabilities.restart}
+          onclick={() => onRestart?.(run.id)}
+        />
+      {/if}
+    {/snippet}
+  </PanelRow>
+</PanelRowCard>

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunsDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunsDialog.svelte
@@ -3,7 +3,7 @@ import type { TaskRecord } from "@nervekit/contracts";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
 import SearchInput from "@nervekit/ui-kit/components/ui/search-input";
 import { ScrollArea } from "@nervekit/ui-kit/components/ui/scroll-area";
-import { PanelList, PanelRowCard } from "$lib/presentation/panel";
+import { PanelList } from "$lib/presentation/panel";
 import TaskRunRow from "./TaskRunRow.svelte";
 import { taskRunLabel } from "./task-panel-controller.js";
 import type {
@@ -92,20 +92,18 @@ function openRun(taskId: string): void {
         <ScrollArea class="h-full">
           <PanelList ariaLabel="All runs" class="gap-1">
             {#each matches as entry (entry.key)}
-              <PanelRowCard>
-                <TaskRunRow
-                  {entry}
-                  {capabilities}
-                  onOpen={openRun}
-                  {onCancel}
-                  {onForceKill}
-                  {onRestart}
-                  onRerunDefinition={() => onRerunDefinition(entry)}
-                  {onRemove}
-                  {onCopy}
-                  {onSaveAsDefinition}
-                />
-              </PanelRowCard>
+              <TaskRunRow
+                {entry}
+                {capabilities}
+                onOpen={openRun}
+                {onCancel}
+                {onForceKill}
+                {onRestart}
+                onRerunDefinition={() => onRerunDefinition(entry)}
+                {onRemove}
+                {onCopy}
+                {onSaveAsDefinition}
+              />
             {/each}
           </PanelList>
         </ScrollArea>

--- a/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
@@ -19,18 +19,21 @@ import {
   PanelEmpty,
   PanelHeader,
   PanelList,
-  PanelRowCard,
   PanelSectionHeader,
   PanelToolbarButton,
   PanelView,
   createPanelRowFit,
 } from "$lib/presentation/panel";
+import { ItemCollection } from "$lib/presentation/items";
 import TaskDefinitionDialog from "./TaskDefinitionDialog.svelte";
 import TaskDefinitionRow from "./TaskDefinitionRow.svelte";
 import TaskOutputPane from "./TaskOutputPane.svelte";
 import TaskRunRow from "./TaskRunRow.svelte";
 import TaskRunsDialog from "./TaskRunsDialog.svelte";
-import { projectTaskPanel } from "./task-panel-controller.js";
+import {
+  projectTaskPanel,
+  taskPanelActiveItemKey,
+} from "./task-panel-controller.js";
 import type {
   TaskEntryCapabilities,
   TaskPanelActions,
@@ -47,6 +50,7 @@ let {
 } = $props();
 
 const projected = $derived(projectTaskPanel(model.definitions, model.tasks));
+const activeItemKey = $derived(taskPanelActiveItemKey(model.selectedTask));
 const selectedSiblingRuns = $derived.by(() => {
   const selected = model.selectedTask;
   if (!selected) return [];
@@ -157,7 +161,10 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
 </script>
 
 {#snippet taskList()}
-  <div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+  <ItemCollection
+    activeKey={activeItemKey}
+    class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+  >
     <div
       class="flex min-w-0 flex-col overflow-y-auto"
       class:flex-1={!model.definitionsLoading &&
@@ -188,21 +195,20 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
       {:else}
         <PanelList role="none" class="gap-1">
           {#each projected.definitions as entry (entry.key)}
-            <PanelRowCard>
-              <TaskDefinitionRow
-                {entry}
-                {capabilities}
-                onOpen={(id) => void panelActions.openTaskOutput(id)}
-                onRun={() => void panelActions.runDefinition(entry.definition)}
-                onCancel={(id) => void panelActions.cancelTask(id)}
-                onForceKill={requestForceKill}
-                onRestart={(id) => void panelActions.restartTask(id)}
-                onEdit={() => (editDefinition = entry.definition)}
-                onDelete={() => (deleteDefinition = entry.definition)}
-                onCleanupRuns={(ids) => (cleanupRunIds = ids)}
-                onCopy={(text) => void panelActions.copyText(text)}
-              />
-            </PanelRowCard>
+            <TaskDefinitionRow
+              {entry}
+              {capabilities}
+              active={activeItemKey === entry.key}
+              onOpen={(id) => void panelActions.openTaskOutput(id)}
+              onRun={() => void panelActions.runDefinition(entry.definition)}
+              onCancel={(id) => void panelActions.cancelTask(id)}
+              onForceKill={requestForceKill}
+              onRestart={(id) => void panelActions.restartTask(id)}
+              onEdit={() => (editDefinition = entry.definition)}
+              onDelete={() => (deleteDefinition = entry.definition)}
+              onCleanupRuns={(ids) => (cleanupRunIds = ids)}
+              onCopy={(text) => void panelActions.copyText(text)}
+            />
           {/each}
         </PanelList>
       {/if}
@@ -226,19 +232,18 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
         </PanelSectionHeader>
         <PanelList ariaLabel="Runs" class="shrink-0 gap-1">
           {#each visibleRuns as entry (entry.key)}
-            <PanelRowCard>
-              <TaskRunRow
-                {entry}
-                {capabilities}
-                onOpen={(id) => void panelActions.openTaskOutput(id)}
-                onCancel={(id) => void panelActions.cancelTask(id)}
-                onForceKill={requestForceKill}
-                onRestart={(id) => void panelActions.restartTask(id)}
-                onRemove={(id) => void panelActions.removeTask(id)}
-                onCopy={(text) => void panelActions.copyText(text)}
-                onSaveAsDefinition={(task) => (saveSourceTask = task)}
-              />
-            </PanelRowCard>
+            <TaskRunRow
+              {entry}
+              {capabilities}
+              active={activeItemKey === entry.key}
+              onOpen={(id) => void panelActions.openTaskOutput(id)}
+              onCancel={(id) => void panelActions.cancelTask(id)}
+              onForceKill={requestForceKill}
+              onRestart={(id) => void panelActions.restartTask(id)}
+              onRemove={(id) => void panelActions.removeTask(id)}
+              onCopy={(text) => void panelActions.copyText(text)}
+              onSaveAsDefinition={(task) => (saveSourceTask = task)}
+            />
           {/each}
         </PanelList>
         {#if hiddenRuns > 0}
@@ -253,7 +258,7 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
         {/if}
       </div>
     {/if}
-  </div>
+  </ItemCollection>
 {/snippet}
 
 <div class="h-full min-h-0" bind:clientWidth={panelWidth}>

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.test.ts
@@ -4,6 +4,7 @@ import type { TaskRecord } from "@nervekit/contracts";
 import {
   projectTaskPanel,
   taskDefinitionLabel,
+  taskPanelActiveItemKey,
   taskRunLabel,
 } from "./task-panel-controller.js";
 import type { TaskPanelDefinition } from "./task-panel-types.js";
@@ -26,6 +27,23 @@ function run(id: string, patch: Partial<TaskRecord> = {}): TaskRecord {
     ...patch,
   };
 }
+
+test("maps selected log streams to their single visual task item", () => {
+  assert.equal(taskPanelActiveItemKey(undefined), undefined);
+  assert.equal(taskPanelActiveItemKey(run("adhoc")), "adhoc");
+  assert.equal(
+    taskPanelActiveItemKey(
+      run("definition-run", { definitionId: "taskdef_a" }),
+    ),
+    "taskdef_a",
+  );
+  assert.equal(
+    taskPanelActiveItemKey(
+      run("restarted-run", { restartRootTaskId: "original-run" }),
+    ),
+    "restarted-run",
+  );
+});
 
 function definition(
   patch: Partial<TaskPanelDefinition> = {},

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
@@ -77,6 +77,13 @@ export function normalizeTaskDefinition(
   };
 }
 
+/** Maps the selected log stream to the single visual item that owns it. */
+export function taskPanelActiveItemKey(
+  task: TaskRecord | undefined,
+): string | undefined {
+  return task ? (task.definitionId ?? task.id) : undefined;
+}
+
 export interface TaskEntryLabel {
   readonly text: string;
   readonly isCommand: boolean;

--- a/packages/workbench-app/src/styles/components/panel.css
+++ b/packages/workbench-app/src/styles/components/panel.css
@@ -16,13 +16,8 @@
   background: color-mix(in oklab, var(--accent) 55%, transparent);
 }
 
-/* Card surface for panel list items (task groups, pull requests). Rows inside a
- * card hover with a softer tint so the composited result matches the standalone
- * row hover instead of stacking into a brighter value. */
-.panel-row-card {
-  background: color-mix(in oklab, var(--accent) 35%, transparent);
-}
-
+/* ItemSurface owns the card background. Rows inside a panel card hover with a
+ * softer tint so the composited result matches a standalone row. */
 .panel-row-card .panel-row-hoverable:hover {
   background: color-mix(in oklab, var(--accent) 38%, transparent);
 }


### PR DESCRIPTION
## Summary
- add reusable item surface, collection, and shadowed scroll-region primitives
- animate a primary outline between active projects, conversations, and opened task logs, including no-active states
- migrate project, task, pull request, and scratch-note surfaces for consistent context menus, hover behavior, scrolling affordances, and improved light-mode contrast

## Validation
- `pnpm fix && pnpm check && pnpm test`