### PR TITLE
Fix conversation card click target

### DIFF
--- a/packages/workbench-app/src/lib/features/projects/components/ProjectAgentTreeNode.svelte
+++ b/packages/workbench-app/src/lib/features/projects/components/ProjectAgentTreeNode.svelte
@@ -52,7 +52,11 @@ const tooltip = $derived(
 );
 </script>
 
-<PanelRowCard itemKey={row.conversation.id} {menuItems}>
+<PanelRowCard
+  itemKey={row.conversation.id}
+  {menuItems}
+  onclick={() => onOpenConversation?.(row.conversation.id)}
+>
   <PanelRow
     label={row.conversation.title}
     labelLines={2}
@@ -62,6 +66,5 @@ const tooltip = $derived(
     pulse={dotActivity.pulse}
     class="px-2"
     active={isActive}
-    onclick={() => onOpenConversation?.(row.conversation.id)}
   />
 </PanelRowCard>

--- a/packages/workbench-app/src/lib/presentation/panel/PanelRowCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelRowCard.svelte
@@ -9,6 +9,7 @@ let {
   menuItems,
   menuDisabled = false,
   class: className,
+  onclick,
   children,
 }: {
   /** Outer semantics; rows inside already carry `listitem` where needed. */
@@ -17,6 +18,7 @@ let {
   menuItems?: ContextMenuItem[];
   menuDisabled?: boolean;
   class?: string;
+  onclick?: (event: MouseEvent) => void;
   children: Snippet;
 } = $props();
 </script>
@@ -27,6 +29,7 @@ let {
   {menuItems}
   {menuDisabled}
   class={`panel-row-card flex-col px-1 py-0.5 ${className ?? ""}`}
+  {onclick}
 >
   {@render children()}
 </ItemSurface>


### PR DESCRIPTION
## Summary
- make the full conversation card surface switch conversations
- preserve the inner accessible row button and context-menu behavior
- apply the fix to both the panel list and conversations dialog through the shared row component

## Validation
- `pnpm fix && pnpm check && pnpm test`