### PR TITLE
fix(ui-kit): allow long confirm dialog descriptions to wrap

### DIFF
--- a/packages/ui-kit/src/lib/components/ui/confirm-dialog/confirm-dialog.svelte
+++ b/packages/ui-kit/src/lib/components/ui/confirm-dialog/confirm-dialog.svelte
@@ -49,7 +49,9 @@ function handleCancel() {
     <AlertDialog.Header>
       <AlertDialog.Title>{title}</AlertDialog.Title>
       {#if description}
-        <AlertDialog.Description>{description}</AlertDialog.Description>
+        <AlertDialog.Description class="min-w-0 [overflow-wrap:anywhere]"
+          >{description}</AlertDialog.Description
+        >
       {/if}
     </AlertDialog.Header>
     <AlertDialog.Footer>


### PR DESCRIPTION
## Summary

Fixes confirm dialog descriptions with long unbroken content (e.g. long paths, URLs, or error messages) overflowing the dialog instead of wrapping.

## Changes

- `packages/ui-kit/src/lib/components/ui/confirm-dialog/confirm-dialog.svelte`
  - Add `min-w-0 [overflow-wrap:anywhere]` to the `AlertDialog.Description` so content wraps at any point and does not force the dialog wider than its container.