### PR TITLE
refactor(workbench): use item surface for git repo selector

### DIFF
--- a/packages/workbench-app/src/lib/presentation/git/GitRepositorySelector.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitRepositorySelector.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 import type { GitRepoSummary } from "@nervekit/contracts";
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from "@nervekit/ui-kit/components/ui/toggle-group";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import { ItemCollection, ItemSurface } from "$lib/presentation";
 import { repoButtonLabel, repoPathLabel } from "./git-change-format";
 import type { FeatureCapability } from "./git-panel-types";
 
@@ -18,29 +16,33 @@ let { repos, selectedRepo, selectCapability, onSelectRepo }: Props = $props();
 </script>
 
 {#if repos.length > 1}
-  <ToggleGroup
-    type="single"
-    value={selectedRepo}
-    variant="outline"
-    size="sm"
-    spacing={1}
+  <ItemCollection
+    activeKey={selectedRepo}
     class="flex w-full flex-wrap items-start gap-1"
-    onValueChange={(value) => {
-      if (value) onSelectRepo(value);
-    }}
   >
     {#each repos as candidate (candidate.relativePath)}
-      <ToggleGroupItem
-        value={candidate.relativePath}
-        disabled={!selectCapability.enabled}
-        aria-label={`Switch to ${repoPathLabel(candidate)}`}
-        title={repoPathLabel(candidate)}
-        class="h-6 max-w-28 min-w-0 rounded-md px-2 text-xs data-[state=on]:border-primary/40 data-[state=on]:bg-primary/10 data-[state=on]:text-primary"
+      {@const active = candidate.relativePath === selectedRepo}
+      <ItemSurface
+        itemKey={candidate.relativePath}
+        hover="soft"
+        class="min-w-0 max-w-28 overflow-hidden"
       >
-        <span class="block truncate font-mono"
-          >{repoButtonLabel(candidate, repos)}</span
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={!selectCapability.enabled}
+          pressed={active}
+          aria-current={active ? "page" : undefined}
+          aria-label={`Switch to ${repoPathLabel(candidate)}`}
+          title={repoPathLabel(candidate)}
+          class={`w-full min-w-0 rounded-md bg-transparent px-2 hover:bg-transparent dark:hover:bg-transparent ${active ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+          onclick={() => onSelectRepo(candidate.relativePath)}
         >
-      </ToggleGroupItem>
+          <span class="block truncate font-mono"
+            >{repoButtonLabel(candidate, repos)}</span
+          >
+        </Button>
+      </ItemSurface>
     {/each}
-  </ToggleGroup>
+  </ItemCollection>
 {/if}


### PR DESCRIPTION
## Summary

Refactor `GitRepositorySelector` to replace the `ToggleGroup`/`ToggleGroupItem` pattern with the shared `ItemCollection`/`ItemSurface` components (used across the workbench for active-item highlighting), wrapping each repo option in a ghost `Button`.

## Changes

- Use `ItemCollection` with `activeKey` for the repo list instead of a single-select `ToggleGroup`.
- Render each repo as an `ItemSurface` containing a ghost `Button`, with `pressed`/`aria-current` reflecting the selected repo.
- Keep existing behavior: selection callback, `selectCapability.enabled` gating, truncated mono repo labels, and `aria-label`/`title` tooltips.