### PR TITLE
Show dialogs for critical external action failures

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/WorkbenchShellContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/WorkbenchShellContainer.svelte
@@ -21,6 +21,7 @@ import {
 } from "$lib/app/shell/shell-layout.svelte";
 import { createWorkbenchGitPanelAdapter } from "$lib/features/git";
 import BrowserNotificationPrompt from "$lib/features/notifications/BrowserNotificationPrompt.svelte";
+import CriticalErrorDialog from "$lib/features/notifications/CriticalErrorDialog.svelte";
 import { OnboardingHost } from "$lib/features/onboarding";
 import { workspaceSelectors } from "$lib/features/workspace";
 
@@ -87,6 +88,7 @@ $effect(() => {
   {#snippet statusBar()}<StatusBarContainer />{/snippet}
   {#snippet overlays()}
     <BrowserNotificationPrompt />
+    <CriticalErrorDialog />
     <OnboardingHost />
     <DesktopShutdownOverlay />
   {/snippet}

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -53,6 +53,10 @@ import {
   fileTreeGitDecoration,
   indexFileTreeGitDecorations,
 } from "$lib/features/filesystem/state/file-git-status";
+import {
+  errorDetails,
+  showCriticalError,
+} from "$lib/features/notifications/critical-errors.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import {
   PanelBanner,
@@ -169,9 +173,12 @@ async function runNativeAction(
       relativePath: entry.path,
     });
   } catch (caught) {
-    notify.error("Could not open project entry", {
-      description: caught instanceof Error ? caught.message : String(caught),
-    });
+    showCriticalError(
+      action === "openProjectEntry"
+        ? "Could not open project entry"
+        : "Could not reveal project entry",
+      errorDetails(caught),
+    );
   }
 }
 
@@ -233,9 +240,7 @@ async function movePendingToTrash(): Promise<void> {
     ]);
     notify.success("Moved to trash");
   } catch (caught) {
-    notify.error("Could not move entry to trash", {
-      description: caught instanceof Error ? caught.message : String(caught),
-    });
+    showCriticalError("Could not move entry to trash", errorDetails(caught));
   } finally {
     pendingTrash = undefined;
   }

--- a/packages/workbench-app/src/lib/features/git/components/PrShell.svelte
+++ b/packages/workbench-app/src/lib/features/git/components/PrShell.svelte
@@ -19,6 +19,10 @@ import {
   selectPrMergeMethod,
   selectPrTab,
 } from "$lib/features/git/state/pr-tabs.svelte";
+import {
+  errorDetails,
+  showCriticalError,
+} from "$lib/features/notifications/critical-errors.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 
 const activeCenterPrView = $derived(gitSelectors.activeCenterPrView);
@@ -32,9 +36,7 @@ async function checkoutActivePr() {
     invalidateGit(view.projectId);
     void refreshPrPane(view.id);
   } catch (caught) {
-    notify.error("Could not check out pull request", {
-      description: caught instanceof Error ? caught.message : String(caught),
-    });
+    showCriticalError("Could not check out pull request", errorDetails(caught));
   }
 }
 
@@ -62,7 +64,7 @@ async function mergeActivePr(method: GithubPrMergeMethod) {
   } catch (caught) {
     const message = caught instanceof Error ? caught.message : String(caught);
     view.mergeError = message;
-    notify.error("Could not merge pull request", { description: message });
+    showCriticalError("Could not merge pull request", message);
   } finally {
     view.merging = false;
   }
@@ -79,8 +81,16 @@ function retrySection(
 ): void {
   const view = activeCenterPrView;
   if (!view) return;
-  if (section === "core") void loadPrCore(view, { force: true });
-  else void loadPrSection(view, section, { force: true });
+  if (section === "core")
+    void loadPrCore(view, {
+      force: true,
+      criticalErrorTitle: "Could not load pull request",
+    });
+  else
+    void loadPrSection(view, section, {
+      force: true,
+      criticalErrorTitle: "Could not load pull request section",
+    });
 }
 
 $effect(() => {

--- a/packages/workbench-app/src/lib/features/git/state/diff-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/diff-tabs.svelte.ts
@@ -5,7 +5,7 @@ import {
   gitState,
   type DiffViewState,
 } from "$lib/features/git/state/git-state.svelte";
-import { notify } from "$lib/features/notifications/notify.svelte";
+import { showCriticalError } from "$lib/features/notifications/critical-errors.svelte";
 import {
   addCenterTab,
   nextCenterTabAfterClose,
@@ -28,7 +28,10 @@ function addDiffTab(id: string): void {
   addCenterTab({ kind: "diff", id });
 }
 
-async function loadDiffView(view: DiffViewState): Promise<void> {
+async function loadDiffView(
+  view: DiffViewState,
+  critical = false,
+): Promise<void> {
   const initial = !view.data;
   if (initial) view.loading = true;
   else view.refreshing = true;
@@ -45,7 +48,7 @@ async function loadDiffView(view: DiffViewState): Promise<void> {
   } catch (caught) {
     const message = caught instanceof Error ? caught.message : String(caught);
     view.error = message;
-    notify.error("Could not load diff", { description: message });
+    if (critical) showCriticalError("Could not load diff", message);
   } finally {
     view.loading = false;
     view.refreshing = false;
@@ -74,7 +77,7 @@ export async function openDiffPane(input: {
   };
   addDiffTab(id);
   setActiveCenterTab({ kind: "diff", id });
-  await loadDiffView(gitState.diffViews[key]);
+  await loadDiffView(gitState.diffViews[key], true);
 }
 
 export async function selectCenterDiffTab(id: string): Promise<void> {
@@ -87,7 +90,7 @@ export async function selectCenterDiffTab(id: string): Promise<void> {
 
 export async function refreshDiffPane(id: string): Promise<void> {
   const view = gitState.diffViews[diffViewKey(id)];
-  if (view && !view.loading && !view.refreshing) await loadDiffView(view);
+  if (view && !view.loading && !view.refreshing) await loadDiffView(view, true);
 }
 
 export function closeDiffTab(id: string): void {

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-mutations.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-mutations.svelte.ts
@@ -19,6 +19,10 @@ import {
   syncGitBranch,
   unstageGitFile,
 } from "$lib/api";
+import {
+  errorDetails,
+  showCriticalError,
+} from "$lib/features/notifications/critical-errors.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import { gitFilesInScope, gitPathspecs } from "$lib/presentation";
 import {
@@ -27,7 +31,6 @@ import {
 } from "./git-panel-refresh.svelte";
 import {
   ensureGitRepoState,
-  errorMessage,
   mergeRepoSummary,
   setBranchesIfChanged,
 } from "./git-panel-state.svelte";
@@ -40,7 +43,7 @@ function refreshAfterRemoteMutation(projectId: string, repo: string): void {
 }
 
 function notifyGitFailure(title: string, error: unknown): void {
-  notify.error(title, { description: errorMessage(error) });
+  showCriticalError(title, errorDetails(error));
 }
 
 export async function fetchGitRepo(

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
@@ -14,6 +14,7 @@ import {
 } from "$lib/core/state/state-keys";
 import { queryClient, queryKeys } from "$lib/core/query";
 import { hasPendingPrChecks } from "$lib/features/git/checks";
+import { showCriticalError } from "$lib/features/notifications/critical-errors.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import {
   GitAutoRefreshScheduler,
@@ -204,14 +205,31 @@ export async function refreshGitProject(
         ? { silent: true, onlyIfChanged: true }
         : {};
       await Promise.all([
-        refreshGitOverview(project.id, state.selectedRepo, refreshOptions),
-        refreshGithub(project.id, state.selectedRepo),
-        refreshPrs(project.id, state.selectedRepo, true, false, true),
+        refreshGitOverview(project.id, state.selectedRepo, {
+          ...refreshOptions,
+          criticalErrorTitle: options.criticalErrorTitle,
+        }),
+        refreshGithub(
+          project.id,
+          state.selectedRepo,
+          false,
+          options.criticalErrorTitle,
+        ),
+        refreshPrs(
+          project.id,
+          state.selectedRepo,
+          !options.criticalErrorTitle,
+          false,
+          true,
+          options.criticalErrorTitle,
+        ),
       ]);
     }
   } catch (error) {
     if (state.requestSeq !== requestSeq) return;
     state.discoverError = errorMessage(error);
+    if (options.criticalErrorTitle)
+      showCriticalError(options.criticalErrorTitle, state.discoverError);
     if (!state.loaded) setProjectRepos(state, []);
   } finally {
     if (state.requestSeq === requestSeq) {
@@ -271,8 +289,10 @@ export async function refreshGitOverview(
     patchGitOverviewState(state, next);
   } catch (error) {
     state.overviewInvalidated = true;
-    if (!options.silent)
-      notify.error(`Git overview failed: ${errorMessage(error)}`);
+    const details = errorMessage(error);
+    if (options.criticalErrorTitle)
+      showCriticalError(options.criticalErrorTitle, details);
+    else if (!options.silent) notify.error(`Git overview failed: ${details}`);
   } finally {
     if (state.requestSeq === requestSeq) {
       if (!options.silent) state.loadingOverview = false;
@@ -295,6 +315,7 @@ export async function refreshGitOverview(
 export async function refreshBranches(
   projectId: string,
   repo: string,
+  criticalErrorTitle?: string,
 ): Promise<void> {
   const state = ensureGitRepoState(projectId, repo);
   state.loadingBranches = true;
@@ -306,7 +327,9 @@ export async function refreshBranches(
     });
     setBranchesIfChanged(state, result.branches);
   } catch (error) {
-    notify.error(`Could not list branches: ${errorMessage(error)}`);
+    const details = errorMessage(error);
+    if (criticalErrorTitle) showCriticalError(criticalErrorTitle, details);
+    else notify.error(`Could not list branches: ${details}`);
   } finally {
     state.loadingBranches = false;
   }
@@ -316,6 +339,7 @@ export async function refreshGithub(
   projectId: string,
   repo: string,
   force = false,
+  criticalErrorTitle?: string,
 ): Promise<void> {
   const state = ensureGitRepoState(projectId, repo);
   if (!repoHasGithubRemote(projectId, repo)) {
@@ -336,9 +360,21 @@ export async function refreshGithub(
     setGithubStatusIfChanged(state, status);
     applyGitContextFromProject(projectId);
     if (status.authenticated) {
-      await refreshPrs(projectId, repo, true, force);
+      await refreshPrs(
+        projectId,
+        repo,
+        !criticalErrorTitle,
+        force,
+        Boolean(criticalErrorTitle),
+        criticalErrorTitle,
+      );
     } else {
       setPrsIfChanged(state, []);
+      if (criticalErrorTitle)
+        showCriticalError(
+          criticalErrorTitle,
+          status.reason ?? "GitHub authentication is required.",
+        );
     }
   } catch (error) {
     setGithubStatusIfChanged(state, {
@@ -349,6 +385,8 @@ export async function refreshGithub(
     });
     setPrsIfChanged(state, []);
     applyGitContextFromProject(projectId);
+    if (criticalErrorTitle)
+      showCriticalError(criticalErrorTitle, errorMessage(error));
   }
 }
 
@@ -376,6 +414,7 @@ export async function refreshPrs(
   silent = false,
   force = false,
   showLoading = !silent,
+  criticalErrorTitle?: string,
 ): Promise<void> {
   const state = ensureGitRepoState(projectId, repo);
   if (!repoHasGithubRemote(projectId, repo)) {
@@ -437,9 +476,13 @@ export async function refreshPrs(
             state.prsLoadedAt = Date.now();
           }
         } catch (error) {
-          if (state.prsRequestSeq === requestSeq && !nextSilent) {
-            state.prsError = errorMessage(error);
-            notify.error(`Could not list PRs: ${state.prsError}`);
+          if (state.prsRequestSeq === requestSeq) {
+            const details = errorMessage(error);
+            if (!nextSilent) state.prsError = details;
+            if (criticalErrorTitle)
+              showCriticalError(criticalErrorTitle, details);
+            else if (!nextSilent)
+              notify.error(`Could not list PRs: ${details}`);
           }
         }
         nextForce = state.prsRefreshQueued;

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
@@ -158,6 +158,7 @@ export type GitPanelRefreshOptions = {
   force?: boolean;
   onlyIfChanged?: boolean;
   loadDetails?: boolean;
+  criticalErrorTitle?: string;
 };
 
 function createOperationsState(): GitPanelOperationsState {

--- a/packages/workbench-app/src/lib/features/git/state/git-refresh-coordinator.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-refresh-coordinator.svelte.ts
@@ -21,6 +21,7 @@ import {
   getGithubPrOverview,
 } from "$lib/api";
 import { queryClient, queryKeys } from "$lib/core/query";
+import { showCriticalError } from "$lib/features/notifications/critical-errors.svelte";
 import { prViewKey } from "$lib/core/state/state-keys";
 import {
   gitState,
@@ -40,7 +41,11 @@ export const PR_CONVERSATION_STALE_MS = 60_000;
 const IMMUTABLE_HEAD_STALE_MS = Number.POSITIVE_INFINITY;
 const PR_DETAIL_CACHE_MS = 5 * 60_000;
 
-type LoadOptions = { force?: boolean; silent?: boolean };
+type LoadOptions = {
+  force?: boolean;
+  silent?: boolean;
+  criticalErrorTitle?: string;
+};
 type Section = "conversation" | "overview" | "commits" | "checks" | "files";
 
 const resourceRequests = new SvelteMap<string, Promise<unknown>>();
@@ -118,11 +123,14 @@ async function fetchResource<T>(input: {
       }
       return data;
     } catch (error) {
+      const details = message(error);
       if (
         ownsResource(input.key, version) &&
         (!input.options?.silent || !hadData)
       )
-        input.resource.error = message(error);
+        input.resource.error = details;
+      if (input.options?.criticalErrorTitle)
+        showCriticalError(input.options.criticalErrorTitle, details);
       return undefined;
     } finally {
       if (ownsResource(input.key, version)) {
@@ -343,6 +351,8 @@ export async function loadPrInitial(
       return data;
     } catch (error) {
       const errorMessage = message(error);
+      if (options.criticalErrorTitle)
+        showCriticalError(options.criticalErrorTitle, errorMessage);
       for (const [resource, key, version] of [
         [view.core, coreKey, versions.core],
         [view.conversation, conversationKey, versions.conversation],
@@ -515,7 +525,10 @@ export async function refreshCurrentPr(view: PrViewState): Promise<void> {
   const previousBaseOid = view.core.data?.baseRefOid;
   const previousHeadOid = view.core.data?.headRefOid;
   try {
-    await loadPrCore(view, { force: true });
+    await loadPrCore(view, {
+      force: true,
+      criticalErrorTitle: "Could not refresh pull request",
+    });
     const refsChanged =
       Boolean(previousBaseOid && previousHeadOid) &&
       Boolean(view.core.data?.baseRefOid && view.core.data?.headRefOid) &&
@@ -534,7 +547,12 @@ export async function refreshCurrentPr(view: PrViewState): Promise<void> {
         ? ["conversation", "overview", "checks"]
         : [view.activeTab];
     await Promise.all(
-      sections.map((section) => loadPrSection(view, section, { force: true })),
+      sections.map((section) =>
+        loadPrSection(view, section, {
+          force: true,
+          criticalErrorTitle: "Could not refresh pull request",
+        }),
+      ),
     );
     view.refreshError =
       view.core.error ??

--- a/packages/workbench-app/src/lib/features/git/state/pr-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/pr-tabs.svelte.ts
@@ -65,7 +65,10 @@ function addPrTab(id: string): void {
   addCenterTab({ kind: "pr", id });
 }
 
-async function ensurePrView(view: PrViewState): Promise<void> {
+async function ensurePrView(
+  view: PrViewState,
+  criticalErrorTitle?: string,
+): Promise<void> {
   if (
     view.activeTab === "conversation" &&
     (!view.core.data || !view.conversation.data || !view.overview.data)
@@ -74,11 +77,15 @@ async function ensurePrView(view: PrViewState): Promise<void> {
       silent: Boolean(
         view.core.data || view.conversation.data || view.overview.data,
       ),
+      criticalErrorTitle,
     });
     if (initial) demandPrTab(view);
     return;
   }
-  await loadPrCore(view, { silent: Boolean(view.core.data) });
+  await loadPrCore(view, {
+    silent: Boolean(view.core.data),
+    criticalErrorTitle,
+  });
   demandPrTab(view);
 }
 
@@ -130,7 +137,7 @@ export async function openPrPane(input: {
   if (summary && !view.checks.data)
     view.checks.data = { checks: summary.checks };
   setActiveCenterTab({ kind: "pr", id });
-  await ensurePrView(view);
+  await ensurePrView(view, "Could not open pull request");
 }
 
 export async function selectCenterPrTab(id: string): Promise<void> {
@@ -158,6 +165,9 @@ export function selectPrTab(
   const view = gitState.prViews[prViewKey(id)];
   if (!view) return;
   view.activeTab = tab;
+  void loadPrSection(view, tab, {
+    criticalErrorTitle: "Could not load pull request section",
+  });
   demandPrTab(view);
 }
 
@@ -171,7 +181,10 @@ export function selectPrFile(id: string, path: string): void {
 export function retrySelectedPrFile(id: string): void {
   const view = gitState.prViews[prViewKey(id)];
   if (view?.selectedFilePath)
-    void loadPrFileDiff(view, view.selectedFilePath, { force: true });
+    void loadPrFileDiff(view, view.selectedFilePath, {
+      force: true,
+      criticalErrorTitle: "Could not load pull request file",
+    });
 }
 
 export function selectPrMergeMethod(

--- a/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
@@ -156,26 +156,51 @@ export function createWorkbenchGitPanelAdapter(
   const host: GitPanelActions = {
     refreshAll: () => {
       const project = activeProject();
-      if (project) return refreshGitProject(project, { force: true });
+      if (project)
+        return refreshGitProject(project, {
+          force: true,
+          criticalErrorTitle: "Could not refresh Git repositories",
+        });
     },
     refreshRepository: async (repository) => {
       const project = activeProject();
       if (project)
         await Promise.all([
-          refreshGitOverview(project.id, repository, { force: true }),
-          refreshGithub(project.id, repository, true),
+          refreshGitOverview(project.id, repository, {
+            force: true,
+            criticalErrorTitle: "Could not refresh repository",
+          }),
+          refreshGithub(
+            project.id,
+            repository,
+            true,
+            "Could not refresh repository",
+          ),
         ]);
     },
     refreshBranches: (repository) => {
       const project = activeProject();
-      if (project) return refreshBranches(project.id, repository);
+      if (project)
+        return refreshBranches(
+          project.id,
+          repository,
+          "Could not refresh branches",
+        );
     },
     refreshPullRequests: async (repository) => {
       const project = activeProject();
       if (project)
         await Promise.all([
-          refreshGitOverview(project.id, repository, { force: true }),
-          refreshGithub(project.id, repository, true),
+          refreshGitOverview(project.id, repository, {
+            force: true,
+            criticalErrorTitle: "Could not refresh pull requests",
+          }),
+          refreshGithub(
+            project.id,
+            repository,
+            true,
+            "Could not refresh pull requests",
+          ),
         ]);
     },
     configurePullRequests: (repository, filters) => {
@@ -188,7 +213,14 @@ export function createWorkbenchGitPanelAdapter(
       if (!state) return;
       state.prFilters = normalizeGitPrFilterConfig(filters);
       savePrFilters(project.id, repository, state.prFilters);
-      return refreshPrs(project.id, repository, false, true);
+      return refreshPrs(
+        project.id,
+        repository,
+        false,
+        true,
+        true,
+        "Could not apply pull request filters",
+      );
     },
     resetPullRequestConfig: (repository) => {
       const project = activeProject();
@@ -200,7 +232,14 @@ export function createWorkbenchGitPanelAdapter(
       if (!state) return;
       state.prFilters = defaultGitPrFilterConfig;
       savePrFilters(project.id, repository, state.prFilters);
-      return refreshPrs(project.id, repository, false, true);
+      return refreshPrs(
+        project.id,
+        repository,
+        false,
+        true,
+        true,
+        "Could not reset pull request filters",
+      );
     },
     selectRepository: (repository) => {
       const project = activeProject();

--- a/packages/workbench-app/src/lib/features/notifications/CriticalErrorDialog.svelte
+++ b/packages/workbench-app/src/lib/features/notifications/CriticalErrorDialog.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import * as AlertDialog from "@nervekit/ui-kit/components/ui/alert-dialog";
+import {
+  acknowledgeCriticalError,
+  criticalErrorState,
+} from "./critical-errors.svelte";
+
+const open = $derived(Boolean(criticalErrorState.current));
+</script>
+
+<AlertDialog.Root
+  {open}
+  onOpenChange={(next) => {
+    if (!next && !criticalErrorState.current) return;
+  }}
+>
+  <AlertDialog.Content
+    onEscapeKeydown={(event) => event.preventDefault()}
+    onInteractOutside={(event) => event.preventDefault()}
+  >
+    <AlertDialog.Header>
+      <AlertDialog.Title>{criticalErrorState.current?.title}</AlertDialog.Title>
+      <AlertDialog.Description class="whitespace-pre-wrap break-words">
+        {criticalErrorState.current?.details}
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+    <AlertDialog.Footer>
+      <AlertDialog.Action size="sm" onclick={acknowledgeCriticalError}>
+        OK
+      </AlertDialog.Action>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>

--- a/packages/workbench-app/src/lib/features/notifications/critical-error-queue.ts
+++ b/packages/workbench-app/src/lib/features/notifications/critical-error-queue.ts
@@ -1,0 +1,47 @@
+export type CriticalErrorRequest = {
+  id: number;
+  title: string;
+  details: string;
+};
+
+export class CriticalErrorQueue {
+  current?: CriticalErrorRequest;
+  queue: CriticalErrorRequest[] = [];
+  private nextId = 1;
+
+  show(title: string, details: string): void {
+    const normalizedDetails = details.trim() || "An unknown error occurred.";
+    const existing =
+      this.current?.title === title
+        ? this.current
+        : this.queue.find((request) => request.title === title);
+    if (existing) {
+      if (!existing.details.split("\n\n").includes(normalizedDetails))
+        existing.details += `\n\n${normalizedDetails}`;
+      return;
+    }
+    const request = {
+      id: this.nextId++,
+      title,
+      details: normalizedDetails,
+    };
+    if (!this.current) this.current = request;
+    else this.queue.push(request);
+  }
+
+  acknowledge(): void {
+    this.current = this.queue.shift();
+  }
+
+  reset(): void {
+    this.current = undefined;
+    this.queue = [];
+    this.nextId = 1;
+  }
+}
+
+export function errorDetails(error: unknown): string {
+  if (error instanceof Error) return error.message || error.name;
+  const details = String(error);
+  return details.trim() || "An unknown error occurred.";
+}

--- a/packages/workbench-app/src/lib/features/notifications/critical-errors.svelte.ts
+++ b/packages/workbench-app/src/lib/features/notifications/critical-errors.svelte.ts
@@ -1,0 +1,18 @@
+import { CriticalErrorQueue, errorDetails } from "./critical-error-queue";
+
+export { errorDetails };
+export type { CriticalErrorRequest } from "./critical-error-queue";
+
+export const criticalErrorState = $state(new CriticalErrorQueue());
+
+export function showCriticalError(title: string, details: string): void {
+  criticalErrorState.show(title, details);
+}
+
+export function acknowledgeCriticalError(): void {
+  criticalErrorState.acknowledge();
+}
+
+export function resetCriticalErrors(): void {
+  criticalErrorState.reset();
+}

--- a/packages/workbench-app/src/lib/features/notifications/critical-errors.test.ts
+++ b/packages/workbench-app/src/lib/features/notifications/critical-errors.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CriticalErrorQueue, errorDetails } from "./critical-error-queue";
+
+describe("critical error queue", () => {
+  it("keeps the active error until it is acknowledged", () => {
+    const errors = new CriticalErrorQueue();
+    errors.show("First failed", "first details");
+    errors.show("Second failed", "second details");
+
+    assert.equal(errors.current?.title, "First failed");
+    assert.equal(errors.queue.length, 1);
+
+    errors.acknowledge();
+    assert.equal(errors.current?.title, "Second failed");
+    errors.acknowledge();
+    assert.equal(errors.current, undefined);
+  });
+
+  it("coalesces errors for the same explicit action", () => {
+    const errors = new CriticalErrorQueue();
+    errors.show("Failed", "first details");
+    errors.show("Failed", "second details");
+    errors.show("Failed", "first details");
+    errors.show("Other", "other details");
+    errors.show("Other", "more details");
+
+    assert.equal(errors.current?.title, "Failed");
+    assert.equal(errors.current?.details, "first details\n\nsecond details");
+    assert.deepEqual(
+      errors.queue.map((request) => request.title),
+      ["Other"],
+    );
+    assert.equal(errors.queue[0]?.details, "other details\n\nmore details");
+  });
+
+  it("normalizes empty and unknown error details", () => {
+    assert.equal(
+      errorDetails(new Error("network unavailable")),
+      "network unavailable",
+    );
+    assert.equal(errorDetails(""), "An unknown error occurred.");
+  });
+});

--- a/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
@@ -11,6 +11,7 @@ import type {
 } from "@nervekit/contracts";
 import { writeClipboardText } from "$lib/core/clipboard";
 import { onEvent } from "$lib/core/events/event-bus";
+import { showCriticalError } from "$lib/features/notifications/critical-errors.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import {
   getTaskLogs,
@@ -165,7 +166,7 @@ export function createWorkbenchTaskPanelAdapter(
           { description: definition.label ?? definition.command },
         );
       } catch (error) {
-        notify.error(`Could not run task: ${errorMessage(error)}`);
+        showCriticalError("Could not run task", errorMessage(error));
       } finally {
         runningDefinitionId = undefined;
       }


### PR DESCRIPTION
## Summary
- add a global FIFO, deduplicating critical-error dialog with an OK-only acknowledgement flow
- surface failures from explicit Git/GitHub actions, task launches, and desktop OS integrations
- keep startup, polling, prefetch, clipboard, and other best-effort failures non-blocking
- preserve inline resource errors and cached data while clearly reporting failed manual refreshes

## Validation
- `pnpm fix && pnpm check && pnpm test`
