### PR TITLE
chore(workbench): remove live preview limit notice from tool output

### DIFF
--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExplainImageToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ExplainImageToolView.svelte
@@ -31,11 +31,7 @@ const liveText = $derived.by(() => {
   </div>
 {:else if view.live && liveText}
   <div class="grid gap-1.5" aria-label="Live image explanation generation">
-    <ToolOutputBlock
-      text={liveText}
-      direction="tail"
-      outputLimits={view.outputLimits}
-    />
+    <ToolOutputBlock text={liveText} direction="tail" />
   </div>
 {:else if view.explanation}
   <ToolOutputBlock text={view.explanation} direction="head" />

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PythonToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PythonToolView.svelte
@@ -28,7 +28,6 @@ const inlineCodeIsMultiline = $derived(
         text={view.output}
         direction="tail"
         {expanded}
-        outputLimits={view.outputLimits}
         terminal
       />
     </section>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolOutputBlock.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolOutputBlock.svelte
@@ -12,14 +12,6 @@ type Props = {
   direction?: "head" | "tail";
   collapsedLines?: number;
   expanded?: boolean;
-  outputLimits?: {
-    live?: {
-      capped?: boolean;
-      omittedChars?: number;
-      displayedLines?: number;
-      displayedChars?: number;
-    };
-  };
   terminal?: boolean;
 };
 let {
@@ -28,7 +20,6 @@ let {
   direction = "head",
   collapsedLines = COLLAPSED_LINES,
   expanded = false,
-  outputLimits,
   terminal = false,
 }: Props = $props();
 
@@ -40,15 +31,6 @@ const visible = $derived.by(() => {
   return lines.slice(0, collapsedLines).join("\n");
 });
 </script>
-
-{#if outputLimits?.live?.capped}
-  <p class="m-0 text-xs text-muted-foreground">
-    Showing latest
-    {outputLimits.live.displayedLines ?? 0} lines / {outputLimits.live
-      .displayedChars ?? 0} chars;
-    {outputLimits.live.omittedChars ?? 0} earlier chars omitted from live preview.
-  </p>
-{/if}
 
 <ResultCodeBlock
   code={visible}


### PR DESCRIPTION
## Summary
Removes the redundant "Showing latest X lines / Y chars; Z earlier chars omitted from live preview." line from tool output previews. The live preview visibly shows only the most recent lines, so the notice was noise.

## Changes
- **ToolOutputBlock.svelte**: removed the `outputLimits` prop and the `{#if outputLimits?.live?.capped}` notice paragraph.
- **ExplainImageToolView.svelte**: dropped the now-unused `outputLimits={view.outputLimits}` attribute (the visible case in the screenshot).
- **PythonToolView.svelte**: dropped the same dead attribute — it used the same shared block and rendered an identical line.
- Bash tool needed no change (it never passed `outputLimits`, so it never rendered the notice).

## Kept intentionally
- The small "live tail" status chip and the underlying `outputLimits` data remain, since other consumers (status meta) still use them.

## Validation
`pnpm fix && pnpm check && pnpm test` all pass (svelte-check 0 errors; all suites green).