### PR TITLE
Fix desktop CPU hotspots and add performance diagnostics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This directory contains engineering sources and editorial planning for Nerve.
 
 - `architecture/` contains editable architecture diagrams and implementation/reliability notes.
 - `release.md` is the maintainer release procedure.
+- `performance-profiling.md` documents the isolated desktop profiling workflow and local metrics summary tool.
 - `website/content-strategy.md` records the evidence, scope, and review plan for the public website.
 
 Public user guides and public developer reference live in `packages/website/src/content/docs/` so the deployed site has one searchable source of truth. Product behavior is ultimately defined by the owning contracts, catalogs, implementation, and focused tests; prose should link concepts together without becoming a second schema catalog.

--- a/docs/performance-profiling.md
+++ b/docs/performance-profiling.md
@@ -1,0 +1,61 @@
+# Desktop performance profiling
+
+Use an isolated Nerve home and Electron profile for performance investigations. Never profile, signal, automate, or stop a live instance that is hosting active work.
+
+## Safe setup
+
+1. Prefer copying a stopped `NERVE_HOME`. On Btrfs, a reflink copy avoids duplicating unchanged data.
+2. If the source daemon must remain online, use SQLite's online backup API for `state.sqlite`; do not copy a live database/WAL trio as independent files.
+3. Remove `daemon.json` and stale SQLite `-wal`/`-shm` files only from the clone after creating the online database backup.
+4. Give the clone all of the following:
+   - a separate `NERVE_HOME`;
+   - a fresh Electron `--user-data-dir` outside `NERVE_HOME`;
+   - non-default daemon/mobile ports;
+   - a non-default CDP `--remote-debugging-port`.
+5. Validate the copied database with `PRAGMA quick_check` before launch.
+
+Example development launch (replace every path/port explicitly):
+
+```sh
+NERVE_HOME=/path/to/isolated-home \
+NERVE_PORT=4747 \
+NERVE_HTTPS_PORT=4748 \
+NERVE_PERFORMANCE_DIAGNOSTICS=1 \
+pnpm desktop -- \
+  --user-data-dir=/path/to/fresh-electron-profile \
+  --remote-debugging-port=49222
+```
+
+`NERVE_PERFORMANCE_DIAGNOSTICS=1` is opt-in. It appends content-free process samples every ten seconds to `<NERVE_HOME>/logs/performance.jsonl`. Startup phase records are in `<NERVE_HOME>/logs/startup.jsonl`.
+
+## Renderer tracing
+
+Read the installed agent-browser core and Electron skill instructions before connecting. Connect only to the isolated CDP port and use a dedicated session name. Keep captures bounded and cover one scenario at a time:
+
+- clean foreground idle;
+- clean minimized idle;
+- Tasks panel mounted for at least 15 seconds;
+- workspace panel navigation;
+- opening and jumping through a large transcript.
+
+Chromium and Node profilers materially increase CPU use. Always repeat idle without any profiler and treat that clean control as the authoritative baseline. Process-tree `/proc` samples are useful alongside traces because they separate Electron main, renderer, GPU, network service, and daemon load.
+
+## Summaries
+
+Generate a Markdown summary:
+
+```sh
+pnpm performance:summarize -- \
+  --startup /path/to/isolated-home/logs/startup.jsonl \
+  --performance /path/to/isolated-home/logs/performance.jsonl \
+  --format markdown
+```
+
+Use `--format json` for machine-readable output. Either input may be omitted. The summarizer streams JSONL, ignores one torn final record, rejects malformed interior records, and emits only known numeric fields.
+
+## Shutdown and review
+
+- Quit only the isolated clone and verify its daemon, Electron helpers, ports, and CDP endpoint are gone.
+- Confirm the original daemon and Electron processes remain alive.
+- Review raw traces and screenshots before sharing. They can contain local paths, conversation text, or visible UI strings even though `performance.jsonl` does not.
+- Delete or securely retain copied homes according to the sensitivity of the source data.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:ui": "pnpm --filter @nervekit/contracts --filter @nervekit/protocol --filter @nervekit/harness --filter @nervekit/tools build && pnpm --filter @nervekit/workbench-app dev",
     "desktop": "pnpm --filter @nervekit/desktop-shell dev --",
     "desktop:remote-enabled": "pnpm desktop -- --host 0.0.0.0 --allow-remote --mobile-https",
+    "performance:summarize": "node scripts/summarize-performance-jsonl.mjs",
     "release:bump-version": "node scripts/bump-release-version.mjs",
     "release:verify-tag": "node scripts/verify-release-tag.mjs",
     "release:verify-npm": "node scripts/verify-npm-tarballs.mjs",

--- a/packages/desktop-shell/src/main.ts
+++ b/packages/desktop-shell/src/main.ts
@@ -34,6 +34,10 @@ import { showDesktopNotification } from "./ipc/notifications-ipc.js";
 import { registerDesktopIpc, windowState } from "./ipc/window-ipc.js";
 import { desktopLog } from "./logging.js";
 import {
+  installDesktopPerformanceMonitor,
+  type DesktopPerformanceMonitor,
+} from "./performance/performance-monitor.js";
+import {
   installDaemonCookie,
   refreshDesktopSettingsFromDaemon,
 } from "./settings/desktop-settings.js";
@@ -97,6 +101,7 @@ let closeToTray = true;
 let stopDaemonPromise: Promise<void> | undefined;
 let unsubscribeDaemonStatus: (() => void) | undefined;
 let desktopNetworkReady: Promise<void> = Promise.resolve();
+let desktopPerformanceMonitor: DesktopPerformanceMonitor | undefined;
 
 const trayController = createTrayController({
   getMainWindow: () => mainWindow,
@@ -212,6 +217,8 @@ if (!gotSingleInstanceLock) {
   app.on("before-quit", (event) => {
     const startedAt = Date.now();
     appQuitting = true;
+    desktopPerformanceMonitor?.stop();
+    desktopPerformanceMonitor = undefined;
     notifyQuitStarted();
     void desktopLog("info", "app", "Electron before-quit received", {
       context: {
@@ -403,6 +410,25 @@ async function openMainWindow(): Promise<void> {
       source: "desktop",
       ...result.timings,
       navigated: result.navigated,
+    });
+    desktopPerformanceMonitor ??= installDesktopPerformanceMonitor({
+      enabled: process.env.NERVE_PERFORMANCE_DIAGNOSTICS === "1",
+      dataDir: desktopDataDir,
+      getMetrics: () => app.getAppMetrics(),
+      getWindowState: () => {
+        const activeWindow = mainWindow;
+        return activeWindow && !activeWindow.isDestroyed()
+          ? {
+              visible: activeWindow.isVisible(),
+              minimized: activeWindow.isMinimized(),
+            }
+          : undefined;
+      },
+      warn: (error) => {
+        void desktopLog("warn", "app", "Desktop performance sampling failed", {
+          error,
+        });
+      },
     });
   } catch (error) {
     void desktopLog("error", "daemon", "Failed to open Nerve daemon", {

--- a/packages/desktop-shell/src/performance/performance-monitor.ts
+++ b/packages/desktop-shell/src/performance/performance-monitor.ts
@@ -1,0 +1,101 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const SAMPLE_INTERVAL_MS = 10_000;
+
+type ElectronProcessMetric = {
+  pid: number;
+  type: string;
+  cpu?: {
+    percentCPUUsage?: number;
+    idleWakeupsPerSecond?: number;
+  };
+  memory?: {
+    workingSetSize?: number;
+    peakWorkingSetSize?: number;
+    privateBytes?: number;
+    sharedBytes?: number;
+  };
+};
+
+type IntervalHandle = ReturnType<typeof setInterval>;
+
+type DesktopPerformanceMonitorOptions = {
+  enabled: boolean;
+  dataDir: string;
+  getMetrics: () => ElectronProcessMetric[];
+  getWindowState: () => { visible: boolean; minimized: boolean } | undefined;
+  append?: (path: string, line: string) => Promise<void>;
+  now?: () => Date;
+  setInterval?: (callback: () => void, delayMs: number) => IntervalHandle;
+  clearInterval?: (handle: IntervalHandle) => void;
+  warn?: (error: unknown) => void;
+};
+
+export type DesktopPerformanceMonitor = { stop: () => void };
+
+async function appendJsonLine(path: string, line: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, line, "utf8");
+}
+
+function kilobytesToBytes(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : value * 1024;
+}
+
+export function installDesktopPerformanceMonitor(
+  options: DesktopPerformanceMonitorOptions,
+): DesktopPerformanceMonitor {
+  if (!options.enabled) return { stop: () => undefined };
+
+  const append = options.append ?? appendJsonLine;
+  const now = options.now ?? (() => new Date());
+  const createInterval = options.setInterval ?? setInterval;
+  const destroyInterval = options.clearInterval ?? clearInterval;
+  const path = join(options.dataDir, "logs", "performance.jsonl");
+  let stopped = false;
+  let writing = false;
+  let warned = false;
+
+  const sample = () => {
+    if (stopped || writing) return;
+    writing = true;
+    const record = {
+      type: "nerve.performance",
+      source: "desktop",
+      ts: now().toISOString(),
+      window: options.getWindowState(),
+      processes: options.getMetrics().map((metric) => ({
+        pid: metric.pid,
+        role: metric.type,
+        cpuPercent: metric.cpu?.percentCPUUsage,
+        idleWakeupsPerSecond: metric.cpu?.idleWakeupsPerSecond,
+        rssBytes: kilobytesToBytes(metric.memory?.workingSetSize),
+        peakRssBytes: kilobytesToBytes(metric.memory?.peakWorkingSetSize),
+        privateBytes: kilobytesToBytes(metric.memory?.privateBytes),
+        sharedBytes: kilobytesToBytes(metric.memory?.sharedBytes),
+      })),
+    };
+    void append(path, `${JSON.stringify(record)}\n`)
+      .catch((error) => {
+        if (warned) return;
+        warned = true;
+        options.warn?.(error);
+      })
+      .finally(() => {
+        writing = false;
+      });
+  };
+
+  sample();
+  const interval = createInterval(sample, SAMPLE_INTERVAL_MS);
+  interval.unref?.();
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      destroyInterval(interval);
+    },
+  };
+}

--- a/packages/desktop-shell/test/performance-monitor.test.ts
+++ b/packages/desktop-shell/test/performance-monitor.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import { installDesktopPerformanceMonitor } from "../src/performance/performance-monitor.js";
 
@@ -43,7 +44,7 @@ describe("desktop performance monitor", () => {
       ],
       getWindowState: () => ({ visible: true, minimized: false }),
       append: async (path, line) => {
-        assert.equal(path, "/safe/home/logs/performance.jsonl");
+        assert.equal(path, join("/safe/home", "logs", "performance.jsonl"));
         lines.push(line);
       },
       setInterval: ((callback: () => void, delay: number) => {

--- a/packages/desktop-shell/test/performance-monitor.test.ts
+++ b/packages/desktop-shell/test/performance-monitor.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { installDesktopPerformanceMonitor } from "../src/performance/performance-monitor.js";
+
+function tick() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("desktop performance monitor", () => {
+  it("does nothing when diagnostics are disabled", () => {
+    let intervals = 0;
+    const monitor = installDesktopPerformanceMonitor({
+      enabled: false,
+      dataDir: "/tmp/ignored",
+      getMetrics: () => {
+        assert.fail("metrics should not be read");
+      },
+      getWindowState: () => undefined,
+      setInterval: (() => {
+        intervals += 1;
+      }) as never,
+    });
+
+    monitor.stop();
+    assert.equal(intervals, 0);
+  });
+
+  it("writes content-free process metrics immediately and periodically", async () => {
+    const lines: string[] = [];
+    let scheduled: (() => void) | undefined;
+    let cleared = 0;
+    const monitor = installDesktopPerformanceMonitor({
+      enabled: true,
+      dataDir: "/safe/home",
+      now: () => new Date("2026-08-14T00:00:00.000Z"),
+      getMetrics: () => [
+        {
+          pid: 42,
+          type: "Tab",
+          cpu: { percentCPUUsage: 12.5, idleWakeupsPerSecond: 3 },
+          memory: { workingSetSize: 100, privateBytes: 60, sharedBytes: 40 },
+        },
+      ],
+      getWindowState: () => ({ visible: true, minimized: false }),
+      append: async (path, line) => {
+        assert.equal(path, "/safe/home/logs/performance.jsonl");
+        lines.push(line);
+      },
+      setInterval: ((callback: () => void, delay: number) => {
+        assert.equal(delay, 10_000);
+        scheduled = callback;
+        return { unref() {} };
+      }) as never,
+      clearInterval: (() => {
+        cleared += 1;
+      }) as never,
+    });
+
+    await tick();
+    scheduled?.();
+    await tick();
+    const record = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
+    assert.equal(lines.length, 2);
+    assert.deepEqual(record, {
+      type: "nerve.performance",
+      source: "desktop",
+      ts: "2026-08-14T00:00:00.000Z",
+      window: { visible: true, minimized: false },
+      processes: [
+        {
+          pid: 42,
+          role: "Tab",
+          cpuPercent: 12.5,
+          idleWakeupsPerSecond: 3,
+          rssBytes: 102_400,
+          privateBytes: 61_440,
+          sharedBytes: 40_960,
+        },
+      ],
+    });
+    monitor.stop();
+    monitor.stop();
+    assert.equal(cleared, 1);
+  });
+
+  it("skips overlapping writes and isolates append failures", async () => {
+    let scheduled: (() => void) | undefined;
+    let completeWrite!: () => void;
+    let writes = 0;
+    let warnings = 0;
+    const monitor = installDesktopPerformanceMonitor({
+      enabled: true,
+      dataDir: "/safe/home",
+      getMetrics: () => [],
+      getWindowState: () => undefined,
+      append: () => {
+        writes += 1;
+        return new Promise<void>((_resolve, reject) => {
+          completeWrite = () => reject(new Error("disk full"));
+        });
+      },
+      warn: () => {
+        warnings += 1;
+      },
+      setInterval: ((callback: () => void) => {
+        scheduled = callback;
+        return { unref() {} };
+      }) as never,
+      clearInterval: (() => undefined) as never,
+    });
+
+    scheduled?.();
+    assert.equal(writes, 1);
+    completeWrite();
+    await tick();
+    scheduled?.();
+    assert.equal(writes, 2);
+    completeWrite();
+    await tick();
+    assert.equal(warnings, 1);
+    monitor.stop();
+  });
+});

--- a/packages/ui-kit/src/lib/core/highlight/highlight-policy.test.ts
+++ b/packages/ui-kit/src/lib/core/highlight/highlight-policy.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isWithinHighlightBudget,
+  MAX_HIGHLIGHT_CODE_UNITS,
+  MAX_HIGHLIGHT_LOGICAL_LINES,
+} from "./highlight-policy";
+
+describe("highlight budget", () => {
+  it("includes the exact character boundary and rejects one unit over", () => {
+    assert.equal(
+      isWithinHighlightBudget("x".repeat(MAX_HIGHLIGHT_CODE_UNITS)),
+      true,
+    );
+    assert.equal(
+      isWithinHighlightBudget("x".repeat(MAX_HIGHLIGHT_CODE_UNITS + 1)),
+      false,
+    );
+  });
+
+  it("includes the exact line boundary and rejects one line over", () => {
+    assert.equal(
+      isWithinHighlightBudget("x\n".repeat(MAX_HIGHLIGHT_LOGICAL_LINES - 1)),
+      true,
+    );
+    assert.equal(
+      isWithinHighlightBudget("x\n".repeat(MAX_HIGHLIGHT_LOGICAL_LINES)),
+      false,
+    );
+  });
+
+  it("accepts empty code", () => {
+    assert.equal(isWithinHighlightBudget(""), true);
+  });
+});

--- a/packages/ui-kit/src/lib/core/highlight/highlight-policy.ts
+++ b/packages/ui-kit/src/lib/core/highlight/highlight-policy.ts
@@ -1,0 +1,18 @@
+export const MAX_HIGHLIGHT_CODE_UNITS = 8_000;
+export const MAX_HIGHLIGHT_LOGICAL_LINES = 160;
+
+/**
+ * Keeps regex tokenization bounded without allocating a line array for large
+ * tool output. Boundaries are inclusive.
+ */
+export function isWithinHighlightBudget(code: string): boolean {
+  if (code.length > MAX_HIGHLIGHT_CODE_UNITS) return false;
+
+  let lines = 1;
+  for (let index = 0; index < code.length; index += 1) {
+    if (code.charCodeAt(index) !== 10) continue;
+    lines += 1;
+    if (lines > MAX_HIGHLIGHT_LOGICAL_LINES) return false;
+  }
+  return true;
+}

--- a/packages/ui-kit/src/lib/core/highlight/highlight-queue.test.ts
+++ b/packages/ui-kit/src/lib/core/highlight/highlight-queue.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createHighlightQueue } from "./highlight-queue";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function fixture() {
+  const scheduled: Array<() => void> = [];
+  const loads: string[] = [];
+  const requests = new Map<
+    string,
+    ReturnType<typeof deferred<string | undefined>>
+  >();
+  const cached = new Map<string, string>();
+  const queue = createHighlightQueue<string>({
+    load: (key) => {
+      loads.push(key);
+      const request = deferred<string | undefined>();
+      requests.set(key, request);
+      return request.promise;
+    },
+    schedule: (start) => scheduled.push(start),
+    lookup: (key) => ({ hit: cached.has(key), value: cached.get(key) }),
+    store: (key, value) => cached.set(key, value),
+  });
+  return { queue, scheduled, loads, requests, cached };
+}
+
+describe("highlight queue", () => {
+  it("shares identical pending work and a resolved cache entry", async () => {
+    const state = fixture();
+    const first = state.queue.acquire("typescript\0code");
+    const second = state.queue.acquire("typescript\0code");
+
+    assert.equal(first.result, second.result);
+    assert.equal(state.scheduled.length, 1);
+    state.scheduled.shift()?.();
+    assert.deepEqual(state.loads, ["typescript\0code"]);
+    state.requests.get("typescript\0code")?.resolve("<pre>code</pre>");
+    assert.equal(await first.result, "<pre>code</pre>");
+    assert.equal(await second.result, "<pre>code</pre>");
+    assert.equal(
+      state.queue.acquire("typescript\0code").result,
+      "<pre>code</pre>",
+    );
+  });
+
+  it("cancels queued work only after its final lease releases", async () => {
+    const state = fixture();
+    const first = state.queue.acquire("one");
+    const second = state.queue.acquire("one");
+
+    first.release();
+    state.scheduled.shift()?.();
+    assert.deepEqual(state.loads, ["one"]);
+    state.requests.get("one")?.resolve("done");
+    assert.equal(await second.result, "done");
+
+    const cancelled = state.queue.acquire("two");
+    cancelled.release();
+    assert.equal(await cancelled.result, undefined);
+    state.scheduled.shift()?.();
+    assert.deepEqual(state.loads, ["one"]);
+  });
+
+  it("runs one job at a time", async () => {
+    const state = fixture();
+    const first = state.queue.acquire("one");
+    const second = state.queue.acquire("two");
+
+    assert.equal(state.scheduled.length, 1);
+    state.scheduled.shift()?.();
+    assert.deepEqual(state.loads, ["one"]);
+    assert.equal(state.scheduled.length, 0);
+    state.requests.get("one")?.resolve("first");
+    await first.result;
+    assert.equal(state.scheduled.length, 1);
+    state.scheduled.shift()?.();
+    assert.deepEqual(state.loads, ["one", "two"]);
+    state.requests.get("two")?.resolve("second");
+    assert.equal(await second.result, "second");
+  });
+
+  it("does not cache failures and permits retry", async () => {
+    const state = fixture();
+    const first = state.queue.acquire("one");
+    state.scheduled.shift()?.();
+    state.requests.get("one")?.reject(new Error("failed"));
+    assert.equal(await first.result, undefined);
+
+    const second = state.queue.acquire("one");
+    assert.equal(state.scheduled.length, 1);
+    state.scheduled.shift()?.();
+    state.requests.get("one")?.resolve("recovered");
+    assert.equal(await second.result, "recovered");
+  });
+});

--- a/packages/ui-kit/src/lib/core/highlight/highlight-queue.ts
+++ b/packages/ui-kit/src/lib/core/highlight/highlight-queue.ts
@@ -1,0 +1,110 @@
+export type HighlightQueueLease<T> = {
+  result: T | Promise<T | undefined> | undefined;
+  release: () => void;
+};
+
+type QueueJob<T> = {
+  key: string;
+  leases: number;
+  started: boolean;
+  cancelled: boolean;
+  promise: Promise<T | undefined>;
+  resolve: (value: T | undefined) => void;
+};
+
+export type HighlightQueueOptions<T> = {
+  load: (key: string) => Promise<T | undefined>;
+  schedule: (start: () => void) => void;
+  lookup: (key: string) => { hit: boolean; value?: T };
+  store: (key: string, value: T) => void;
+};
+
+/** Single-concurrency work queue whose pending jobs are reference-counted. */
+export function createHighlightQueue<T>(options: HighlightQueueOptions<T>): {
+  acquire: (key: string) => HighlightQueueLease<T>;
+} {
+  const pending = new Map<string, QueueJob<T>>();
+  const queued: QueueJob<T>[] = [];
+  let active: QueueJob<T> | undefined;
+
+  function finish(job: QueueJob<T>, value: T | undefined): void {
+    if (value !== undefined) options.store(job.key, value);
+    if (pending.get(job.key) === job) pending.delete(job.key);
+    if (active === job) active = undefined;
+    job.resolve(value);
+    pump();
+  }
+
+  function pump(): void {
+    if (active) return;
+    const job = queued.shift();
+    if (!job) return;
+    if (job.cancelled || job.leases === 0) {
+      pump();
+      return;
+    }
+
+    active = job;
+    try {
+      options.schedule(() => {
+        if (job.cancelled || job.leases === 0) {
+          if (active === job) active = undefined;
+          pump();
+          return;
+        }
+        job.started = true;
+        void options.load(job.key).then(
+          (value) => finish(job, value),
+          () => finish(job, undefined),
+        );
+      });
+    } catch {
+      finish(job, undefined);
+    }
+  }
+
+  return {
+    acquire(key) {
+      const cached = options.lookup(key);
+      if (cached.hit) {
+        return { result: cached.value, release: () => undefined };
+      }
+
+      let job = pending.get(key);
+      if (!job) {
+        let resolve!: (value: T | undefined) => void;
+        const promise = new Promise<T | undefined>((complete) => {
+          resolve = complete;
+        });
+        job = {
+          key,
+          leases: 0,
+          started: false,
+          cancelled: false,
+          promise,
+          resolve,
+        };
+        pending.set(key, job);
+        queued.push(job);
+      }
+      job.leases += 1;
+      let released = false;
+
+      pump();
+      return {
+        result: job.promise,
+        release() {
+          if (released) return;
+          released = true;
+          job.leases = Math.max(0, job.leases - 1);
+          if (job.leases > 0 || job.started || job.cancelled) return;
+          job.cancelled = true;
+          if (pending.get(job.key) === job) pending.delete(job.key);
+          if (active === job) active = undefined;
+          job.resolve(undefined);
+          pump();
+        },
+      };
+    },
+  };
+}

--- a/packages/ui-kit/src/lib/core/highlight/highlight.ts
+++ b/packages/ui-kit/src/lib/core/highlight/highlight.ts
@@ -1,4 +1,9 @@
 import { LruCache } from "@nervekit/ui-kit/core/utils/lru-cache";
+import { isWithinHighlightBudget } from "./highlight-policy";
+import {
+  createHighlightQueue,
+  type HighlightQueueLease,
+} from "./highlight-queue";
 
 const languageLoaders = {
   bash: () => import("@shikijs/langs/bash"),
@@ -53,18 +58,15 @@ const languageAliases = new Map<string, HighlightLanguage>([
 
 const supported = new Set<string>(Object.keys(languageLoaders));
 let highlighterPromise: Promise<HighlighterLike> | undefined;
-// Bounded so long sessions with many unique code/tool blocks don't grow the
-// cache without limit. Stores resolved HTML (and in-flight promises) by
-// `${lang}\0${code}`.
-const highlightCache = new LruCache<
-  string,
-  string | Promise<string | undefined> | undefined
->(500);
+const resolvedHighlightCache = new LruCache<string, string>(500);
+const HIGHLIGHT_SETTLE_DELAY_MS = 500;
 
 export type HighlightCodeResult =
   | string
   | Promise<string | undefined>
   | undefined;
+
+export type HighlightCodeLease = HighlightQueueLease<string>;
 
 export function normalizeHighlightLanguage(
   language: string | undefined,
@@ -99,6 +101,24 @@ function runWhenIdle<T>(task: () => Promise<T>): Promise<T> {
   });
 }
 
+function scheduleWhenIdle(start: () => void): void {
+  if (typeof window === "undefined") {
+    queueMicrotask(start);
+    return;
+  }
+
+  // Virtual rows commonly remain mounted for only a few frames while the user
+  // scrolls. Let that churn settle before claiming renderer time; leases will
+  // cancel jobs whose rows disappear during this window.
+  window.setTimeout(() => {
+    if (typeof window.requestIdleCallback === "function") {
+      window.requestIdleCallback(start, { timeout: 750 });
+    } else {
+      start();
+    }
+  }, HIGHLIGHT_SETTLE_DELAY_MS);
+}
+
 async function getHighlighter(): Promise<HighlighterLike> {
   highlighterPromise ??= Promise.all([
     import("@shikijs/core"),
@@ -117,49 +137,77 @@ async function getHighlighter(): Promise<HighlighterLike> {
   return highlighterPromise;
 }
 
+async function performHighlight(
+  code: string,
+  lang: HighlightLanguage,
+): Promise<string> {
+  const highlighter = await getHighlighter();
+  return highlighter.codeToHtml(code, {
+    lang,
+    themes: {
+      light: "github-light",
+      dark: "github-dark-dimmed",
+    },
+    defaultColor: false,
+  });
+}
+
 export async function highlightCode(
   code: string,
   language: string | undefined,
 ): Promise<string | undefined> {
   const lang = normalizeHighlightLanguage(language);
-  if (!lang) return undefined;
-  return runWhenIdle(async () => {
-    const highlighter = await getHighlighter();
-    return highlighter.codeToHtml(code, {
-      lang,
-      themes: {
-        light: "github-light",
-        dark: "github-dark-dimmed",
-      },
-      defaultColor: false,
-    });
-  });
+  if (!lang || !isWithinHighlightBudget(code)) return undefined;
+  return runWhenIdle(() => performHighlight(code, lang));
 }
 
 function highlightCacheKey(code: string, lang: HighlightLanguage): string {
   return `${lang}\0${code}`;
 }
 
+function splitHighlightCacheKey(key: string): {
+  code: string;
+  lang: HighlightLanguage;
+} {
+  const separator = key.indexOf("\0");
+  return {
+    lang: key.slice(0, separator) as HighlightLanguage,
+    code: key.slice(separator + 1),
+  };
+}
+
+const highlightQueue = createHighlightQueue<string>({
+  load: (key) => {
+    const { code, lang } = splitHighlightCacheKey(key);
+    return performHighlight(code, lang);
+  },
+  schedule: scheduleWhenIdle,
+  lookup: (key) => ({
+    hit: resolvedHighlightCache.has(key),
+    value: resolvedHighlightCache.get(key),
+  }),
+  store: (key, value) => resolvedHighlightCache.set(key, value),
+});
+
+/**
+ * Acquires shared highlighting work. Releasing before queued work starts lets
+ * virtualized callers cancel obsolete offscreen tokenization.
+ */
+export function acquireHighlightCode(
+  code: string,
+  language: string | undefined,
+): HighlightCodeLease {
+  const lang = normalizeHighlightLanguage(language);
+  if (!lang || !isWithinHighlightBudget(code)) {
+    return { result: undefined, release: () => undefined };
+  }
+  return highlightQueue.acquire(highlightCacheKey(code, lang));
+}
+
+/** Cached highlighting for non-cancellable consumers such as Markdown. */
 export function highlightCodeCached(
   code: string,
   language: string | undefined,
 ): HighlightCodeResult {
-  const lang = normalizeHighlightLanguage(language);
-  if (!lang) return undefined;
-
-  const key = highlightCacheKey(code, lang);
-  const cached = highlightCache.get(key);
-  if (cached !== undefined || highlightCache.has(key)) return cached;
-
-  const promise = highlightCode(code, lang)
-    .then((result) => {
-      highlightCache.set(key, result);
-      return result;
-    })
-    .catch(() => {
-      highlightCache.delete(key);
-      return undefined;
-    });
-  highlightCache.set(key, promise);
-  return promise;
+  return acquireHighlightCode(code, language).result;
 }

--- a/packages/workbench-app/src/lib/features/tasks/state/task-definition-revalidation.test.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/task-definition-revalidation.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createTaskDefinitionRevalidationGate } from "./task-definition-revalidation";
+
+describe("task definition revalidation gate", () => {
+  it("schedules once for repeated observations of one project", () => {
+    const gate = createTaskDefinitionRevalidationGate();
+    const first = gate.enter("project-a");
+
+    assert.ok(first);
+    assert.equal(gate.enter("project-a"), undefined);
+    assert.equal(gate.enter("project-a"), undefined);
+    assert.equal(gate.isCurrent(first), true);
+  });
+
+  it("resets when no project is active", () => {
+    const gate = createTaskDefinitionRevalidationGate();
+    const first = gate.enter("project-a");
+
+    assert.ok(first);
+    assert.equal(gate.enter(undefined), undefined);
+    assert.equal(gate.isCurrent(first), false);
+    assert.ok(gate.enter("project-a"));
+  });
+
+  it("schedules every real project switch, including returning to a project", () => {
+    const gate = createTaskDefinitionRevalidationGate();
+
+    const firstA = gate.enter("project-a");
+    const firstB = gate.enter("project-b");
+    const secondA = gate.enter("project-a");
+
+    assert.ok(firstA);
+    assert.ok(firstB);
+    assert.ok(secondA);
+    assert.equal(gate.isCurrent(firstA), false);
+    assert.equal(gate.isCurrent(firstB), false);
+    assert.equal(gate.isCurrent(secondA), true);
+  });
+});

--- a/packages/workbench-app/src/lib/features/tasks/state/task-definition-revalidation.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/task-definition-revalidation.ts
@@ -1,0 +1,41 @@
+export type TaskDefinitionRevalidation = {
+  projectId: string;
+  generation: number;
+};
+
+export type TaskDefinitionRevalidationGate = {
+  enter: (
+    projectId: string | undefined,
+  ) => TaskDefinitionRevalidation | undefined;
+  isCurrent: (revalidation: TaskDefinitionRevalidation) => boolean;
+};
+
+/**
+ * Limits background definition revalidation to panel mount/project changes.
+ * A generation also prevents an older project's completion from mutating the
+ * loading state for the currently active project.
+ */
+export function createTaskDefinitionRevalidationGate(): TaskDefinitionRevalidationGate {
+  let currentProjectId: string | undefined;
+  let generation = 0;
+
+  return {
+    enter(projectId) {
+      if (!projectId) {
+        currentProjectId = undefined;
+        generation += 1;
+        return undefined;
+      }
+      if (projectId === currentProjectId) return undefined;
+      currentProjectId = projectId;
+      generation += 1;
+      return { projectId, generation };
+    },
+    isCurrent(revalidation) {
+      return (
+        revalidation.projectId === currentProjectId &&
+        revalidation.generation === generation
+      );
+    },
+  };
+}

--- a/packages/workbench-app/src/lib/features/tasks/state/task-definitions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/task-definitions.svelte.ts
@@ -1,56 +1,88 @@
 import { SvelteMap } from "svelte/reactivity";
 import { getTaskDefinitions, type TaskDefinition } from "$lib/api";
 
+type FetchTaskDefinitions = (projectId: string) => Promise<TaskDefinition[]>;
+
+export type TaskDefinitionStore = {
+  cached: (projectId: string | undefined) => TaskDefinition[] | undefined;
+  load: (projectId: string) => Promise<void>;
+  upsert: (projectId: string, definition: TaskDefinition) => void;
+  remove: (definitionId: string) => void;
+};
+
 /**
- * Project-scoped cache for task definitions. It outlives the tasks panel so
- * re-opening the panel renders the known definitions immediately and only
- * revalidates in the background.
+ * Creates a project-scoped reactive cache with non-reactive in-flight request
+ * bookkeeping. The cache may outlive a panel while explicit loads revalidate
+ * known data in the background.
  */
-const byProject = new SvelteMap<string, TaskDefinition[]>();
-// Request de-duplication only; deliberately non-reactive.
-const inFlight = new SvelteMap<string, Promise<void>>();
+export function createTaskDefinitionStore(
+  fetchDefinitions: FetchTaskDefinitions,
+): TaskDefinitionStore {
+  const byProject = new SvelteMap<string, TaskDefinition[]>();
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity -- request bookkeeping must not invalidate rune effects.
+  const inFlight = new Map<string, Promise<void>>();
+
+  return {
+    cached(projectId) {
+      return projectId ? byProject.get(projectId) : undefined;
+    },
+    async load(projectId) {
+      const pending = inFlight.get(projectId);
+      if (pending) return pending;
+      const request = fetchDefinitions(projectId)
+        .then((definitions) => {
+          byProject.set(projectId, definitions);
+        })
+        .finally(() => {
+          inFlight.delete(projectId);
+        });
+      inFlight.set(projectId, request);
+      return request;
+    },
+    upsert(projectId, definition) {
+      const current = byProject.get(projectId) ?? [];
+      const index = current.findIndex((item) => item.id === definition.id);
+      byProject.set(
+        projectId,
+        index === -1
+          ? [...current, definition]
+          : current.map((item) =>
+              item.id === definition.id ? definition : item,
+            ),
+      );
+    },
+    remove(definitionId) {
+      for (const [projectId, definitions] of byProject) {
+        if (!definitions.some((item) => item.id === definitionId)) continue;
+        byProject.set(
+          projectId,
+          definitions.filter((item) => item.id !== definitionId),
+        );
+      }
+    },
+  };
+}
+
+const taskDefinitionStore = createTaskDefinitionStore(getTaskDefinitions);
 
 export function cachedTaskDefinitions(
   projectId: string | undefined,
 ): TaskDefinition[] | undefined {
-  return projectId ? byProject.get(projectId) : undefined;
+  return taskDefinitionStore.cached(projectId);
 }
 
-/** Fetches definitions once per project, reusing an in-flight request. */
-export async function loadTaskDefinitions(projectId: string): Promise<void> {
-  const pending = inFlight.get(projectId);
-  if (pending) return pending;
-  const request = getTaskDefinitions(projectId)
-    .then((definitions) => {
-      byProject.set(projectId, definitions);
-    })
-    .finally(() => {
-      inFlight.delete(projectId);
-    });
-  inFlight.set(projectId, request);
-  return request;
+/** Revalidates one project while sharing any request already in flight. */
+export function loadTaskDefinitions(projectId: string): Promise<void> {
+  return taskDefinitionStore.load(projectId);
 }
 
 export function upsertCachedTaskDefinition(
   projectId: string,
   definition: TaskDefinition,
 ): void {
-  const current = byProject.get(projectId) ?? [];
-  const index = current.findIndex((item) => item.id === definition.id);
-  byProject.set(
-    projectId,
-    index === -1
-      ? [...current, definition]
-      : current.map((item) => (item.id === definition.id ? definition : item)),
-  );
+  taskDefinitionStore.upsert(projectId, definition);
 }
 
 export function removeCachedTaskDefinition(definitionId: string): void {
-  for (const [projectId, definitions] of byProject) {
-    if (!definitions.some((item) => item.id === definitionId)) continue;
-    byProject.set(
-      projectId,
-      definitions.filter((item) => item.id !== definitionId),
-    );
-  }
+  taskDefinitionStore.remove(definitionId);
 }

--- a/packages/workbench-app/src/lib/features/tasks/state/task-definitions.test.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/task-definitions.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { TaskDefinition } from "$lib/api";
+import { createTaskDefinitionStore } from "./task-definitions.svelte";
+
+function definition(
+  id: string,
+  projectId = "proj_a",
+  command = "pnpm test",
+): TaskDefinition {
+  return {
+    id,
+    scope: { kind: "project", projectId },
+    command,
+    runPolicy: "single",
+    createdAt: "2026-08-14T00:00:00.000Z",
+    updatedAt: "2026-08-14T00:00:00.000Z",
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("task definition store", () => {
+  it("deduplicates concurrent project loads", async () => {
+    const request = deferred<TaskDefinition[]>();
+    let calls = 0;
+    const store = createTaskDefinitionStore(() => {
+      calls += 1;
+      return request.promise;
+    });
+
+    const first = store.load("proj_a");
+    const second = store.load("proj_a");
+    assert.equal(calls, 1);
+    request.resolve([definition("taskdef_one")]);
+    await Promise.all([first, second]);
+    assert.deepEqual(store.cached("proj_a"), [definition("taskdef_one")]);
+  });
+
+  it("loads different projects concurrently", async () => {
+    const requests = new Map<
+      string,
+      ReturnType<typeof deferred<TaskDefinition[]>>
+    >();
+    const store = createTaskDefinitionStore((projectId) => {
+      const request = deferred<TaskDefinition[]>();
+      requests.set(projectId, request);
+      return request.promise;
+    });
+
+    const a = store.load("proj_a");
+    const b = store.load("proj_b");
+    assert.equal(requests.size, 2);
+    requests.get("proj_a")?.resolve([definition("taskdef_a", "proj_a")]);
+    requests.get("proj_b")?.resolve([definition("taskdef_b", "proj_b")]);
+    await Promise.all([a, b]);
+  });
+
+  it("retains cached data after failure and permits retry", async () => {
+    let attempt = 0;
+    const store = createTaskDefinitionStore(async () => {
+      attempt += 1;
+      if (attempt === 2) throw new Error("offline");
+      return [definition("taskdef_one", "proj_a", `command-${attempt}`)];
+    });
+
+    await store.load("proj_a");
+    const cached = store.cached("proj_a");
+    await assert.rejects(store.load("proj_a"), /offline/);
+    assert.equal(store.cached("proj_a"), cached);
+    await store.load("proj_a");
+    assert.equal(store.cached("proj_a")?.[0]?.command, "command-3");
+  });
+
+  it("updates and removes cached definitions without fetching", () => {
+    let calls = 0;
+    const store = createTaskDefinitionStore(async () => {
+      calls += 1;
+      return [];
+    });
+    const first = definition("taskdef_one");
+    const updated = definition("taskdef_one", "proj_a", "pnpm check");
+
+    store.upsert("proj_a", first);
+    store.upsert("proj_a", updated);
+    assert.deepEqual(store.cached("proj_a"), [updated]);
+    store.remove(first.id);
+    assert.deepEqual(store.cached("proj_a"), []);
+    assert.equal(calls, 0);
+  });
+});

--- a/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
@@ -1,3 +1,4 @@
+import { untrack } from "svelte";
 import type {
   ProjectRecord,
   StartTaskRequest,
@@ -34,6 +35,7 @@ import {
   removeCachedTaskDefinition,
   upsertCachedTaskDefinition,
 } from "$lib/features/tasks/state/task-definitions.svelte";
+import { createTaskDefinitionRevalidationGate } from "$lib/features/tasks/state/task-definition-revalidation";
 import {
   createTaskPanelActions,
   disabledCapability,
@@ -71,6 +73,7 @@ export function createWorkbenchTaskPanelAdapter(
 ): { readonly model: TaskPanelModel; readonly actions: TaskPanelActions } {
   let loadingDefinitions = $state(false);
   let runningDefinitionId = $state<string | undefined>(undefined);
+  const definitionRevalidation = createTaskDefinitionRevalidationGate();
   const definitions = $derived(
     cachedTaskDefinitions(activeProject()?.id) ?? [],
   );
@@ -264,16 +267,28 @@ export function createWorkbenchTaskPanelAdapter(
   // immediately, so the loading state only shows on a cold cache.
   $effect(() => {
     const projectId = activeProject()?.id;
-    if (!projectId) return;
-    const cold = cachedTaskDefinitions(projectId) === undefined;
-    if (cold) loadingDefinitions = true;
-    void loadTaskDefinitions(projectId)
-      .catch((error) =>
-        notify.error(`Could not load task definitions: ${errorMessage(error)}`),
-      )
-      .finally(() => {
-        if (cold) loadingDefinitions = false;
-      });
+    const revalidation = definitionRevalidation.enter(projectId);
+    if (!projectId) {
+      loadingDefinitions = false;
+      return;
+    }
+    if (!revalidation) return;
+
+    untrack(() => {
+      const cold = cachedTaskDefinitions(revalidation.projectId) === undefined;
+      loadingDefinitions = cold;
+      void loadTaskDefinitions(revalidation.projectId)
+        .catch((error) =>
+          notify.error(
+            `Could not load task definitions: ${errorMessage(error)}`,
+          ),
+        )
+        .finally(() => {
+          if (cold && definitionRevalidation.isCurrent(revalidation)) {
+            loadingDefinitions = false;
+          }
+        });
+    });
   });
 
   return adapter;

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ResultCodeBlock.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ResultCodeBlock.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { highlightCodeCached } from "@nervekit/ui-kit/core/highlight/highlight";
+import { acquireHighlightCode } from "@nervekit/ui-kit/core/highlight/highlight";
 import { ansiToHtml } from "@nervekit/ui-kit/core/terminal/ansi";
 import { trimTextPreview } from "@nervekit/ui-kit/core/utils/text-preview";
 import {
@@ -153,10 +153,14 @@ $effect(() => {
 });
 
 $effect(() => {
-  // Re-measure after content, highlighting, terminal rendering, or row caps
-  // change. Width-driven reflows are handled by the ResizeObserver below.
-  const measurementKey = `${preview.text}\0${html ?? ""}\0${terminalHtml}\0${fixedRows ?? ""}`;
-  if (!hasFixedRows || measurementKey === undefined) return;
+  // Track compact render revisions rather than allocating a string containing
+  // the complete highlighted HTML. Width reflows use the observer below.
+  void signature;
+  void htmlSignature;
+  void terminal;
+  void isDiff;
+  void fixedRows;
+  if (!hasFixedRows) return;
   scheduleMeasure();
 });
 
@@ -209,15 +213,18 @@ $effect(() => {
   )
     return;
 
-  const result = highlightCodeCached(preview.text, language);
+  const lease = acquireHighlightCode(preview.text, language);
+  const result = lease.result;
   if (typeof result === "string") {
     html = result;
     htmlSignature = currentSignature;
     unavailableSignature = undefined;
+    lease.release();
     return;
   }
   if (!result) {
     unavailableSignature = currentSignature;
+    lease.release();
     return;
   }
 
@@ -234,6 +241,7 @@ $effect(() => {
   });
   return () => {
     cancelled = true;
+    lease.release();
   };
 });
 </script>
@@ -286,26 +294,6 @@ $effect(() => {
           >{/each}</pre>
     </div>
   </div>
-{:else if highlight && html && htmlSignature === signature}
-  <div
-    bind:this={blockEl}
-    class="code-block"
-    data-wrap={wrap ? "true" : "false"}
-    data-overflow={overflow}
-    data-fixed-rows={hasFixedRows ? "true" : undefined}
-    data-tail={tail ? "true" : undefined}
-    style:--code-block-fixed-rows={fixedRowsVar}
-    style:--code-block-visible-rows={visibleRowsVar}
-  >
-    <div
-      bind:this={viewportEl}
-      class="code-block__viewport"
-      style:max-height={hasFixedRows ? undefined : maxHeight}
-    >
-      <!-- eslint-disable-next-line svelte/no-at-html-tags -- Shiki serializes source code into controlled highlighted markup. -->
-      <div bind:this={contentEl} class="code-block__content">{@html html}</div>
-    </div>
-  </div>
 {:else}
   <div
     bind:this={blockEl}
@@ -322,9 +310,14 @@ $effect(() => {
       class="code-block__viewport"
       style:max-height={hasFixedRows ? undefined : maxHeight}
     >
-      <pre
-        bind:this={contentEl}
-        class="code-block__content">{preview.text}</pre>
+      <div bind:this={contentEl} class="code-block__content">
+        {#if highlight && html && htmlSignature === signature}
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -- Shiki serializes source code into controlled highlighted markup. -->
+          {@html html}
+        {:else}
+          <pre>{preview.text}</pre>
+        {/if}
+      </div>
     </div>
   </div>
 {/if}

--- a/packages/workbench-server/src/infrastructure/diagnostics/index.ts
+++ b/packages/workbench-server/src/infrastructure/diagnostics/index.ts
@@ -1,2 +1,3 @@
 export * from "./crash-reports.js";
 export * from "./logging.js";
+export * from "./performance-monitor.js";

--- a/packages/workbench-server/src/infrastructure/diagnostics/performance-monitor.ts
+++ b/packages/workbench-server/src/infrastructure/diagnostics/performance-monitor.ts
@@ -1,0 +1,133 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const SAMPLE_INTERVAL_MS = 10_000;
+
+type IntervalHandle = ReturnType<typeof setInterval>;
+type CpuUsage = { user: number; system: number };
+type MemoryUsage = {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+};
+
+export type DaemonPerformanceCounts = Record<string, number>;
+
+type DaemonPerformanceMonitorOptions = {
+  enabled: boolean;
+  dataDir: string;
+  getCounts: () => DaemonPerformanceCounts;
+  cpuUsage?: () => CpuUsage;
+  memoryUsage?: () => MemoryUsage;
+  uptime?: () => number;
+  activeHandles?: () => number;
+  activeRequests?: () => number;
+  now?: () => Date;
+  monotonicNowMs?: () => number;
+  append?: (path: string, line: string) => Promise<void>;
+  setInterval?: (callback: () => void, delayMs: number) => IntervalHandle;
+  clearInterval?: (handle: IntervalHandle) => void;
+  warn?: (error: unknown) => void;
+};
+
+export type DaemonPerformanceMonitor = { stop: () => void };
+
+async function appendJsonLine(path: string, line: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, line, "utf8");
+}
+
+function defaultActiveHandles(): number {
+  const runtime = process as NodeJS.Process & {
+    _getActiveHandles?: () => unknown[];
+  };
+  return runtime._getActiveHandles?.().length ?? 0;
+}
+
+function defaultActiveRequests(): number {
+  const runtime = process as NodeJS.Process & {
+    _getActiveRequests?: () => unknown[];
+  };
+  return runtime._getActiveRequests?.().length ?? 0;
+}
+
+export function installDaemonPerformanceMonitor(
+  options: DaemonPerformanceMonitorOptions,
+): DaemonPerformanceMonitor {
+  if (!options.enabled) return { stop: () => undefined };
+
+  const cpuUsage = options.cpuUsage ?? (() => process.cpuUsage());
+  const memoryUsage = options.memoryUsage ?? (() => process.memoryUsage());
+  const uptime = options.uptime ?? (() => process.uptime());
+  const activeHandles = options.activeHandles ?? defaultActiveHandles;
+  const activeRequests = options.activeRequests ?? defaultActiveRequests;
+  const now = options.now ?? (() => new Date());
+  const monotonicNowMs = options.monotonicNowMs ?? (() => performance.now());
+  const append = options.append ?? appendJsonLine;
+  const createInterval = options.setInterval ?? setInterval;
+  const destroyInterval = options.clearInterval ?? clearInterval;
+  const path = join(options.dataDir, "logs", "performance.jsonl");
+  let previousCpu = cpuUsage();
+  let previousAtMs = monotonicNowMs();
+  let stopped = false;
+  let writing = false;
+  let warned = false;
+
+  const sample = () => {
+    if (stopped || writing) return;
+    const currentCpu = cpuUsage();
+    const currentAtMs = monotonicNowMs();
+    const elapsedMicros = Math.max(0, currentAtMs - previousAtMs) * 1000;
+    const consumedMicros =
+      currentCpu.user +
+      currentCpu.system -
+      previousCpu.user -
+      previousCpu.system;
+    previousCpu = currentCpu;
+    previousAtMs = currentAtMs;
+    const memory = memoryUsage();
+    writing = true;
+    const record = {
+      type: "nerve.performance",
+      source: "daemon",
+      ts: now().toISOString(),
+      pid: process.pid,
+      uptimeMs: Math.round(uptime() * 1000),
+      cpuPercent:
+        elapsedMicros > 0
+          ? Math.max(0, (consumedMicros / elapsedMicros) * 100)
+          : undefined,
+      rssBytes: memory.rss,
+      heapTotalBytes: memory.heapTotal,
+      heapUsedBytes: memory.heapUsed,
+      externalBytes: memory.external,
+      arrayBuffersBytes: memory.arrayBuffers,
+      activeHandles: activeHandles(),
+      activeRequests: activeRequests(),
+      counts: options.getCounts(),
+    };
+    void append(path, `${JSON.stringify(record)}\n`)
+      .catch((error) => {
+        if (warned) return;
+        warned = true;
+        options.warn?.(error);
+      })
+      .finally(() => {
+        writing = false;
+      });
+  };
+
+  sample();
+  const interval = createInterval(sample, SAMPLE_INTERVAL_MS);
+  interval.unref?.();
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      destroyInterval(interval);
+    },
+  };
+}

--- a/packages/workbench-server/src/main.ts
+++ b/packages/workbench-server/src/main.ts
@@ -12,7 +12,9 @@ import {
 } from "./app/orchestrator-state.js";
 import { createApp } from "./app/server.js";
 import {
+  type DaemonPerformanceMonitor,
   type DaemonRuntimeMonitor,
+  installDaemonPerformanceMonitor,
   installDaemonRuntimeMonitor,
   installNodeDiagnosticReports,
   serializeCrashError,
@@ -84,6 +86,7 @@ function prepareEnterpriseNetworkEnvironment(): void {
 }
 
 let runtimeMonitor: DaemonRuntimeMonitor | undefined;
+let performanceMonitor: DaemonPerformanceMonitor | undefined;
 const processStartupStartedAt = performance.now();
 
 /**
@@ -275,6 +278,8 @@ async function main() {
         registryStateDurationMs: registryTimings.stateDurationMs,
         indexDurationMs: registryTimings.indexDurationMs,
         storesHydrationDurationMs: registryTimings.storesHydrationDurationMs,
+        storeDurationsMs: registryTimings.storeDurationsMs,
+        hydrationCounts: registryTimings.counts,
         agentsHydrationDurationMs: registryTimings.agentsHydrationDurationMs,
         runRecoveryDurationMs: registryTimings.runRecoveryDurationMs,
         humanInputRecoveryDurationMs:
@@ -283,6 +288,22 @@ async function main() {
         taskNotificationsDurationMs:
           registryTimings.taskNotificationsDurationMs,
         toolCallHydrationSource: registryTimings.toolCallHydrationSource,
+      });
+      performanceMonitor ??= installDaemonPerformanceMonitor({
+        enabled: process.env.NERVE_PERFORMANCE_DIAGNOSTICS === "1",
+        dataDir: storage.paths.home,
+        getCounts: () => ({
+          ...registryTimings.counts,
+          projects: state.registry.listProjects().length,
+          conversations: state.registry.listConversations().length,
+          agents: state.registry.listAgents().length,
+          tasks: state.registry.listTasks().length,
+        }),
+        warn: (error) => {
+          void state.logger.warn("Daemon performance sampling failed", {
+            error,
+          });
+        },
       });
       setImmediate(() => state.registry.startBackgroundMaintenance());
     },
@@ -335,6 +356,8 @@ async function main() {
   const shutdown = async (signal: NodeJS.Signals) => {
     if (shuttingDown) return;
     shuttingDown = true;
+    performanceMonitor?.stop();
+    performanceMonitor = undefined;
     const startedAt = Date.now();
     const forceExitTimer = setTimeout(() => process.exit(0), 2000);
     forceExitTimer.unref();

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -48,6 +48,27 @@ import { composeRuntime, type RuntimeServices } from "./runtime-composition.js";
 import { RuntimeState } from "./runtime-state.js";
 import type { AppendEntryInput, AppendEntryOptions } from "./types.js";
 
+export type StoreHydrationDurations = {
+  auth: number;
+  providers: number;
+  workers: number;
+  tasks: number;
+  tools: number;
+  plans: number;
+  projects: number;
+  conversations: number;
+};
+
+export type RegistryHydrationCounts = {
+  projects: number;
+  conversations: number;
+  agents: number;
+  tasks: number;
+  toolCalls: number;
+  runMetadata: number;
+  activeRuns: number;
+};
+
 export interface RegistryHydrationTimings {
   stateDurationMs: number;
   indexDurationMs: number;
@@ -55,6 +76,10 @@ export interface RegistryHydrationTimings {
   toolCallHydrationSource: "snapshot" | "journal";
   /** ms: parallel store hydration (tasks/tools/plans/projects/conversations). */
   storesHydrationDurationMs: number;
+  /** Individual concurrent store operation durations. */
+  storeDurationsMs: StoreHydrationDurations;
+  /** Hydrated workload cardinalities recorded without loading terminal runs. */
+  counts: RegistryHydrationCounts;
   /** ms: agent records load. */
   agentsHydrationDurationMs: number;
   /** ms: run coordinator recovery (metadata scan + active run hydrates). */
@@ -173,6 +198,16 @@ export class RuntimeRegistry {
   async hydrate(): Promise<RegistryHydrationTimings> {
     const stateStartedAt = performance.now();
     let storesHydrationDurationMs = 0;
+    let storeDurationsMs = emptyStoreHydrationDurations();
+    let counts: RegistryHydrationCounts = {
+      projects: 0,
+      conversations: 0,
+      agents: 0,
+      tasks: 0,
+      toolCalls: 0,
+      runMetadata: 0,
+      activeRuns: 0,
+    };
     let agentsHydrationDurationMs = 0;
     let runRecoveryDurationMs = 0;
     let humanInputRecoveryDurationMs = 0;
@@ -180,16 +215,18 @@ export class RuntimeRegistry {
     let taskNotificationsDurationMs = 0;
     await this.index.withUpdatesDeferred(async () => {
       const storesStartedAt = performance.now();
-      const workersHydrated = this.workers.hydrate();
-      await settleHydrationOperations([
-        this.auth.refreshModels({ allowNetwork: false }),
-        this.providerCatalog.load(),
-        workersHydrated,
-        this.tasks.hydrate(),
-        this.tools.hydrate(),
-        this.plans.hydrate(),
-        this.loadProjects(),
-        this.loadConversations(),
+      storeDurationsMs = await settleMeasuredHydrationOperations([
+        {
+          name: "auth",
+          run: () => this.auth.refreshModels({ allowNetwork: false }),
+        },
+        { name: "providers", run: () => this.providerCatalog.load() },
+        { name: "workers", run: () => this.workers.hydrate() },
+        { name: "tasks", run: () => this.tasks.hydrate() },
+        { name: "tools", run: () => this.tools.hydrate() },
+        { name: "plans", run: () => this.plans.hydrate() },
+        { name: "projects", run: () => this.loadProjects() },
+        { name: "conversations", run: () => this.loadConversations() },
       ]);
       storesHydrationDurationMs = Math.round(
         performance.now() - storesStartedAt,
@@ -215,11 +252,24 @@ export class RuntimeRegistry {
       // the full states of the already-recovered active runs; terminal run
       // history is never hydrated during startup.
       const projectorStartedAt = performance.now();
+      const activeStates =
+        await this.services.runRuntime.unitOfWork.listActive();
+      const runRecords =
+        await this.services.runRuntime.unitOfWork.listMetadata();
       await this.services.runRuntime.projector.rebuild({
-        activeStates: await this.services.runRuntime.unitOfWork.listActive(),
-        runRecords: await this.services.runRuntime.unitOfWork.listMetadata(),
+        activeStates,
+        runRecords,
       });
       projectorDurationMs = Math.round(performance.now() - projectorStartedAt);
+      counts = {
+        projects: this.listProjects().length,
+        conversations: this.listConversations().length,
+        agents: this.listAgents().length,
+        tasks: this.tasks.listTasks().length,
+        toolCalls: this.tools.listToolCalls().length,
+        runMetadata: runRecords.length,
+        activeRuns: activeStates.length,
+      };
       await this.services.runRuntime.delivery.flush();
       const taskNotificationsStartedAt = performance.now();
       await this.services.taskNotifications.recoverPendingNotifications();
@@ -239,6 +289,8 @@ export class RuntimeRegistry {
       indexDurationMs: Math.round(performance.now() - indexStartedAt),
       toolCallHydrationSource: this.tools.toolCallHydrationSource,
       storesHydrationDurationMs,
+      storeDurationsMs,
+      counts,
       agentsHydrationDurationMs,
       runRecoveryDurationMs,
       humanInputRecoveryDurationMs,
@@ -836,12 +888,41 @@ export class RuntimeRegistry {
   }
 }
 
-async function settleHydrationOperations(
-  operations: readonly Promise<unknown>[],
-): Promise<void> {
-  const results = await Promise.allSettled(operations);
+type StoreHydrationOperation = {
+  name: keyof StoreHydrationDurations;
+  run: () => Promise<unknown>;
+};
+
+function emptyStoreHydrationDurations(): StoreHydrationDurations {
+  return {
+    auth: 0,
+    providers: 0,
+    workers: 0,
+    tasks: 0,
+    tools: 0,
+    plans: 0,
+    projects: 0,
+    conversations: 0,
+  };
+}
+
+export async function settleMeasuredHydrationOperations(
+  operations: readonly StoreHydrationOperation[],
+  now: () => number = () => performance.now(),
+): Promise<StoreHydrationDurations> {
+  const durations = emptyStoreHydrationDurations();
+  const pending = operations.map(async ({ name, run }) => {
+    const startedAt = now();
+    try {
+      await run();
+    } finally {
+      durations[name] = Math.round(now() - startedAt);
+    }
+  });
+  const results = await Promise.allSettled(pending);
   const failure = results.find(
     (result): result is PromiseRejectedResult => result.status === "rejected",
   );
   if (failure) throw failure.reason;
+  return durations;
 }

--- a/packages/workbench-server/test/performance-monitor.test.ts
+++ b/packages/workbench-server/test/performance-monitor.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import { installDaemonPerformanceMonitor } from "../src/infrastructure/diagnostics/performance-monitor.js";
 
@@ -49,7 +50,7 @@ describe("daemon performance monitor", () => {
       activeRequests: () => 3,
       now: () => new Date("2026-08-14T00:00:00.000Z"),
       append: async (path, line) => {
-        assert.equal(path, "/safe/home/logs/performance.jsonl");
+        assert.equal(path, join("/safe/home", "logs", "performance.jsonl"));
         lines.push(line);
       },
       setInterval: ((callback: () => void, delay: number) => {

--- a/packages/workbench-server/test/performance-monitor.test.ts
+++ b/packages/workbench-server/test/performance-monitor.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { installDaemonPerformanceMonitor } from "../src/infrastructure/diagnostics/performance-monitor.js";
+
+function tick() {
+  return new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("daemon performance monitor", () => {
+  it("is inert unless explicitly enabled", () => {
+    let reads = 0;
+    const monitor = installDaemonPerformanceMonitor({
+      enabled: false,
+      dataDir: "/tmp/ignored",
+      getCounts: () => {
+        reads += 1;
+        return {};
+      },
+    });
+    monitor.stop();
+    assert.equal(reads, 0);
+  });
+
+  it("records CPU deltas, memory, handles, requests, and counts", async () => {
+    const cpu = [
+      { user: 100_000, system: 20_000 },
+      { user: 130_000, system: 30_000 },
+      { user: 160_000, system: 40_000 },
+    ];
+    const times = [1_000, 2_000, 3_000];
+    const lines: string[] = [];
+    let scheduled: (() => void) | undefined;
+    let clears = 0;
+    const monitor = installDaemonPerformanceMonitor({
+      enabled: true,
+      dataDir: "/safe/home",
+      getCounts: () => ({ projects: 4, activeRuns: 2 }),
+      cpuUsage: () => cpu.shift() ?? { user: 160_000, system: 40_000 },
+      monotonicNowMs: () => times.shift() ?? 3_000,
+      memoryUsage: () => ({
+        rss: 100,
+        heapTotal: 80,
+        heapUsed: 60,
+        external: 20,
+        arrayBuffers: 10,
+      }),
+      uptime: () => 12.5,
+      activeHandles: () => 7,
+      activeRequests: () => 3,
+      now: () => new Date("2026-08-14T00:00:00.000Z"),
+      append: async (path, line) => {
+        assert.equal(path, "/safe/home/logs/performance.jsonl");
+        lines.push(line);
+      },
+      setInterval: ((callback: () => void, delay: number) => {
+        assert.equal(delay, 10_000);
+        scheduled = callback;
+        return { unref() {} };
+      }) as never,
+      clearInterval: (() => {
+        clears += 1;
+      }) as never,
+    });
+
+    await tick();
+    scheduled?.();
+    await tick();
+    const first = JSON.parse(lines[0] ?? "{}") as Record<string, unknown>;
+    assert.equal(lines.length, 2);
+    assert.equal(first.cpuPercent, 4);
+    assert.equal(first.rssBytes, 100);
+    assert.equal(first.heapUsedBytes, 60);
+    assert.equal(first.activeHandles, 7);
+    assert.equal(first.activeRequests, 3);
+    assert.deepEqual(first.counts, { projects: 4, activeRuns: 2 });
+    assert.equal("argv" in first, false);
+    monitor.stop();
+    monitor.stop();
+    assert.equal(clears, 1);
+  });
+
+  it("skips overlapping appends and warns only once", async () => {
+    let scheduled: (() => void) | undefined;
+    let rejectWrite!: (error: Error) => void;
+    let writes = 0;
+    let warnings = 0;
+    const monitor = installDaemonPerformanceMonitor({
+      enabled: true,
+      dataDir: "/safe/home",
+      getCounts: () => ({}),
+      append: () => {
+        writes += 1;
+        return new Promise<void>((_resolve, reject) => {
+          rejectWrite = reject;
+        });
+      },
+      warn: () => {
+        warnings += 1;
+      },
+      setInterval: ((callback: () => void) => {
+        scheduled = callback;
+        return { unref() {} };
+      }) as never,
+      clearInterval: (() => undefined) as never,
+    });
+
+    scheduled?.();
+    assert.equal(writes, 1);
+    rejectWrite(new Error("disk full"));
+    await tick();
+    scheduled?.();
+    assert.equal(writes, 2);
+    rejectWrite(new Error("still full"));
+    await tick();
+    assert.equal(warnings, 1);
+    monitor.stop();
+  });
+});

--- a/packages/workbench-server/test/runtime-registry-hydration-timings.test.ts
+++ b/packages/workbench-server/test/runtime-registry-hydration-timings.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { settleMeasuredHydrationOperations } from "../src/runtime/runtime-registry.js";
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("registry store hydration timings", () => {
+  it("starts operations concurrently and records each duration", async () => {
+    let clock = 100;
+    const auth = deferred();
+    const tasks = deferred();
+    const started: string[] = [];
+    const result = settleMeasuredHydrationOperations(
+      [
+        {
+          name: "auth",
+          run: () => {
+            started.push("auth");
+            return auth.promise;
+          },
+        },
+        {
+          name: "tasks",
+          run: () => {
+            started.push("tasks");
+            return tasks.promise;
+          },
+        },
+      ],
+      () => clock,
+    );
+
+    assert.deepEqual(started, ["auth", "tasks"]);
+    clock = 135;
+    auth.resolve();
+    await Promise.resolve();
+    clock = 180;
+    tasks.resolve();
+
+    const durations = await result;
+    assert.equal(durations.auth, 35);
+    assert.equal(durations.tasks, 80);
+    assert.equal(durations.tools, 0);
+  });
+
+  it("settles every operation and rethrows the first rejection by input order", async () => {
+    const first = deferred();
+    const second = deferred();
+    let secondSettled = false;
+    const result = settleMeasuredHydrationOperations([
+      { name: "auth", run: () => first.promise },
+      {
+        name: "tasks",
+        run: async () => {
+          await second.promise;
+          secondSettled = true;
+        },
+      },
+    ]);
+
+    first.reject(new Error("auth failed"));
+    await Promise.resolve();
+    let rejected = false;
+    void result.catch(() => {
+      rejected = true;
+    });
+    await Promise.resolve();
+    assert.equal(rejected, false);
+
+    second.resolve();
+    await assert.rejects(result, /auth failed/);
+    assert.equal(secondSettled, true);
+  });
+});

--- a/scripts/summarize-performance-jsonl.mjs
+++ b/scripts/summarize-performance-jsonl.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+import { createReadStream } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const STARTUP_PHASES = [
+  "totalMs",
+  "daemonMs",
+  "navigationMs",
+  "listeningDurationMs",
+  "storageDurationMs",
+  "loggerHydrateDurationMs",
+  "agentSkillsDurationMs",
+  "eventsHydrateDurationMs",
+  "registryStateDurationMs",
+  "indexDurationMs",
+  "storesHydrationDurationMs",
+  "agentsHydrationDurationMs",
+  "runRecoveryDurationMs",
+  "humanInputRecoveryDurationMs",
+  "projectorDurationMs",
+  "taskNotificationsDurationMs",
+];
+
+function percentile(sorted, fraction) {
+  if (sorted.length === 0) return undefined;
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)];
+}
+
+function numericSummary(values) {
+  if (values.length === 0) return undefined;
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    count: values.length,
+    average: values.reduce((sum, value) => sum + value, 0) / values.length,
+    median: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+    min: sorted[0],
+    max: sorted.at(-1),
+  };
+}
+
+export async function readJsonLines(path, onRecord) {
+  let buffer = "";
+  let lineNumber = 0;
+  for await (const chunk of createReadStream(path, { encoding: "utf8" })) {
+    buffer += chunk;
+    let newline = buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      lineNumber += 1;
+      if (line) {
+        try {
+          onRecord(JSON.parse(line));
+        } catch (error) {
+          throw new Error(`Malformed JSONL at ${path}:${lineNumber}`, {
+            cause: error,
+          });
+        }
+      }
+      newline = buffer.indexOf("\n");
+    }
+  }
+
+  const finalLine = buffer.trim();
+  if (!finalLine) return;
+  try {
+    onRecord(JSON.parse(finalLine));
+  } catch {
+    // Append-oriented logs may end with one torn record after a crash.
+  }
+}
+
+export async function summarizeStartup(path) {
+  const bySource = new Map();
+  await readJsonLines(path, (record) => {
+    if (record?.type !== "nerve.startup") return;
+    const source = record.source === "desktop" ? "desktop" : "daemon";
+    const sourcePhases = bySource.get(source) ?? new Map();
+    bySource.set(source, sourcePhases);
+    for (const phase of STARTUP_PHASES) {
+      const value = record[phase];
+      if (typeof value !== "number" || !Number.isFinite(value)) continue;
+      const values = sourcePhases.get(phase) ?? [];
+      values.push(value);
+      sourcePhases.set(phase, values);
+    }
+    if (source === "daemon" && record.storeDurationsMs) {
+      for (const [name, value] of Object.entries(record.storeDurationsMs)) {
+        if (typeof value !== "number" || !Number.isFinite(value)) continue;
+        const phase = `store.${name}`;
+        const values = sourcePhases.get(phase) ?? [];
+        values.push(value);
+        sourcePhases.set(phase, values);
+      }
+    }
+  });
+
+  return Object.fromEntries(
+    [...bySource].map(([source, phases]) => [
+      source,
+      Object.fromEntries(
+        [...phases].map(([phase, values]) => [phase, numericSummary(values)]),
+      ),
+    ]),
+  );
+}
+
+function addPerformanceSample(groups, key, sample) {
+  const group = groups.get(key) ?? {
+    source: sample.source,
+    role: sample.role,
+    samples: 0,
+    cpu: [],
+    rss: [],
+    heap: [],
+  };
+  group.samples += 1;
+  if (typeof sample.cpuPercent === "number") group.cpu.push(sample.cpuPercent);
+  if (typeof sample.rssBytes === "number") group.rss.push(sample.rssBytes);
+  if (typeof sample.heapUsedBytes === "number")
+    group.heap.push(sample.heapUsedBytes);
+  groups.set(key, group);
+}
+
+function metricSummary(values, includeGrowth = false) {
+  const summary = numericSummary(values);
+  if (!summary) return undefined;
+  return includeGrowth
+    ? { ...summary, growth: values.at(-1) - values[0] }
+    : summary;
+}
+
+export async function summarizePerformance(path) {
+  const groups = new Map();
+  await readJsonLines(path, (record) => {
+    if (record?.type !== "nerve.performance") return;
+    if (record.source === "daemon") {
+      addPerformanceSample(groups, "daemon:daemon", {
+        source: "daemon",
+        role: "daemon",
+        cpuPercent: record.cpuPercent,
+        rssBytes: record.rssBytes,
+        heapUsedBytes: record.heapUsedBytes,
+      });
+      return;
+    }
+    if (record.source !== "desktop" || !Array.isArray(record.processes)) return;
+    for (const process of record.processes) {
+      const role = typeof process?.role === "string" ? process.role : "unknown";
+      addPerformanceSample(groups, `desktop:${role}`, {
+        source: "desktop",
+        role,
+        cpuPercent: process?.cpuPercent,
+        rssBytes: process?.rssBytes,
+      });
+    }
+  });
+
+  return Object.fromEntries(
+    [...groups].map(([key, group]) => [
+      key,
+      {
+        source: group.source,
+        role: group.role,
+        samples: group.samples,
+        cpuPercent: metricSummary(group.cpu),
+        rssBytes: metricSummary(group.rss, true),
+        heapUsedBytes: metricSummary(group.heap, true),
+      },
+    ]),
+  );
+}
+
+export async function buildPerformanceSummary({ startup, performance }) {
+  return {
+    startup: startup ? await summarizeStartup(startup) : {},
+    performance: performance ? await summarizePerformance(performance) : {},
+  };
+}
+
+function formatNumber(value) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+export function formatMarkdown(summary) {
+  const lines = ["# Nerve performance summary", "", "## Startup", ""];
+  for (const [source, phases] of Object.entries(summary.startup)) {
+    lines.push(
+      `### ${source}`,
+      "",
+      "| Phase | Runs | Median ms | Min–max ms |",
+      "|---|---:|---:|---:|",
+    );
+    for (const [phase, stats] of Object.entries(phases)) {
+      lines.push(
+        `| ${phase} | ${stats.count} | ${formatNumber(stats.median)} | ${formatNumber(stats.min)}–${formatNumber(stats.max)} |`,
+      );
+    }
+    lines.push("");
+  }
+  if (Object.keys(summary.startup).length === 0)
+    lines.push("No startup records.", "");
+
+  lines.push("## Process metrics", "");
+  if (Object.keys(summary.performance).length === 0) {
+    lines.push("No performance records.", "");
+  } else {
+    lines.push(
+      "| Source / role | Samples | CPU avg/p95/max % | RSS avg/p95/max bytes | RSS growth bytes |",
+      "|---|---:|---:|---:|---:|",
+    );
+    for (const [key, group] of Object.entries(summary.performance)) {
+      const cpu = group.cpuPercent;
+      const rss = group.rssBytes;
+      lines.push(
+        `| ${key} | ${group.samples} | ${cpu ? `${formatNumber(cpu.average)}/${formatNumber(cpu.p95)}/${formatNumber(cpu.max)}` : "—"} | ${rss ? `${formatNumber(rss.average)}/${formatNumber(rss.p95)}/${formatNumber(rss.max)}` : "—"} | ${rss ? formatNumber(rss.growth) : "—"} |`,
+      );
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function parseArguments(argv) {
+  const options = { format: "markdown" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--") continue;
+    if (argument === "--startup") options.startup = argv[++index];
+    else if (argument === "--performance") options.performance = argv[++index];
+    else if (argument === "--format") options.format = argv[++index];
+    else throw new Error(`Unknown argument: ${argument}`);
+  }
+  if (!options.startup && !options.performance) {
+    throw new Error("Provide --startup and/or --performance JSONL path.");
+  }
+  if (options.format !== "json" && options.format !== "markdown") {
+    throw new Error("--format must be json or markdown.");
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const summary = await buildPerformanceSummary(options);
+  process.stdout.write(
+    options.format === "json"
+      ? `${JSON.stringify(summary, undefined, 2)}\n`
+      : formatMarkdown(summary),
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/summarize-performance-jsonl.test.mjs
+++ b/scripts/summarize-performance-jsonl.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import {
+  buildPerformanceSummary,
+  formatMarkdown,
+  readJsonLines,
+} from "./summarize-performance-jsonl.mjs";
+
+const roots = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+async function fixture(name, content) {
+  const root = await mkdtemp(join(tmpdir(), "nerve-performance-summary-"));
+  roots.push(root);
+  const path = join(root, name);
+  await writeFile(path, content, "utf8");
+  return path;
+}
+
+describe("performance JSONL summary", () => {
+  it("summarizes startup phases, store timings, and process metrics", async () => {
+    const startup = await fixture(
+      "startup.jsonl",
+      [
+        {
+          type: "nerve.startup",
+          source: "daemon",
+          listeningDurationMs: 300,
+          storeDurationsMs: { tasks: 100 },
+        },
+        {
+          type: "nerve.startup",
+          source: "daemon",
+          listeningDurationMs: 100,
+          storeDurationsMs: { tasks: 50 },
+        },
+        {
+          type: "nerve.startup",
+          source: "daemon",
+          listeningDurationMs: 200,
+          storeDurationsMs: { tasks: 75 },
+          secret: "ignored",
+        },
+        { type: "nerve.startup", source: "desktop", totalMs: 400 },
+      ]
+        .map((record) => JSON.stringify(record))
+        .join("\n") + "\n",
+    );
+    const performance = await fixture(
+      "performance.jsonl",
+      [
+        {
+          type: "nerve.performance",
+          source: "daemon",
+          cpuPercent: 1,
+          rssBytes: 100,
+          heapUsedBytes: 50,
+        },
+        {
+          type: "nerve.performance",
+          source: "daemon",
+          cpuPercent: 3,
+          rssBytes: 160,
+          heapUsedBytes: 70,
+        },
+        {
+          type: "nerve.performance",
+          source: "desktop",
+          processes: [
+            { role: "Tab", cpuPercent: 10, rssBytes: 200 },
+            { role: "GPU", cpuPercent: 2, rssBytes: 80 },
+          ],
+        },
+        {
+          type: "nerve.performance",
+          source: "desktop",
+          processes: [{ role: "Tab", cpuPercent: 20, rssBytes: 260 }],
+        },
+      ]
+        .map((record) => JSON.stringify(record))
+        .join("\n") + "\n",
+    );
+
+    const summary = await buildPerformanceSummary({ startup, performance });
+    assert.equal(summary.startup.daemon.listeningDurationMs.median, 200);
+    assert.equal(summary.startup.daemon["store.tasks"].average, 75);
+    assert.equal(summary.performance["daemon:daemon"].cpuPercent.average, 2);
+    assert.equal(summary.performance["daemon:daemon"].rssBytes.growth, 60);
+    assert.equal(summary.performance["desktop:Tab"].cpuPercent.p95, 20);
+    assert.equal(summary.performance["desktop:Tab"].rssBytes.growth, 60);
+    assert.equal(JSON.stringify(summary).includes("secret"), false);
+
+    const markdown = formatMarkdown(summary);
+    assert.match(markdown, /store\.tasks/);
+    assert.match(markdown, /desktop:Tab/);
+  });
+
+  it("accepts a valid final line and ignores one torn final line", async () => {
+    const valid = await fixture("valid.jsonl", '{"value":1}');
+    const torn = await fixture("torn.jsonl", '{"value":1}\n{"value":');
+    const values = [];
+    await readJsonLines(valid, (record) => values.push(record.value));
+    await readJsonLines(torn, (record) => values.push(record.value));
+    assert.deepEqual(values, [1, 1]);
+  });
+
+  it("rejects malformed interior records", async () => {
+    const path = await fixture(
+      "malformed.jsonl",
+      '{"value":1}\nnot-json\n{"value":2}\n',
+    );
+    await assert.rejects(
+      readJsonLines(path, () => undefined),
+      /:2/,
+    );
+  });
+
+  it("returns empty sections for empty inputs", async () => {
+    const startup = await fixture("startup.jsonl", "");
+    const performance = await fixture("performance.jsonl", "");
+    assert.deepEqual(await buildPerformanceSummary({ startup, performance }), {
+      startup: {},
+      performance: {},
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- stop the Tasks panel's reactive task-definition refetch loop and make request de-duplication non-reactive
- bound, defer, deduplicate, and cancel obsolete Shiki highlighting work while keeping code-block DOM stable
- add per-store startup timings plus opt-in Electron/daemon CPU and memory sampling
- add a streaming performance JSONL summarizer and isolated profiling documentation

## Validation

- `pnpm fix && pnpm check && pnpm test` (run twice successfully)
- isolated copied-data Electron validation on ports 5747/5748 with CDP 59222
- Tasks panel produced one `taskDefinition.list` request over 15 seconds, down from 3,932 requests in the original trace
- deep transcript scroll reduced sampled `findNextMatchSync` time from 0.210s to 0.034s (~84%)
- startup records include per-store timings/counts and both performance monitors emitted valid samples
- isolated ports released and the original live Nerve processes remained healthy
