### PR TITLE
Fix Mermaid ERD row colors in dark themes

### DIFF
--- a/packages/ui-kit/src/lib/core/components/mermaid-render.test.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-render.test.ts
@@ -20,10 +20,10 @@ describe("Mermaid theme variables", () => {
   it("uses themed surfaces for alternating ER attribute rows", () => {
     const variables = mermaidThemeVariables(theme);
 
-    assert.equal(variables.attributeBackgroundColorOdd, theme.card);
-    assert.equal(variables.attributeBackgroundColorEven, theme.background);
-    assert.notEqual(variables.attributeBackgroundColorOdd, "#ffffff");
-    assert.notEqual(variables.attributeBackgroundColorEven, "#f2f2f2");
+    assert.equal(variables.rowOdd, theme.card);
+    assert.equal(variables.rowEven, theme.background);
+    assert.notEqual(variables.rowOdd, "#ffffff");
+    assert.notEqual(variables.rowEven, "#f2f2f2");
   });
 
   it("preserves core diagram color mappings", () => {

--- a/packages/ui-kit/src/lib/core/components/mermaid-render.test.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-render.test.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { mermaidThemeVariables, type MermaidTheme } from "./mermaid-render";
+
+const theme: MermaidTheme = {
+  fingerprint: "dark-theme",
+  dark: true,
+  fontFamily: "Outfit",
+  background: "#242424",
+  foreground: "#e5e5e5",
+  card: "#2b2b2b",
+  surface: "#3d3d3d",
+  primary: "#f0c674",
+  border: "#555555",
+  strongBorder: "#777777",
+  mutedForeground: "#aaaaaa",
+};
+
+describe("Mermaid theme variables", () => {
+  it("uses themed surfaces for alternating ER attribute rows", () => {
+    const variables = mermaidThemeVariables(theme);
+
+    assert.equal(variables.attributeBackgroundColorOdd, theme.card);
+    assert.equal(variables.attributeBackgroundColorEven, theme.background);
+    assert.notEqual(variables.attributeBackgroundColorOdd, "#ffffff");
+    assert.notEqual(variables.attributeBackgroundColorEven, "#f2f2f2");
+  });
+
+  it("preserves core diagram color mappings", () => {
+    const variables = mermaidThemeVariables(theme);
+
+    assert.equal(variables.primaryColor, theme.surface);
+    assert.equal(variables.primaryTextColor, theme.foreground);
+    assert.equal(variables.primaryBorderColor, theme.strongBorder);
+    assert.equal(variables.lineColor, theme.mutedForeground);
+  });
+});

--- a/packages/ui-kit/src/lib/core/components/mermaid-render.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-render.ts
@@ -1,4 +1,4 @@
-type MermaidTheme = {
+export type MermaidTheme = {
   fingerprint: string;
   dark: boolean;
   fontFamily: string;
@@ -121,6 +121,47 @@ async function sanitizeSvg(svg: string): Promise<string | undefined> {
   return document.documentElement.outerHTML;
 }
 
+export function mermaidThemeVariables(theme: MermaidTheme) {
+  return {
+    background: theme.background,
+    primaryColor: theme.surface,
+    primaryTextColor: theme.foreground,
+    primaryBorderColor: theme.strongBorder,
+    secondaryColor: theme.background,
+    secondaryTextColor: theme.foreground,
+    secondaryBorderColor: theme.strongBorder,
+    tertiaryColor: theme.surface,
+    tertiaryTextColor: theme.foreground,
+    tertiaryBorderColor: theme.strongBorder,
+    lineColor: theme.mutedForeground,
+    textColor: theme.foreground,
+    mainBkg: theme.surface,
+    nodeBorder: theme.strongBorder,
+    clusterBkg: theme.background,
+    clusterBorder: theme.strongBorder,
+    titleColor: theme.foreground,
+    edgeLabelBackground: theme.background,
+    actorBkg: theme.surface,
+    actorBorder: theme.strongBorder,
+    actorTextColor: theme.foreground,
+    actorLineColor: theme.strongBorder,
+    signalColor: theme.foreground,
+    signalTextColor: theme.foreground,
+    labelBoxBkgColor: theme.background,
+    labelBoxBorderColor: theme.strongBorder,
+    labelTextColor: theme.foreground,
+    loopTextColor: theme.foreground,
+    activationBkgColor: theme.surface,
+    activationBorderColor: theme.primary,
+    noteBkgColor: theme.surface,
+    noteBorderColor: theme.primary,
+    noteTextColor: theme.foreground,
+    sequenceNumberColor: theme.background,
+    attributeBackgroundColorOdd: theme.card,
+    attributeBackgroundColorEven: theme.background,
+  };
+}
+
 async function renderWithTheme(
   source: string,
   theme: MermaidTheme,
@@ -132,42 +173,7 @@ async function renderWithTheme(
     htmlLabels: false,
     theme: "base",
     fontFamily: theme.fontFamily,
-    themeVariables: {
-      background: theme.background,
-      primaryColor: theme.surface,
-      primaryTextColor: theme.foreground,
-      primaryBorderColor: theme.strongBorder,
-      secondaryColor: theme.background,
-      secondaryTextColor: theme.foreground,
-      secondaryBorderColor: theme.strongBorder,
-      tertiaryColor: theme.surface,
-      tertiaryTextColor: theme.foreground,
-      tertiaryBorderColor: theme.strongBorder,
-      lineColor: theme.mutedForeground,
-      textColor: theme.foreground,
-      mainBkg: theme.surface,
-      nodeBorder: theme.strongBorder,
-      clusterBkg: theme.background,
-      clusterBorder: theme.strongBorder,
-      titleColor: theme.foreground,
-      edgeLabelBackground: theme.background,
-      actorBkg: theme.surface,
-      actorBorder: theme.strongBorder,
-      actorTextColor: theme.foreground,
-      actorLineColor: theme.strongBorder,
-      signalColor: theme.foreground,
-      signalTextColor: theme.foreground,
-      labelBoxBkgColor: theme.background,
-      labelBoxBorderColor: theme.strongBorder,
-      labelTextColor: theme.foreground,
-      loopTextColor: theme.foreground,
-      activationBkgColor: theme.surface,
-      activationBorderColor: theme.primary,
-      noteBkgColor: theme.surface,
-      noteBorderColor: theme.primary,
-      noteTextColor: theme.foreground,
-      sequenceNumberColor: theme.background,
-    },
+    themeVariables: mermaidThemeVariables(theme),
     flowchart: { htmlLabels: false },
   });
   const id = `nerve-mermaid-${++renderSequence}`;

--- a/packages/ui-kit/src/lib/core/components/mermaid-render.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-render.ts
@@ -157,8 +157,8 @@ export function mermaidThemeVariables(theme: MermaidTheme) {
     noteBorderColor: theme.primary,
     noteTextColor: theme.foreground,
     sequenceNumberColor: theme.background,
-    attributeBackgroundColorOdd: theme.card,
-    attributeBackgroundColorEven: theme.background,
+    rowOdd: theme.card,
+    rowEven: theme.background,
   };
 }
 


### PR DESCRIPTION
## Summary
- map Mermaid ERD alternating attribute rows to Nerve theme surfaces
- share the theme-variable construction across Mermaid rendering
- add regression coverage for ERD row colors and core color mappings

## Validation
- `pnpm fix && pnpm check && pnpm test`