### PR TITLE
Fix local Markdown link navigation

### DIFF
--- a/packages/desktop-shell/src/window/navigation-guards.ts
+++ b/packages/desktop-shell/src/window/navigation-guards.ts
@@ -1,51 +1,58 @@
 import type { BrowserWindowType } from "../electron.js";
 import { shell } from "../electron.js";
 
+export type NavigationTarget = "daemon-root" | "external" | "blocked";
+
+/** Classify document navigation without granting every daemon-origin path app access. */
+export function classifyNavigationTarget(
+  rawUrl: string,
+  daemonUrl: string | undefined,
+): NavigationTarget {
+  try {
+    const url = new URL(rawUrl);
+    if (daemonUrl) {
+      const daemon = new URL(daemonUrl);
+      if (url.origin === daemon.origin) {
+        return url.pathname === "/" ? "daemon-root" : "blocked";
+      }
+    }
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? "external"
+      : "blocked";
+  } catch {
+    return "blocked";
+  }
+}
+
 export function installNavigationGuards(
   window: BrowserWindowType,
   getDaemonUrl: () => string | undefined,
   isTrustedShellUrl: (url: string) => boolean = () => false,
 ): void {
   window.webContents.setWindowOpenHandler(({ url }) => {
-    if (isAllowedDaemonUrl(url, getDaemonUrl())) void window.loadURL(url);
-    else openExternallyIfSafe(url);
+    const target = classifyNavigationTarget(url, getDaemonUrl());
+    if (target === "daemon-root") void window.loadURL(url);
+    else if (target === "external") openExternally(url);
     return { action: "deny" };
   });
 
   window.webContents.on("will-navigate", (event, url) => {
-    if (isTrustedShellUrl(url) || isAllowedDaemonUrl(url, getDaemonUrl()))
-      return;
+    if (isTrustedShellUrl(url)) return;
+    const target = classifyNavigationTarget(url, getDaemonUrl());
+    if (target === "daemon-root") return;
     event.preventDefault();
-    openExternallyIfSafe(url);
+    if (target === "external") openExternally(url);
   });
 
   window.webContents.on("will-redirect", (event, url) => {
-    if (isTrustedShellUrl(url) || isAllowedDaemonUrl(url, getDaemonUrl()))
-      return;
+    if (isTrustedShellUrl(url)) return;
+    const target = classifyNavigationTarget(url, getDaemonUrl());
+    if (target === "daemon-root") return;
     event.preventDefault();
-    openExternallyIfSafe(url);
+    if (target === "external") openExternally(url);
   });
 }
 
-function isAllowedDaemonUrl(
-  rawUrl: string,
-  daemonUrl: string | undefined,
-): boolean {
-  if (!daemonUrl) return false;
-  try {
-    return new URL(rawUrl).origin === new URL(daemonUrl).origin;
-  } catch {
-    return false;
-  }
-}
-
-function openExternallyIfSafe(rawUrl: string): void {
-  try {
-    const url = new URL(rawUrl);
-    if (url.protocol === "http:" || url.protocol === "https:") {
-      void shell.openExternal(url.toString());
-    }
-  } catch {
-    // Ignore malformed navigation targets.
-  }
+function openExternally(rawUrl: string): void {
+  void shell.openExternal(rawUrl);
 }

--- a/packages/desktop-shell/test/navigation-guards.test.ts
+++ b/packages/desktop-shell/test/navigation-guards.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classifyNavigationTarget } from "../src/window/navigation-guards.js";
+
+const daemonUrl = "http://127.0.0.1:3747";
+
+describe("classifyNavigationTarget", () => {
+  it("allows only the daemon application root", () => {
+    assert.equal(classifyNavigationTarget(daemonUrl, daemonUrl), "daemon-root");
+    assert.equal(
+      classifyNavigationTarget(`${daemonUrl}/?zoom=1#workspace`, daemonUrl),
+      "daemon-root",
+    );
+    assert.equal(
+      classifyNavigationTarget(`${daemonUrl}/LICENSE`, daemonUrl),
+      "blocked",
+    );
+    assert.equal(
+      classifyNavigationTarget(`${daemonUrl}/settings`, daemonUrl),
+      "blocked",
+    );
+  });
+
+  it("opens safe cross-origin web URLs externally", () => {
+    assert.equal(
+      classifyNavigationTarget("https://example.test/docs", daemonUrl),
+      "external",
+    );
+    assert.equal(
+      classifyNavigationTarget("http://example.test/docs", daemonUrl),
+      "external",
+    );
+    assert.equal(
+      classifyNavigationTarget("https://example.test/docs", undefined),
+      "external",
+    );
+  });
+
+  it("blocks malformed URLs and unsafe protocols", () => {
+    for (const url of [
+      "LICENSE",
+      "not a URL",
+      "file:///tmp/README.md",
+      "data:text/html,hello",
+      "javascript:alert(1)",
+    ]) {
+      assert.equal(classifyNavigationTarget(url, daemonUrl), "blocked", url);
+    }
+  });
+});

--- a/packages/ui-kit/src/lib/core/utils/path-links.test.ts
+++ b/packages/ui-kit/src/lib/core/utils/path-links.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  localPathDirectory,
   parseLocalFileHref,
   resolveDisplayPath,
   splitPathLineSuffix,
@@ -42,6 +43,22 @@ describe("path link helpers", () => {
     ]) {
       assert.equal(parseLocalFileHref(href), undefined);
     }
+  });
+
+  it("finds local containing directories across path styles", () => {
+    assert.equal(localPathDirectory("README.md"), ".");
+    assert.equal(localPathDirectory("docs/guide.md"), "docs");
+    assert.equal(localPathDirectory("/repo/README.md"), "/repo");
+    assert.equal(localPathDirectory("/README.md"), "/");
+    assert.equal(
+      localPathDirectory("C:\\Users\\me\\repo\\README.md"),
+      "C:\\Users\\me\\repo",
+    );
+    assert.equal(localPathDirectory("C:\\README.md"), "C:\\");
+    assert.equal(
+      localPathDirectory("\\\\server\\share\\README.md"),
+      "\\\\server\\share",
+    );
   });
 
   it("splits line suffixes without treating drive letters as lines", () => {

--- a/packages/ui-kit/src/lib/core/utils/path-links.ts
+++ b/packages/ui-kit/src/lib/core/utils/path-links.ts
@@ -90,6 +90,22 @@ export function resolveDisplayPath(
   return joinLocalPath(cwd, clean);
 }
 
+/** Return the containing directory while preserving native path separators. */
+export function localPathDirectory(path: string): string {
+  const value = trimTrailingSeparators(path.trim());
+  if (!value) return ".";
+
+  const slash = value.lastIndexOf("/");
+  const backslash = value.lastIndexOf("\\");
+  const index = Math.max(slash, backslash);
+  if (index < 0) return ".";
+  if (index === 0) return value[0] ?? ".";
+  if (index === 2 && WINDOWS_DRIVE_PREFIX.test(value.slice(0, 2))) {
+    return value.slice(0, 3);
+  }
+  return value.slice(0, index);
+}
+
 function decodePathComponent(path: string): string | undefined {
   try {
     return decodeURIComponent(path);

--- a/packages/workbench-app/src/lib/features/filesystem/components/FileShell.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FileShell.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
 import { FilePane } from "$lib/presentation/components/file";
+import { openFilePane } from "$lib/features/filesystem/state/file-tabs.svelte";
 import { fileSelectors } from "$lib/features/filesystem/state/file-selectors.svelte";
 
 const activeCenterFileView = $derived(fileSelectors.activeCenterFileView);
+
+function openLinkedFile(path: string, line?: number): void {
+  if (!activeCenterFileView) return;
+  void openFilePane({
+    projectId: activeCenterFileView.projectId,
+    path,
+    line,
+  });
+}
 </script>
 
-<FilePane view={activeCenterFileView} />
+<FilePane view={activeCenterFileView} onOpenFile={openLinkedFile} />

--- a/packages/workbench-app/src/lib/presentation/components/file/FilePane.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/file/FilePane.svelte
@@ -10,7 +10,13 @@ import { CodeMirrorViewer } from "$lib/presentation/components/code";
 import { resolveFilePaneModel } from "./file-pane-model.js";
 import type { FilePaneViewModel } from "./types.js";
 
-let { view }: { view?: FilePaneViewModel } = $props();
+let {
+  view,
+  onOpenFile,
+}: {
+  view?: FilePaneViewModel;
+  onOpenFile?: (path: string, line?: number) => void;
+} = $props();
 
 const resolved = $derived(view ? resolveFilePaneModel(view) : undefined);
 const file = $derived(view?.content);
@@ -106,6 +112,8 @@ const showMermaidPreview = $derived(
           <Markdown
             text={file.text ?? ""}
             trimCodeBlocks={false}
+            linkBasePath={resolved.linkBasePath}
+            {onOpenFile}
             onCopy={(ok) => notifyCopyResult(ok, "code block")}
           />
         </div>

--- a/packages/workbench-app/src/lib/presentation/components/file/file-pane-model.test.ts
+++ b/packages/workbench-app/src/lib/presentation/components/file/file-pane-model.test.ts
@@ -29,6 +29,17 @@ describe("resolveFilePaneModel", () => {
     assert.equal(mermaid.displayMode, "rendered");
   });
 
+  it("resolves Markdown links from the loaded file directory", () => {
+    assert.equal(
+      resolveFilePaneModel(view("/repo/docs/guide.md")).linkBasePath,
+      "/repo/docs",
+    );
+    assert.equal(
+      resolveFilePaneModel(view("C:\\repo\\docs\\guide.md")).linkBasePath,
+      "C:\\repo\\docs",
+    );
+  });
+
   it("keeps ordinary and line-targeted files in code view", () => {
     const text = resolveFilePaneModel(view("notes.txt"));
     assert.equal(text.renderKind, undefined);

--- a/packages/workbench-app/src/lib/presentation/components/file/file-pane-model.ts
+++ b/packages/workbench-app/src/lib/presentation/components/file/file-pane-model.ts
@@ -4,10 +4,12 @@ import {
   type FileDisplayMode,
   type FileRenderKind,
 } from "@nervekit/ui-kit/core/utils/file-display";
+import { localPathDirectory } from "@nervekit/ui-kit/core/utils/path-links";
 import type { FilePaneViewModel } from "./types.js";
 
 export type ResolvedFilePaneModel = {
   filePath: string;
+  linkBasePath: string;
   renderKind?: FileRenderKind;
   lineStart: number;
   targetLine?: number;
@@ -44,6 +46,7 @@ export function resolveFilePaneModel(
 
   return {
     filePath,
+    linkBasePath: localPathDirectory(file?.path ?? view.path),
     renderKind: fileRenderKind(filePath),
     lineStart: file?.lineStart ?? 1,
     targetLine,


### PR DESCRIPTION
## Summary
- open local Markdown links in workbench file tabs and resolve them relative to the current file
- support POSIX, Windows, and UNC containing-directory paths
- block same-origin non-root navigation in the Electron window while preserving external HTTP(S) links
- add path-resolution and desktop navigation policy tests

## Validation
- `pnpm fix && pnpm check && pnpm test`