### PR TITLE
fix(workbench): hide bottom dock toggle when it has no content

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/StatusBarContainer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/StatusBarContainer.svelte
@@ -8,6 +8,7 @@ import StatusBar from "$lib/app/shell/StatusBar.svelte";
 import { zoomState } from "$lib/app/shell/appearance.svelte";
 import { responsive } from "$lib/app/shell/responsive.svelte";
 import {
+  hasPanelDockContent,
   isPanelDockVisible,
   shellSheets,
   togglePanelDock,
@@ -41,16 +42,18 @@ const isPhone = $derived(responsive.isPhone);
 // desktop collapse model; mirror the sheet state so the pressed affordance
 // stays correct (open = panel visible).
 const dockToggles = $derived<DockToggle[]>(
-  DOCK_IDS.map((dock) => ({
-    dock,
-    label: DOCK_LABELS[dock].toLowerCase(),
-    open: isCompact
-      ? dock === "left"
-        ? shellSheets.primary
-        : shellSheets.secondary
-      : isPanelDockVisible(dock),
-    onToggle: () => togglePanelDock(dock, isCompact),
-  })),
+  DOCK_IDS.filter((dock) => dock !== "bottom" || hasPanelDockContent(dock)).map(
+    (dock) => ({
+      dock,
+      label: DOCK_LABELS[dock].toLowerCase(),
+      open: isCompact
+        ? dock === "left"
+          ? shellSheets.primary
+          : shellSheets.secondary
+        : isPanelDockVisible(dock),
+      onToggle: () => togglePanelDock(dock, isCompact),
+    }),
+  ),
 );
 </script>
 

--- a/packages/workbench-app/src/lib/app/shell/shell-layout.svelte.ts
+++ b/packages/workbench-app/src/lib/app/shell/shell-layout.svelte.ts
@@ -108,6 +108,11 @@ export function isPanelDockVisible(dock: DockId): boolean {
   return isDockVisible(state.layout, dock);
 }
 
+export function hasPanelDockContent(dock: DockId): boolean {
+  const { views } = state.layout.docks[dock];
+  return views.some((viewId) => !state.layout.hidden.includes(viewId));
+}
+
 let resizeTimer: ReturnType<typeof setTimeout> | undefined;
 
 export function resizeDock(dock: DockId, size: number) {


### PR DESCRIPTION
## Summary

The status bar showed a toggle for the bottom panel dock even when it contained no visible content (e.g. fresh installs where Tasks lives in the left dock and the bottom dock starts empty/collapsed). This led to a dead control that expanded an empty dock.

## Changes

- **`shell-layout.svelte.ts`**: added `hasPanelDockContent(dock)` which reports whether a dock has at least one view that isn't hidden.
- **`StatusBarContainer.svelte`**: filters dock toggles so the bottom dock toggle is only rendered when the dock actually has content.

## Validation

- No behavior change for the left/right docks; only the empty bottom dock toggle is suppressed.