### PR TITLE
Improve file viewer navigation and references

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller-types.ts
+++ b/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller-types.ts
@@ -83,6 +83,10 @@ export type VirtualScrollerProps<T> = {
   viewportAriaLabel?: string;
   /** Class applied to the scrolling viewport element. */
   viewportClass?: string;
+  /** Allows the viewport and generated rows to overflow horizontally. */
+  horizontalScroll?: boolean;
+  /** Class applied to each generated virtual row. */
+  rowClass?: string;
   /** Class applied to the inner sized spacer element. */
   class?: string;
   /** Row renderer. */

--- a/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller.svelte
+++ b/packages/ui-kit/src/lib/components/ui/virtual-list/virtual-scroller.svelte
@@ -41,6 +41,8 @@ let {
   viewportTabIndex,
   viewportAriaLabel,
   viewportClass,
+  horizontalScroll = false,
+  rowClass,
   class: className,
   row,
 }: VirtualScrollerProps<T> = $props();
@@ -386,7 +388,11 @@ $effect(() => {
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
   bind:this={viewportEl}
-  class={cn("virtual-scroller-viewport", viewportClass)}
+  class={cn(
+    "virtual-scroller-viewport",
+    horizontalScroll && "virtual-scroller-horizontal",
+    viewportClass,
+  )}
   role={viewportAriaLabel ? "region" : undefined}
   tabindex={viewportTabIndex}
   aria-label={viewportAriaLabel}
@@ -401,7 +407,7 @@ $effect(() => {
       {@const item = items[virtualRow.index]}
       {#if item !== undefined}
         <div
-          class="virtual-scroller-row"
+          class={cn("virtual-scroller-row", rowClass)}
           class:cv-auto={contentVisibility}
           data-index={virtualRow.index}
           data-item-key={rendered.encodedItemKey}
@@ -429,6 +435,10 @@ $effect(() => {
   overflow-x: hidden;
   overflow-y: auto;
   overflow-anchor: none;
+}
+
+.virtual-scroller-viewport.virtual-scroller-horizontal {
+  overflow-x: auto;
 }
 
 .virtual-scroller-spacer {

--- a/packages/workbench-app/package.json
+++ b/packages/workbench-app/package.json
@@ -55,6 +55,7 @@
     "@nervekit/protocol": "workspace:*",
     "@nervekit/ui-kit": "workspace:*",
     "@replit/codemirror-lang-svelte": "^6.0.0",
+    "@replit/codemirror-minimap": "^0.5.2",
     "@tailwindcss/vite": "4.3.1",
     "@tanstack/svelte-query": "6.0.0",
     "@xyflow/svelte": "1.6.2",

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -16,7 +16,9 @@ import type {
   FilesystemProjectEntry,
   GitProjectFileStatus,
 } from "@nervekit/contracts";
-import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
+import ContextMenuList, {
+  type ContextMenuItem,
+} from "@nervekit/ui-kit/components/ui/context-menu-list";
 import ConfirmDialog from "@nervekit/ui-kit/components/ui/confirm-dialog";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import { cn } from "@nervekit/ui-kit/core/utils";
@@ -59,6 +61,11 @@ import {
 } from "$lib/features/notifications/critical-errors.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import {
+  formatProjectEntryReference,
+  PROJECT_ENTRY_DRAG_MIME,
+  serializeProjectEntryDrag,
+} from "$lib/presentation/dnd/project-entry-drag";
+import {
   PanelBanner,
   PanelEmpty,
   PanelHeader,
@@ -71,6 +78,7 @@ import MaterialFileIcon from "./MaterialFileIcon.svelte";
 import {
   absoluteProjectPath,
   buildFileExplorerMenu,
+  buildProjectRootMenu,
 } from "./file-explorer-menu";
 
 let { activeProject }: { activeProject?: ProjectRecord } = $props();
@@ -95,6 +103,16 @@ const activeRelativePath = $derived.by(() => {
   if (!file || file.projectId !== activeProject?.id) return undefined;
   return file.content?.relativePath ?? file.path;
 });
+const rootEntry = $derived<FilesystemProjectEntry | undefined>(
+  activeProject
+    ? {
+        name: activeProject.name,
+        path: "",
+        kind: "directory",
+        symlink: false,
+      }
+    : undefined,
+);
 const busy = $derived(
   Object.values(project?.directories ?? {}).some(
     (directory) => directory.loading || directory.refreshing,
@@ -103,6 +121,29 @@ const busy = $derived(
 
 function itemPath(item: FileExplorerTreeItem): string | undefined {
   return item.type === "entry" ? item.entry.path : undefined;
+}
+
+function isDraggableEntry(item: FileExplorerTreeItem): boolean {
+  return (
+    item.type === "entry" &&
+    (item.entry.kind === "file" || item.entry.kind === "directory")
+  );
+}
+
+function startEntryDrag(event: DragEvent, item: FileExplorerTreeItem): void {
+  if (
+    item.type !== "entry" ||
+    (item.entry.kind !== "file" && item.entry.kind !== "directory") ||
+    !event.dataTransfer
+  )
+    return;
+  const entry = { path: item.entry.path, kind: item.entry.kind } as const;
+  event.dataTransfer.setData(
+    PROJECT_ENTRY_DRAG_MIME,
+    serializeProjectEntryDrag([entry]),
+  );
+  event.dataTransfer.setData("text/plain", formatProjectEntryReference(entry));
+  event.dataTransfer.effectAllowed = "copy";
 }
 
 function activate(item: FileExplorerTreeItem): void {
@@ -246,6 +287,30 @@ async function movePendingToTrash(): Promise<void> {
   }
 }
 
+function rootMenu(): ContextMenuItem[] {
+  const entry = rootEntry;
+  if (!activeProject || !entry) return [];
+  return buildProjectRootMenu(
+    {
+      createFile: () => requestCreate("file", entry),
+      createFolder: () => requestCreate("directory", entry),
+      openDefault: () => void runNativeAction("openProjectEntry", entry),
+      reveal: () => void runNativeAction("revealProjectEntry", entry),
+      copyPath: () => void copyPath(activeProject.dir, "path"),
+    },
+    desktopRuntime.isDesktop,
+    {
+      open: ArrowRight,
+      copy: Copy,
+      openDefault: ExternalLink,
+      newFile: FilePlus,
+      reveal: FolderOpen,
+      newFolder: FolderPlus,
+      trash: Trash2,
+    },
+  );
+}
+
 function itemMenu(item: FileExplorerTreeItem): ContextMenuItem[] {
   if (item.type !== "entry" || !activeProject) return [];
   const entry = item.entry;
@@ -344,70 +409,80 @@ $effect(() => {
         />
       {/snippet}
     </PanelEmpty>
-  {:else if root.entries.length === 0}
-    <PanelEmpty icon={Folder} title="This project is empty" />
   {:else if project}
-    <PanelTree
-      {nodes}
-      ariaLabel={`${activeProject.name} files`}
-      virtualized
-      showDisclosure={false}
-      expandedIds={project.expandedIds}
-      getItemTitle={(item) =>
-        item.type === "entry"
-          ? item.entry.path
-          : item.type === "error"
-            ? item.message
-            : "Load more files"}
-      getItemSelected={(item) => itemPath(item) === activeRelativePath}
-      getItemTone={(item) =>
-        item.type === "entry"
-          ? fileTreeGitDecoration(gitDecorations, item.entry.path)?.tone
-          : undefined}
-      getItemMenuItems={itemMenu}
-      onItemActivate={activate}
-      onItemExpansionChange={(item, expanded) =>
-        setFileExplorerItemExpanded(activeProject.id, item, expanded)}
+    <ContextMenuList
+      items={rootMenu()}
+      triggerClass="flex min-h-0 flex-1 flex-col"
     >
-      {#snippet itemLeading(item)}
-        {#if item.type === "entry"}
-          {@const open = project.expandedIds.has(
-            fileExplorerEntryNodeId(activeProject.id, item.entry.path),
-          )}
-          <MaterialFileIcon
-            name={item.entry.name}
-            kind={item.entry.kind}
-            {open}
-          />
-          {#if item.entry.symlink}
-            <Link class="size-2.5" aria-hidden="true" />
-          {/if}
-          {#if item.entry.kind === "directory" && project.directories[item.entry.path]?.loading}
-            <Spinner class="ml-0.5 size-3" />
-          {/if}
-        {:else if item.type === "error"}
-          <TriangleAlert class="size-3.5 text-destructive" aria-hidden="true" />
-        {/if}
-      {/snippet}
-      {#snippet itemBadges(item)}
-        {#if item.type === "entry" && item.entry.kind === "file"}
-          {@const decoration = fileTreeGitDecoration(
-            gitDecorations,
-            item.entry.path,
-          )}
-          {#if decoration?.label}
-            <span
-              class={cn(
-                "w-3 text-center text-xs font-medium",
-                decoration.class,
+      {#if root.entries.length === 0}
+        <PanelEmpty icon={Folder} title="This project is empty" />
+      {:else}
+        <PanelTree
+          {nodes}
+          ariaLabel={`${activeProject.name} files`}
+          virtualized
+          horizontalScroll
+          showDisclosure={false}
+          expandedIds={project.expandedIds}
+          getItemTitle={(item) =>
+            item.type === "entry"
+              ? item.entry.path
+              : item.type === "error"
+                ? item.message
+                : "Load more files"}
+          getItemSelected={(item) => itemPath(item) === activeRelativePath}
+          getItemDraggable={isDraggableEntry}
+          onItemDragStart={startEntryDrag}
+          getItemTone={(item) =>
+            item.type === "entry"
+              ? fileTreeGitDecoration(gitDecorations, item.entry.path)?.tone
+              : undefined}
+          getItemMenuItems={itemMenu}
+          onItemActivate={activate}
+          onItemExpansionChange={(item, expanded) =>
+            setFileExplorerItemExpanded(activeProject.id, item, expanded)}
+        >
+          {#snippet itemLeading(item)}
+            {#if item.type === "entry"}
+              {@const open = project.expandedIds.has(
+                fileExplorerEntryNodeId(activeProject.id, item.entry.path),
               )}
-              title={decoration.title}
-              aria-label={decoration.title}>{decoration.label}</span
-            >
-          {/if}
-        {/if}
-      {/snippet}
-    </PanelTree>
+              <MaterialFileIcon
+                name={item.entry.name}
+                kind={item.entry.kind}
+                {open}
+              />
+              {#if item.entry.symlink}
+                <Link class="size-2.5" aria-hidden="true" />
+              {/if}
+            {:else if item.type === "error"}
+              <TriangleAlert
+                class="size-3.5 text-destructive"
+                aria-hidden="true"
+              />
+            {/if}
+          {/snippet}
+          {#snippet itemBadges(item)}
+            {#if item.type === "entry" && item.entry.kind === "file"}
+              {@const decoration = fileTreeGitDecoration(
+                gitDecorations,
+                item.entry.path,
+              )}
+              {#if decoration?.label}
+                <span
+                  class={cn(
+                    "w-3 text-center text-xs font-medium",
+                    decoration.class,
+                  )}
+                  title={decoration.title}
+                  aria-label={decoration.title}>{decoration.label}</span
+                >
+              {/if}
+            {/if}
+          {/snippet}
+        </PanelTree>
+      {/if}
+    </ContextMenuList>
   {/if}
 </PanelView>
 

--- a/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.test.ts
@@ -4,6 +4,7 @@ import type { FilesystemProjectEntry } from "@nervekit/contracts";
 import {
   absoluteProjectPath,
   buildFileExplorerMenu,
+  buildProjectRootMenu,
   type FileExplorerMenuActions,
   type FileExplorerMenuIcons,
 } from "./file-explorer-menu";
@@ -57,6 +58,19 @@ describe("file explorer menus", () => {
     assert.ok(labels(directory, false).includes("New File"));
     assert.ok(labels(directory, true).includes("Open in Default Application"));
     assert.ok(labels(directory, true).includes("Move to Trash"));
+  });
+
+  it("offers root operations without destructive or relative-path actions", () => {
+    const rootLabels = buildProjectRootMenu(actions, true, icons).flatMap(
+      (item) => ("label" in item ? [item.label] : []),
+    );
+    assert.deepEqual(rootLabels, [
+      "New File",
+      "New Folder",
+      "Open in Default Application",
+      "Reveal in File Manager",
+      "Copy Path",
+    ]);
   });
 
   it("constructs platform display paths without duplicate separators", () => {

--- a/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.ts
@@ -14,6 +14,14 @@ export type FileExplorerMenuIcons = {
   trash: MenuIcon;
 };
 
+export type ProjectRootMenuActions = {
+  createFile: () => void;
+  createFolder: () => void;
+  openDefault: () => void;
+  reveal: () => void;
+  copyPath: () => void;
+};
+
 export type FileExplorerMenuActions = {
   open: () => void;
   createFile: () => void;
@@ -40,6 +48,41 @@ export function absoluteProjectPath(
   return base.endsWith(separator)
     ? `${base}${normalizedRelative}`
     : `${base}${separator}${normalizedRelative}`;
+}
+
+export function buildProjectRootMenu(
+  actions: ProjectRootMenuActions,
+  nativeActions: boolean,
+  icons: FileExplorerMenuIcons,
+): ContextMenuItem[] {
+  const items: ContextMenuItem[] = [
+    { label: "New File", icon: icons.newFile, onSelect: actions.createFile },
+    {
+      label: "New Folder",
+      icon: icons.newFolder,
+      onSelect: actions.createFolder,
+    },
+  ];
+  if (nativeActions) {
+    items.push(
+      { type: "separator" },
+      {
+        label: "Open in Default Application",
+        icon: icons.openDefault,
+        onSelect: actions.openDefault,
+      },
+      {
+        label: "Reveal in File Manager",
+        icon: icons.reveal,
+        onSelect: actions.reveal,
+      },
+    );
+  }
+  items.push(
+    { type: "separator" },
+    { label: "Copy Path", icon: icons.copy, onSelect: actions.copyPath },
+  );
+  return items;
 }
 
 export function buildFileExplorerMenu(

--- a/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorViewer.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorViewer.svelte
@@ -7,6 +7,7 @@ import {
   loadCodeLanguage,
   localLineNumber,
   readOnlyCodeExtensions,
+  shouldShowCodeMinimap,
 } from "./code-mirror-config";
 
 type Props = {
@@ -56,7 +57,11 @@ async function renderEditor(): Promise<void> {
   if (!host || currentGeneration !== generation) return;
 
   const baseExtensions: Extension[] = [
-    ...readOnlyCodeExtensions({ lineStart, ariaLabel }),
+    ...readOnlyCodeExtensions({
+      lineStart,
+      ariaLabel,
+      minimap: shouldShowCodeMinimap(text, wrap),
+    }),
     languageExtension,
     wrap ? EditorView.lineWrapping : [],
   ];

--- a/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.test.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.test.ts
@@ -7,6 +7,7 @@ import {
   codeLanguageId,
   loadCodeLanguage,
   localLineNumber,
+  shouldShowCodeMinimap,
 } from "./code-mirror-config";
 
 const newLanguageIds: CodeLanguageId[] = [
@@ -66,6 +67,16 @@ describe("CodeMirror viewer helpers", () => {
       const tree = await ensureSyntaxTree(state, doc.length, 10_000);
       assert.equal(tree?.length, doc.length, id);
     }
+  });
+
+  it("shows the minimap only for long, unwrapped documents", () => {
+    const lines = (count: number) =>
+      Array.from({ length: count }, () => "x").join("\n");
+
+    assert.equal(shouldShowCodeMinimap(lines(100), false), false);
+    assert.equal(shouldShowCodeMinimap(lines(101), false), true);
+    assert.equal(shouldShowCodeMinimap(lines(101), true), false);
+    assert.equal(shouldShowCodeMinimap("", false), false);
   });
 
   it("maps external lines into a windowed document", () => {

--- a/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.ts
@@ -12,6 +12,7 @@ import {
   lineNumbers,
 } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
+import { showMinimap } from "@replit/codemirror-minimap";
 
 export type CodeLanguageId =
   | "javascript"
@@ -273,15 +274,15 @@ export const codeMirrorTheme = EditorView.theme({
     caretColor: "var(--primary)",
   },
   ".cm-line": {
-    padding: "0 calc(var(--spacing) * 4)",
+    padding: "0 calc(var(--spacing) * 4) 0 calc(var(--spacing) * 2)",
   },
   ".cm-gutters": {
     backgroundColor: "var(--background)",
     color: "var(--muted-foreground)",
-    borderRight: "1px solid var(--border)",
+    borderRight: "none",
   },
   ".cm-lineNumbers .cm-gutterElement": {
-    padding: "0 calc(var(--spacing) * 3)",
+    padding: "0 calc(var(--spacing) * 2)",
   },
   "&.cm-focused": { outline: "none" },
   "&.cm-focused .cm-cursor": { borderLeftColor: "var(--primary)" },
@@ -299,11 +300,47 @@ export const codeMirrorTheme = EditorView.theme({
     color: "var(--foreground)",
     backgroundColor: "var(--card)",
   },
+  ".cm-minimap-gutter": {
+    backgroundColor: "var(--background)",
+    borderLeft: "1px solid var(--border)",
+  },
+  ".cm-minimap-overlay": {
+    backgroundColor: "var(--primary)",
+  },
+  ".cm-minimap-box-shadow": {
+    boxShadow: "none",
+  },
 });
+
+const CODE_MINIMAP_LINE_THRESHOLD = 100;
+
+export function shouldShowCodeMinimap(text: string, wrap: boolean): boolean {
+  if (wrap) return false;
+  let lines = 1;
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) === 10) lines += 1;
+    if (lines > CODE_MINIMAP_LINE_THRESHOLD) return true;
+  }
+  return false;
+}
+
+function codeMinimapExtension(): Extension {
+  return showMinimap.of({
+    create: () => {
+      const dom = document.createElement("div");
+      dom.setAttribute("aria-label", "Code minimap");
+      dom.title = "Code minimap";
+      return { dom };
+    },
+    displayText: "blocks",
+    showOverlay: "always",
+  });
+}
 
 export function readOnlyCodeExtensions(input: {
   lineStart?: number;
   ariaLabel: string;
+  minimap?: boolean;
 }): Extension[] {
   const lineStart = input.lineStart ?? 1;
   return [
@@ -314,6 +351,7 @@ export function readOnlyCodeExtensions(input: {
     highlightSpecialChars(),
     drawSelection(),
     syntaxHighlighting(codeHighlightStyle),
+    input.minimap ? codeMinimapExtension() : [],
     codeMirrorTheme,
   ];
 }

--- a/packages/workbench-app/src/lib/presentation/components/code/index.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/index.ts
@@ -5,4 +5,5 @@ export {
   loadCodeLanguage,
   localLineNumber,
   readOnlyCodeExtensions,
+  shouldShowCodeMinimap,
 } from "./code-mirror-config.js";

--- a/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ComposerEditor.svelte
@@ -21,6 +21,12 @@ import {
   type ViewUpdate,
 } from "@codemirror/view";
 import type { CompletionItem } from "@nervekit/contracts";
+import {
+  formatProjectEntryReferences,
+  hasProjectEntryDragType,
+  parseProjectEntryDrag,
+  PROJECT_ENTRY_DRAG_MIME,
+} from "$lib/presentation/dnd/project-entry-drag";
 import { executableCommandBlockHighlighter } from "./composer-command-blocks";
 import {
   bestFileCompletionSelector,
@@ -124,7 +130,7 @@ function insertDroppedPaths(
   insertAtRange(`${leadingSpace}${paths.join(" ")}${trailingSpace}`, from, to);
 }
 
-function hasFileItems(dataTransfer: DataTransfer | null): boolean {
+function hasNativeFileItems(dataTransfer: DataTransfer | null): boolean {
   if (!dataTransfer) return false;
   return (
     Array.from(dataTransfer.items).some((item) => item.kind === "file") ||
@@ -132,8 +138,18 @@ function hasFileItems(dataTransfer: DataTransfer | null): boolean {
   );
 }
 
+function hasProjectEntryItems(dataTransfer: DataTransfer | null): boolean {
+  return Boolean(
+    dataTransfer && hasProjectEntryDragType(Array.from(dataTransfer.types)),
+  );
+}
+
 function canHandleFileDrag(event: DragEvent): boolean {
-  return Boolean(!disabled && onDropFiles && hasFileItems(event.dataTransfer));
+  if (disabled) return false;
+  return (
+    hasProjectEntryItems(event.dataTransfer) ||
+    Boolean(onDropFiles && hasNativeFileItems(event.dataTransfer))
+  );
 }
 
 function handleFileDragEnter(event: DragEvent): void {
@@ -160,15 +176,25 @@ function handleFileDragLeave(event: DragEvent): void {
 }
 
 function handleFileDrop(event: DragEvent): void {
-  if (!canHandleFileDrag(event) || !onDropFiles || !view) return;
+  if (!canHandleFileDrag(event) || !view) return;
   event.preventDefault();
   event.stopPropagation();
   fileDragDepth = 0;
   fileDragActive = false;
 
+  const { from, to } = view.state.selection.main;
+  const internalPayload = event.dataTransfer?.getData(PROJECT_ENTRY_DRAG_MIME);
+  if (internalPayload) {
+    const entries = parseProjectEntryDrag(internalPayload);
+    if (entries) {
+      insertDroppedPaths(formatProjectEntryReferences(entries), { from, to });
+    }
+    return;
+  }
+
+  if (!onDropFiles) return;
   const files = Array.from(event.dataTransfer?.files ?? []);
   if (files.length === 0) return;
-  const { from, to } = view.state.selection.main;
   void onDropFiles(files)
     .then((paths) => insertDroppedPaths(paths, { from, to }))
     .catch((error: unknown) => {

--- a/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.test.ts
+++ b/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  PROJECT_ENTRY_DRAG_MIME,
+  formatProjectEntryReference,
+  formatProjectEntryReferences,
+  hasProjectEntryDragType,
+  parseProjectEntryDrag,
+  serializeProjectEntryDrag,
+  type ProjectEntryDragItem,
+} from "./project-entry-drag";
+
+const entries: ProjectEntryDragItem[] = [
+  { path: "src/main.ts", kind: "file" },
+  { path: "src/components", kind: "directory" },
+];
+
+describe("project entry drag payload", () => {
+  it("round-trips entries in order", () => {
+    assert.deepEqual(
+      parseProjectEntryDrag(serializeProjectEntryDrag(entries)),
+      entries,
+    );
+  });
+
+  it("formats file and directory references", () => {
+    assert.deepEqual(formatProjectEntryReferences(entries), [
+      "@src/main.ts",
+      "@src/components/",
+    ]);
+  });
+
+  it("quotes whitespace and escapes quotes", () => {
+    assert.equal(
+      formatProjectEntryReference({
+        path: "docs/design notes.md",
+        kind: "file",
+      }),
+      '"@docs/design notes.md"',
+    );
+    assert.equal(
+      formatProjectEntryReference({
+        path: 'docs/a "draft"',
+        kind: "directory",
+      }),
+      '"@docs/a \\"draft\\"/"',
+    );
+  });
+
+  it("rejects malformed and unsafe payloads", () => {
+    assert.equal(parseProjectEntryDrag("not-json"), undefined);
+    assert.equal(
+      parseProjectEntryDrag(JSON.stringify({ version: 2, entries })),
+      undefined,
+    );
+    for (const path of [
+      "",
+      "/etc/passwd",
+      "../secret",
+      "src/../secret",
+      "C:\\secret",
+    ])
+      assert.equal(
+        parseProjectEntryDrag(
+          JSON.stringify({ version: 1, entries: [{ path, kind: "file" }] }),
+        ),
+        undefined,
+      );
+    assert.equal(
+      parseProjectEntryDrag(
+        JSON.stringify({
+          version: 1,
+          entries: [{ path: "src", kind: "other" }],
+        }),
+      ),
+      undefined,
+    );
+  });
+
+  it("recognizes the custom MIME type", () => {
+    assert.equal(
+      hasProjectEntryDragType(["text/plain", PROJECT_ENTRY_DRAG_MIME]),
+      true,
+    );
+    assert.equal(hasProjectEntryDragType(["Files"]), false);
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.ts
+++ b/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.ts
@@ -1,0 +1,81 @@
+export const PROJECT_ENTRY_DRAG_MIME = "application/x-nerve-project-entries";
+
+export type ProjectEntryDragItem = {
+  path: string;
+  kind: "file" | "directory";
+};
+
+type ProjectEntryDragPayload = {
+  version: 1;
+  entries: readonly ProjectEntryDragItem[];
+};
+
+function isRelativeProjectPath(path: string): boolean {
+  if (!path || path.startsWith("/") || path.startsWith("\\")) return false;
+  if (/^[a-zA-Z]:[\\/]/.test(path)) return false;
+  const segments = path.replaceAll("\\", "/").split("/");
+  return segments.every(
+    (segment) => segment !== "" && segment !== "." && segment !== "..",
+  );
+}
+
+function isProjectEntryDragItem(value: unknown): value is ProjectEntryDragItem {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<ProjectEntryDragItem>;
+  return (
+    (item.kind === "file" || item.kind === "directory") &&
+    typeof item.path === "string" &&
+    isRelativeProjectPath(item.path)
+  );
+}
+
+export function serializeProjectEntryDrag(
+  entries: readonly ProjectEntryDragItem[],
+): string {
+  if (entries.length === 0 || !entries.every(isProjectEntryDragItem)) {
+    throw new Error("Project entry drag payload contains invalid entries.");
+  }
+  return JSON.stringify({
+    version: 1,
+    entries,
+  } satisfies ProjectEntryDragPayload);
+}
+
+export function parseProjectEntryDrag(
+  value: string,
+): ProjectEntryDragItem[] | undefined {
+  if (!value) return undefined;
+  try {
+    const payload = JSON.parse(value) as Partial<ProjectEntryDragPayload>;
+    if (
+      payload.version !== 1 ||
+      !Array.isArray(payload.entries) ||
+      payload.entries.length === 0 ||
+      !payload.entries.every(isProjectEntryDragItem)
+    ) {
+      return undefined;
+    }
+    return payload.entries;
+  } catch {
+    return undefined;
+  }
+}
+
+export function hasProjectEntryDragType(types: readonly string[]): boolean {
+  return types.includes(PROJECT_ENTRY_DRAG_MIME);
+}
+
+export function formatProjectEntryReference(
+  entry: ProjectEntryDragItem,
+): string {
+  const normalizedPath = entry.path.replaceAll("\\", "/");
+  const reference = `@${normalizedPath}${entry.kind === "directory" ? "/" : ""}`;
+  if (!/[\s"]/.test(reference)) return reference;
+  return `"${reference.replaceAll('"', '\\"')}"`;
+}
+
+export function formatProjectEntryReferences(
+  entries: readonly ProjectEntryDragItem[],
+): string[] {
+  return entries.map(formatProjectEntryReference);
+}

--- a/packages/workbench-app/src/lib/presentation/git/CodeMirrorGitDiff.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/CodeMirrorGitDiff.svelte
@@ -6,6 +6,7 @@ import { onDestroy } from "svelte";
 import {
   loadCodeLanguage,
   readOnlyCodeExtensions,
+  shouldShowCodeMinimap,
 } from "$lib/presentation/components/code";
 
 type Props = {
@@ -46,7 +47,10 @@ async function renderDiff(): Promise<void> {
   const state = EditorState.create({
     doc: modified,
     extensions: [
-      ...readOnlyCodeExtensions({ ariaLabel: `Diff for ${path}` }),
+      ...readOnlyCodeExtensions({
+        ariaLabel: `Diff for ${path}`,
+        minimap: shouldShowCodeMinimap(modified, false),
+      }),
       language,
       unifiedMergeView({
         original,

--- a/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelRow.svelte
@@ -42,6 +42,9 @@ let {
   ariaPosInSet,
   ariaSetSize,
   dataId,
+  draggable,
+  ondragstart,
+  ondragend,
   onkeydown,
   onfocus,
   leading,
@@ -98,6 +101,9 @@ let {
   ariaSetSize?: number;
   /** Stable DOM lookup key for composite widgets such as trees. */
   dataId?: string;
+  draggable?: boolean;
+  ondragstart?: (event: DragEvent) => void;
+  ondragend?: (event: DragEvent) => void;
   onkeydown?: (event: KeyboardEvent) => void;
   onfocus?: (event: FocusEvent) => void;
   /** Compact content rendered before the primary label. */
@@ -170,6 +176,9 @@ const toneClass = $derived(
     aria-posinset={ariaPosInSet}
     aria-setsize={ariaSetSize}
     data-panel-row-id={dataId}
+    {draggable}
+    {ondragstart}
+    {ondragend}
     {onkeydown}
     {onfocus}
   >

--- a/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelTree.svelte
@@ -66,6 +66,8 @@ type Props = {
   onGroupExpansionChange?: (path: readonly string[], expanded: boolean) => void;
   /** Opt into a single fixed-height virtualized viewport for large trees. */
   virtualized?: boolean;
+  /** Allow deeply indented rows to scroll horizontally instead of clipping. */
+  horizontalScroll?: boolean;
   /** Hide item disclosure arrows when open/closed leading icons carry state. */
   showDisclosure?: boolean;
   /** Hide generated-directory chevrons when folder icons carry state. */
@@ -78,6 +80,9 @@ type Props = {
    * the same click, so selecting and disclosing stay a single gesture.
    */
   onItemActivate?: (item: T) => void;
+  getItemDraggable?: (item: T) => boolean;
+  onItemDragStart?: (event: DragEvent, item: T) => void;
+  onItemDragEnd?: (event: DragEvent, item: T) => void;
   itemLeading?: Snippet<[T]>;
   /** Inline content after the label of a stacked item row. */
   itemLabelTrailing?: Snippet<[T]>;
@@ -110,11 +115,15 @@ let {
   onItemExpansionChange,
   onGroupExpansionChange,
   virtualized = false,
+  horizontalScroll = false,
   showDisclosure = true,
   showGroupDisclosure = true,
   itemMono = false,
   itemStacked = false,
   onItemActivate,
+  getItemDraggable,
+  onItemDragStart,
+  onItemDragEnd,
   itemLeading,
   itemLabelTrailing,
   itemBadges,
@@ -303,6 +312,7 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       actions={groupActions ? renderedGroupActions : undefined}
       menuItems={getGroupMenuItems?.(node.path)}
       dense
+      class={horizontalScroll ? "w-max min-w-full" : undefined}
       alwaysShowActions={!overlayActions}
       {overlayActions}
       indent={baseIndent + row.depth}
@@ -361,7 +371,11 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       dense
       alwaysShowActions={!overlayActions}
       {overlayActions}
-      class={cn(cardClass(rowIndex), itemClass)}
+      class={cn(
+        horizontalScroll && "w-max min-w-full",
+        cardClass(rowIndex),
+        itemClass,
+      )}
       indent={baseIndent + (indentItems ? row.depth : 0)}
       role="treeitem"
       tabindex={focusedId === node.id ? 0 : -1}
@@ -371,6 +385,9 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       ariaPosInSet={row.posInSet}
       ariaSetSize={row.setSize}
       dataId={node.id}
+      draggable={getItemDraggable?.(node.value) ?? false}
+      ondragstart={(event) => onItemDragStart?.(event, node.value)}
+      ondragend={(event) => onItemDragEnd?.(event, node.value)}
       onfocus={() => (focusedId = node.id)}
       onkeydown={(event) => handleKeydown(event, node)}
       onclick={(event) => activateFromPointer(event, node)}
@@ -395,6 +412,8 @@ function handleKeydown(event: KeyboardEvent, node: PanelTreeNode<T>): void {
       estimateSize={() => 20}
       bind:controller={virtualController}
       viewportClass="h-full"
+      {horizontalScroll}
+      rowClass={horizontalScroll ? "w-max min-w-full" : undefined}
     >
       {#snippet row({ item, index })}
         {@render renderRow(item, index)}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,9 @@ importers:
       '@replit/codemirror-lang-svelte':
         specifier: ^6.0.0
         version: 6.0.0(@codemirror/autocomplete@6.20.2)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/language@6.12.4)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/javascript@1.5.4)(@lezer/lr@1.4.10)
+      '@replit/codemirror-minimap':
+        specifier: ^0.5.2
+        version: 0.5.2(@codemirror/language@6.12.4)(@codemirror/lint@6.9.6)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)
       '@tailwindcss/vite':
         specifier: 4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@24.10.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -2332,6 +2335,16 @@ packages:
       '@lezer/highlight': ^1.0.0
       '@lezer/javascript': ^1.2.0
       '@lezer/lr': ^1.0.0
+
+  '@replit/codemirror-minimap@0.5.2':
+    resolution: {integrity: sha512-eNAtpr0hOG09/5zqAQ5PkgZEb3V/MHi30zentCxiR73r+utR2m9yVMCpBmfsWbb8mWxUWhMGPiHxM5hFtnscQA==}
+    peerDependencies:
+      '@codemirror/language': ^6.9.1
+      '@codemirror/lint': ^6.4.2
+      '@codemirror/state': ^6.3.1
+      '@codemirror/view': ^6.21.3
+      '@lezer/common': ^1.1.0
+      '@lezer/highlight': ^1.1.6
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -9171,6 +9184,16 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/javascript': 1.5.4
       '@lezer/lr': 1.4.10
+
+  '@replit/codemirror-minimap@0.5.2(@codemirror/language@6.12.4)(@codemirror/lint@6.9.6)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      crelt: 1.0.6
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true


### PR DESCRIPTION
## Summary
- add horizontal scrolling and project-root context actions to the Files panel
- support dragging file and folder references from Files into the prompt composer
- tighten CodeMirror line-number spacing and add conditional minimaps to file and Git diff views
- remove the directory loading indicator that caused expansion layout shifts

## Validation
- `pnpm fix && pnpm check && pnpm test`