### PR TITLE
Add development CPU attribution diagnostics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory contains engineering sources and editorial planning for Nerve.
 
 - `architecture/` contains editable architecture diagrams and implementation/reliability notes.
 - `release.md` is the maintainer release procedure.
-- `performance-profiling.md` documents the isolated desktop profiling workflow and local metrics summary tool.
+- `performance-profiling.md` documents automatic source-desktop performance diagnostics and the local summary tool.
 - `website/content-strategy.md` records the evidence, scope, and review plan for the public website.
 
 Public user guides and public developer reference live in `packages/website/src/content/docs/` so the deployed site has one searchable source of truth. Product behavior is ultimately defined by the owning contracts, catalogs, implementation, and focused tests; prose should link concepts together without becoming a second schema catalog.

--- a/docs/performance-profiling.md
+++ b/docs/performance-profiling.md
@@ -1,61 +1,67 @@
-# Desktop performance profiling
+# Development performance diagnostics
 
-Use an isolated Nerve home and Electron profile for performance investigations. Never profile, signal, automate, or stop a live instance that is hosting active work.
-
-## Safe setup
-
-1. Prefer copying a stopped `NERVE_HOME`. On Btrfs, a reflink copy avoids duplicating unchanged data.
-2. If the source daemon must remain online, use SQLite's online backup API for `state.sqlite`; do not copy a live database/WAL trio as independent files.
-3. Remove `daemon.json` and stale SQLite `-wal`/`-shm` files only from the clone after creating the online database backup.
-4. Give the clone all of the following:
-   - a separate `NERVE_HOME`;
-   - a fresh Electron `--user-data-dir` outside `NERVE_HOME`;
-   - non-default daemon/mobile ports;
-   - a non-default CDP `--remote-debugging-port`.
-5. Validate the copied database with `PRAGMA quick_check` before launch.
-
-Example development launch (replace every path/port explicitly):
+Source desktop launches collect lightweight performance diagnostics automatically. Run Nerve normally:
 
 ```sh
-NERVE_HOME=/path/to/isolated-home \
-NERVE_PORT=4747 \
-NERVE_HTTPS_PORT=4748 \
-NERVE_PERFORMANCE_DIAGNOSTICS=1 \
-pnpm desktop -- \
-  --user-data-dir=/path/to/fresh-electron-profile \
-  --remote-debugging-port=49222
+pnpm desktop
 ```
 
-`NERVE_PERFORMANCE_DIAGNOSTICS=1` is opt-in. It appends content-free process samples every ten seconds to `<NERVE_HOME>/logs/performance.jsonl`. Startup phase records are in `<NERVE_HOME>/logs/startup.jsonl`.
+No alternate home, ports, Electron profile, or profiling flags are required. The unpackaged desktop process enables diagnostics for itself and the local daemon it owns. Packaged/released Nerve does not enable these diagnostics automatically.
 
-## Renderer tracing
+## When CPU becomes high
 
-Read the installed agent-browser core and Electron skill instructions before connecting. Connect only to the isolated CDP port and use a dedicated session name. Keep captures bounded and cover one scenario at a time:
+1. Note the approximate clock time.
+2. If practical, leave the activity running for another 10–20 seconds so at least one complete sample captures it.
+3. Tell the coding agent that CPU is high and what was running in parallel.
 
-- clean foreground idle;
-- clean minimized idle;
-- Tasks panel mounted for at least 15 seconds;
-- workspace panel navigation;
-- opening and jumping through a large transcript.
+The agent can inspect the normal files directly:
 
-Chromium and Node profilers materially increase CPU use. Always repeat idle without any profiler and treat that clean control as the authoritative baseline. Process-tree `/proc` samples are useful alongside traces because they separate Electron main, renderer, GPU, network service, and daemon load.
+- `~/.nerve/logs/performance-<session-id>.jsonl` (or the equivalent beneath `<NERVE_HOME>`);
+- `~/.nerve/logs/startup.jsonl`.
 
-## Summaries
+Each desktop launch creates a timestamped performance file. Desktop and daemon samples share that file, and automatic daemon restarts remain in the same desktop session. Fully quitting and reopening Nerve creates a new file. The agent selects the newest file for the current incident or an older timestamped file for a previous launch.
 
-Generate a Markdown summary:
+Routine samples are written every ten seconds. They contain process CPU/memory, event-loop health, and aggregate RPC, event, WebSocket, task-output, and Git-watcher activity. They do not contain prompts, output text, paths, record IDs, request arguments, or event payloads.
+
+If the source desktop attached to a daemon that was already running outside this launch, stop that daemon and reopen the source desktop once so the newly owned daemon inherits the session ID.
+
+## AI-oriented analysis
+
+The coding agent uses the summarizer directly. Its default output is structured JSON with aggregate metrics and the ten hottest daemon samples:
+
+```sh
+latest=$(ls -1t "$HOME/.nerve/logs"/performance-*.jsonl | head -n1)
+pnpm performance:summarize -- \
+  --startup "$HOME/.nerve/logs/startup.jsonl" \
+  --performance "$latest"
+```
+
+For an intermittent incident, the agent can isolate an inclusive time window:
 
 ```sh
 pnpm performance:summarize -- \
-  --startup /path/to/isolated-home/logs/startup.jsonl \
-  --performance /path/to/isolated-home/logs/performance.jsonl \
-  --format markdown
+  --performance "$latest" \
+  --since "2026-08-15T10:20:00Z" \
+  --until "2026-08-15T10:25:00Z"
 ```
 
-Use `--format json` for machine-readable output. Either input may be omitted. The summarizer streams JSONL, ignores one torn final record, rejects malformed interior records, and emits only known numeric fields.
+`--format markdown` remains available for human review. Either input may be omitted. The summarizer streams JSONL, bounds hot samples, ignores one torn final record, rejects malformed interior records, and emits only recognized content-free fields.
 
-## Shutdown and review
+Common signatures are:
 
-- Quit only the isolated clone and verify its daemon, Electron helpers, ports, and CDP endpoint are gone.
-- Confirm the original daemon and Electron processes remain alive.
-- Review raw traces and screenshots before sharing. They can contain local paths, conversation text, or visible UI strings even though `performance.jsonl` does not.
-- Delete or securely retain copied homes according to the sensitivity of the source data.
+- task bytes/lines rising with event delivery: task-output amplification;
+- many Git filesystem callbacks but few invalidations: watcher churn;
+- event publications multiplied by delivery attempts: WebSocket fan-out;
+- high RPC count or duration: a chatty or slow operation;
+- high CPU and event-loop utilization with little recorded activity: an uninstrumented CPU path;
+- low CPU with high event-loop delay: blocking I/O or native pauses.
+
+## Clean baseline
+
+To compare against a source launch with diagnostics disabled:
+
+```sh
+NERVE_PERFORMANCE_DIAGNOSTICS=0 pnpm desktop
+```
+
+An explicit `0` or `1` is always respected. Do not run two daemons against the same `NERVE_HOME`. Diagnostics remain local and are never uploaded automatically.

--- a/packages/desktop-shell/src/main.ts
+++ b/packages/desktop-shell/src/main.ts
@@ -37,6 +37,7 @@ import {
   installDesktopPerformanceMonitor,
   type DesktopPerformanceMonitor,
 } from "./performance/performance-monitor.js";
+import { applyDevelopmentPerformanceDiagnostics } from "./performance/development-diagnostics.js";
 import {
   installDaemonCookie,
   refreshDesktopSettingsFromDaemon,
@@ -58,6 +59,8 @@ import {
   resolvePackagedWebDistPath,
   resolvePreloadPath,
 } from "./window/preload-paths.js";
+
+applyDevelopmentPerformanceDiagnostics(app.isPackaged);
 
 const desktopOptions = parseDesktopOptions(process.argv.slice(1));
 const desktopDataDir = resolveDataDir();
@@ -414,6 +417,7 @@ async function openMainWindow(): Promise<void> {
     desktopPerformanceMonitor ??= installDesktopPerformanceMonitor({
       enabled: process.env.NERVE_PERFORMANCE_DIAGNOSTICS === "1",
       dataDir: desktopDataDir,
+      sessionId: process.env.NERVE_PERFORMANCE_SESSION_ID,
       getMetrics: () => app.getAppMetrics(),
       getWindowState: () => {
         const activeWindow = mainWindow;

--- a/packages/desktop-shell/src/performance/development-diagnostics.ts
+++ b/packages/desktop-shell/src/performance/development-diagnostics.ts
@@ -1,0 +1,26 @@
+const PERFORMANCE_DIAGNOSTICS_ENV = "NERVE_PERFORMANCE_DIAGNOSTICS";
+const PERFORMANCE_SESSION_ENV = "NERVE_PERFORMANCE_SESSION_ID";
+
+/** Enable lightweight performance logs automatically for source desktop runs. */
+export function applyDevelopmentPerformanceDiagnostics(
+  isPackaged: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+  options: { now?: () => Date; pid?: number } = {},
+): void {
+  if (!isPackaged && env[PERFORMANCE_DIAGNOSTICS_ENV] === undefined)
+    env[PERFORMANCE_DIAGNOSTICS_ENV] = "1";
+  if (
+    env[PERFORMANCE_DIAGNOSTICS_ENV] !== "1" ||
+    env[PERFORMANCE_SESSION_ENV] !== undefined
+  )
+    return;
+  env[PERFORMANCE_SESSION_ENV] = createPerformanceSessionId(
+    options.now?.() ?? new Date(),
+    options.pid ?? process.pid,
+  );
+}
+
+export function createPerformanceSessionId(now: Date, pid: number): string {
+  const timestamp = now.toISOString().replace(/[-:.]/g, "");
+  return `${timestamp}-desktop-${Math.max(0, Math.trunc(pid))}`;
+}

--- a/packages/desktop-shell/src/performance/performance-monitor.ts
+++ b/packages/desktop-shell/src/performance/performance-monitor.ts
@@ -23,6 +23,8 @@ type IntervalHandle = ReturnType<typeof setInterval>;
 type DesktopPerformanceMonitorOptions = {
   enabled: boolean;
   dataDir: string;
+  sessionId?: string;
+  pid?: number;
   getMetrics: () => ElectronProcessMetric[];
   getWindowState: () => { visible: boolean; minimized: boolean } | undefined;
   append?: (path: string, line: string) => Promise<void>;
@@ -39,6 +41,20 @@ async function appendJsonLine(path: string, line: string): Promise<void> {
   await appendFile(path, line, "utf8");
 }
 
+const SAFE_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function performanceLogFilename(
+  sessionId: string | undefined,
+  source: "desktop",
+  now: Date,
+  pid: number,
+): string {
+  const safeSessionId = SAFE_SESSION_ID.test(sessionId ?? "")
+    ? sessionId
+    : `${now.toISOString().replace(/[-:.]/g, "")}-${source}-${Math.max(0, Math.trunc(pid))}`;
+  return `performance-${safeSessionId}.jsonl`;
+}
+
 function kilobytesToBytes(value: number | undefined): number | undefined {
   return value === undefined ? undefined : value * 1024;
 }
@@ -52,7 +68,16 @@ export function installDesktopPerformanceMonitor(
   const now = options.now ?? (() => new Date());
   const createInterval = options.setInterval ?? setInterval;
   const destroyInterval = options.clearInterval ?? clearInterval;
-  const path = join(options.dataDir, "logs", "performance.jsonl");
+  const path = join(
+    options.dataDir,
+    "logs",
+    performanceLogFilename(
+      options.sessionId,
+      "desktop",
+      now(),
+      options.pid ?? process.pid,
+    ),
+  );
   let stopped = false;
   let writing = false;
   let warned = false;

--- a/packages/desktop-shell/test/development-performance-diagnostics.test.ts
+++ b/packages/desktop-shell/test/development-performance-diagnostics.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  applyDevelopmentPerformanceDiagnostics,
+  createPerformanceSessionId,
+} from "../src/performance/development-diagnostics.js";
+
+const sessionOptions = {
+  now: () => new Date("2026-08-15T10:20:30.456Z"),
+  pid: 42,
+};
+
+describe("development performance diagnostics policy", () => {
+  it("enables diagnostics for an unpackaged source launch", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyDevelopmentPerformanceDiagnostics(false, env, sessionOptions);
+    assert.equal(env.NERVE_PERFORMANCE_DIAGNOSTICS, "1");
+    assert.equal(
+      env.NERVE_PERFORMANCE_SESSION_ID,
+      "20260815T102030456Z-desktop-42",
+    );
+  });
+
+  it("does not affect packaged launches", () => {
+    const env: NodeJS.ProcessEnv = {};
+    applyDevelopmentPerformanceDiagnostics(true, env, sessionOptions);
+    assert.equal(env.NERVE_PERFORMANCE_DIAGNOSTICS, undefined);
+  });
+
+  it("preserves explicit developer overrides", () => {
+    const disabled: NodeJS.ProcessEnv = {
+      NERVE_PERFORMANCE_DIAGNOSTICS: "0",
+    };
+    const enabled: NodeJS.ProcessEnv = {
+      NERVE_PERFORMANCE_DIAGNOSTICS: "1",
+      NERVE_PERFORMANCE_SESSION_ID: "existing-session",
+    };
+    applyDevelopmentPerformanceDiagnostics(false, disabled, sessionOptions);
+    applyDevelopmentPerformanceDiagnostics(false, enabled, sessionOptions);
+    assert.equal(disabled.NERVE_PERFORMANCE_DIAGNOSTICS, "0");
+    assert.equal(disabled.NERVE_PERFORMANCE_SESSION_ID, undefined);
+    assert.equal(enabled.NERVE_PERFORMANCE_DIAGNOSTICS, "1");
+    assert.equal(enabled.NERVE_PERFORMANCE_SESSION_ID, "existing-session");
+  });
+
+  it("creates safe IDs and supports explicit packaged diagnostics", () => {
+    assert.equal(
+      createPerformanceSessionId(new Date("2026-08-15T10:20:30.456Z"), 42),
+      "20260815T102030456Z-desktop-42",
+    );
+    const env: NodeJS.ProcessEnv = { NERVE_PERFORMANCE_DIAGNOSTICS: "1" };
+    applyDevelopmentPerformanceDiagnostics(true, env, sessionOptions);
+    assert.equal(
+      env.NERVE_PERFORMANCE_SESSION_ID,
+      "20260815T102030456Z-desktop-42",
+    );
+  });
+});

--- a/packages/desktop-shell/test/performance-monitor.test.ts
+++ b/packages/desktop-shell/test/performance-monitor.test.ts
@@ -33,6 +33,7 @@ describe("desktop performance monitor", () => {
     const monitor = installDesktopPerformanceMonitor({
       enabled: true,
       dataDir: "/safe/home",
+      sessionId: "20260814T000000000Z-desktop-42",
       now: () => new Date("2026-08-14T00:00:00.000Z"),
       getMetrics: () => [
         {
@@ -44,7 +45,14 @@ describe("desktop performance monitor", () => {
       ],
       getWindowState: () => ({ visible: true, minimized: false }),
       append: async (path, line) => {
-        assert.equal(path, join("/safe/home", "logs", "performance.jsonl"));
+        assert.equal(
+          path,
+          join(
+            "/safe/home",
+            "logs",
+            "performance-20260814T000000000Z-desktop-42.jsonl",
+          ),
+        );
         lines.push(line);
       },
       setInterval: ((callback: () => void, delay: number) => {
@@ -82,6 +90,32 @@ describe("desktop performance monitor", () => {
     monitor.stop();
     monitor.stop();
     assert.equal(cleared, 1);
+  });
+
+  it("contains unsafe session IDs in a generated local filename", async () => {
+    let writtenPath = "";
+    const monitor = installDesktopPerformanceMonitor({
+      enabled: true,
+      dataDir: "/safe/home",
+      sessionId: "../../escape",
+      pid: 42,
+      now: () => new Date("2026-08-14T00:00:00.000Z"),
+      getMetrics: () => [],
+      getWindowState: () => undefined,
+      append: async (path) => {
+        writtenPath = path;
+      },
+    });
+    await tick();
+    monitor.stop();
+    assert.equal(
+      writtenPath,
+      join(
+        "/safe/home",
+        "logs",
+        "performance-20260814T000000000Z-desktop-42.jsonl",
+      ),
+    );
   });
 
   it("skips overlapping writes and isolates append failures", async () => {

--- a/packages/website/src/content/docs/operations/diagnostics.md
+++ b/packages/website/src/content/docs/operations/diagnostics.md
@@ -21,6 +21,12 @@ The daemon writes structured reports for handled fatal errors, enables Node repo
 
 There is no dedicated in-app crash-report list/download route. Inspect the directory directly and redact before sharing.
 
+## Developer performance diagnostics
+
+Unpackaged source desktop launches (`pnpm desktop`) automatically write content-free 10-second process, event-loop, and subsystem activity samples to `<NERVE_HOME>/logs/performance-<session-id>.jsonl`. Each desktop launch gets a separate timestamped file shared with its owned daemon; daemon restarts during that launch remain in the same file. When CPU becomes high, note the time and ask the coding agent to inspect the recent samples. No alternate profile, ports, or launch flags are required.
+
+Packaged/released Nerve does not enable performance sampling automatically. Developers can set `NERVE_PERFORMANCE_DIAGNOSTICS=0` for a clean source-launch baseline. Samples remain local, contain no prompts or task output, and are never uploaded.
+
 ## Proxy diagnostics
 
 Run with `NERVE_DEBUG_PROXY=1` for redacted proxy configuration diagnostics. Redaction reduces obvious credential exposure but does not make complete logs safe to publish.

--- a/packages/workbench-server/src/app/orchestrator-state.ts
+++ b/packages/workbench-server/src/app/orchestrator-state.ts
@@ -5,6 +5,7 @@ import {
   setCustomModelProvider,
 } from "@nervekit/harness";
 import {
+  allOperationDefinitions,
   createId,
   type DaemonFile,
   type MobileHttpsInfo,
@@ -26,7 +27,12 @@ import {
 } from "../domains/storage/index.js";
 import { LatestReleaseService } from "../domains/status/latest-release-service.js";
 import { SubscriptionUsageService } from "../domains/usage/subscription-usage-service.js";
-import { ApplicationLogger } from "../infrastructure/diagnostics/index.js";
+import {
+  ApplicationLogger,
+  noopPerformanceDiagnostics,
+  PerformanceMetricsCollector,
+} from "../infrastructure/diagnostics/index.js";
+import type { PerformanceDiagnosticsPort } from "../core/ports.js";
 import { StreamLogRegistry } from "../infrastructure/events/index.js";
 import { IndexStore } from "../infrastructure/index-store/index.js";
 import {
@@ -59,16 +65,25 @@ export interface OrchestratorState {
   oauthFlows: OAuthFlowManager;
   subscriptionUsage: SubscriptionUsageService;
   agentBrowserSkills: AgentBrowserSkillCatalog;
+  performanceDiagnostics: PerformanceDiagnosticsPort;
 }
 
 export function createOrchestratorState(
   storage: InitializedStorage,
   host: string,
   port: number,
-  options: { applicationLogsEnabled?: boolean } = {},
+  options: {
+    applicationLogsEnabled?: boolean;
+    performanceDiagnosticsEnabled?: boolean;
+  } = {},
 ): OrchestratorState {
   const index = new IndexStore(storage.paths.sqlitePath);
   index.initialize();
+  const performanceDiagnostics = options.performanceDiagnosticsEnabled
+    ? new PerformanceMetricsCollector(
+        allOperationDefinitions().map((definition) => definition.method),
+      )
+    : noopPerformanceDiagnostics;
   const logger = new ApplicationLogger({
     dataDir: storage.paths.home,
     source: "orchestrator",
@@ -79,6 +94,10 @@ export function createOrchestratorState(
     enabled: options.applicationLogsEnabled ?? false,
   });
   const events = new StreamLogRegistry(storage.paths.home, {
+    diagnostics: performanceDiagnostics.enabled
+      ? performanceDiagnostics
+      : undefined,
+    onFsync: () => performanceDiagnostics.count("event.fsync"),
     onPublishFailed: ({ type, context, error }) =>
       logger.error("Best-effort event publication failed", {
         context: {
@@ -88,6 +107,14 @@ export function createOrchestratorState(
         },
       }),
     onFlushCompleted: (observation) => {
+      performanceDiagnostics.duration(
+        "event.streamFlush",
+        observation.durationMs,
+      );
+      performanceDiagnostics.count(
+        "event.streamFlushEvents",
+        observation.eventCount,
+      );
       if (observation.durationMs < 50) return;
       void logger.warn("Slow event stream flush", {
         durationMs: Math.round(observation.durationMs),
@@ -146,6 +173,7 @@ export function createOrchestratorState(
     logger,
     agentBrowserSkills,
     providerCatalog,
+    performanceDiagnostics,
   );
   const storageUsage = new StorageUsageService({
     paths: storage.paths,
@@ -183,6 +211,7 @@ export function createOrchestratorState(
     oauthFlows,
     agentBrowserSkills,
     subscriptionUsage,
+    performanceDiagnostics,
   };
 }
 

--- a/packages/workbench-server/src/core/ports.ts
+++ b/packages/workbench-server/src/core/ports.ts
@@ -25,3 +25,57 @@ export interface DomainEventIntent<
 export interface DomainEventPublisherPort {
   publish(event: DomainEventIntent): Promise<void>;
 }
+
+export type PerformanceMetricName =
+  | "rpc.handler"
+  | "rpc.error"
+  | "event.durable"
+  | "event.ephemeral"
+  | "event.listenerDelivery"
+  | "event.publishFailure"
+  | "event.streamFlush"
+  | "event.streamFlushEvents"
+  | "event.fsync"
+  | "websocket.sessionOpened"
+  | "websocket.sessionClosed"
+  | "websocket.sequencedDelivery"
+  | "websocket.notifyDelivery"
+  | "task.outputChunk"
+  | "task.outputBytes"
+  | "task.outputLine"
+  | "task.outputCapture"
+  | "task.outputPublication"
+  | "git.watcherCreated"
+  | "git.watcherEvicted"
+  | "git.filesystemEvent"
+  | "git.invalidation"
+  | "git.metadataInvalidation";
+
+export interface PerformanceMetricAggregate {
+  readonly count: number;
+  readonly totalDurationMs?: number;
+  readonly maxDurationMs?: number;
+}
+
+export interface PerformanceMetricsSnapshot {
+  readonly metrics: Readonly<Record<string, PerformanceMetricAggregate>>;
+  readonly operations: Readonly<Record<string, PerformanceMetricAggregate>>;
+  readonly gauges: Readonly<Record<string, number>>;
+}
+
+/** Content-free, non-throwing diagnostics used only by opt-in performance runs. */
+export interface PerformanceDiagnosticsPort {
+  readonly enabled: boolean;
+  count(
+    metric: PerformanceMetricName,
+    amount?: number,
+    operation?: string,
+  ): void;
+  duration(
+    metric: PerformanceMetricName,
+    durationMs: number,
+    operation?: string,
+  ): void;
+  gauge(name: "websocket.sessions", value: number): void;
+  snapshotAndReset(): PerformanceMetricsSnapshot;
+}

--- a/packages/workbench-server/src/domains/tasks/task-log.service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-log.service.ts
@@ -8,6 +8,7 @@ import type {
 import { taskLogEventSchema } from "@nervekit/contracts";
 import { queryTaskLogEvents } from "./task-log-query.js";
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
+import type { PerformanceDiagnosticsPort } from "../../core/ports.js";
 import {
   appendJsonLine,
   readJsonLines,
@@ -34,7 +35,10 @@ export function createTaskLogCursor(logSeq = 0): TaskLogCursor {
 export class TaskLogService {
   constructor(
     private readonly events: StreamLogRegistry,
-    private readonly options: { publishOutputEvents?: boolean } = {},
+    private readonly options: {
+      publishOutputEvents?: boolean;
+      diagnostics?: PerformanceDiagnosticsPort;
+    } = {},
   ) {}
 
   async queryLogs(
@@ -56,9 +60,21 @@ export class TaskLogService {
     onLog: (event: TaskLogEvent) => Promise<void>,
   ): Promise<void> {
     const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+    const diagnostics = this.options.diagnostics;
+    const startedAt = diagnostics?.enabled ? performance.now() : undefined;
+    if (diagnostics?.enabled) {
+      diagnostics.count("task.outputChunk");
+      diagnostics.count("task.outputBytes", Buffer.byteLength(text));
+    }
     return this.enqueue(cursor, () =>
       this.captureOutputNow(record, cursor, stream, text, onLog),
-    );
+    ).finally(() => {
+      if (startedAt !== undefined)
+        diagnostics?.duration(
+          "task.outputCapture",
+          performance.now() - startedAt,
+        );
+    });
   }
 
   async flushOutput(
@@ -170,12 +186,14 @@ export class TaskLogService {
       line: cleaned,
     };
     await appendJsonLine(record.logsPath, event, 0o600);
+    this.options.diagnostics?.count("task.outputLine");
     if (this.options.publishOutputEvents !== false) {
       await this.events.publish("task.output", {
         taskId: record.id,
         stream,
         text: cleaned.slice(-16_384),
       });
+      this.options.diagnostics?.count("task.outputPublication");
     }
     await onLog(event);
   }

--- a/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
@@ -7,7 +7,10 @@ import type {
   TaskServicePorts,
   TaskStartInput,
 } from "./task-service.js";
-import type { DomainEventPublisherPort } from "../../core/ports.js";
+import type {
+  DomainEventPublisherPort,
+  PerformanceDiagnosticsPort,
+} from "../../core/ports.js";
 import type { StartTaskRequest, TaskRecord } from "@nervekit/contracts";
 import type { ApplicationLogger } from "../../infrastructure/diagnostics/index.js";
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
@@ -163,6 +166,7 @@ export type WorkbenchTaskResources = {
 export type WorkbenchTaskAdapterOptions = {
   supervisor?: TaskSupervisor;
   launchConfigs?: TaskLaunchConfigStore;
+  diagnostics?: PerformanceDiagnosticsPort;
 };
 
 export function createWorkbenchTaskResources(
@@ -175,7 +179,10 @@ export function createWorkbenchTaskResources(
   const tasks = new Map<string, TaskRecord>();
   const managed = new Map<string, WorkbenchManagedTask>();
   const repository = new TaskRepository(storage);
-  const logs = new TaskLogService(events, { publishOutputEvents: false });
+  const logs = new TaskLogService(events, {
+    publishOutputEvents: false,
+    diagnostics: options.diagnostics,
+  });
   const supervisor = options.supervisor ?? defaultTaskSupervisor;
   const launchConfigs =
     options.launchConfigs ?? new UnconfiguredTaskLaunchConfigStore();
@@ -184,6 +191,8 @@ export function createWorkbenchTaskResources(
   const eventPublisher: DomainEventPublisherPort = {
     publish: async (event) => {
       await events.publish(event.type, event.data);
+      if (event.type === "task.output")
+        options.diagnostics?.count("task.outputPublication");
     },
   };
 

--- a/packages/workbench-server/src/domains/tasks/workbench-task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-service.ts
@@ -14,6 +14,7 @@ import {
   type TaskRuntime,
 } from "@nervekit/contracts";
 import type { ApplicationLogger } from "../../infrastructure/diagnostics/index.js";
+import type { PerformanceDiagnosticsPort } from "../../core/ports.js";
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { IndexStore } from "../../infrastructure/index-store/index.js";
 import type { InitializedStorage } from "../../infrastructure/storage/index.js";
@@ -50,6 +51,7 @@ import { createWorkbenchTaskResources } from "./workbench-task-adapters.js";
 export interface WorkbenchTaskServiceOptions {
   supervisor?: TaskSupervisor;
   launchConfigs?: TaskLaunchConfigStore;
+  diagnostics?: PerformanceDiagnosticsPort;
 }
 
 export type ForegroundBashPromotionInput = {

--- a/packages/workbench-server/src/domains/tools/git-repository-watcher.ts
+++ b/packages/workbench-server/src/domains/tools/git-repository-watcher.ts
@@ -5,6 +5,7 @@ import {
   type WatchOptions,
 } from "node:fs";
 import { dirname, isAbsolute, join, normalize, resolve, sep } from "node:path";
+import type { PerformanceDiagnosticsPort } from "../../core/ports.js";
 
 export type GitRepositoryInvalidation = {
   readonly projectId: string;
@@ -56,6 +57,7 @@ export type GitRepositoryWatcherOptions = {
   readonly quietMs?: number;
   readonly maxWaitMs?: number;
   readonly maxRepositories?: number;
+  readonly diagnostics?: PerformanceDiagnosticsPort;
   readonly onWarning?: (message: string, error: unknown) => void;
   readonly onRepositoryMetadataChanged?: (repoDir: string) => void;
 };
@@ -111,6 +113,7 @@ export class GitRepositoryWatcher {
           repoDir,
           { recursive: true, persistent: false },
           (_eventType, filename) => {
+            this.options.diagnostics?.count("git.filesystemEvent");
             const change = classifyWorktreePath(filename);
             if (change) this.#invalidate(entry, change === "metadata");
           },
@@ -122,11 +125,16 @@ export class GitRepositoryWatcher {
             gitDir,
             { recursive: true, persistent: false },
             (_eventType, filename) => {
+              this.options.diagnostics?.count("git.filesystemEvent");
               if (relevantGitPath(filename)) this.#invalidate(entry, true);
             },
           ),
         );
       }
+      this.options.diagnostics?.count(
+        "git.watcherCreated",
+        entry.watchers.length,
+      );
       for (const watcher of entry.watchers) {
         watcher.on("error", (error) => {
           this.options.onWarning?.("Git repository watcher failed", error);
@@ -178,8 +186,11 @@ export class GitRepositoryWatcher {
     )
       return;
     try {
-      if (metadataChanged)
+      this.options.diagnostics?.count("git.invalidation");
+      if (metadataChanged) {
+        this.options.diagnostics?.count("git.metadataInvalidation");
         this.options.onRepositoryMetadataChanged?.(entry.repoDir);
+      }
       this.publisher.publishBestEffort(
         "git.repository.invalidated",
         {
@@ -200,6 +211,7 @@ export class GitRepositoryWatcher {
         ([, left], [, right]) => left.touchedAt - right.touchedAt,
       )[0];
       if (!oldest) return;
+      this.options.diagnostics?.count("git.watcherEvicted");
       this.#remove(oldest[0], oldest[1]);
     }
   }

--- a/packages/workbench-server/src/infrastructure/diagnostics/index.ts
+++ b/packages/workbench-server/src/infrastructure/diagnostics/index.ts
@@ -1,3 +1,4 @@
 export * from "./crash-reports.js";
 export * from "./logging.js";
 export * from "./performance-monitor.js";
+export * from "./performance-metrics.js";

--- a/packages/workbench-server/src/infrastructure/diagnostics/performance-metrics.ts
+++ b/packages/workbench-server/src/infrastructure/diagnostics/performance-metrics.ts
@@ -1,0 +1,115 @@
+import type {
+  PerformanceDiagnosticsPort,
+  PerformanceMetricAggregate,
+  PerformanceMetricName,
+  PerformanceMetricsSnapshot,
+} from "../../core/ports.js";
+
+type MutableAggregate = {
+  count: number;
+  totalDurationMs?: number;
+  maxDurationMs?: number;
+};
+
+const emptySnapshot = (): PerformanceMetricsSnapshot => ({
+  metrics: {},
+  operations: {},
+  gauges: {},
+});
+
+export const noopPerformanceDiagnostics: PerformanceDiagnosticsPort = {
+  enabled: false,
+  count: () => undefined,
+  duration: () => undefined,
+  gauge: () => undefined,
+  snapshotAndReset: emptySnapshot,
+};
+
+export class PerformanceMetricsCollector implements PerformanceDiagnosticsPort {
+  readonly enabled = true;
+  readonly #allowedOperations: ReadonlySet<string>;
+  #metrics = new Map<PerformanceMetricName, MutableAggregate>();
+  #operations = new Map<string, MutableAggregate>();
+  #gauges = new Map<string, number>();
+
+  constructor(allowedOperations: Iterable<string> = []) {
+    this.#allowedOperations = new Set(allowedOperations);
+  }
+
+  count(metric: PerformanceMetricName, amount = 1, operation?: string): void {
+    if (!Number.isFinite(amount) || amount < 0) return;
+    const aggregate = this.#aggregate(this.#metrics, metric);
+    aggregate.count += amount;
+    const operationAggregate = this.#operationAggregate(metric, operation);
+    if (operationAggregate) operationAggregate.count += amount;
+  }
+
+  duration(
+    metric: PerformanceMetricName,
+    durationMs: number,
+    operation?: string,
+  ): void {
+    if (!Number.isFinite(durationMs) || durationMs < 0) return;
+    this.#observe(this.#aggregate(this.#metrics, metric), durationMs);
+    const operationAggregate = this.#operationAggregate(metric, operation);
+    if (operationAggregate) this.#observe(operationAggregate, durationMs);
+  }
+
+  gauge(name: "websocket.sessions", value: number): void {
+    if (!Number.isFinite(value) || value < 0) return;
+    this.#gauges.set(name, value);
+  }
+
+  snapshotAndReset(): PerformanceMetricsSnapshot {
+    const snapshot = {
+      metrics: entries(this.#metrics),
+      operations: entries(this.#operations),
+      gauges: Object.fromEntries(this.#gauges),
+    };
+    this.#metrics = new Map();
+    this.#operations = new Map();
+    return snapshot;
+  }
+
+  #aggregate<K>(map: Map<K, MutableAggregate>, key: K): MutableAggregate {
+    const existing = map.get(key);
+    if (existing) return existing;
+    const aggregate = { count: 0 };
+    map.set(key, aggregate);
+    return aggregate;
+  }
+
+  #operationAggregate(
+    metric: PerformanceMetricName,
+    operation: string | undefined,
+  ): MutableAggregate | undefined {
+    if (!operation || !this.#allowedOperations.has(operation)) return undefined;
+    return this.#aggregate(this.#operations, `${metric}:${operation}`);
+  }
+
+  #observe(aggregate: MutableAggregate, durationMs: number): void {
+    aggregate.count += 1;
+    aggregate.totalDurationMs = (aggregate.totalDurationMs ?? 0) + durationMs;
+    aggregate.maxDurationMs = Math.max(
+      aggregate.maxDurationMs ?? 0,
+      durationMs,
+    );
+  }
+}
+
+function entries<K extends string>(
+  values: ReadonlyMap<K, MutableAggregate>,
+): Record<string, PerformanceMetricAggregate> {
+  return Object.fromEntries(
+    [...values].map(([key, value]) => [
+      key,
+      value.totalDurationMs === undefined
+        ? { count: value.count }
+        : {
+            count: value.count,
+            totalDurationMs: value.totalDurationMs,
+            maxDurationMs: value.maxDurationMs,
+          },
+    ]),
+  );
+}

--- a/packages/workbench-server/src/infrastructure/diagnostics/performance-monitor.ts
+++ b/packages/workbench-server/src/infrastructure/diagnostics/performance-monitor.ts
@@ -1,5 +1,10 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import {
+  monitorEventLoopDelay,
+  performance as nodePerformance,
+} from "node:perf_hooks";
+import type { PerformanceMetricsSnapshot } from "../../core/ports.js";
 
 const SAMPLE_INTERVAL_MS = 10_000;
 
@@ -12,13 +17,28 @@ type MemoryUsage = {
   external: number;
   arrayBuffers: number;
 };
+type EventLoopUtilization = {
+  utilization: number;
+  idle: number;
+  active: number;
+};
+type EventLoopDelayMonitor = {
+  enable(): void;
+  disable(): void;
+  reset(): void;
+  percentile(percentile: number): number;
+  readonly max: number;
+};
 
 export type DaemonPerformanceCounts = Record<string, number>;
 
 type DaemonPerformanceMonitorOptions = {
   enabled: boolean;
   dataDir: string;
+  sessionId?: string;
+  pid?: number;
   getCounts: () => DaemonPerformanceCounts;
+  getActivity?: () => PerformanceMetricsSnapshot;
   cpuUsage?: () => CpuUsage;
   memoryUsage?: () => MemoryUsage;
   uptime?: () => number;
@@ -26,6 +46,11 @@ type DaemonPerformanceMonitorOptions = {
   activeRequests?: () => number;
   now?: () => Date;
   monotonicNowMs?: () => number;
+  eventLoopUtilization?: (
+    current?: EventLoopUtilization,
+    previous?: EventLoopUtilization,
+  ) => EventLoopUtilization;
+  eventLoopDelay?: EventLoopDelayMonitor;
   append?: (path: string, line: string) => Promise<void>;
   setInterval?: (callback: () => void, delayMs: number) => IntervalHandle;
   clearInterval?: (handle: IntervalHandle) => void;
@@ -37,6 +62,20 @@ export type DaemonPerformanceMonitor = { stop: () => void };
 async function appendJsonLine(path: string, line: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await appendFile(path, line, "utf8");
+}
+
+const SAFE_SESSION_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+function performanceLogFilename(
+  sessionId: string | undefined,
+  source: "daemon",
+  now: Date,
+  pid: number,
+): string {
+  const safeSessionId = SAFE_SESSION_ID.test(sessionId ?? "")
+    ? sessionId
+    : `${now.toISOString().replace(/[-:.]/g, "")}-${source}-${Math.max(0, Math.trunc(pid))}`;
+  return `performance-${safeSessionId}.jsonl`;
 }
 
 function defaultActiveHandles(): number {
@@ -65,21 +104,39 @@ export function installDaemonPerformanceMonitor(
   const activeRequests = options.activeRequests ?? defaultActiveRequests;
   const now = options.now ?? (() => new Date());
   const monotonicNowMs = options.monotonicNowMs ?? (() => performance.now());
+  const eventLoopUtilization =
+    options.eventLoopUtilization ??
+    ((current?: EventLoopUtilization, previous?: EventLoopUtilization) =>
+      nodePerformance.eventLoopUtilization(current, previous));
+  const eventLoopDelay =
+    options.eventLoopDelay ?? monitorEventLoopDelay({ resolution: 20 });
   const append = options.append ?? appendJsonLine;
   const createInterval = options.setInterval ?? setInterval;
   const destroyInterval = options.clearInterval ?? clearInterval;
-  const path = join(options.dataDir, "logs", "performance.jsonl");
+  const path = join(
+    options.dataDir,
+    "logs",
+    performanceLogFilename(
+      options.sessionId,
+      "daemon",
+      now(),
+      options.pid ?? process.pid,
+    ),
+  );
   let previousCpu = cpuUsage();
   let previousAtMs = monotonicNowMs();
+  let previousEventLoop = eventLoopUtilization();
   let stopped = false;
   let writing = false;
   let warned = false;
+  eventLoopDelay.enable();
 
   const sample = () => {
     if (stopped || writing) return;
     const currentCpu = cpuUsage();
     const currentAtMs = monotonicNowMs();
-    const elapsedMicros = Math.max(0, currentAtMs - previousAtMs) * 1000;
+    const sampleWindowMs = Math.max(0, currentAtMs - previousAtMs);
+    const elapsedMicros = sampleWindowMs * 1000;
     const consumedMicros =
       currentCpu.user +
       currentCpu.system -
@@ -87,6 +144,15 @@ export function installDaemonPerformanceMonitor(
       previousCpu.system;
     previousCpu = currentCpu;
     previousAtMs = currentAtMs;
+    const currentEventLoop = eventLoopUtilization();
+    const eventLoop = eventLoopUtilization(currentEventLoop, previousEventLoop);
+    previousEventLoop = currentEventLoop;
+    const delay = {
+      medianMs: nanosecondsToMs(eventLoopDelay.percentile(50)),
+      p95Ms: nanosecondsToMs(eventLoopDelay.percentile(95)),
+      maxMs: nanosecondsToMs(eventLoopDelay.max),
+    };
+    eventLoopDelay.reset();
     const memory = memoryUsage();
     writing = true;
     const record = {
@@ -95,10 +161,13 @@ export function installDaemonPerformanceMonitor(
       ts: now().toISOString(),
       pid: process.pid,
       uptimeMs: Math.round(uptime() * 1000),
+      sampleWindowMs,
       cpuPercent:
         elapsedMicros > 0
           ? Math.max(0, (consumedMicros / elapsedMicros) * 100)
           : undefined,
+      eventLoopUtilization: finiteOrUndefined(eventLoop.utilization),
+      eventLoopDelayMs: delay,
       rssBytes: memory.rss,
       heapTotalBytes: memory.heapTotal,
       heapUsedBytes: memory.heapUsed,
@@ -107,6 +176,7 @@ export function installDaemonPerformanceMonitor(
       activeHandles: activeHandles(),
       activeRequests: activeRequests(),
       counts: options.getCounts(),
+      activity: options.getActivity?.(),
     };
     void append(path, `${JSON.stringify(record)}\n`)
       .catch((error) => {
@@ -128,6 +198,15 @@ export function installDaemonPerformanceMonitor(
       if (stopped) return;
       stopped = true;
       destroyInterval(interval);
+      eventLoopDelay.disable();
     },
   };
+}
+
+function nanosecondsToMs(value: number): number | undefined {
+  return Number.isFinite(value) ? value / 1_000_000 : undefined;
+}
+
+function finiteOrUndefined(value: number): number | undefined {
+  return Number.isFinite(value) ? value : undefined;
 }

--- a/packages/workbench-server/src/infrastructure/events/stream-log-registry.ts
+++ b/packages/workbench-server/src/infrastructure/events/stream-log-registry.ts
@@ -11,6 +11,7 @@ import {
   validatePublicEvent,
 } from "@nervekit/contracts";
 import type { RenameDependencies } from "../storage/index.js";
+import type { PerformanceDiagnosticsPort } from "../../core/ports.js";
 import { StreamLog, type StreamFlushObservation } from "./stream-log.js";
 
 export type PublishedEvent<T = unknown> = EventEnvelope<T> | NotifyEvent<T>;
@@ -26,6 +27,7 @@ export interface StreamLogRegistryOptions {
   readonly retentionBytes?: number;
   readonly flushDelayMs?: number;
   readonly flushEventThreshold?: number;
+  readonly diagnostics?: PerformanceDiagnosticsPort;
   readonly onFsync?: () => void;
   readonly onFlushCompleted?: (observation: StreamFlushObservation) => void;
   readonly onPublishFailed?: (
@@ -191,9 +193,11 @@ export class StreamLogRegistry {
     const ts = new Date().toISOString();
 
     if (definition.delivery === "ephemeral") {
+      this.options.diagnostics?.count("event.ephemeral");
       const event: NotifyEvent<T> = { id, ts, type, data: normalized };
       this.#intentResults.set(id, event as NotifyEvent);
       for (const listener of this.#notifyListeners) {
+        this.options.diagnostics?.count("event.listenerDelivery");
         safelyNotify(() => listener(event as NotifyEvent), event.type);
       }
       return event;
@@ -218,11 +222,14 @@ export class StreamLogRegistry {
       definition.supersedable,
       ts,
     )) as EventEnvelope<T>;
+    this.options.diagnostics?.count("event.durable");
     this.#intentResults.set(id, event as EventEnvelope);
     for (const listener of this.#eventListeners) {
+      this.options.diagnostics?.count("event.listenerDelivery");
       safelyNotify(() => listener(event as EventEnvelope), event.type);
     }
     for (const listener of this.#sequencedListeners) {
+      this.options.diagnostics?.count("event.listenerDelivery");
       safelyNotify(() => listener(stream, event as EventEnvelope), event.type);
     }
     return event;
@@ -246,6 +253,7 @@ export class StreamLogRegistry {
   }
 
   #reportPublishFailure(failure: EventPublishFailure): void {
+    this.options.diagnostics?.count("event.publishFailure");
     const report = this.options.onPublishFailed;
     if (!report) {
       process.emitWarning(

--- a/packages/workbench-server/src/main.ts
+++ b/packages/workbench-server/src/main.ts
@@ -144,8 +144,11 @@ async function main() {
   if (mobileHttpsEnabled && (!Number.isFinite(httpsPort) || httpsPort <= 0)) {
     throw new Error(`Invalid Nerve HTTPS port: ${String(httpsPort)}`);
   }
+  const performanceDiagnosticsEnabled =
+    process.env.NERVE_PERFORMANCE_DIAGNOSTICS === "1";
   const state = createOrchestratorState(storage, host, port, {
     applicationLogsEnabled: process.env.NERVE_LOGGING_ENABLED === "1",
+    performanceDiagnosticsEnabled,
   });
   const loggerHydrateStartedAt = performance.now();
   await state.logger.hydrate();
@@ -290,8 +293,10 @@ async function main() {
         toolCallHydrationSource: registryTimings.toolCallHydrationSource,
       });
       performanceMonitor ??= installDaemonPerformanceMonitor({
-        enabled: process.env.NERVE_PERFORMANCE_DIAGNOSTICS === "1",
+        enabled: performanceDiagnosticsEnabled,
         dataDir: storage.paths.home,
+        sessionId: process.env.NERVE_PERFORMANCE_SESSION_ID,
+        getActivity: () => state.performanceDiagnostics.snapshotAndReset(),
         getCounts: () => ({
           ...registryTimings.counts,
           projects: state.registry.listProjects().length,

--- a/packages/workbench-server/src/protocol/method-handler-registry.ts
+++ b/packages/workbench-server/src/protocol/method-handler-registry.ts
@@ -92,7 +92,21 @@ export function createWorkbenchMethodRegistry(
   ): Promise<unknown> {
     const handler = handlers.get(method);
     if (!handler) throw new Error(`Unsupported workbench operation: ${method}`);
-    return handler(state, params as never);
+    if (!state.performanceDiagnostics.enabled)
+      return handler(state, params as never);
+    const startedAt = performance.now();
+    try {
+      return await handler(state, params as never);
+    } catch (error) {
+      state.performanceDiagnostics.count("rpc.error", 1, method);
+      throw error;
+    } finally {
+      state.performanceDiagnostics.duration(
+        "rpc.handler",
+        performance.now() - startedAt,
+        method,
+      );
+    }
   }
 
   function bind(state: OrchestratorState): Partial<OperationHandlerRegistry> {

--- a/packages/workbench-server/src/protocol/protocol-websocket.ts
+++ b/packages/workbench-server/src/protocol/protocol-websocket.ts
@@ -31,6 +31,15 @@ export interface LocalProtocolSession {
   shutdown(message?: string): Promise<void>;
 }
 
+const activeSessionCounts = new WeakMap<OrchestratorState, number>();
+
+function updateActiveSessions(state: OrchestratorState, delta: number): void {
+  if (!state.performanceDiagnostics.enabled) return;
+  const count = Math.max(0, (activeSessionCounts.get(state) ?? 0) + delta);
+  activeSessionCounts.set(state, count);
+  state.performanceDiagnostics.gauge("websocket.sessions", count);
+}
+
 export interface ProtocolSocketServer {
   on(
     event: "upgrade",
@@ -76,6 +85,11 @@ export function createLocalProtocolSession(
   state: OrchestratorState,
   onDispose: () => void = () => undefined,
 ): LocalProtocolSession {
+  const diagnostics = state.performanceDiagnostics.enabled
+    ? state.performanceDiagnostics
+    : undefined;
+  diagnostics?.count("websocket.sessionOpened");
+  updateActiveSessions(state, 1);
   const peer = orchestratorSource(state.daemonId);
   const messages = createMessageFactory({
     source: peer,
@@ -93,6 +107,8 @@ export function createLocalProtocolSession(
   const dispose = () => {
     if (disposed) return;
     disposed = true;
+    diagnostics?.count("websocket.sessionClosed");
+    updateActiveSessions(state, -1);
     try {
       unsubscribeSequenced();
       unsubscribeNotify();
@@ -180,6 +196,7 @@ export function createLocalProtocolSession(
     },
   });
   unsubscribeSequenced = state.events.subscribeSequenced((stream, event) => {
+    diagnostics?.count("websocket.sequencedDelivery");
     void session.publish(stream, event).catch((error: unknown) => {
       if (disposed) return;
       state.logger.warn("Protocol event publication failed", {
@@ -196,6 +213,7 @@ export function createLocalProtocolSession(
     }
   });
   unsubscribeNotify = state.events.subscribeNotify((event) => {
+    diagnostics?.count("websocket.notifyDelivery");
     void session.notify(event).catch((error: unknown) => {
       if (disposed) return;
       state.logger.warn("Protocol notify publication failed", {

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -77,6 +77,7 @@ import { WorkbenchRunQuery } from "../domains/runs/workbench-run-query.js";
 import type { SubscriptionUsageService } from "../domains/usage/subscription-usage-service.js";
 import { WorkerManager } from "../domains/workers/worker-manager.js";
 import type { ApplicationLogger } from "../infrastructure/diagnostics/index.js";
+import type { PerformanceDiagnosticsPort } from "../core/ports.js";
 import type { StreamLogRegistry } from "../infrastructure/events/index.js";
 import type { IndexStore } from "../infrastructure/index-store/index.js";
 import type { SecretProvider } from "../infrastructure/secrets/index.js";
@@ -93,6 +94,7 @@ export interface RuntimeDeps {
   subscriptionUsage: SubscriptionUsageService;
   logger: ApplicationLogger;
   agentBrowserSkills: AgentBrowserSkillCatalog;
+  performanceDiagnostics: PerformanceDiagnosticsPort;
 }
 
 export interface RuntimeServices {
@@ -135,8 +137,16 @@ export function composeRuntime(
   state: RuntimeState,
   deps: RuntimeDeps,
 ): RuntimeServices {
-  const { storage, events, index, auth, secrets, subscriptionUsage, logger } =
-    deps;
+  const {
+    storage,
+    events,
+    index,
+    auth,
+    secrets,
+    subscriptionUsage,
+    logger,
+    performanceDiagnostics,
+  } = deps;
   const services = {} as RuntimeServices;
   const subagentExecutions = new WorkbenchSubagentExecutions();
   const exploreAdmission = new WorkbenchExploreAdmission();
@@ -310,7 +320,12 @@ export function composeRuntime(
     events,
     index,
     logger.child({ component: "task" }),
-    { launchConfigs: taskLaunchConfigs },
+    {
+      launchConfigs: taskLaunchConfigs,
+      diagnostics: performanceDiagnostics.enabled
+        ? performanceDiagnostics
+        : undefined,
+    },
   );
   services.pythonRuntime = new PythonRuntimeService(storage);
   services.workers = new WorkerManager(storage, events, index);
@@ -406,6 +421,9 @@ export function composeRuntime(
     },
   });
   services.gitRepositoryWatcher = new GitRepositoryWatcher(events, {
+    diagnostics: performanceDiagnostics.enabled
+      ? performanceDiagnostics
+      : undefined,
     onRepositoryMetadataChanged: (repoDir) =>
       gitService.invalidateStableRepoMetadata(repoDir),
     onWarning: (message, error) => {

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -39,6 +39,7 @@ import type { AgentBrowserSkillCatalog } from "../domains/agents/prompting/agent
 import type { ProviderCatalogStore } from "../domains/providers/index.js";
 import type { SubscriptionUsageService } from "../domains/usage/subscription-usage-service.js";
 import { ApplicationError } from "../core/application-error.js";
+import type { PerformanceDiagnosticsPort } from "../core/ports.js";
 import type { ApplicationLogger } from "../infrastructure/diagnostics/index.js";
 import type { StreamLogRegistry } from "../infrastructure/events/index.js";
 import type { IndexStore } from "../infrastructure/index-store/index.js";
@@ -161,6 +162,7 @@ export class RuntimeRegistry {
     private readonly logger: ApplicationLogger,
     agentBrowserSkills: AgentBrowserSkillCatalog,
     private readonly providerCatalog: ProviderCatalogStore,
+    performanceDiagnostics: PerformanceDiagnosticsPort,
   ) {
     this.services = composeRuntime(this.state, {
       storage,
@@ -171,6 +173,7 @@ export class RuntimeRegistry {
       subscriptionUsage,
       logger,
       agentBrowserSkills,
+      performanceDiagnostics,
     });
   }
 

--- a/packages/workbench-server/test/git-repository-watcher.test.ts
+++ b/packages/workbench-server/test/git-repository-watcher.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 import { mkdtemp } from "node:fs/promises";
 import { GitRepositoryWatcher } from "../src/domains/tools/git-repository-watcher.js";
+import { PerformanceMetricsCollector } from "../src/infrastructure/diagnostics/performance-metrics.js";
 
 type Timer = { at: number; callback: () => void; cancelled: boolean };
 
@@ -60,6 +61,7 @@ function setup(
   const publications: unknown[] = [];
   const warnings: string[] = [];
   const metadataChanges: string[] = [];
+  const metrics = new PerformanceMetricsCollector();
   const watcher = new GitRepositoryWatcher(
     {
       publishBestEffort: (_type, data) => {
@@ -69,6 +71,7 @@ function setup(
     },
     {
       clock,
+      diagnostics: metrics,
       now: () => clock.nowMs,
       quietMs: 300,
       maxWaitMs: 2_000,
@@ -85,6 +88,7 @@ function setup(
   return {
     clock,
     metadataChanges,
+    metrics,
     publications,
     warnings,
     watcher,
@@ -94,7 +98,7 @@ function setup(
 
 describe("GitRepositoryWatcher", () => {
   it("trailing-debounces a repository burst and ignores noisy git internals", () => {
-    const { clock, publications, watcher, watches } = setup();
+    const { clock, publications, watcher, watches, metrics } = setup();
     watcher.watch("proj_one", ".", "/repo");
     const emit = watches[0]?.listener;
     assert.ok(emit);
@@ -113,6 +117,10 @@ describe("GitRepositoryWatcher", () => {
     assert.deepEqual(publications, [
       { projectId: "proj_one", repo: ".", source: "filesystem" },
     ]);
+    const snapshot = metrics.snapshotAndReset();
+    assert.equal(snapshot.metrics["git.watcherCreated"]?.count, 1);
+    assert.equal(snapshot.metrics["git.filesystemEvent"]?.count, 4);
+    assert.equal(snapshot.metrics["git.invalidation"]?.count, 1);
   });
 
   it("flushes continuous writes at the maximum wait and isolates repositories", () => {

--- a/packages/workbench-server/test/performance-metrics.test.ts
+++ b/packages/workbench-server/test/performance-metrics.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  noopPerformanceDiagnostics,
+  PerformanceMetricsCollector,
+} from "../src/infrastructure/diagnostics/performance-metrics.js";
+
+describe("performance metrics collector", () => {
+  it("aggregates bounded metrics and resets window activity", () => {
+    const metrics = new PerformanceMetricsCollector(["project.list"]);
+    metrics.count("task.outputBytes", 12);
+    metrics.duration("rpc.handler", 4, "project.list");
+    metrics.duration("rpc.handler", 9, "project.list");
+    metrics.count("rpc.error", 1, "unknown.user.value");
+    metrics.gauge("websocket.sessions", 2);
+
+    assert.deepEqual(metrics.snapshotAndReset(), {
+      metrics: {
+        "task.outputBytes": { count: 12 },
+        "rpc.handler": { count: 2, totalDurationMs: 13, maxDurationMs: 9 },
+        "rpc.error": { count: 1 },
+      },
+      operations: {
+        "rpc.handler:project.list": {
+          count: 2,
+          totalDurationMs: 13,
+          maxDurationMs: 9,
+        },
+      },
+      gauges: { "websocket.sessions": 2 },
+    });
+    assert.deepEqual(metrics.snapshotAndReset(), {
+      metrics: {},
+      operations: {},
+      gauges: { "websocket.sessions": 2 },
+    });
+  });
+
+  it("ignores invalid measurements and the no-op collector stays empty", () => {
+    const metrics = new PerformanceMetricsCollector();
+    metrics.count("event.durable", -1);
+    metrics.duration("event.streamFlush", Number.NaN);
+    assert.deepEqual(metrics.snapshotAndReset().metrics, {});
+    noopPerformanceDiagnostics.count("task.outputBytes", 100);
+    assert.deepEqual(noopPerformanceDiagnostics.snapshotAndReset(), {
+      metrics: {},
+      operations: {},
+      gauges: {},
+    });
+  });
+});

--- a/packages/workbench-server/test/performance-monitor.test.ts
+++ b/packages/workbench-server/test/performance-monitor.test.ts
@@ -32,10 +32,18 @@ describe("daemon performance monitor", () => {
     const lines: string[] = [];
     let scheduled: (() => void) | undefined;
     let clears = 0;
+    let delayResets = 0;
+    let delayDisabled = 0;
     const monitor = installDaemonPerformanceMonitor({
       enabled: true,
       dataDir: "/safe/home",
+      sessionId: "20260814T000000000Z-desktop-42",
       getCounts: () => ({ projects: 4, activeRuns: 2 }),
+      getActivity: () => ({
+        metrics: { "task.outputBytes": { count: 12 } },
+        operations: {},
+        gauges: { "websocket.sessions": 1 },
+      }),
       cpuUsage: () => cpu.shift() ?? { user: 160_000, system: 40_000 },
       monotonicNowMs: () => times.shift() ?? 3_000,
       memoryUsage: () => ({
@@ -48,9 +56,31 @@ describe("daemon performance monitor", () => {
       uptime: () => 12.5,
       activeHandles: () => 7,
       activeRequests: () => 3,
+      eventLoopUtilization: (current, previous) =>
+        current && previous
+          ? { utilization: 0.25, idle: 75, active: 25 }
+          : { utilization: 0, idle: 100, active: 0 },
+      eventLoopDelay: {
+        enable: () => undefined,
+        disable: () => {
+          delayDisabled += 1;
+        },
+        reset: () => {
+          delayResets += 1;
+        },
+        percentile: (percentile) => (percentile === 50 ? 2_000_000 : 5_000_000),
+        max: 8_000_000,
+      },
       now: () => new Date("2026-08-14T00:00:00.000Z"),
       append: async (path, line) => {
-        assert.equal(path, join("/safe/home", "logs", "performance.jsonl"));
+        assert.equal(
+          path,
+          join(
+            "/safe/home",
+            "logs",
+            "performance-20260814T000000000Z-desktop-42.jsonl",
+          ),
+        );
         lines.push(line);
       },
       setInterval: ((callback: () => void, delay: number) => {
@@ -73,11 +103,45 @@ describe("daemon performance monitor", () => {
     assert.equal(first.heapUsedBytes, 60);
     assert.equal(first.activeHandles, 7);
     assert.equal(first.activeRequests, 3);
+    assert.equal(first.eventLoopUtilization, 0.25);
+    assert.deepEqual(first.eventLoopDelayMs, {
+      medianMs: 2,
+      p95Ms: 5,
+      maxMs: 8,
+    });
+    assert.equal(first.activity.metrics["task.outputBytes"].count, 12);
     assert.deepEqual(first.counts, { projects: 4, activeRuns: 2 });
     assert.equal("argv" in first, false);
     monitor.stop();
     monitor.stop();
     assert.equal(clears, 1);
+    assert.equal(delayResets, 2);
+    assert.equal(delayDisabled, 1);
+  });
+
+  it("contains unsafe session IDs in a daemon-local filename", async () => {
+    let writtenPath = "";
+    const monitor = installDaemonPerformanceMonitor({
+      enabled: true,
+      dataDir: "/safe/home",
+      sessionId: "../../escape",
+      pid: 84,
+      now: () => new Date("2026-08-14T00:00:00.000Z"),
+      getCounts: () => ({}),
+      append: async (path) => {
+        writtenPath = path;
+      },
+    });
+    await tick();
+    monitor.stop();
+    assert.equal(
+      writtenPath,
+      join(
+        "/safe/home",
+        "logs",
+        "performance-20260814T000000000Z-daemon-84.jsonl",
+      ),
+    );
   });
 
   it("skips overlapping appends and warns only once", async () => {

--- a/packages/workbench-server/test/stream-log.test.ts
+++ b/packages/workbench-server/test/stream-log.test.ts
@@ -17,6 +17,7 @@ import {
   StreamLog,
   StreamLogRegistry,
 } from "../src/infrastructure/events/index.js";
+import { PerformanceMetricsCollector } from "../src/infrastructure/diagnostics/performance-metrics.js";
 
 async function tempHome(): Promise<string> {
   return mkdtemp(join(tmpdir(), "nerve-stream-log-"));
@@ -82,6 +83,24 @@ describe("StreamLogRegistry", () => {
     assert.throws(() =>
       registry.publish("conversation.live.tool_output.delta", invalid),
     );
+  });
+
+  it("records content-free publication and listener activity", async () => {
+    const home = await tempHome();
+    const metrics = new PerformanceMetricsCollector();
+    const registry = new StreamLogRegistry(home, { diagnostics: metrics });
+    const unsubscribe = registry.subscribeSequenced(() => undefined);
+    try {
+      await registry.publish("git.repository.changed", gitData("one"));
+      const snapshot = metrics.snapshotAndReset();
+      assert.equal(snapshot.metrics["event.durable"]?.count, 1);
+      assert.equal(snapshot.metrics["event.listenerDelivery"]?.count, 1);
+      assert.equal(JSON.stringify(snapshot).includes("one"), false);
+    } finally {
+      unsubscribe();
+      await registry.shutdown();
+      await rm(home, { recursive: true, force: true });
+    }
   });
 
   it("assigns independent dense sequences and routes conversations", async () => {

--- a/packages/workbench-server/test/task-log.service.test.ts
+++ b/packages/workbench-server/test/task-log.service.test.ts
@@ -14,6 +14,7 @@ import {
   TaskLogService,
 } from "../src/domains/tasks/task-log.service.js";
 import { StreamLogRegistry } from "../src/infrastructure/events/index.js";
+import { PerformanceMetricsCollector } from "../src/infrastructure/diagnostics/performance-metrics.js";
 
 const roots: string[] = [];
 
@@ -25,7 +26,8 @@ after(async () => {
 
 describe("task log service line buffering", () => {
   it("keeps stdout and stderr buffers separate", async () => {
-    const { record, service, cursor, onLog, emitted } = await createFixture();
+    const { record, service, cursor, onLog, emitted, metrics } =
+      await createFixture();
 
     await service.captureOutput(record, cursor, "stdout", "out-", onLog);
     await service.captureOutput(record, cursor, "stderr", "err-", onLog);
@@ -39,6 +41,11 @@ describe("task log service line buffering", () => {
         ["stderr", "err-line"],
       ],
     );
+    const snapshot = metrics.snapshotAndReset();
+    assert.equal(snapshot.metrics["task.outputChunk"]?.count, 4);
+    assert.equal(snapshot.metrics["task.outputBytes"]?.count, 18);
+    assert.equal(snapshot.metrics["task.outputLine"]?.count, 2);
+    assert.equal(snapshot.metrics["task.outputCapture"]?.count, 4);
   });
 
   it("flush emits final non-newline fragment once", async () => {
@@ -160,6 +167,7 @@ async function createFixture(): Promise<{
   cursor: ReturnType<typeof createTaskLogCursor>;
   emitted: TaskLogEvent[];
   onLog: (event: TaskLogEvent) => Promise<void>;
+  metrics: PerformanceMetricsCollector;
 }> {
   const root = await mkdtemp(join(tmpdir(), "nerve-task-log-"));
   roots.push(root);
@@ -180,12 +188,16 @@ async function createFixture(): Promise<{
     updatedAt: now,
   };
   const emitted: TaskLogEvent[] = [];
-  const service = new TaskLogService(new StreamLogRegistry(root));
+  const metrics = new PerformanceMetricsCollector();
+  const service = new TaskLogService(new StreamLogRegistry(root), {
+    diagnostics: metrics,
+  });
   return {
     record,
     service,
     cursor: createTaskLogCursor(),
     emitted,
+    metrics,
     onLog: async (event) => {
       emitted.push(event);
     },

--- a/scripts/summarize-performance-jsonl.mjs
+++ b/scripts/summarize-performance-jsonl.mjs
@@ -21,6 +21,49 @@ const STARTUP_PHASES = [
   "taskNotificationsDurationMs",
 ];
 
+export function normalizeTimeWindow({ since, until } = {}) {
+  const sinceMs = parseTimestamp("--since", since);
+  const untilMs = parseTimestamp("--until", until);
+  if (sinceMs !== undefined && untilMs !== undefined && sinceMs > untilMs) {
+    throw new Error("--since must be earlier than or equal to --until.");
+  }
+  return {
+    sinceMs,
+    untilMs,
+    requestedSince:
+      sinceMs === undefined ? null : new Date(sinceMs).toISOString(),
+    requestedUntil:
+      untilMs === undefined ? null : new Date(untilMs).toISOString(),
+  };
+}
+
+function parseTimestamp(name, value) {
+  if (value === undefined) return undefined;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed))
+    throw new Error(`${name} must be an ISO timestamp.`);
+  return parsed;
+}
+
+function includedTimestamp(record, window) {
+  const timestamp =
+    typeof record?.ts === "string" ? Date.parse(record.ts) : NaN;
+  if (window.sinceMs === undefined && window.untilMs === undefined) {
+    return Number.isFinite(timestamp) ? timestamp : undefined;
+  }
+  if (!Number.isFinite(timestamp)) return undefined;
+  if (window.sinceMs !== undefined && timestamp < window.sinceMs)
+    return undefined;
+  if (window.untilMs !== undefined && timestamp > window.untilMs)
+    return undefined;
+  return timestamp;
+}
+
+function recordIncluded(record, window) {
+  if (window.sinceMs === undefined && window.untilMs === undefined) return true;
+  return includedTimestamp(record, window) !== undefined;
+}
+
 function percentile(sorted, fraction) {
   if (sorted.length === 0) return undefined;
   return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)];
@@ -71,10 +114,13 @@ export async function readJsonLines(path, onRecord) {
   }
 }
 
-export async function summarizeStartup(path) {
+export async function summarizeStartup(path, options = {}) {
+  const window = options.window ?? normalizeTimeWindow();
   const bySource = new Map();
   await readJsonLines(path, (record) => {
-    if (record?.type !== "nerve.startup") return;
+    if (record?.type !== "nerve.startup" || !recordIncluded(record, window))
+      return;
+    options.observeTimestamp?.(includedTimestamp(record, window));
     const source = record.source === "desktop" ? "desktop" : "daemon";
     const sourcePhases = bySource.get(source) ?? new Map();
     bySource.set(source, sourcePhases);
@@ -131,11 +177,190 @@ function metricSummary(values, includeGrowth = false) {
     : summary;
 }
 
-export async function summarizePerformance(path) {
+function addActivityAggregate(groups, key, value, includeInRate) {
+  if (!value || typeof value !== "object") return;
+  const count = typeof value.count === "number" ? value.count : 0;
+  const group = groups.get(key) ?? {
+    count: 0,
+    totalDurationMs: 0,
+    durationSamples: 0,
+    maxDurationMs: 0,
+    rateCount: 0,
+  };
+  group.count += count;
+  if (includeInRate) group.rateCount += count;
+  if (typeof value.totalDurationMs === "number") {
+    group.totalDurationMs += value.totalDurationMs;
+    group.durationSamples += count;
+  }
+  if (typeof value.maxDurationMs === "number") {
+    group.maxDurationMs = Math.max(group.maxDurationMs, value.maxDurationMs);
+  }
+  groups.set(key, group);
+}
+
+function activitySummary(groups, sampledMs) {
+  return Object.fromEntries(
+    [...groups].map(([key, group]) => [
+      key,
+      {
+        count: group.count,
+        averageRatePerSecond:
+          sampledMs > 0 ? group.rateCount / (sampledMs / 1000) : undefined,
+        totalDurationMs:
+          group.durationSamples > 0 ? group.totalDurationMs : undefined,
+        averageDurationMs:
+          group.durationSamples > 0
+            ? group.totalDurationMs / group.durationSamples
+            : undefined,
+        maxDurationMs:
+          group.durationSamples > 0 ? group.maxDurationMs : undefined,
+      },
+    ]),
+  );
+}
+
+const KNOWN_ACTIVITY_METRICS = new Set([
+  "rpc.handler",
+  "rpc.error",
+  "event.durable",
+  "event.ephemeral",
+  "event.listenerDelivery",
+  "event.publishFailure",
+  "event.streamFlush",
+  "event.streamFlushEvents",
+  "event.fsync",
+  "websocket.sessionOpened",
+  "websocket.sessionClosed",
+  "websocket.sequencedDelivery",
+  "websocket.notifyDelivery",
+  "task.outputChunk",
+  "task.outputBytes",
+  "task.outputLine",
+  "task.outputCapture",
+  "task.outputPublication",
+  "git.watcherCreated",
+  "git.watcherEvicted",
+  "git.filesystemEvent",
+  "git.invalidation",
+  "git.metadataInvalidation",
+]);
+
+function knownOperationMetric(key) {
+  return /^rpc\.(?:handler|error):[A-Za-z0-9_.-]{1,160}$/.test(key);
+}
+
+function sanitizedAggregates(
+  values,
+  allowKey,
+  limit = Number.POSITIVE_INFINITY,
+) {
+  if (!values || typeof values !== "object") return {};
+  const entries = [];
+  for (const [key, value] of Object.entries(values)) {
+    if (!allowKey(key) || !value || typeof value !== "object") continue;
+    const aggregate = {};
+    for (const field of ["count", "totalDurationMs", "maxDurationMs"]) {
+      const number = value[field];
+      if (typeof number === "number" && Number.isFinite(number) && number >= 0)
+        aggregate[field] = number;
+    }
+    if (typeof aggregate.count === "number") entries.push([key, aggregate]);
+  }
+  return Object.fromEntries(
+    entries
+      .sort(
+        ([, left], [, right]) =>
+          (right.totalDurationMs ?? right.count) -
+          (left.totalDurationMs ?? left.count),
+      )
+      .slice(0, limit),
+  );
+}
+
+function hottestSample(record) {
+  if (
+    typeof record.cpuPercent !== "number" ||
+    !Number.isFinite(record.cpuPercent)
+  )
+    return undefined;
+  return {
+    ts: typeof record.ts === "string" ? record.ts : null,
+    cpuPercent: record.cpuPercent,
+    sampleWindowMs:
+      typeof record.sampleWindowMs === "number" ? record.sampleWindowMs : null,
+    eventLoopUtilization:
+      typeof record.eventLoopUtilization === "number"
+        ? record.eventLoopUtilization
+        : null,
+    eventLoopDelayP95Ms:
+      typeof record.eventLoopDelayMs?.p95Ms === "number"
+        ? record.eventLoopDelayMs.p95Ms
+        : null,
+    rssBytes: typeof record.rssBytes === "number" ? record.rssBytes : null,
+    heapUsedBytes:
+      typeof record.heapUsedBytes === "number" ? record.heapUsedBytes : null,
+    activity: sanitizedAggregates(
+      record.activity?.metrics,
+      (key) => KNOWN_ACTIVITY_METRICS.has(key),
+      12,
+    ),
+    operations: sanitizedAggregates(
+      record.activity?.operations,
+      knownOperationMetric,
+      12,
+    ),
+  };
+}
+
+function retainHottest(samples, sample) {
+  if (!sample) return;
+  samples.push(sample);
+  samples.sort(
+    (left, right) =>
+      right.cpuPercent - left.cpuPercent ||
+      String(left.ts).localeCompare(String(right.ts)),
+  );
+  if (samples.length > 10) samples.length = 10;
+}
+
+export async function summarizePerformance(path, options = {}) {
+  const window = options.window ?? normalizeTimeWindow();
   const groups = new Map();
+  const activity = new Map();
+  const operations = new Map();
+  const eventLoopUtilization = [];
+  const eventLoopDelayP95 = [];
+  const eventLoopDelayMax = [];
+  const hottestDaemonSamples = [];
+  let sampledMs = 0;
   await readJsonLines(path, (record) => {
-    if (record?.type !== "nerve.performance") return;
+    if (record?.type !== "nerve.performance" || !recordIncluded(record, window))
+      return;
+    options.observeTimestamp?.(includedTimestamp(record, window));
     if (record.source === "daemon") {
+      retainHottest(hottestDaemonSamples, hottestSample(record));
+      const sampleWindowMs =
+        typeof record.sampleWindowMs === "number"
+          ? Math.max(0, record.sampleWindowMs)
+          : 0;
+      sampledMs += sampleWindowMs;
+      if (typeof record.eventLoopUtilization === "number")
+        eventLoopUtilization.push(record.eventLoopUtilization);
+      if (typeof record.eventLoopDelayMs?.p95Ms === "number")
+        eventLoopDelayP95.push(record.eventLoopDelayMs.p95Ms);
+      if (typeof record.eventLoopDelayMs?.maxMs === "number")
+        eventLoopDelayMax.push(record.eventLoopDelayMs.maxMs);
+      for (const [key, value] of Object.entries(
+        sanitizedAggregates(record.activity?.metrics, (metric) =>
+          KNOWN_ACTIVITY_METRICS.has(metric),
+        ),
+      ))
+        addActivityAggregate(activity, key, value, sampleWindowMs > 0);
+      for (const [key, value] of Object.entries(
+        sanitizedAggregates(record.activity?.operations, knownOperationMetric),
+      ))
+        addActivityAggregate(operations, key, value, sampleWindowMs > 0);
       addPerformanceSample(groups, "daemon:daemon", {
         source: "daemon",
         role: "daemon",
@@ -157,25 +382,88 @@ export async function summarizePerformance(path) {
     }
   });
 
-  return Object.fromEntries(
-    [...groups].map(([key, group]) => [
-      key,
-      {
-        source: group.source,
-        role: group.role,
-        samples: group.samples,
-        cpuPercent: metricSummary(group.cpu),
-        rssBytes: metricSummary(group.rss, true),
-        heapUsedBytes: metricSummary(group.heap, true),
-      },
-    ]),
-  );
+  return {
+    processes: Object.fromEntries(
+      [...groups].map(([key, group]) => [
+        key,
+        {
+          source: group.source,
+          role: group.role,
+          samples: group.samples,
+          cpuPercent: metricSummary(group.cpu),
+          rssBytes: metricSummary(group.rss, true),
+          heapUsedBytes: metricSummary(group.heap, true),
+        },
+      ]),
+    ),
+    eventLoop: {
+      utilization: numericSummary(eventLoopUtilization),
+      delayP95Ms: numericSummary(eventLoopDelayP95),
+      delayMaxMs: numericSummary(eventLoopDelayMax),
+    },
+    activity: activitySummary(activity, sampledMs),
+    hottestDaemonSamples,
+    operations: Object.fromEntries(
+      Object.entries(activitySummary(operations, sampledMs)).sort(
+        ([, left], [, right]) =>
+          (right.totalDurationMs ?? 0) - (left.totalDurationMs ?? 0) ||
+          right.count - left.count,
+      ),
+    ),
+  };
 }
 
-export async function buildPerformanceSummary({ startup, performance }) {
+export async function buildPerformanceSummary({
+  startup,
+  performance,
+  since,
+  until,
+}) {
+  const timeWindow = normalizeTimeWindow({ since, until });
+  let firstIncludedMs;
+  let lastIncludedMs;
+  const observeTimestamp = (timestamp) => {
+    if (timestamp === undefined) return;
+    firstIncludedMs = Math.min(firstIncludedMs ?? timestamp, timestamp);
+    lastIncludedMs = Math.max(lastIncludedMs ?? timestamp, timestamp);
+  };
+  const startupSummary = startup
+    ? await summarizeStartup(startup, {
+        window: timeWindow,
+        observeTimestamp,
+      })
+    : {};
+  const summarizedPerformance = performance
+    ? await summarizePerformance(performance, {
+        window: timeWindow,
+        observeTimestamp,
+      })
+    : {
+        processes: {},
+        eventLoop: {},
+        activity: {},
+        hottestDaemonSamples: [],
+        operations: {},
+      };
   return {
-    startup: startup ? await summarizeStartup(startup) : {},
-    performance: performance ? await summarizePerformance(performance) : {},
+    window: {
+      requestedSince: timeWindow.requestedSince,
+      requestedUntil: timeWindow.requestedUntil,
+      firstIncludedAt:
+        firstIncludedMs === undefined
+          ? null
+          : new Date(firstIncludedMs).toISOString(),
+      lastIncludedAt:
+        lastIncludedMs === undefined
+          ? null
+          : new Date(lastIncludedMs).toISOString(),
+    },
+    startup: startupSummary,
+    performance: summarizedPerformance.processes,
+    eventLoop: summarizedPerformance.eventLoop,
+    activity: summarizedPerformance.activity,
+    operations: summarizedPerformance.operations,
+    hottestDaemonSamples: summarizedPerformance.hottestDaemonSamples,
   };
 }
 
@@ -184,7 +472,14 @@ function formatNumber(value) {
 }
 
 export function formatMarkdown(summary) {
-  const lines = ["# Nerve performance summary", "", "## Startup", ""];
+  const lines = [
+    "# Nerve performance summary",
+    "",
+    `Window: ${summary.window?.firstIncludedAt ?? "unknown"} to ${summary.window?.lastIncludedAt ?? "unknown"}`,
+    "",
+    "## Startup",
+    "",
+  ];
   for (const [source, phases] of Object.entries(summary.startup)) {
     lines.push(
       `### ${source}`,
@@ -219,17 +514,86 @@ export function formatMarkdown(summary) {
     }
     lines.push("");
   }
+
+  lines.push("## Daemon event loop", "");
+  const utilization = summary.eventLoop?.utilization;
+  const delayP95 = summary.eventLoop?.delayP95Ms;
+  lines.push(
+    utilization
+      ? `Utilization avg/p95/max: ${formatNumber(utilization.average)}/${formatNumber(utilization.p95)}/${formatNumber(utilization.max)}`
+      : "No event-loop records.",
+    delayP95
+      ? `Delay p95 avg/p95/max ms: ${formatNumber(delayP95.average)}/${formatNumber(delayP95.p95)}/${formatNumber(delayP95.max)}`
+      : "",
+    "",
+  );
+
+  lines.push("## Daemon activity", "");
+  if (Object.keys(summary.activity ?? {}).length === 0) {
+    lines.push("No activity records.", "");
+  } else {
+    lines.push(
+      "| Metric | Count | Avg rate/s | Total duration ms | Avg/max duration ms |",
+      "|---|---:|---:|---:|---:|",
+    );
+    for (const [key, metric] of Object.entries(summary.activity)) {
+      lines.push(
+        `| ${key} | ${formatNumber(metric.count)} | ${metric.averageRatePerSecond === undefined ? "—" : formatNumber(metric.averageRatePerSecond)} | ${metric.totalDurationMs === undefined ? "—" : formatNumber(metric.totalDurationMs)} | ${metric.averageDurationMs === undefined ? "—" : `${formatNumber(metric.averageDurationMs)}/${formatNumber(metric.maxDurationMs)}`} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## Hottest daemon samples", "");
+  if ((summary.hottestDaemonSamples ?? []).length === 0) {
+    lines.push("No daemon CPU samples.", "");
+  } else {
+    lines.push(
+      "| Time | CPU % | Event-loop utilization | Event-loop p95 ms | RSS bytes |",
+      "|---|---:|---:|---:|---:|",
+    );
+    for (const sample of summary.hottestDaemonSamples) {
+      lines.push(
+        `| ${sample.ts ?? "—"} | ${formatNumber(sample.cpuPercent)} | ${sample.eventLoopUtilization === null ? "—" : formatNumber(sample.eventLoopUtilization)} | ${sample.eventLoopDelayP95Ms === null ? "—" : formatNumber(sample.eventLoopDelayP95Ms)} | ${sample.rssBytes === null ? "—" : formatNumber(sample.rssBytes)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## RPC operations", "");
+  if (Object.keys(summary.operations ?? {}).length === 0) {
+    lines.push("No operation records.", "");
+  } else {
+    lines.push(
+      "| Operation metric | Count | Total duration ms | Avg/max duration ms |",
+      "|---|---:|---:|---:|",
+    );
+    for (const [key, metric] of Object.entries(summary.operations)) {
+      lines.push(
+        `| ${key} | ${formatNumber(metric.count)} | ${metric.totalDurationMs === undefined ? "—" : formatNumber(metric.totalDurationMs)} | ${metric.averageDurationMs === undefined ? "—" : `${formatNumber(metric.averageDurationMs)}/${formatNumber(metric.maxDurationMs)}`} |`,
+      );
+    }
+    lines.push("");
+  }
+
   return `${lines.join("\n")}\n`;
 }
 
-function parseArguments(argv) {
-  const options = { format: "markdown" };
+export function parseArguments(argv) {
+  const options = { format: "json" };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--") continue;
-    if (argument === "--startup") options.startup = argv[++index];
-    else if (argument === "--performance") options.performance = argv[++index];
-    else if (argument === "--format") options.format = argv[++index];
+    if (argument === "--startup")
+      options.startup = argumentValue(argv, ++index, argument);
+    else if (argument === "--performance")
+      options.performance = argumentValue(argv, ++index, argument);
+    else if (argument === "--format")
+      options.format = argumentValue(argv, ++index, argument);
+    else if (argument === "--since")
+      options.since = argumentValue(argv, ++index, argument);
+    else if (argument === "--until")
+      options.until = argumentValue(argv, ++index, argument);
     else throw new Error(`Unknown argument: ${argument}`);
   }
   if (!options.startup && !options.performance) {
@@ -238,7 +602,15 @@ function parseArguments(argv) {
   if (options.format !== "json" && options.format !== "markdown") {
     throw new Error("--format must be json or markdown.");
   }
+  normalizeTimeWindow(options);
   return options;
+}
+
+function argumentValue(argv, index, name) {
+  const value = argv[index];
+  if (!value || value.startsWith("--"))
+    throw new Error(`${name} requires a value.`);
+  return value;
 }
 
 async function main() {

--- a/scripts/summarize-performance-jsonl.test.mjs
+++ b/scripts/summarize-performance-jsonl.test.mjs
@@ -6,6 +6,8 @@ import { afterEach, describe, it } from "node:test";
 import {
   buildPerformanceSummary,
   formatMarkdown,
+  normalizeTimeWindow,
+  parseArguments,
   readJsonLines,
 } from "./summarize-performance-jsonl.mjs";
 
@@ -33,23 +35,31 @@ describe("performance JSONL summary", () => {
         {
           type: "nerve.startup",
           source: "daemon",
+          ts: "2026-08-15T10:00:00.000Z",
           listeningDurationMs: 300,
           storeDurationsMs: { tasks: 100 },
         },
         {
           type: "nerve.startup",
           source: "daemon",
+          ts: "2026-08-15T10:01:00.000Z",
           listeningDurationMs: 100,
           storeDurationsMs: { tasks: 50 },
         },
         {
           type: "nerve.startup",
           source: "daemon",
+          ts: "2026-08-15T10:02:00.000Z",
           listeningDurationMs: 200,
           storeDurationsMs: { tasks: 75 },
           secret: "ignored",
         },
-        { type: "nerve.startup", source: "desktop", totalMs: 400 },
+        {
+          type: "nerve.startup",
+          source: "desktop",
+          ts: "2026-08-15T10:03:00.000Z",
+          totalMs: 400,
+        },
       ]
         .map((record) => JSON.stringify(record))
         .join("\n") + "\n",
@@ -60,20 +70,63 @@ describe("performance JSONL summary", () => {
         {
           type: "nerve.performance",
           source: "daemon",
+          ts: "2026-08-15T10:04:00.000Z",
           cpuPercent: 1,
           rssBytes: 100,
           heapUsedBytes: 50,
+          sampleWindowMs: 10000,
+          eventLoopUtilization: 0.25,
+          eventLoopDelayMs: { p95Ms: 4, maxMs: 8 },
+          activity: {
+            metrics: {
+              "private.payload.key": { count: 99 },
+              "rpc.handler": {
+                count: 2,
+                totalDurationMs: 10,
+                maxDurationMs: 7,
+              },
+            },
+            operations: {
+              "private.operation:secret": { count: 99 },
+              "rpc.handler:project.list": {
+                count: 2,
+                totalDurationMs: 10,
+                maxDurationMs: 7,
+              },
+            },
+          },
         },
         {
           type: "nerve.performance",
           source: "daemon",
+          ts: "2026-08-15T10:05:00.000Z",
           cpuPercent: 3,
           rssBytes: 160,
           heapUsedBytes: 70,
+          sampleWindowMs: 10000,
+          eventLoopUtilization: 0.75,
+          eventLoopDelayMs: { p95Ms: 6, maxMs: 12 },
+          activity: {
+            metrics: {
+              "rpc.handler": {
+                count: 3,
+                totalDurationMs: 20,
+                maxDurationMs: 9,
+              },
+            },
+            operations: {
+              "rpc.handler:project.list": {
+                count: 3,
+                totalDurationMs: 20,
+                maxDurationMs: 9,
+              },
+            },
+          },
         },
         {
           type: "nerve.performance",
           source: "desktop",
+          ts: "2026-08-15T10:06:00.000Z",
           processes: [
             { role: "Tab", cpuPercent: 10, rssBytes: 200 },
             { role: "GPU", cpuPercent: 2, rssBytes: 80 },
@@ -82,6 +135,7 @@ describe("performance JSONL summary", () => {
         {
           type: "nerve.performance",
           source: "desktop",
+          ts: "2026-08-15T10:07:00.000Z",
           processes: [{ role: "Tab", cpuPercent: 20, rssBytes: 260 }],
         },
       ]
@@ -90,17 +144,99 @@ describe("performance JSONL summary", () => {
     );
 
     const summary = await buildPerformanceSummary({ startup, performance });
+    assert.deepEqual(summary.window, {
+      requestedSince: null,
+      requestedUntil: null,
+      firstIncludedAt: "2026-08-15T10:00:00.000Z",
+      lastIncludedAt: "2026-08-15T10:07:00.000Z",
+    });
     assert.equal(summary.startup.daemon.listeningDurationMs.median, 200);
     assert.equal(summary.startup.daemon["store.tasks"].average, 75);
     assert.equal(summary.performance["daemon:daemon"].cpuPercent.average, 2);
     assert.equal(summary.performance["daemon:daemon"].rssBytes.growth, 60);
     assert.equal(summary.performance["desktop:Tab"].cpuPercent.p95, 20);
     assert.equal(summary.performance["desktop:Tab"].rssBytes.growth, 60);
+    assert.equal(summary.eventLoop.utilization.average, 0.5);
+    assert.equal(summary.activity["rpc.handler"].count, 5);
+    assert.equal(summary.activity["rpc.handler"].averageRatePerSecond, 0.25);
+    assert.equal(
+      summary.operations["rpc.handler:project.list"].totalDurationMs,
+      30,
+    );
+    assert.deepEqual(
+      summary.hottestDaemonSamples.map((sample) => sample.cpuPercent),
+      [3, 1],
+    );
     assert.equal(JSON.stringify(summary).includes("secret"), false);
+    assert.equal(JSON.stringify(summary).includes("private"), false);
 
     const markdown = formatMarkdown(summary);
     assert.match(markdown, /store\.tasks/);
     assert.match(markdown, /desktop:Tab/);
+    assert.match(markdown, /rpc\.handler:project\.list/);
+    assert.match(markdown, /Hottest daemon samples/);
+  });
+
+  it("filters incident windows and bounds hottest daemon samples", async () => {
+    const records = Array.from({ length: 12 }, (_, index) => ({
+      type: "nerve.performance",
+      source: "daemon",
+      ts: `2026-08-15T10:${String(index).padStart(2, "0")}:00.000Z`,
+      cpuPercent: index,
+      sampleWindowMs: 10_000,
+      activity: {
+        metrics: { "task.outputLine": { count: index } },
+        operations: {},
+      },
+    }));
+    const performance = await fixture(
+      "performance-window.jsonl",
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+
+    const complete = await buildPerformanceSummary({ performance });
+    assert.equal(complete.hottestDaemonSamples.length, 10);
+    assert.deepEqual(
+      complete.hottestDaemonSamples.map((sample) => sample.cpuPercent),
+      [11, 10, 9, 8, 7, 6, 5, 4, 3, 2],
+    );
+
+    const incident = await buildPerformanceSummary({
+      performance,
+      since: "2026-08-15T10:05:00Z",
+      until: "2026-08-15T10:10:00Z",
+    });
+    assert.deepEqual(incident.window, {
+      requestedSince: "2026-08-15T10:05:00.000Z",
+      requestedUntil: "2026-08-15T10:10:00.000Z",
+      firstIncludedAt: "2026-08-15T10:05:00.000Z",
+      lastIncludedAt: "2026-08-15T10:10:00.000Z",
+    });
+    assert.equal(incident.performance["daemon:daemon"].samples, 6);
+    assert.equal(incident.activity["task.outputLine"].count, 45);
+  });
+
+  it("defaults to JSON arguments and validates incident bounds", () => {
+    assert.deepEqual(parseArguments(["--performance", "/tmp/perf.jsonl"]), {
+      format: "json",
+      performance: "/tmp/perf.jsonl",
+    });
+    assert.throws(
+      () => normalizeTimeWindow({ since: "not-a-time" }),
+      /--since must be an ISO timestamp/,
+    );
+    assert.throws(
+      () =>
+        normalizeTimeWindow({
+          since: "2026-08-15T11:00:00Z",
+          until: "2026-08-15T10:00:00Z",
+        }),
+      /--since must be earlier/,
+    );
+    assert.throws(
+      () => parseArguments(["--performance"]),
+      /--performance requires a value/,
+    );
   });
 
   it("accepts a valid final line and ignores one torn final line", async () => {
@@ -127,8 +263,22 @@ describe("performance JSONL summary", () => {
     const startup = await fixture("startup.jsonl", "");
     const performance = await fixture("performance.jsonl", "");
     assert.deepEqual(await buildPerformanceSummary({ startup, performance }), {
+      window: {
+        requestedSince: null,
+        requestedUntil: null,
+        firstIncludedAt: null,
+        lastIncludedAt: null,
+      },
       startup: {},
       performance: {},
+      eventLoop: {
+        utilization: undefined,
+        delayP95Ms: undefined,
+        delayMaxMs: undefined,
+      },
+      activity: {},
+      operations: {},
+      hottestDaemonSamples: [],
     });
   });
 });


### PR DESCRIPTION
## Summary
- automatically enable lightweight performance diagnostics for unpackaged desktop development while leaving packaged users unaffected
- record content-free daemon attribution metrics for RPC, events, WebSockets, task output, Git watchers, and event-loop health
- write desktop and daemon samples to a shared timestamped file per desktop session
- make the performance summarizer AI-oriented with JSON defaults, incident time windows, and bounded hottest-sample output
- document the zero-setup investigation workflow

## Validation
- `pnpm fix && pnpm check && pnpm test`