### PR TITLE
Polish git repository controls and stash drop confirmation

### DIFF
--- a/packages/workbench-app/src/lib/presentation/git/GitRepositoryControls.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitRepositoryControls.svelte
@@ -47,15 +47,15 @@ let {
 </script>
 
 <div class="flex shrink-0 flex-col gap-1.5 pt-1.5">
+  <GitRepositorySelector
+    {repos}
+    {selectedRepo}
+    selectCapability={capabilities.selectRepository}
+    {onSelectRepo}
+  />
+
   {#if repoSummary}
     {@const repo = repoSummary}
-    <GitRepositorySelector
-      {repos}
-      {selectedRepo}
-      selectCapability={capabilities.selectRepository}
-      {onSelectRepo}
-    />
-
     <button
       type="button"
       disabled={!capabilities.branches.enabled}
@@ -99,7 +99,5 @@ let {
       {onSwitchBranch}
       {onCreateBranch}
     />
-  {:else}
-    <p class="text-xs text-muted-foreground">Loading…</p>
   {/if}
 </div>

--- a/packages/workbench-app/src/lib/presentation/git/GitStashDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitStashDialog.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { GitStashEntry } from "@nervekit/contracts";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
-import ConfirmDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
 import { ItemScrollRegion } from "$lib/presentation/items";
 import GitStashRow from "./GitStashRow.svelte";
@@ -27,16 +26,34 @@ let {
 
 let dropCandidate = $state<GitStashEntry>();
 const busy = $derived(Boolean(mutation));
+
+function confirmDrop(): void {
+  const candidate = dropCandidate;
+  if (!candidate) return;
+  dropCandidate = undefined;
+  onDrop(candidate);
+}
 </script>
 
 <Dialog
   bind:open
   flush
-  title="Stashes"
-  description={`Saved changes for ${repositoryName}`}
+  title={dropCandidate ? "Drop stash?" : "Stashes"}
+  description={dropCandidate
+    ? "This action cannot be undone."
+    : `Saved changes for ${repositoryName}`}
   size="md"
+  onOpenChange={(next) => {
+    if (!next) dropCandidate = undefined;
+  }}
 >
-  {#if stashes.length === 0}
+  {#if dropCandidate}
+    <p class="p-4 text-sm text-muted-foreground">
+      This permanently removes
+      <span class="font-mono text-foreground">{dropCandidate.ref}</span>:
+      {dropCandidate.message}
+    </p>
+  {:else if stashes.length === 0}
     <p class="p-8 text-center text-sm text-muted-foreground">
       No stashes in this repository.
     </p>
@@ -65,27 +82,19 @@ const busy = $derived(Boolean(mutation));
   {/if}
 
   {#snippet footer()}
-    <Button size="sm" variant="ghost" onclick={() => (open = false)}>
-      Close
-    </Button>
+    {#if dropCandidate}
+      <Button
+        size="sm"
+        variant="ghost"
+        onclick={() => (dropCandidate = undefined)}>Cancel</Button
+      >
+      <Button size="sm" variant="destructive" onclick={confirmDrop}
+        >Drop stash</Button
+      >
+    {:else}
+      <Button size="sm" variant="ghost" onclick={() => (open = false)}>
+        Close
+      </Button>
+    {/if}
   {/snippet}
 </Dialog>
-
-<ConfirmDialog
-  open={Boolean(dropCandidate)}
-  title="Drop stash?"
-  description={dropCandidate
-    ? `This permanently removes ${dropCandidate.ref}: ${dropCandidate.message}`
-    : "This permanently removes the selected stash."}
-  confirmLabel="Drop stash"
-  destructive
-  onConfirm={() => {
-    const candidate = dropCandidate;
-    dropCandidate = undefined;
-    if (candidate) onDrop(candidate);
-  }}
-  onCancel={() => (dropCandidate = undefined)}
-  onOpenChange={(next) => {
-    if (!next) dropCandidate = undefined;
-  }}
-/>


### PR DESCRIPTION
## Summary

Two small UX polish changes to the workbench git UI:

- **`GitRepositoryControls.svelte`** — the repository selector now renders immediately instead of waiting on the repo summary, so the picker is always available even while summary data is loading (the temporary "Loading…" fallback was removed).
- **`GitStashDialog.svelte`** — replacing the separate `ConfirmDialog` used for dropping a stash with an in-dialog confirmation state. The dialog title/description switch to a "Drop stash?" confirmation with Cancel / Drop stash footer actions, keeping the destructive action in context and removing one dialog layer.

## Notes

- `pnpm --filter @nervekit/workbench-app check` (svelte-check) passes with 0 errors/warnings; eslint clean on both files.