### PR TITLE
fix(ci): drop redundant pnpm cache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -279,7 +278,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Removes `cache: pnpm` from `actions/setup-node@v6` in the release workflow (`check-release` and `native-package-smoke` jobs).

## Why

The repo already runs `pnpm/action-setup@v6`, which sets up pnpm and handles its own dependency caching. `setup-node`'s `cache: pnpm` duplicates that caching and can interact poorly with shared caches across jobs. Dropping it keeps the release pipeline simpler and avoids stale-cache issues.

## Validation

- `git diff` confirms only the two `cache: pnpm` lines were removed (workflow YAML otherwise unchanged).