### PR TITLE
refactor(workbench): compact context menus with composable menu set

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-item.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-item.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import * as ContextMenu from "@nervekit/ui-kit/components/ui/context-menu";
+import type { MenuIcon } from "./context-menu-list.svelte";
+
+let {
+  label,
+  icon,
+  shortcut,
+  disabled = false,
+  destructive = false,
+  onSelect,
+  class: className,
+  children,
+}: {
+  label: string;
+  icon?: MenuIcon;
+  shortcut?: string;
+  disabled?: boolean;
+  destructive?: boolean;
+  onSelect?: () => void;
+  class?: string;
+  children?: Snippet;
+} = $props();
+</script>
+
+<ContextMenu.Item
+  variant={destructive ? "destructive" : "default"}
+  {disabled}
+  {onSelect}
+  class={className}
+>
+  <span class="grid w-4 shrink-0 place-items-center">
+    {#if icon}
+      {@const Icon = icon}
+      <Icon class="size-3.5" aria-hidden="true" />
+    {/if}
+  </span>
+  <span class="truncate">{label}</span>
+  {#if shortcut}
+    <ContextMenu.Shortcut>{shortcut}</ContextMenu.Shortcut>
+  {/if}
+  {@render children?.()}
+</ContextMenu.Item>

--- a/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-items.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-items.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import ContextMenuListItem from "./context-menu-list-item.svelte";
+import ContextMenuListLabel from "./context-menu-list-label.svelte";
+import ContextMenuListSeparator from "./context-menu-list-separator.svelte";
+import ContextMenuListSub from "./context-menu-list-sub.svelte";
+import type { ContextMenuItem } from "./context-menu-list.svelte";
+
+let { items }: { items: ContextMenuItem[] } = $props();
+</script>
+
+{#each items as item, index (index)}
+  {#if item.type === "separator"}
+    <ContextMenuListSeparator />
+  {:else if item.type === "label"}
+    <ContextMenuListLabel label={item.label} />
+  {:else if item.type === "submenu"}
+    <ContextMenuListSub
+      label={item.label}
+      icon={item.icon}
+      disabled={item.disabled}
+      items={item.items}
+    />
+  {:else}
+    <ContextMenuListItem
+      label={item.label}
+      icon={item.icon}
+      shortcut={item.shortcut}
+      disabled={item.disabled}
+      destructive={item.destructive}
+      onSelect={item.onSelect}
+    />
+  {/if}
+{/each}

--- a/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-label.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-label.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import * as ContextMenu from "@nervekit/ui-kit/components/ui/context-menu";
+
+let { label, class: className }: { label: string; class?: string } = $props();
+</script>
+
+<ContextMenu.Group>
+  <ContextMenu.GroupHeading class={className}>{label}</ContextMenu.GroupHeading>
+</ContextMenu.Group>

--- a/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-separator.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-separator.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+import * as ContextMenu from "@nervekit/ui-kit/components/ui/context-menu";
+
+let { class: className }: { class?: string } = $props();
+</script>
+
+<ContextMenu.Separator class={className} />

--- a/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-sub.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list-sub.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import * as ContextMenu from "@nervekit/ui-kit/components/ui/context-menu";
+import ContextMenuListItems from "./context-menu-list-items.svelte";
+import type { ContextMenuItem, MenuIcon } from "./context-menu-list.svelte";
+
+let {
+  label,
+  icon,
+  disabled = false,
+  items,
+  class: className,
+}: {
+  label: string;
+  icon?: MenuIcon;
+  disabled?: boolean;
+  items: ContextMenuItem[];
+  class?: string;
+} = $props();
+</script>
+
+<ContextMenu.Sub>
+  <ContextMenu.SubTrigger {disabled} class={className}>
+    <span class="grid w-4 shrink-0 place-items-center">
+      {#if icon}
+        {@const Icon = icon}
+        <Icon class="size-3.5" aria-hidden="true" />
+      {/if}
+    </span>
+    <span class="truncate">{label}</span>
+  </ContextMenu.SubTrigger>
+  <ContextMenu.SubContent>
+    <ContextMenuListItems {items} />
+  </ContextMenu.SubContent>
+</ContextMenu.Sub>

--- a/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu-list/context-menu-list.svelte
@@ -27,6 +27,7 @@ export type ContextMenuItem =
 <script lang="ts">
 import type { Snippet } from "svelte";
 import * as ContextMenu from "@nervekit/ui-kit/components/ui/context-menu";
+import ContextMenuListItems from "./context-menu-list-items.svelte";
 
 let {
   children,
@@ -44,49 +45,38 @@ let {
   disabled?: boolean;
   onOpenChange?: (open: boolean) => void;
 } = $props();
-</script>
 
-{#snippet renderItems(list: ContextMenuItem[])}
-  {#each list as item, index (index)}
-    {#if item.type === "separator"}
-      <ContextMenu.Separator />
-    {:else if item.type === "label"}
-      <ContextMenu.Group>
-        <ContextMenu.GroupHeading>{item.label}</ContextMenu.GroupHeading>
-      </ContextMenu.Group>
-    {:else if item.type === "submenu"}
-      {@const SubIcon = item.icon}
-      <ContextMenu.Sub>
-        <ContextMenu.SubTrigger disabled={item.disabled}>
-          {#if SubIcon}<SubIcon />{/if}
-          <span class="truncate">{item.label}</span>
-        </ContextMenu.SubTrigger>
-        <ContextMenu.SubContent>
-          {@render renderItems(item.items)}
-        </ContextMenu.SubContent>
-      </ContextMenu.Sub>
-    {:else}
-      {@const Icon = item.icon}
-      <ContextMenu.Item
-        variant={item.destructive ? "destructive" : "default"}
-        disabled={item.disabled}
-        onSelect={item.onSelect}
-      >
-        {#if Icon}<Icon />{/if}
-        <span class="truncate">{item.label}</span>
-        {#if item.shortcut}
-          <ContextMenu.Shortcut>{item.shortcut}</ContextMenu.Shortcut>
-        {/if}
-      </ContextMenu.Item>
-    {/if}
-  {/each}
-{/snippet}
+function assertNoEllipsis(list: ContextMenuItem[]): void {
+  if (!import.meta.env.DEV) return;
+  for (const item of list) {
+    if (item.type === "separator") continue;
+    if (item.type === "label") {
+      checkLabel(item.label);
+      continue;
+    }
+    if (item.type === "submenu") {
+      checkLabel(item.label);
+      assertNoEllipsis(item.items);
+      continue;
+    }
+    checkLabel(item.label);
+  }
+}
+
+function checkLabel(label: string): void {
+  if (label.includes("…") || label.includes("...")) {
+    console.warn(`Context menu label must not contain an ellipsis: "${label}"`);
+  }
+}
+
+$effect(() => assertNoEllipsis(items));
+</script>
 
 <ContextMenu.Root {onOpenChange}>
   <ContextMenu.Trigger class={triggerClass} {disabled}>
     {@render children()}
   </ContextMenu.Trigger>
   <ContextMenu.Content class={className}>
-    {@render renderItems(items)}
+    <ContextMenuListItems {items} />
   </ContextMenu.Content>
 </ContextMenu.Root>

--- a/packages/ui-kit/src/lib/components/ui/context-menu-list/index.ts
+++ b/packages/ui-kit/src/lib/components/ui/context-menu-list/index.ts
@@ -1,2 +1,9 @@
 export type { ContextMenuItem, MenuIcon } from "./context-menu-list.svelte";
-export { default } from "./context-menu-list.svelte";
+export {
+  default,
+  default as ContextMenuList,
+} from "./context-menu-list.svelte";
+export { default as ContextMenuListItem } from "./context-menu-list-item.svelte";
+export { default as ContextMenuListLabel } from "./context-menu-list-label.svelte";
+export { default as ContextMenuListSeparator } from "./context-menu-list-separator.svelte";
+export { default as ContextMenuListSub } from "./context-menu-list-sub.svelte";

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
@@ -25,7 +25,7 @@ let {
   data-slot="context-menu-checkbox-item"
   data-inset={inset}
   class={cn(
-    "focus:bg-accent focus:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "focus:bg-accent focus:text-accent-foreground gap-1.5 rounded-sm py-1 pr-7 pl-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-3.5 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     className,
   )}
   {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-content.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-content.svelte
@@ -22,7 +22,7 @@ let {
     bind:ref
     data-slot="context-menu-content"
     class={cn(
-      "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-md p-1 shadow-md ring-1 duration-100 z-50 overflow-x-hidden overflow-y-auto outline-none",
+      "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 border-border/80 bg-popover text-popover-foreground min-w-36 rounded-md border p-0.5 shadow-md duration-100 z-50 overflow-x-hidden overflow-y-auto outline-none",
       className,
     )}
     {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-group-heading.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-group-heading.svelte
@@ -17,7 +17,7 @@ let {
   data-slot="context-menu-group-heading"
   data-inset={inset}
   class={cn(
-    "text-foreground px-2 py-1.5 text-sm font-medium data-inset:ps-8",
+    "text-foreground px-1.5 py-1 text-sm font-medium data-inset:ps-8",
     className,
   )}
   {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-item.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-item.svelte
@@ -20,7 +20,7 @@ let {
   data-inset={inset}
   data-variant={variant}
   class={cn(
-    "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-2 rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-1.5 rounded-sm px-1.5 py-1 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-3.5 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     className,
   )}
   {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-label.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-label.svelte
@@ -18,7 +18,7 @@ let {
   data-slot="context-menu-label"
   data-inset={inset}
   class={cn(
-    "text-muted-foreground px-2 py-1.5 text-xs font-medium data-inset:pl-8 data-inset:pl-8",
+    "text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-8",
     className,
   )}
   {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
@@ -19,7 +19,7 @@ let {
   data-slot="context-menu-radio-item"
   data-inset={inset}
   class={cn(
-    "focus:bg-accent focus:text-accent-foreground gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "focus:bg-accent focus:text-accent-foreground gap-1.5 rounded-sm py-1 pr-7 pl-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-3.5 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     className,
   )}
   {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-separator.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-separator.svelte
@@ -12,6 +12,6 @@ let {
 <ContextMenuPrimitive.Separator
   bind:ref
   data-slot="context-menu-separator"
-  class={cn("bg-border -mx-1 my-1 h-px", className)}
+  class={cn("bg-border -mx-0.5 my-0.5 h-px", className)}
   {...restProps}
 />

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-shortcut.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-shortcut.svelte
@@ -14,7 +14,7 @@ let {
   bind:this={ref}
   data-slot="context-menu-shortcut"
   class={cn(
-    "text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest",
+    "text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-wide",
     className,
   )}
   {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-sub-content.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-sub-content.svelte
@@ -13,7 +13,7 @@ let {
   bind:ref
   data-slot="context-menu-sub-content"
   class={cn(
-    "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-32 rounded-md border p-1 shadow-lg duration-100",
+    "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-36 rounded-md border p-0.5 shadow-lg duration-100",
     className,
   )}
   {...restProps}

--- a/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/packages/ui-kit/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
@@ -19,11 +19,11 @@ let {
   data-slot="context-menu-sub-trigger"
   data-inset={inset}
   class={cn(
-    "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground rounded-sm px-2 py-1.5 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-inset:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground rounded-sm px-1.5 py-1 text-sm data-inset:pl-8 [&_svg:not([class*='size-'])]:size-3.5 flex cursor-default items-center outline-hidden select-none data-inset:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     className,
   )}
   {...restProps}
 >
   {@render children?.()}
-  <ChevronRightIcon class="ml-auto" />
+  <ChevronRightIcon class="ml-auto size-3.5" />
 </ContextMenuPrimitive.SubTrigger>

--- a/packages/workbench-app/src/lib/app/shell/EditorTabStripContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/EditorTabStripContainer.svelte
@@ -11,6 +11,7 @@ import MoveLeft from "@lucide/svelte/icons/move-left";
 import MoveRight from "@lucide/svelte/icons/move-right";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import Settings from "@lucide/svelte/icons/settings";
+import TextAlignStart from "@lucide/svelte/icons/text-align-start";
 import Terminal from "@lucide/svelte/icons/terminal";
 import X from "@lucide/svelte/icons/x";
 import { EditorTabStrip } from "$lib/presentation/shell";
@@ -157,13 +158,13 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
     const relativePath = source.relativePath ?? source.file?.relativePath;
     items.push(
       {
-        label: "Copy Path",
+        label: "Copy path",
         icon: Copy,
         disabled: !absolutePath,
         onSelect: () => void copyToClipboard(absolutePath, "path"),
       },
       {
-        label: "Copy Relative Path",
+        label: "Copy relative path",
         icon: Copy,
         disabled: !relativePath,
         onSelect: () => void copyToClipboard(relativePath, "relative path"),
@@ -171,7 +172,7 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
       { type: "separator" },
       {
         label: fileWrapLabel(source),
-        icon: Code2,
+        icon: TextAlignStart,
         disabled: !onToggleFileLineWrap,
         onSelect: () => onToggleFileLineWrap?.(source.id),
       },
@@ -190,13 +191,13 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
     items.push(
       { type: "separator" },
       {
-        label: "Move Left",
+        label: "Move left",
         icon: MoveLeft,
         disabled: !hasLeft,
         onSelect: () => onReorder(identity, index - 1),
       },
       {
-        label: "Move Right",
+        label: "Move right",
         icon: MoveRight,
         disabled: !hasRight,
         onSelect: () => onReorder(identity, index + 1),
@@ -207,26 +208,26 @@ function tabMenu(tab: WorkbenchTabModel): ContextMenuItem[] {
   items.push(
     { type: "separator" },
     {
-      label: "Close Pane",
+      label: "Close pane",
       icon: X,
       shortcut: closeShortcut,
       onSelect: () => onClose?.(identity),
     },
     {
-      label: "Close Other Panes",
+      label: "Close others",
       icon: X,
       shortcut: closeOthersShortcut,
       disabled: tabs.length <= 1 || !onCloseOther,
       onSelect: () => onCloseOther?.(identity),
     },
     {
-      label: "Close Panes on Right",
+      label: "Close to the right",
       icon: X,
       disabled: !hasRight || !onCloseRight,
       onSelect: () => onCloseRight?.(identity),
     },
     {
-      label: "Close Panes on Left",
+      label: "Close to the left",
       icon: X,
       disabled: !hasLeft || !onCloseLeft,
       onSelect: () => onCloseLeft?.(identity),

--- a/packages/workbench-app/src/lib/features/conversations/components/HistoryGraphNode.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/HistoryGraphNode.svelte
@@ -54,7 +54,7 @@ function entryMenu(entryData: HistoryEntryNodeData): ContextMenuItem[] {
   ];
   if (entry.role === "user") {
     items.push({
-      label: "Edit & resend",
+      label: "Edit and resend",
       icon: Pencil,
       onSelect: () => entryData.actions?.onEditEntry?.(entry),
     });
@@ -62,7 +62,7 @@ function entryMenu(entryData: HistoryEntryNodeData): ContextMenuItem[] {
   items.push(
     { type: "separator" },
     {
-      label: "Copy entry id",
+      label: "Copy entry ID",
       icon: Copy,
       onSelect: () => copyId(entry.id),
     },

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-import ArrowRight from "@lucide/svelte/icons/arrow-right";
 import Copy from "@lucide/svelte/icons/copy";
 import ExternalLink from "@lucide/svelte/icons/external-link";
 import FilePlus from "@lucide/svelte/icons/file-plus";
+import FileText from "@lucide/svelte/icons/file-text";
 import Files from "@lucide/svelte/icons/files";
 import Folder from "@lucide/svelte/icons/folder";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
 import FolderPlus from "@lucide/svelte/icons/folder-plus";
 import Link from "@lucide/svelte/icons/link";
+import Locate from "@lucide/svelte/icons/locate";
 import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
@@ -300,11 +301,11 @@ function rootMenu(): ContextMenuItem[] {
     },
     desktopRuntime.isDesktop,
     {
-      open: ArrowRight,
+      open: FolderOpen,
       copy: Copy,
       openDefault: ExternalLink,
       newFile: FilePlus,
-      reveal: FolderOpen,
+      reveal: Locate,
       newFolder: FolderPlus,
       trash: Trash2,
     },
@@ -333,11 +334,11 @@ function itemMenu(item: FileExplorerTreeItem): ContextMenuItem[] {
     },
     desktopRuntime.isDesktop,
     {
-      open: ArrowRight,
+      open: entry.kind === "directory" ? FolderOpen : FileText,
       copy: Copy,
       openDefault: ExternalLink,
       newFile: FilePlus,
-      reveal: FolderOpen,
+      reveal: Locate,
       newFolder: FolderPlus,
       trash: Trash2,
     },

--- a/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.test.ts
@@ -52,12 +52,12 @@ describe("file explorer menus", () => {
     };
     assert.deepEqual(labels(file, false), [
       "Open",
-      "Copy Path",
-      "Copy Relative Path",
+      "Copy path",
+      "Copy relative path",
     ]);
-    assert.ok(labels(directory, false).includes("New File"));
-    assert.ok(labels(directory, true).includes("Open in Default Application"));
-    assert.ok(labels(directory, true).includes("Move to Trash"));
+    assert.ok(labels(directory, false).includes("New file"));
+    assert.ok(labels(directory, true).includes("Open with default app"));
+    assert.ok(labels(directory, true).includes("Move to trash"));
   });
 
   it("offers root operations without destructive or relative-path actions", () => {
@@ -65,11 +65,11 @@ describe("file explorer menus", () => {
       (item) => ("label" in item ? [item.label] : []),
     );
     assert.deepEqual(rootLabels, [
-      "New File",
-      "New Folder",
-      "Open in Default Application",
-      "Reveal in File Manager",
-      "Copy Path",
+      "New file",
+      "New folder",
+      "Open with default app",
+      "Show in file manager",
+      "Copy path",
     ]);
   });
 

--- a/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/components/file-explorer-menu.ts
@@ -56,9 +56,9 @@ export function buildProjectRootMenu(
   icons: FileExplorerMenuIcons,
 ): ContextMenuItem[] {
   const items: ContextMenuItem[] = [
-    { label: "New File", icon: icons.newFile, onSelect: actions.createFile },
+    { label: "New file", icon: icons.newFile, onSelect: actions.createFile },
     {
-      label: "New Folder",
+      label: "New folder",
       icon: icons.newFolder,
       onSelect: actions.createFolder,
     },
@@ -67,12 +67,12 @@ export function buildProjectRootMenu(
     items.push(
       { type: "separator" },
       {
-        label: "Open in Default Application",
+        label: "Open with default app",
         icon: icons.openDefault,
         onSelect: actions.openDefault,
       },
       {
-        label: "Reveal in File Manager",
+        label: "Show in file manager",
         icon: icons.reveal,
         onSelect: actions.reveal,
       },
@@ -80,7 +80,7 @@ export function buildProjectRootMenu(
   }
   items.push(
     { type: "separator" },
-    { label: "Copy Path", icon: icons.copy, onSelect: actions.copyPath },
+    { label: "Copy path", icon: icons.copy, onSelect: actions.copyPath },
   );
   return items;
 }
@@ -102,9 +102,9 @@ export function buildFileExplorerMenu(
   if (entry.kind === "directory" && !entry.symlink) {
     items.push(
       { type: "separator" },
-      { label: "New File", icon: icons.newFile, onSelect: actions.createFile },
+      { label: "New file", icon: icons.newFile, onSelect: actions.createFile },
       {
-        label: "New Folder",
+        label: "New folder",
         icon: icons.newFolder,
         onSelect: actions.createFolder,
       },
@@ -114,12 +114,12 @@ export function buildFileExplorerMenu(
     items.push(
       { type: "separator" },
       {
-        label: "Open in Default Application",
+        label: "Open with default app",
         icon: icons.openDefault,
         onSelect: actions.openDefault,
       },
       {
-        label: "Reveal in File Manager",
+        label: "Show in file manager",
         icon: icons.reveal,
         onSelect: actions.reveal,
       },
@@ -127,9 +127,9 @@ export function buildFileExplorerMenu(
   }
   items.push(
     { type: "separator" },
-    { label: "Copy Path", icon: icons.copy, onSelect: actions.copyPath },
+    { label: "Copy path", icon: icons.copy, onSelect: actions.copyPath },
     {
-      label: "Copy Relative Path",
+      label: "Copy relative path",
       icon: icons.copy,
       onSelect: actions.copyRelativePath,
     },
@@ -138,7 +138,7 @@ export function buildFileExplorerMenu(
     items.push(
       { type: "separator" },
       {
-        label: "Move to Trash",
+        label: "Move to trash",
         icon: icons.trash,
         destructive: true,
         onSelect: actions.trash,

--- a/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/RecentProjectsView.svelte
@@ -2,7 +2,7 @@
 import ArrowRight from "@lucide/svelte/icons/arrow-right";
 import Copy from "@lucide/svelte/icons/copy";
 import FolderOpen from "@lucide/svelte/icons/folder-open";
-import Plus from "@lucide/svelte/icons/plus";
+import MessageSquarePlus from "@lucide/svelte/icons/message-square-plus";
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
@@ -70,7 +70,11 @@ let {
 function projectMenu(item: ProjectSwitcherItem): ContextMenuItem[] {
   const project = item.project;
   const menuItems: ContextMenuItem[] = [
-    { label: "New chat", icon: Plus, onSelect: () => onNewChat(project.dir) },
+    {
+      label: "New chat",
+      icon: MessageSquarePlus,
+      onSelect: () => onNewChat(project.dir),
+    },
     { label: "Copy path", icon: Copy, onSelect: () => onCopyPath(project.dir) },
   ];
   if (onForget) {

--- a/packages/workbench-app/src/lib/features/projects/components/project-tree-menus.ts
+++ b/packages/workbench-app/src/lib/features/projects/components/project-tree-menus.ts
@@ -1,6 +1,6 @@
-import ArrowRight from "@lucide/svelte/icons/arrow-right";
+import MessageSquarePlus from "@lucide/svelte/icons/message-square-plus";
+import MessageSquareText from "@lucide/svelte/icons/message-square-text";
 import Copy from "@lucide/svelte/icons/copy";
-import Plus from "@lucide/svelte/icons/plus";
 import Trash2 from "@lucide/svelte/icons/trash-2";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
 import type {
@@ -103,7 +103,7 @@ export function buildProjectMenu(
   const items: ContextMenuItem[] = [
     {
       label: "New chat",
-      icon: Plus,
+      icon: MessageSquarePlus,
       shortcut: ctx.newConversationShortcut,
       onSelect: () => ctx.onNewConversationInProject?.(project.dir),
     },
@@ -119,7 +119,7 @@ export function buildProjectMenu(
       onSelect: () => void copyToClipboard(project.dir, "path"),
     },
     {
-      label: "Clean up",
+      label: "Clean up conversations",
       icon: Trash2,
       destructive: true,
       disabled: ctx.conversationCount(project.id) === 0,
@@ -148,18 +148,18 @@ export function buildConversationMenu(
   return [
     {
       label: "Open conversation",
-      icon: ArrowRight,
+      icon: MessageSquareText,
       onSelect: () => ctx.onOpenConversation?.(conversation.id),
     },
     {
       label: "New chat",
-      icon: Plus,
+      icon: MessageSquarePlus,
       shortcut: ctx.newConversationShortcut,
       onSelect: () => ctx.onNewConversationInProject?.(project.dir),
     },
     { type: "separator" },
     {
-      label: "Copy conversation id",
+      label: "Copy conversation ID",
       icon: Copy,
       onSelect: () => void copyToClipboard(conversation.id, "conversation id"),
     },

--- a/packages/workbench-app/src/lib/presentation/git/GitChangesArea.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GitChangesArea.svelte
@@ -5,6 +5,7 @@ import ArrowUpFromLine from "@lucide/svelte/icons/arrow-up-from-line";
 import ChevronDown from "@lucide/svelte/icons/chevron-down";
 import ChevronRight from "@lucide/svelte/icons/chevron-right";
 import Eye from "@lucide/svelte/icons/eye";
+import Trash2 from "@lucide/svelte/icons/trash-2";
 import X from "@lucide/svelte/icons/x";
 import type {
   GitDiffArea,
@@ -155,7 +156,7 @@ function scopeMenu(area: GitStashArea, path?: string): ContextMenuItem[] {
     { type: "separator" },
     {
       label: "Discard",
-      icon: X,
+      icon: Trash2,
       destructive: true,
       disabled: !capabilities.bulkMutateFiles.enabled || anyMutation,
       onSelect: () => onRequestDiscardScope(area, path),
@@ -186,7 +187,7 @@ function fileMenu(area: GitStashArea, file: GitFileChange): ContextMenuItem[] {
     { type: "separator" },
     {
       label: "Discard",
-      icon: X,
+      icon: Trash2,
       destructive: true,
       disabled: !capabilities.mutateFiles.enabled || anyMutation,
       onSelect: () => onRequestDiscard(file),

--- a/packages/workbench-app/src/lib/presentation/shell/DockTabStrip.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/DockTabStrip.svelte
@@ -106,7 +106,7 @@ function defaultMenu(
   index: number,
 ): ContextMenuItem[] {
   const items: ContextMenuItem[] = DOCK_IDS.map((target) => ({
-    label: `Move to ${DOCK_LABELS[target]}`,
+    label: `Move to ${DOCK_LABELS[target].toLowerCase()}`,
     icon: dockIcons[target],
     disabled: target === dock || !onMove,
     onSelect: () =>
@@ -118,13 +118,13 @@ function defaultMenu(
   items.push(
     { type: "separator" },
     {
-      label: "Move Left",
+      label: "Move left",
       icon: MoveLeft,
       disabled: index === 0 || !onMove,
       onSelect: () => move(view.id, { dock, index: index - 1 }),
     },
     {
-      label: "Move Right",
+      label: "Move right",
       icon: MoveRight,
       disabled: index >= views.length - 1 || !onMove,
       onSelect: () => move(view.id, { dock, index: index + 1 }),

--- a/packages/workbench-app/src/lib/presentation/shell/EditorTabStrip.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/EditorTabStrip.svelte
@@ -139,13 +139,13 @@ function defaultMenu(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
     items.push(
       { type: "separator" },
       {
-        label: "Move Left",
+        label: "Move left",
         icon: MoveLeft,
         disabled: !hasLeft,
         onSelect: () => onReorder(id, index - 1),
       },
       {
-        label: "Move Right",
+        label: "Move right",
         icon: MoveRight,
         disabled: !hasRight,
         onSelect: () => onReorder(id, index + 1),
@@ -155,27 +155,27 @@ function defaultMenu(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
   items.push(
     { type: "separator" },
     {
-      label: "Close Pane",
+      label: "Close pane",
       icon: X,
       shortcut: closeShortcut,
       disabled: tab.closeable === false || !onClose,
       onSelect: () => onClose?.(id),
     },
     {
-      label: "Close Other Panes",
+      label: "Close others",
       icon: X,
       shortcut: closeOthersShortcut,
       disabled: tabs.length <= 1 || !onCloseOther,
       onSelect: () => onCloseOther?.(id),
     },
     {
-      label: "Close Panes on Right",
+      label: "Close to the right",
       icon: X,
       disabled: !hasRight || !onCloseRight,
       onSelect: () => onCloseRight?.(id),
     },
     {
-      label: "Close Panes on Left",
+      label: "Close to the left",
       icon: X,
       disabled: !hasLeft || !onCloseLeft,
       onSelect: () => onCloseLeft?.(id),

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import Copy from "@lucide/svelte/icons/copy";
-import FolderOpen from "@lucide/svelte/icons/folder-open";
+import Folder from "@lucide/svelte/icons/folder";
 import History from "@lucide/svelte/icons/history";
 import Pencil from "@lucide/svelte/icons/pencil";
 import Play from "@lucide/svelte/icons/play";
@@ -87,7 +87,7 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
     });
   if (cleanableRuns.length > 0)
     items.push({
-      label: "Clean up old runs",
+      label: "Clean up runs",
       icon: Trash2,
       destructive: true,
       disabled: !capabilities.remove,
@@ -150,7 +150,7 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
   if (cwd)
     trailing.push({
       label: "Copy working directory",
-      icon: FolderOpen,
+      icon: Folder,
       disabled: !capabilities.copy,
       onSelect: () => onCopy?.(cwd),
     });

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskRunRow.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-import BookmarkPlus from "@lucide/svelte/icons/bookmark-plus";
+import Save from "@lucide/svelte/icons/save";
 import Copy from "@lucide/svelte/icons/copy";
-import FolderOpen from "@lucide/svelte/icons/folder-open";
+import Folder from "@lucide/svelte/icons/folder";
+import Play from "@lucide/svelte/icons/play";
 import RotateCw from "@lucide/svelte/icons/rotate-cw";
 import Skull from "@lucide/svelte/icons/skull";
 import Square from "@lucide/svelte/icons/square";
 import Terminal from "@lucide/svelte/icons/terminal";
-import X from "@lucide/svelte/icons/x";
+import Trash2 from "@lucide/svelte/icons/trash-2";
 import type { TaskRecord } from "@nervekit/contracts";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
 import {
@@ -78,8 +79,8 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
   ];
   if (entry.definition && entry.isRemovable)
     items.push({
-      label: "Run saved task again",
-      icon: RotateCw,
+      label: "Run again",
+      icon: Play,
       disabled: !capabilities.start,
       onSelect: () => onRerunDefinition?.(),
     });
@@ -103,8 +104,8 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
     items.push(
       { type: "separator" },
       {
-        label: "Save as task definition",
-        icon: BookmarkPlus,
+        label: "Save as task",
+        icon: Save,
         disabled: !capabilities.manageDefinitions,
         onSelect: () => onSaveAsDefinition?.(run),
       },
@@ -119,7 +120,7 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
     },
     {
       label: "Copy working directory",
-      icon: FolderOpen,
+      icon: Folder,
       disabled: !capabilities.copy,
       onSelect: () => onCopy?.(run.cwd),
     },
@@ -127,7 +128,7 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
   if (entry.isRemovable)
     trailing.push({
       label: "Remove run",
-      icon: X,
+      icon: Trash2,
       destructive: true,
       disabled: !capabilities.remove,
       onSelect: () => onRemove?.(run.id),


### PR DESCRIPTION
## Summary

Overhaul all context menus in the workbench app: compact styling, a composable component set, aligned icon/label/shortcut rows, and consistent sentence-case labels.

### Compact design (`@nervekit/ui-kit` context-menu primitives)
- Items/sub-triggers: `px-1.5 py-1 gap-1.5` with `size-3.5` icons (was `px-2 py-1.5 gap-2`, `size-4`)
- Content: `p-0.5`, `border-border/80` instead of the heavier `ring-1 ring-foreground/10`
- Denser separators, subtler shortcut tracking, fixed duplicated `data-inset:pl-8` in the label, matching treatment for checkbox/radio items and sub-content

### Composable set (`context-menu-list/`)
- New reusable sub-components: `ContextMenuListItem` (fixed-width icon column + label + right-aligned shortcut), `ContextMenuListSeparator`, `ContextMenuListLabel`, `ContextMenuListSub`, and an internal `ContextMenuListItems` renderer
- `ContextMenuList` root keeps the existing `items` prop API — all 19 consumer files unchanged; new exports enable direct composition
- Dev-only guard warns if any label contains an ellipsis (`…`/`...`)

### Labels & icons
- Normalized to sentence case and trimmed wordy options ("Close others", "Close to the right/left", "Run again", "Save as task", "Open with default app", "Show in file manager", "Clean up conversations", ...)
- Best-fit lucide icons verified against installed lucide 1.24.0 (`Play`, `Save`, `Folder`, `Trash2`, `TextAlignStart` for the wrap toggle, `MessageSquarePlus`, `MessageSquareText`, `Locate`, per-kind `FolderOpen`/`FileText` for Open)

## Validation
- `pnpm fix && pnpm check && pnpm test` green (eslint, formatting, boundaries, svelte-check 0 errors/warnings, all test suites pass)
- `file-explorer-menu.test.ts` updated to the new labels

## Notes
- `dropdown-menu` set untouched (only used by `GithubPrMergeBox` as a button-triggered select)
- Visual pass (light/dark) recommended before release