### PR TITLE
Gate task outline on active log tab

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
@@ -78,7 +78,7 @@ const compacting = $derived(conversationSelectors.compacting);
 const contextUsage = $derived(conversationSelectors.activeContextUsage);
 const contextWindow = $derived(conversationSelectors.activeContextWindow);
 const tasks = $derived(taskSelectors.scopedTasks);
-const selectedTask = $derived(taskSelectors.selectedTask);
+const selectedTask = $derived(taskSelectors.activeCenterTask);
 
 $effect(() => {
   if (viewId === "files")


### PR DESCRIPTION
## Summary
- derive the Tasks panel's active item from the active center task tab
- hide task and task-definition outlines when no log-stream tab is active
- preserve definition/run outline mapping while a task log tab is open

## Validation
- `pnpm fix && pnpm check && pnpm test`