### PR TITLE
feat(settings): add application configuration controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "dev": "pnpm --filter @nervekit/contracts --filter @nervekit/protocol --filter @nervekit/harness --filter @nervekit/tools build && pnpm --parallel --stream --filter @nervekit/workbench-server --filter @nervekit/workbench-app dev",
     "dev:ui": "pnpm --filter @nervekit/contracts --filter @nervekit/protocol --filter @nervekit/harness --filter @nervekit/tools build && pnpm --filter @nervekit/workbench-app dev",
     "desktop": "pnpm --filter @nervekit/desktop-shell dev --",
-    "desktop:remote-enabled": "pnpm desktop -- --host 0.0.0.0 --allow-remote --mobile-https",
     "performance:summarize": "node scripts/summarize-performance-jsonl.mjs",
     "release:bump-version": "node scripts/bump-release-version.mjs",
     "release:verify-tag": "node scripts/verify-release-tag.mjs",

--- a/packages/contracts/src/domains/settings/application-configuration.schema.ts
+++ b/packages/contracts/src/domains/settings/application-configuration.schema.ts
@@ -1,0 +1,167 @@
+import { z } from "zod";
+import { applicationLogLevelSchema } from "../logs/index.js";
+
+export const electronOzonePlatformSchema = z.enum(["auto", "x11", "wayland"]);
+export type ElectronOzonePlatform = z.infer<typeof electronOzonePlatformSchema>;
+
+export const electronFontRenderHintingSchema = z.enum([
+  "system",
+  "none",
+  "slight",
+  "medium",
+  "full",
+]);
+export type ElectronFontRenderHinting = z.infer<
+  typeof electronFontRenderHintingSchema
+>;
+
+export const applicationSettingsSchema = z.object({
+  network: z.object({
+    host: z.string().trim().min(1).default("127.0.0.1"),
+    port: z.number().int().min(1).max(65_535).default(3747),
+    allowRemote: z.boolean().default(false),
+    mobileHttps: z.boolean().default(false),
+    httpsPort: z.number().int().min(1).max(65_535).default(3748),
+  }),
+  diagnostics: z.object({
+    loggingEnabled: z.boolean().default(false),
+    performanceEnabled: z.boolean().optional(),
+  }),
+  daemon: z.object({
+    startupTimeoutMs: z.number().int().positive().default(60_000),
+    maxOldSpaceMb: z.number().int().positive().default(4096),
+  }),
+  electron: z.object({
+    ozonePlatform: electronOzonePlatformSchema.default("auto"),
+    fontRenderHinting: electronFontRenderHintingSchema.default("slight"),
+  }),
+});
+export type ApplicationSettings = z.infer<typeof applicationSettingsSchema>;
+
+export const defaultApplicationSettings: ApplicationSettings = {
+  network: {
+    host: "127.0.0.1",
+    port: 3747,
+    allowRemote: false,
+    mobileHttps: false,
+    httpsPort: 3748,
+  },
+  diagnostics: { loggingEnabled: false },
+  daemon: { startupTimeoutMs: 60_000, maxOldSpaceMb: 4096 },
+  electron: { ozonePlatform: "auto", fontRenderHinting: "slight" },
+};
+
+export const applicationSettingsPatchSchema = z.object({
+  network: z
+    .object({
+      host: z.string().trim().min(1).optional(),
+      port: z.number().int().min(1).max(65_535).optional(),
+      allowRemote: z.boolean().optional(),
+      mobileHttps: z.boolean().optional(),
+      httpsPort: z.number().int().min(1).max(65_535).optional(),
+    })
+    .optional(),
+  diagnostics: z
+    .object({
+      loggingEnabled: z.boolean().optional(),
+      performanceEnabled: z.boolean().optional(),
+    })
+    .optional(),
+  daemon: z
+    .object({
+      startupTimeoutMs: z.number().int().positive().optional(),
+      maxOldSpaceMb: z.number().int().positive().optional(),
+    })
+    .optional(),
+  electron: z
+    .object({
+      ozonePlatform: electronOzonePlatformSchema.optional(),
+      fontRenderHinting: electronFontRenderHintingSchema.optional(),
+    })
+    .optional(),
+});
+export type ApplicationSettingsPatch = z.infer<
+  typeof applicationSettingsPatchSchema
+>;
+
+export const updateApplicationConfigurationRequestSchema = z.object({
+  application: applicationSettingsPatchSchema.optional(),
+  logging: z
+    .object({
+      level: applicationLogLevelSchema.optional(),
+      retentionDays: z.number().int().positive().optional(),
+      maxBufferedLogs: z.number().int().positive().optional(),
+    })
+    .optional(),
+});
+export type UpdateApplicationConfigurationRequest = z.infer<
+  typeof updateApplicationConfigurationRequestSchema
+>;
+
+export const configurationSourceSchema = z.object({
+  kind: z.enum([
+    "settings",
+    "environment",
+    "command_line",
+    "development_default",
+  ]),
+  name: z.string().optional(),
+});
+export type ConfigurationSource = z.infer<typeof configurationSourceSchema>;
+
+export const restartTargetSchema = z.enum(["none", "daemon", "desktop"]);
+export type RestartTarget = z.infer<typeof restartTargetSchema>;
+
+function resolvedSettingSchema<T extends z.ZodTypeAny>(value: T) {
+  return z.object({
+    activeValue: value,
+    savedValue: value,
+    source: configurationSourceSchema,
+    editable: z.boolean(),
+    restartTarget: restartTargetSchema,
+    pendingRestart: z.boolean(),
+  });
+}
+
+const resolvedStringSettingSchema = resolvedSettingSchema(z.string());
+const resolvedNumberSettingSchema = resolvedSettingSchema(z.number());
+const resolvedBooleanSettingSchema = resolvedSettingSchema(z.boolean());
+
+export const applicationConfigurationSnapshotSchema = z.object({
+  application: z.object({
+    network: z.object({
+      host: resolvedStringSettingSchema,
+      port: resolvedNumberSettingSchema,
+      allowRemote: resolvedBooleanSettingSchema,
+      mobileHttps: resolvedBooleanSettingSchema,
+      httpsPort: resolvedNumberSettingSchema,
+    }),
+    diagnostics: z.object({
+      loggingEnabled: resolvedBooleanSettingSchema,
+      performanceEnabled: resolvedBooleanSettingSchema,
+      level: resolvedSettingSchema(applicationLogLevelSchema),
+      retentionDays: resolvedNumberSettingSchema,
+      maxBufferedLogs: resolvedNumberSettingSchema,
+    }),
+    daemon: z.object({
+      startupTimeoutMs: resolvedNumberSettingSchema,
+      maxOldSpaceMb: resolvedNumberSettingSchema,
+    }),
+    electron: z.object({
+      ozonePlatform: resolvedSettingSchema(electronOzonePlatformSchema),
+      fontRenderHinting: resolvedSettingSchema(electronFontRenderHintingSchema),
+    }),
+  }),
+  context: z.object({
+    dataDir: z.string(),
+    dataDirSource: z.enum(["default", "environment"]),
+    platform: z.string(),
+    packaged: z.boolean().optional(),
+    webAssetsOverridden: z.boolean(),
+    proxyConfigured: z.boolean(),
+    proxyDebugEnabled: z.boolean(),
+  }),
+});
+export type ApplicationConfigurationSnapshot = z.infer<
+  typeof applicationConfigurationSnapshotSchema
+>;

--- a/packages/contracts/src/domains/settings/index.ts
+++ b/packages/contracts/src/domains/settings/index.ts
@@ -1,2 +1,3 @@
+export * from "./application-configuration.schema.js";
 export * from "./settings.schema.js";
 export * from "./settings.events.schema.js";

--- a/packages/contracts/src/domains/settings/settings.events.schema.ts
+++ b/packages/contracts/src/domains/settings/settings.events.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { definePublicEvent } from "../events/event-definition.schema.js";
+import { applicationConfigurationSnapshotSchema } from "./application-configuration.schema.js";
 import { settingsSchema } from "./settings.schema.js";
 
 const workbenchRoles = ["workbench_server"] as const;
@@ -8,6 +9,11 @@ export const settingsEventDefinitions = [
   definePublicEvent(
     "settings.updated",
     z.object({ settings: settingsSchema }),
+    { allowedSourceRoles: workbenchRoles },
+  ),
+  definePublicEvent(
+    "applicationConfiguration.updated",
+    z.object({ snapshot: applicationConfigurationSnapshotSchema }),
     { allowedSourceRoles: workbenchRoles },
   ),
 ];

--- a/packages/contracts/src/domains/settings/settings.operations.schema.ts
+++ b/packages/contracts/src/domains/settings/settings.operations.schema.ts
@@ -1,4 +1,9 @@
-import { settingsSchema, updateSettingsRequestSchema } from "./index.js";
+import {
+  applicationConfigurationSnapshotSchema,
+  settingsSchema,
+  updateApplicationConfigurationRequestSchema,
+  updateSettingsRequestSchema,
+} from "./index.js";
 import { z } from "zod";
 import { defineOperation } from "../protocol/operation-definition.schema.js";
 
@@ -22,5 +27,23 @@ export const settingsOperationDefinitions = [
     "recommended",
     ["workbench_server"] as const,
     "operation.settings.update",
+  ),
+  defineOperation(
+    "applicationConfiguration.get",
+    emptyParamsSchema,
+    applicationConfigurationSnapshotSchema,
+    "read",
+    "none",
+    ["workbench_server"] as const,
+    "operation.applicationConfiguration.get",
+  ),
+  defineOperation(
+    "applicationConfiguration.update",
+    updateApplicationConfigurationRequestSchema,
+    applicationConfigurationSnapshotSchema,
+    "mutation",
+    "recommended",
+    ["workbench_server"] as const,
+    "operation.applicationConfiguration.update",
   ),
 ] as const;

--- a/packages/contracts/src/domains/settings/settings.schema.ts
+++ b/packages/contracts/src/domains/settings/settings.schema.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { applicationLogLevelSchema } from "../logs/index.js";
 import { modelSelectionSchema, thinkingLevelSchema } from "../models/index.js";
+import {
+  applicationSettingsPatchSchema,
+  applicationSettingsSchema,
+  defaultApplicationSettings,
+} from "./application-configuration.schema.js";
 import { userConfigurableToolNameSchema } from "../tools/index.js";
 
 export const modeSchema = z.enum(["planning", "coding"]);
@@ -168,11 +173,7 @@ export const settingsSchema = z.object({
     model: modelSelectionSchema.optional(),
     thinkingLevel: thinkingLevelSchema.default("off"),
   }),
-  server: z.object({
-    host: z.string().default("127.0.0.1"),
-    port: z.number().int().positive().default(3747),
-    allowRemote: z.boolean().default(false),
-  }),
+  application: applicationSettingsSchema.default(defaultApplicationSettings),
   ui: z.object({
     theme: colorThemeSchema.default("nerve"),
     colorMode: colorModeSchema.default("system"),
@@ -244,11 +245,7 @@ export const defaultSettings: Settings = {
   exploreAgent: {
     thinkingLevel: "off",
   },
-  server: {
-    host: "127.0.0.1",
-    port: 3747,
-    allowRemote: false,
-  },
+  application: defaultApplicationSettings,
   ui: {
     theme: "nerve",
     colorMode: "system",
@@ -313,13 +310,7 @@ export const updateSettingsRequestSchema = z.object({
       thinkingLevel: thinkingLevelSchema.optional(),
     })
     .optional(),
-  server: z
-    .object({
-      host: z.string().optional(),
-      port: z.number().int().positive().optional(),
-      allowRemote: z.boolean().optional(),
-    })
-    .optional(),
+  application: applicationSettingsPatchSchema.optional(),
   ui: z
     .object({
       theme: colorThemeSchema.optional(),

--- a/packages/contracts/test/settings.test.ts
+++ b/packages/contracts/test/settings.test.ts
@@ -48,6 +48,7 @@ describe("settings schema", () => {
       closeToTray: true,
       headerType: "auto",
     });
+    assert.deepEqual(settings.application, defaultSettings.application);
     assert.deepEqual(settings.notifications, {
       systemEnabled: true,
       soundsEnabled: true,

--- a/packages/desktop-shell/scripts/start-electron.mjs
+++ b/packages/desktop-shell/scripts/start-electron.mjs
@@ -20,8 +20,6 @@ const nerveHome = process.env.NERVE_HOME?.trim() || join(homedir(), ".nerve");
 const env = {
   ...process.env,
   NERVE_HOME: nerveHome,
-  NERVE_PORT: process.env.NERVE_PORT?.trim() || "3747",
-  NERVE_HTTPS_PORT: process.env.NERVE_HTTPS_PORT?.trim() || "3748",
 };
 delete env.ELECTRON_RUN_AS_NODE;
 
@@ -34,7 +32,9 @@ const ozonePlatform = parseElectronOzonePlatform(
 );
 const linuxSwitches = [
   "--class=io.github.thilinatlm.nerve-v2",
-  ...(ozonePlatform ? [`--ozone-platform=${ozonePlatform}`] : []),
+  ...(ozonePlatform && ozonePlatform !== "auto"
+    ? [`--ozone-platform=${ozonePlatform}`]
+    : []),
 ];
 const electronArgs = [
   ...(process.platform === "linux" ? linuxSwitches : []),

--- a/packages/desktop-shell/src/app/cli-options.ts
+++ b/packages/desktop-shell/src/app/cli-options.ts
@@ -5,6 +5,7 @@ import {
   resolveElectronFontRenderHinting,
 } from "../shared/font-rendering.js";
 import {
+  electronOzonePlatformSwitch,
   type ElectronOzonePlatform,
   parseElectronOzonePlatform,
 } from "../shared/ozone-platform.js";
@@ -116,8 +117,9 @@ function parsePort(value: string): number {
 export function applyElectronOzonePlatform(
   platform: ElectronOzonePlatform | undefined,
 ): void {
-  if (process.platform !== "linux" || !platform) return;
-  app.commandLine.appendSwitch("ozone-platform", platform);
+  const platformSwitch = electronOzonePlatformSwitch(platform);
+  if (process.platform !== "linux" || !platformSwitch) return;
+  app.commandLine.appendSwitch("ozone-platform", platformSwitch);
 }
 
 export function applyElectronFontRenderHinting(

--- a/packages/desktop-shell/src/bin.ts
+++ b/packages/desktop-shell/src/bin.ts
@@ -14,7 +14,10 @@ import {
   prepareElectronDownloadEnv,
 } from "./electron-download-env.js";
 import { resolveElectronFontRenderHinting } from "./shared/font-rendering.js";
-import { parseElectronOzonePlatform } from "./shared/ozone-platform.js";
+import {
+  electronOzonePlatformSwitch,
+  parseElectronOzonePlatform,
+} from "./shared/ozone-platform.js";
 
 const require = createRequire(import.meta.url);
 
@@ -98,8 +101,8 @@ const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 const env = { ...process.env };
 delete env.ELECTRON_RUN_AS_NODE;
 
-const ozonePlatform = parseElectronOzonePlatform(
-  process.env.NERVE_ELECTRON_OZONE_PLATFORM,
+const ozonePlatform = electronOzonePlatformSwitch(
+  parseElectronOzonePlatform(process.env.NERVE_ELECTRON_OZONE_PLATFORM),
 );
 const fontRenderHinting = resolveElectronFontRenderHinting(
   process.env.NERVE_ELECTRON_FONT_RENDER_HINTING,

--- a/packages/desktop-shell/src/daemon/connection-service.ts
+++ b/packages/desktop-shell/src/daemon/connection-service.ts
@@ -1,5 +1,6 @@
 import type { DaemonConnectionPorts } from "./ports.js";
 import {
+  buildOrchestratorArgs,
   buildOrchestratorEnv,
   resolveDaemonPaths,
   resolveReadinessTimeoutMs,
@@ -50,7 +51,10 @@ async function connectRemoteDaemon(
     {
       mode: "remote",
       owned: false,
-      readinessTimeoutMs: resolveReadinessTimeoutMs(ports.env),
+      readinessTimeoutMs: resolveReadinessTimeoutMs(
+        ports.env,
+        options.startupTimeoutMs,
+      ),
     },
     ports,
   );
@@ -62,7 +66,10 @@ async function ensureLocalDaemon(
   ports: DaemonConnectionPorts,
 ): Promise<ManagedDaemon> {
   const paths = resolveDaemonPaths(ports.env);
-  const readinessTimeoutMs = resolveReadinessTimeoutMs(ports.env);
+  const readinessTimeoutMs = resolveReadinessTimeoutMs(
+    ports.env,
+    options.startupTimeoutMs,
+  );
   const existing = await ports.discovery.findHealthyDaemon(paths);
   if (existing) {
     if (
@@ -102,6 +109,7 @@ async function ensureLocalDaemon(
       paths,
       serverMain,
       launchEnv: buildOrchestratorEnv(options, ports.env),
+      launchArgs: buildOrchestratorArgs(options),
       readinessTimeoutMs,
     },
     ports,

--- a/packages/desktop-shell/src/daemon/node-integration.ts
+++ b/packages/desktop-shell/src/daemon/node-integration.ts
@@ -19,11 +19,15 @@ export function createNodeDaemonPorts(): DaemonConnectionPorts {
     discovery: { findHealthyDaemon },
     launcher: {
       launch: (input) => {
-        const child = spawn(process.execPath, [input.serverMain], {
-          env: input.env,
-          stdio: ["ignore", "pipe", "pipe"],
-          windowsHide: true,
-        });
+        const child = spawn(
+          process.execPath,
+          [input.serverMain, ...(input.args ?? [])],
+          {
+            env: input.env,
+            stdio: ["ignore", "pipe", "pipe"],
+            windowsHide: true,
+          },
+        );
         child.stdout?.on("data", (chunk) => input.onOutput("stdout", chunk));
         child.stderr?.on("data", (chunk) => input.onOutput("stderr", chunk));
         child.once("error", (error) => input.onError(error));

--- a/packages/desktop-shell/src/daemon/ports.ts
+++ b/packages/desktop-shell/src/daemon/ports.ts
@@ -25,6 +25,7 @@ export interface DaemonChildHandle {
 export interface DaemonChildLauncherPort {
   launch(input: {
     serverMain: string;
+    args?: string[];
     env: NodeJS.ProcessEnv;
     onOutput: (stream: "stdout" | "stderr", chunk: unknown) => void;
     onError: (error: Error) => void;

--- a/packages/desktop-shell/src/daemon/profile.ts
+++ b/packages/desktop-shell/src/daemon/profile.ts
@@ -27,24 +27,36 @@ export function resolveDaemonPaths(
 
 export function resolveReadinessTimeoutMs(
   env: NodeJS.ProcessEnv = process.env,
+  configured = DEFAULT_READINESS_TIMEOUT_MS,
 ): number {
   const raw = env.NERVE_DAEMON_STARTUP_TIMEOUT_MS?.trim();
-  if (!raw) return DEFAULT_READINESS_TIMEOUT_MS;
+  if (!raw) return configured;
   const value = Number(raw);
   if (!Number.isFinite(value) || value <= 0) {
-    return DEFAULT_READINESS_TIMEOUT_MS;
+    return configured;
   }
   return Math.max(1, Math.trunc(value));
 }
 
 export function resolveDaemonMaxOldSpaceMb(
   env: NodeJS.ProcessEnv = process.env,
+  configured = DEFAULT_DAEMON_MAX_OLD_SPACE_MB,
 ): number {
   const raw = env.NERVE_DAEMON_MAX_OLD_SPACE_MB?.trim();
   const parsed = raw ? Number(raw) : NaN;
   return Number.isFinite(parsed) && parsed > 0
     ? Math.floor(parsed)
-    : DEFAULT_DAEMON_MAX_OLD_SPACE_MB;
+    : configured;
+}
+
+export function buildOrchestratorArgs(options: EnsureDaemonOptions): string[] {
+  return [
+    ...(options.host ? ["--host", options.host] : []),
+    ...(options.port ? ["--port", String(options.port)] : []),
+    ...(options.httpsPort ? ["--https-port", String(options.httpsPort)] : []),
+    ...(options.allowRemote ? ["--allow-remote"] : []),
+    ...(options.mobileHttps ? ["--mobile-https"] : []),
+  ];
 }
 
 /** Launch environment for the owned workbench-server child. */
@@ -54,21 +66,22 @@ export function buildOrchestratorEnv(
 ): NodeJS.ProcessEnv {
   const nodeOptions = [
     env.NODE_OPTIONS,
-    `--max-old-space-size=${resolveDaemonMaxOldSpaceMb(env)}`,
+    `--max-old-space-size=${resolveDaemonMaxOldSpaceMb(
+      env,
+      options.maxOldSpaceMb,
+    )}`,
   ]
     .filter(Boolean)
     .join(" ");
+  const childEnv = { ...env };
+  if (childEnv.NERVE_DESKTOP_SYNTHETIC_PERFORMANCE === "1") {
+    delete childEnv.NERVE_PERFORMANCE_DIAGNOSTICS;
+    delete childEnv.NERVE_DESKTOP_SYNTHETIC_PERFORMANCE;
+  }
   return {
-    ...env,
+    ...childEnv,
     ELECTRON_RUN_AS_NODE: "1",
     NODE_OPTIONS: nodeOptions,
-    NERVE_HOST: options.host ?? env.NERVE_HOST ?? "127.0.0.1",
-    ...(options.port ? { NERVE_PORT: String(options.port) } : {}),
-    ...(options.httpsPort
-      ? { NERVE_HTTPS_PORT: String(options.httpsPort) }
-      : {}),
-    ...(options.allowRemote ? { NERVE_ALLOW_REMOTE: "1" } : {}),
-    ...(options.mobileHttps ? { NERVE_MOBILE_HTTPS: "1" } : {}),
     ...(options.webDistPath ? { NERVE_WEB_DIST: options.webDistPath } : {}),
   };
 }

--- a/packages/desktop-shell/src/daemon/supervisor.ts
+++ b/packages/desktop-shell/src/daemon/supervisor.ts
@@ -30,6 +30,7 @@ export interface DaemonSupervisorConfig {
   paths?: DaemonPaths;
   serverMain?: string;
   launchEnv?: NodeJS.ProcessEnv;
+  launchArgs?: string[];
 }
 
 interface OwnedChild {
@@ -205,7 +206,7 @@ export class DaemonSupervisor {
   }
 
   private async spawnAndWait(): Promise<HealthyDaemon> {
-    const { paths, serverMain, launchEnv, readinessTimeoutMs } =
+    const { paths, serverMain, launchEnv, launchArgs, readinessTimeoutMs } =
       this.requireOwnedConfig();
     const output = new OutputBuffer();
     this.ports.logger.log("info", "Starting owned local daemon", {
@@ -222,6 +223,7 @@ export class DaemonSupervisor {
     };
     child.handle = this.ports.launcher.launch({
       serverMain,
+      args: launchArgs,
       env: launchEnv,
       onOutput: (stream, chunk) => output.append(stream, chunk),
       onError: (error) => {
@@ -548,6 +550,7 @@ export class DaemonSupervisor {
     paths: DaemonPaths;
     serverMain: string;
     launchEnv: NodeJS.ProcessEnv;
+    launchArgs: string[];
     readinessTimeoutMs: number;
   } {
     if (
@@ -563,6 +566,7 @@ export class DaemonSupervisor {
       paths: this.config.paths,
       serverMain: this.config.serverMain,
       launchEnv: this.config.launchEnv,
+      launchArgs: this.config.launchArgs ?? [],
       readinessTimeoutMs: this.config.readinessTimeoutMs,
     };
   }

--- a/packages/desktop-shell/src/daemon/types.ts
+++ b/packages/desktop-shell/src/daemon/types.ts
@@ -43,6 +43,8 @@ export interface EnsureDaemonOptions {
   httpsPort?: number;
   allowRemote?: boolean;
   mobileHttps?: boolean;
+  startupTimeoutMs?: number;
+  maxOldSpaceMb?: number;
 }
 
 export interface DaemonPaths {

--- a/packages/desktop-shell/src/ipc/window-ipc.ts
+++ b/packages/desktop-shell/src/ipc/window-ipc.ts
@@ -10,6 +10,12 @@ interface RegisterDesktopIpcOptions {
   closeWindowOrQuit: (window: BrowserWindowType, source?: QuitSource) => void;
   sendWindowState: (window: BrowserWindowType) => void;
   showDesktopNotification: (payload: unknown) => { shown: boolean };
+  getDaemonCapability: () => {
+    mode?: "local" | "remote";
+    owned: boolean;
+    canRestart: boolean;
+  };
+  restartDaemon: () => Promise<void>;
 }
 
 export function registerDesktopIpc(options: RegisterDesktopIpcOptions): void {
@@ -35,6 +41,19 @@ export function registerDesktopIpc(options: RegisterDesktopIpcOptions): void {
       context: { closeToTray: options.getCloseToTray() },
     });
     options.closeWindowOrQuit(window, "titlebar-close");
+  });
+
+  ipcMain.handle("desktop.daemon.getCapability", () =>
+    options.getDaemonCapability(),
+  );
+
+  ipcMain.handle("desktop.daemon.restart", async () => {
+    const capability = options.getDaemonCapability();
+    if (!capability.canRestart) {
+      throw new Error("The current daemon is not owned by this desktop app.");
+    }
+    await options.restartDaemon();
+    return { ok: true };
   });
 
   ipcMain.handle("desktop.settings.setCloseToTray", (_event, value) => {

--- a/packages/desktop-shell/src/logging.ts
+++ b/packages/desktop-shell/src/logging.ts
@@ -8,11 +8,19 @@ import {
 import { resolveDataDir } from "@nervekit/workbench-server";
 
 let seq = 0;
+let configuredApplicationLogging: boolean | undefined;
+
+export function configureApplicationLogging(enabled: boolean): void {
+  configuredApplicationLogging = enabled;
+}
 
 export function applicationLoggingEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  return env.NERVE_LOGGING_ENABLED === "1";
+  if (env.NERVE_LOGGING_ENABLED !== undefined) {
+    return env.NERVE_LOGGING_ENABLED === "1";
+  }
+  return configuredApplicationLogging ?? false;
 }
 
 export async function desktopLog(

--- a/packages/desktop-shell/src/main.ts
+++ b/packages/desktop-shell/src/main.ts
@@ -1,6 +1,10 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { resolveDataDir } from "@nervekit/workbench-server";
+import {
+  readPersistedSettingsForBootstrap,
+  resolveApplicationConfiguration,
+  resolveDataDir,
+} from "@nervekit/workbench-server";
 import {
   applyElectronFontRenderHinting,
   applyElectronOzonePlatform,
@@ -32,7 +36,7 @@ import {
 import { chromiumLoopbackProxyBypassRules } from "./electron-download-env.js";
 import { showDesktopNotification } from "./ipc/notifications-ipc.js";
 import { registerDesktopIpc, windowState } from "./ipc/window-ipc.js";
-import { desktopLog } from "./logging.js";
+import { configureApplicationLogging, desktopLog } from "./logging.js";
 import {
   installDesktopPerformanceMonitor,
   type DesktopPerformanceMonitor,
@@ -60,15 +64,51 @@ import {
   resolvePreloadPath,
 } from "./window/preload-paths.js";
 
-applyDevelopmentPerformanceDiagnostics(app.isPackaged);
-
 const desktopOptions = parseDesktopOptions(process.argv.slice(1));
 const desktopDataDir = resolveDataDir();
+const bootstrapSettings =
+  await readPersistedSettingsForBootstrap(desktopDataDir);
+const desktopConfiguration = resolveApplicationConfiguration({
+  settings: bootstrapSettings,
+  env: process.env,
+  argv: process.argv.slice(1),
+  dataDir: desktopDataDir,
+  platform: process.platform,
+  development: !app.isPackaged,
+  packaged: app.isPackaged,
+});
+const performanceEnvironmentWasExplicit =
+  process.env.NERVE_PERFORMANCE_DIAGNOSTICS !== undefined;
+if (process.env.NERVE_LOGGING_ENABLED !== undefined) {
+  process.env.NERVE_LOGGING_ENABLED = desktopConfiguration.values.loggingEnabled
+    ? "1"
+    : "0";
+}
+if (performanceEnvironmentWasExplicit) {
+  process.env.NERVE_PERFORMANCE_DIAGNOSTICS = desktopConfiguration.values
+    .performanceEnabled
+    ? "1"
+    : "0";
+}
+applyDevelopmentPerformanceDiagnostics(app.isPackaged, process.env, {
+  enabled: desktopConfiguration.values.performanceEnabled,
+});
+configureApplicationLogging(desktopConfiguration.values.loggingEnabled);
+if (!performanceEnvironmentWasExplicit) {
+  process.env.NERVE_DESKTOP_SYNTHETIC_PERFORMANCE = "1";
+  if (
+    bootstrapSettings.application.diagnostics.performanceEnabled ===
+      undefined &&
+    desktopConfiguration.values.performanceEnabled
+  ) {
+    process.env.NERVE_DEVELOPMENT_PERFORMANCE_DEFAULT = "1";
+  }
+}
 const electronOzonePlatform = parseElectronOzonePlatform(
-  process.env.NERVE_ELECTRON_OZONE_PLATFORM,
+  desktopConfiguration.values.ozonePlatform,
 );
 const electronFontRenderHinting = resolveElectronFontRenderHinting(
-  process.env.NERVE_ELECTRON_FONT_RENDER_HINTING,
+  desktopConfiguration.values.fontRenderHinting,
 );
 applyElectronOzonePlatform(electronOzonePlatform);
 applyElectronFontRenderHinting(electronFontRenderHinting);
@@ -137,6 +177,17 @@ if (!gotSingleInstanceLock) {
     sendWindowState,
     showDesktopNotification: (payload) =>
       showDesktopNotification(payload, showMainWindow),
+    getDaemonCapability: () => ({
+      mode: managedDaemon?.mode,
+      owned: managedDaemon?.owned ?? false,
+      canRestart: managedDaemon?.owned === true,
+    }),
+    restartDaemon: async () => {
+      if (!managedDaemon?.owned) {
+        throw new Error("The current daemon is not owned by this desktop app.");
+      }
+      await managedDaemon.restart();
+    },
   });
 
   app.on("second-instance", () => {
@@ -352,6 +403,9 @@ async function openMainWindow(): Promise<void> {
               start: () =>
                 ensureDaemon({
                   webDistPath: resolvePackagedWebDistPath(),
+                  startupTimeoutMs:
+                    desktopConfiguration.values.startupTimeoutMs,
+                  maxOldSpaceMb: desktopConfiguration.values.maxOldSpaceMb,
                   ...desktopOptions,
                 }),
             },

--- a/packages/desktop-shell/src/performance/development-diagnostics.ts
+++ b/packages/desktop-shell/src/performance/development-diagnostics.ts
@@ -5,10 +5,15 @@ const PERFORMANCE_SESSION_ENV = "NERVE_PERFORMANCE_SESSION_ID";
 export function applyDevelopmentPerformanceDiagnostics(
   isPackaged: boolean,
   env: NodeJS.ProcessEnv = process.env,
-  options: { now?: () => Date; pid?: number } = {},
+  options: { now?: () => Date; pid?: number; enabled?: boolean } = {},
 ): void {
-  if (!isPackaged && env[PERFORMANCE_DIAGNOSTICS_ENV] === undefined)
-    env[PERFORMANCE_DIAGNOSTICS_ENV] = "1";
+  if (
+    env[PERFORMANCE_DIAGNOSTICS_ENV] === undefined &&
+    (options.enabled !== undefined || !isPackaged)
+  ) {
+    const enabled = options.enabled ?? true;
+    env[PERFORMANCE_DIAGNOSTICS_ENV] = enabled ? "1" : "0";
+  }
   if (
     env[PERFORMANCE_DIAGNOSTICS_ENV] !== "1" ||
     env[PERFORMANCE_SESSION_ENV] !== undefined

--- a/packages/desktop-shell/src/preload.cjs
+++ b/packages/desktop-shell/src/preload.cjs
@@ -30,6 +30,10 @@ contextBridge.exposeInMainWorld("nerveDesktop", {
       };
     },
   },
+  daemon: {
+    getCapability: () => ipcRenderer.invoke("desktop.daemon.getCapability"),
+    restart: () => ipcRenderer.invoke("desktop.daemon.restart"),
+  },
   settings: {
     setCloseToTray: (closeToTray) =>
       ipcRenderer.invoke("desktop.settings.setCloseToTray", closeToTray),

--- a/packages/desktop-shell/src/shared/ozone-platform.ts
+++ b/packages/desktop-shell/src/shared/ozone-platform.ts
@@ -4,6 +4,12 @@
 
 export type ElectronOzonePlatform = "x11" | "wayland" | "auto";
 
+export function electronOzonePlatformSwitch(
+  platform: ElectronOzonePlatform | undefined,
+): "x11" | "wayland" | undefined {
+  return platform === "x11" || platform === "wayland" ? platform : undefined;
+}
+
 export function parseElectronOzonePlatform(
   value: string | undefined,
 ): ElectronOzonePlatform | undefined {

--- a/packages/desktop-shell/test/cli-options.test.ts
+++ b/packages/desktop-shell/test/cli-options.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { parseDesktopOptions } from "../src/app/cli-options.js";
+import {
+  electronOzonePlatformSwitch,
+  parseElectronOzonePlatform,
+} from "../src/shared/ozone-platform.js";
 import { ShellPageUrlRegistry } from "../src/window/loading-pages.js";
 
 describe("desktop CLI options", () => {
@@ -12,6 +16,23 @@ describe("desktop CLI options", () => {
     assert.throws(
       () => parseDesktopOptions(["--connect=https://host", "--local"]),
       /either --local or --connect/,
+    );
+  });
+});
+
+describe("Electron Ozone platform", () => {
+  it("treats auto as Chromium's default rather than a literal switch", () => {
+    assert.equal(
+      electronOzonePlatformSwitch(parseElectronOzonePlatform("auto")),
+      undefined,
+    );
+    assert.equal(
+      electronOzonePlatformSwitch(parseElectronOzonePlatform("x11")),
+      "x11",
+    );
+    assert.equal(
+      electronOzonePlatformSwitch(parseElectronOzonePlatform("wayland")),
+      "wayland",
     );
   });
 });

--- a/packages/desktop-shell/test/daemon-connection-service.test.ts
+++ b/packages/desktop-shell/test/daemon-connection-service.test.ts
@@ -99,7 +99,8 @@ describe("daemon connection service", () => {
     assert.equal(daemon.mode, "local");
     assert.equal(world.launches.length, 1);
     assert.equal(world.launches[0]?.serverMain, "/opt/nerve/server/main.js");
-    assert.equal(world.launches[0]?.env.NERVE_PORT, "4000");
+    assert.equal(world.launches[0]?.env.NERVE_PORT, undefined);
+    assert.deepEqual(world.launches[0]?.args, ["--port", "4000"]);
     assert.equal(world.launches[0]?.env.ELECTRON_RUN_AS_NODE, "1");
     assert.equal(daemon.url, "http://127.0.0.1:3747");
     await daemon.stop();

--- a/packages/desktop-shell/test/daemon-profile.test.ts
+++ b/packages/desktop-shell/test/daemon-profile.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import {
+  buildOrchestratorArgs,
   buildOrchestratorEnv,
   resolveDaemonMaxOldSpaceMb,
   resolveDaemonPaths,
@@ -78,16 +79,35 @@ describe("daemon profile policy", () => {
       env.NODE_OPTIONS,
       "--enable-source-maps --max-old-space-size=4096",
     );
-    assert.equal(env.NERVE_HOST, "0.0.0.0");
-    assert.equal(env.NERVE_PORT, "4000");
-    assert.equal(env.NERVE_HTTPS_PORT, "4443");
-    assert.equal(env.NERVE_ALLOW_REMOTE, "1");
-    assert.equal(env.NERVE_MOBILE_HTTPS, "1");
+    assert.equal(env.NERVE_HOST, undefined);
+    assert.equal(env.NERVE_PORT, undefined);
+    assert.equal(env.NERVE_HTTPS_PORT, undefined);
+    assert.equal(env.NERVE_ALLOW_REMOTE, undefined);
+    assert.equal(env.NERVE_MOBILE_HTTPS, undefined);
+    assert.deepEqual(
+      buildOrchestratorArgs({
+        host: "0.0.0.0",
+        port: 4000,
+        httpsPort: 4443,
+        allowRemote: true,
+        mobileHttps: true,
+      }),
+      [
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "4000",
+        "--https-port",
+        "4443",
+        "--allow-remote",
+        "--mobile-https",
+      ],
+    );
     assert.equal(env.NERVE_WEB_DIST, "/opt/web");
     assert.equal(env.PATH, "/usr/bin");
 
     const defaults = buildOrchestratorEnv({}, {});
-    assert.equal(defaults.NERVE_HOST, "127.0.0.1");
+    assert.equal(defaults.NERVE_HOST, undefined);
     assert.equal(defaults.NERVE_PORT, undefined);
     assert.equal(defaults.NERVE_ALLOW_REMOTE, undefined);
   });

--- a/packages/desktop-shell/test/support/fake-daemon-ports.ts
+++ b/packages/desktop-shell/test/support/fake-daemon-ports.ts
@@ -178,7 +178,12 @@ export interface FakeDaemonWorld {
   ports: DaemonConnectionPorts;
   scheduler: FakeScheduler;
   children: FakeChild[];
-  launches: Array<{ serverMain: string; env: NodeJS.ProcessEnv; at: number }>;
+  launches: Array<{
+    serverMain: string;
+    args?: string[];
+    env: NodeJS.ProcessEnv;
+    at: number;
+  }>;
   crashReports: RecordedCrashReport[];
   logs: Array<{ level: string; message: string }>;
   healthResults: { value: boolean };
@@ -200,6 +205,7 @@ export function fakeDaemonWorld(
   const children: FakeChild[] = [];
   const launches: Array<{
     serverMain: string;
+    args?: string[];
     env: NodeJS.ProcessEnv;
     at: number;
   }> = [];
@@ -233,6 +239,7 @@ export function fakeDaemonWorld(
       launch: (input) => {
         launches.push({
           serverMain: input.serverMain,
+          args: input.args,
           env: input.env,
           at: scheduler.now(),
         });

--- a/packages/website/src/content/docs/developers/development.md
+++ b/packages/website/src/content/docs/developers/development.md
@@ -18,7 +18,6 @@ pnpm desktop
 
 ```sh
 pnpm desktop                # Electron app from source
-pnpm desktop:remote-enabled # trusted-LAN/mobile HTTPS flags
 pnpm dev                    # daemon + Vite workbench
 pnpm dev:ui                 # UI against an existing daemon
 pnpm build                  # all packages and staged Workbench assets
@@ -26,6 +25,8 @@ pnpm fix                    # format and ESLint fixes
 pnpm check                  # formatting, lint, boundaries, package checks
 pnpm test                   # package tests
 ```
+
+Enable trusted-LAN and mobile HTTPS access from **Settings → System → Network**, then restart the owned daemon when prompted.
 
 For UI-only development against a running daemon:
 

--- a/packages/website/src/content/docs/operations/configuration.md
+++ b/packages/website/src/content/docs/operations/configuration.md
@@ -1,11 +1,33 @@
 ---
 title: Configuration and ports
-description: Understand desktop flags, environment variables, saved settings, and daemon ownership.
+description: Understand saved application settings, environment overrides, desktop flags, and restart behavior.
 sidebar:
   order: 4
 ---
 
-Defaults are `NERVE_HOME=~/.nerve`, host `127.0.0.1`, HTTP port `3747`, remote access off, and mobile HTTPS port `3748` when enabled.
+Nerve program-level configuration has one resolution order:
+
+1. command-line option;
+2. environment variable;
+3. saved value in `<NERVE_HOME>/config.json`;
+4. product default.
+
+The effective value and its source are visible under **Settings → System**. A control is disabled when an environment variable or command-line option owns it; unset that override and restart before editing it in the UI. An explicit boolean `0` or `false` overrides a saved `true` just as `1` or `true` overrides `false`.
+
+Defaults are `NERVE_HOME=~/.nerve`, host `127.0.0.1`, HTTP port `3747`, remote access off, and mobile HTTPS port `3748`.
+
+## Settings → System
+
+The System page persists safe application configuration for:
+
+- bind host, HTTP/HTTPS ports, remote access, and mobile HTTPS;
+- application logging and performance diagnostics;
+- log policy, owned-daemon startup timeout, and heap cap;
+- Linux Electron Ozone platform and font rendering.
+
+Enabling **Allow remote connections** also changes a loopback bind host to `0.0.0.0`, so the next daemon launch can accept LAN clients. Disabling it restores `127.0.0.1` when the host is a wildcard. You can still enter a specific interface address in the advanced host field.
+
+The page distinguishes active and saved values. Network, diagnostics enablement, and heap changes need a daemon restart. Timeout and Electron rendering changes need the desktop app to restart. The page can restart an owned local daemon; browser clients and remote or adopted daemons show manual guidance instead.
 
 ## Desktop flags
 
@@ -20,7 +42,7 @@ Defaults are `NERVE_HOME=~/.nerve`, host `127.0.0.1`, HTTP port `3747`, remote a
 --mobile-https
 ```
 
-Remote URL and token select monitor-only mode. Local bind flags configure an owned daemon.
+Remote URL and token select monitor-only mode. Local bind flags configure an owned daemon and lock the corresponding Settings controls for that launch.
 
 ## Environment
 
@@ -28,23 +50,11 @@ Common overrides include:
 
 - `NERVE_HOME`
 - `NERVE_HOST`, `NERVE_PORT`, `NERVE_HTTPS_PORT`
-- `NERVE_ALLOW_REMOTE=1`, `NERVE_MOBILE_HTTPS=1`
-- `NERVE_DAEMON_TOKEN` for remote connection
-- `NERVE_WEB_DIST`
-- `NERVE_DAEMON_STARTUP_TIMEOUT_MS` (60 seconds default)
-- `NERVE_DAEMON_MAX_OLD_SPACE_MB` (4096 default)
-- `NERVE_ELECTRON_OZONE_PLATFORM`
-- `NERVE_DEBUG_PROXY=1`
+- `NERVE_ALLOW_REMOTE`, `NERVE_MOBILE_HTTPS`
+- `NERVE_LOGGING_ENABLED`, `NERVE_PERFORMANCE_DIAGNOSTICS`
+- `NERVE_DAEMON_STARTUP_TIMEOUT_MS`, `NERVE_DAEMON_MAX_OLD_SPACE_MB`
+- `NERVE_ELECTRON_OZONE_PLATFORM`, `NERVE_ELECTRON_FONT_RENDER_HINTING`
+
+`NERVE_HOME`, remote tokens, generated performance session IDs, web asset/build routing, and proxy/toolchain variables are launch context rather than saved UI preferences. Secret values are never returned in the configuration snapshot.
 
 See the [complete CLI/environment reference](/reference/cli-environment/).
-
-## Precedence and source launch
-
-The daemon resolves host configuration from command-line flags, then environment, then saved settings, then defaults. The source Electron launcher sets HTTP/HTTPS defaults through environment when absent, so those values can outrank saved port settings.
-
-Use explicit environment overrides for isolated development. Keep Electron's active profile outside `NERVE_HOME` so complete Nerve-home backup/migration remains safe.
-
-## Next steps
-
-- [CLI and environment reference](/reference/cli-environment/)
-- [Connectivity troubleshooting](/troubleshooting/connectivity/)

--- a/packages/website/src/content/docs/operations/diagnostics.md
+++ b/packages/website/src/content/docs/operations/diagnostics.md
@@ -7,7 +7,7 @@ sidebar:
 
 ## Application logs
 
-Nerve application logging is disabled by default. Developers can explicitly enable it for a launch by setting `NERVE_LOGGING_ENABLED=1`. When enabled, the Nerve Logs button and tab can filter, expand, copy, refresh, and prune application logs.
+Nerve application logging is disabled by default. Enable it under **Settings → System → Diagnostics** or override a launch with `NERVE_LOGGING_ENABLED=1`. Environment overrides appear as locked controls in Settings. When enabled, the Nerve Logs button and tab can filter, expand, copy, refresh, and prune application logs.
 
 Desktop and daemon application logs are JSONL under `<NERVE_HOME>/logs`, including daily desktop files. Existing files are retained but are not read or appended while application logging is disabled.
 
@@ -25,7 +25,7 @@ There is no dedicated in-app crash-report list/download route. Inspect the direc
 
 Unpackaged source desktop launches (`pnpm desktop`) automatically write content-free 10-second process, event-loop, and subsystem activity samples to `<NERVE_HOME>/logs/performance-<session-id>.jsonl`. Each desktop launch gets a separate timestamped file shared with its owned daemon; daemon restarts during that launch remain in the same file. When CPU becomes high, note the time and ask the coding agent to inspect the recent samples. No alternate profile, ports, or launch flags are required.
 
-Packaged/released Nerve does not enable performance sampling automatically. Developers can set `NERVE_PERFORMANCE_DIAGNOSTICS=0` for a clean source-launch baseline. Samples remain local, contain no prompts or task output, and are never uploaded.
+Packaged/released Nerve does not enable performance sampling automatically. Configure it under **Settings → System → Diagnostics**. Unpackaged source launches use sampling as a fallback until a saved choice exists; `NERVE_PERFORMANCE_DIAGNOSTICS=0` or `1` always overrides it. Samples remain local, contain no prompts or task output, and are never uploaded.
 
 ## Proxy diagnostics
 

--- a/packages/website/src/content/docs/reference/cli-environment.md
+++ b/packages/website/src/content/docs/reference/cli-environment.md
@@ -24,24 +24,25 @@ Pass app options after `--` when using `npx` or `pnpm dlx`.
 
 ## Nerve environment
 
-| Variable                             | Purpose / default                                                      |
-| ------------------------------------ | ---------------------------------------------------------------------- |
-| `NERVE_HOME`                         | Portable state root; `~/.nerve`                                        |
-| `NERVE_HOST`                         | Daemon bind host; `127.0.0.1`                                          |
-| `NERVE_PORT`                         | HTTP port; normal default 3747                                         |
-| `NERVE_HTTPS_PORT`                   | Mobile HTTPS port; source desktop default 3748, server fallback HTTP+1 |
-| `NERVE_ALLOW_REMOTE=1`               | Explicit non-loopback opt-in                                           |
-| `NERVE_MOBILE_HTTPS=1`               | Enable mobile HTTPS                                                    |
-| `NERVE_DAEMON_TOKEN`                 | Token for `--connect`; secret                                          |
-| `NERVE_WEB_DIST`                     | Override built Workbench asset directory                               |
-| `NERVE_DAEMON_STARTUP_TIMEOUT_MS`    | Owned readiness timeout; 60000                                         |
-| `NERVE_DAEMON_MAX_OLD_SPACE_MB`      | Owned Node heap cap; 4096                                              |
-| `NERVE_API_TARGET`                   | Vite UI development daemon target                                      |
-| `NERVE_LOGGING_ENABLED=1`            | Write persistent application logs                                      |
-| `NERVE_ELECTRON_OZONE_PLATFORM`      | Linux: `x11`, `wayland`, `auto`                                        |
-| `NERVE_ELECTRON_FONT_RENDER_HINTING` | Linux: `system`, `none`, `slight`, `medium`, `full`; default slight    |
-| `NERVE_DEBUG_PROXY=1`                | Redacted startup proxy diagnostics                                     |
+| Variable                             | Purpose / default                                                          |
+| ------------------------------------ | -------------------------------------------------------------------------- |
+| `NERVE_HOME`                         | Portable state root; `~/.nerve`                                            |
+| `NERVE_HOST`                         | Daemon bind host; `127.0.0.1`                                              |
+| `NERVE_PORT`                         | HTTP port; normal default 3747                                             |
+| `NERVE_HTTPS_PORT`                   | Mobile HTTPS port; source desktop default 3748, server fallback HTTP+1     |
+| `NERVE_ALLOW_REMOTE=1\|0`            | Enable/disable LAN access; enable implies wildcard host when none supplied |
+| `NERVE_MOBILE_HTTPS=1\|0`            | Enable/disable mobile HTTPS                                                |
+| `NERVE_DAEMON_TOKEN`                 | Token for `--connect`; secret                                              |
+| `NERVE_WEB_DIST`                     | Override built Workbench asset directory                                   |
+| `NERVE_DAEMON_STARTUP_TIMEOUT_MS`    | Owned readiness timeout; 60000                                             |
+| `NERVE_DAEMON_MAX_OLD_SPACE_MB`      | Owned Node heap cap; 4096                                                  |
+| `NERVE_API_TARGET`                   | Vite UI development daemon target                                          |
+| `NERVE_LOGGING_ENABLED=1\|0`         | Enable/disable persistent application logs                                 |
+| `NERVE_PERFORMANCE_DIAGNOSTICS=1\|0` | Enable/disable local performance sampling                                  |
+| `NERVE_ELECTRON_OZONE_PLATFORM`      | Linux: `x11`, `wayland`, `auto`                                            |
+| `NERVE_ELECTRON_FONT_RENDER_HINTING` | Linux: `system`, `none`, `slight`, `medium`, `full`; default slight        |
+| `NERVE_DEBUG_PROXY=1`                | Redacted startup proxy diagnostics                                         |
 
 Standard `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, `NODE_EXTRA_CA_CERTS`, `ELECTRON_GET_USE_PROXY`, and `ELECTRON_MIRROR` apply to proxy/download scenarios.
 
-Daemon host settings resolve CLI → environment → saved settings → defaults. Non-loopback still requires `--allow-remote`, env opt-in, or saved allow-remote. Never place tokens or proxy credentials in committed config/examples.
+Managed application settings resolve CLI → environment → saved settings → defaults. Explicit boolean `0`/`false` values are overrides. Settings shows the effective source and locks CLI/environment-controlled fields. `--allow-remote` or `NERVE_ALLOW_REMOTE=1` implies `0.0.0.0` when no host was supplied. Never place tokens or proxy credentials in committed config/examples.

--- a/packages/workbench-app/src/lib/features/desktop/state/desktop-bridge.svelte.ts
+++ b/packages/workbench-app/src/lib/features/desktop/state/desktop-bridge.svelte.ts
@@ -26,6 +26,14 @@ export interface NerveDesktopBridge {
       listener: (state: DesktopWindowState) => void,
     ) => () => void;
   };
+  daemon: {
+    getCapability: () => Promise<{
+      mode?: "local" | "remote";
+      owned: boolean;
+      canRestart: boolean;
+    }>;
+    restart: () => Promise<{ ok: true }>;
+  };
   settings: {
     setCloseToTray: (closeToTray: boolean) => Promise<void>;
   };
@@ -126,6 +134,26 @@ export async function closeDesktopWindow(options?: {
   closeToTray?: boolean;
 }): Promise<void> {
   await getDesktopBridge()?.window.close(options);
+}
+
+export async function getDesktopDaemonCapability(): Promise<{
+  mode?: "local" | "remote";
+  owned: boolean;
+  canRestart: boolean;
+}> {
+  return (
+    (await getDesktopBridge()?.daemon.getCapability()) ?? {
+      owned: false,
+      canRestart: false,
+    }
+  );
+}
+
+export async function restartDesktopDaemon(): Promise<boolean> {
+  const bridge = getDesktopBridge();
+  if (!bridge) return false;
+  await bridge.daemon.restart();
+  return true;
 }
 
 export async function syncDesktopCloseToTray(

--- a/packages/workbench-app/src/lib/features/settings/api/settings.api.ts
+++ b/packages/workbench-app/src/lib/features/settings/api/settings.api.ts
@@ -1,12 +1,19 @@
 import type {
+  ApplicationConfigurationSnapshot,
   NotificationTone,
   Settings,
+  UpdateApplicationConfigurationRequest,
   UpdateSettingsRequest,
 } from "@nervekit/contracts";
 import { protocolRequest } from "@nervekit/protocol";
 
 export type SettingsResponse = Settings;
-export type { NotificationTone, UpdateSettingsRequest };
+export type {
+  ApplicationConfigurationSnapshot,
+  NotificationTone,
+  UpdateApplicationConfigurationRequest,
+  UpdateSettingsRequest,
+};
 
 export async function getSettings(): Promise<Settings> {
   return (await protocolRequest("settings.get", {})).result;
@@ -16,4 +23,15 @@ export async function updateSettings(
   patch: UpdateSettingsRequest,
 ): Promise<Settings> {
   return (await protocolRequest("settings.update", patch)).result.settings;
+}
+
+export async function getApplicationConfiguration(): Promise<ApplicationConfigurationSnapshot> {
+  return (await protocolRequest("applicationConfiguration.get", {})).result;
+}
+
+export async function updateApplicationConfiguration(
+  patch: UpdateApplicationConfigurationRequest,
+): Promise<ApplicationConfigurationSnapshot> {
+  return (await protocolRequest("applicationConfiguration.update", patch))
+    .result;
 }

--- a/packages/workbench-app/src/lib/features/settings/components/SettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/SettingsPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type {
+  ApplicationConfigurationSnapshot,
   AuthProviderMetadata,
   AvailableSkill,
   ColorMode,
@@ -8,6 +9,7 @@ import type {
   ProjectRecord,
   Settings,
   StatusResponse,
+  UpdateApplicationConfigurationRequest,
   UpdateSettingsRequest,
 } from "$lib/api";
 import {
@@ -46,6 +48,13 @@ type SettingsChange = (
 type Props = {
   status?: StatusResponse;
   settingsDraft?: Settings;
+  applicationConfiguration?: ApplicationConfigurationSnapshot;
+  daemonCapability?: {
+    mode?: "local" | "remote";
+    owned: boolean;
+    canRestart: boolean;
+  };
+  daemonRestarting?: boolean;
   activePageId?: string;
   activeSectionId?: string;
   models?: ModelInfo[];
@@ -59,6 +68,10 @@ type Props = {
   settingsSaveStatus?: SettingsSaveStatus;
   settingsMessage?: string;
   onSettingsChange?: SettingsChange;
+  onApplicationConfigurationChange?: (
+    patch: UpdateApplicationConfigurationRequest,
+  ) => void;
+  onRestartDaemon?: () => void;
   onColorThemeChange?: (theme: ColorTheme) => void;
   onColorModeChange?: (colorMode: ColorMode) => void;
   onSkillsRetry?: () => void;
@@ -67,6 +80,9 @@ type Props = {
 let {
   status,
   settingsDraft = $bindable<Settings | undefined>(),
+  applicationConfiguration,
+  daemonCapability,
+  daemonRestarting = false,
   activePageId = $bindable("workbench"),
   activeSectionId = $bindable("appearance"),
   models = [],
@@ -80,6 +96,8 @@ let {
   settingsSaveStatus = "idle",
   settingsMessage,
   onSettingsChange,
+  onApplicationConfigurationChange,
+  onRestartDaemon,
   onColorThemeChange,
   onColorModeChange,
   onSkillsRetry,
@@ -208,7 +226,14 @@ function statusText(): string {
       {:else if page.id === "storage"}
         <StorageSettingsPage controller={storageController} />
       {:else if page.id === "system"}
-        <SystemSettingsPage {settingsDraft} {status} {onSettingsChange} />
+        <SystemSettingsPage
+          configuration={applicationConfiguration}
+          {status}
+          {daemonCapability}
+          {daemonRestarting}
+          onConfigurationChange={onApplicationConfigurationChange}
+          {onRestartDaemon}
+        />
       {/if}
     {:else}
       <div class="grid gap-1 py-12 text-center">

--- a/packages/workbench-app/src/lib/features/settings/components/SettingsShell.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/SettingsShell.svelte
@@ -7,6 +7,8 @@ import { workspaceSelectors } from "$lib/features/workspace/state/workspace-sele
 import {
   loadSettingsSkills,
   queueSettingsSave,
+  restartOwnedDaemon,
+  saveApplicationConfiguration,
   setColorMode,
   setColorTheme,
 } from "$lib/features/settings/state/settings-actions.svelte";
@@ -26,6 +28,9 @@ $effect(() => {
 <SettingsPage
   {status}
   bind:settingsDraft={settingsState.settingsDraft}
+  applicationConfiguration={settingsState.applicationConfiguration}
+  daemonCapability={settingsState.daemonCapability}
+  daemonRestarting={settingsState.daemonRestarting}
   bind:activePageId={settingsState.activePageId}
   bind:activeSectionId={settingsState.activeSectionId}
   models={settingsState.models}
@@ -40,6 +45,8 @@ $effect(() => {
   {settingsSaveStatus}
   {settingsMessage}
   onSettingsChange={queueSettingsSave}
+  onApplicationConfigurationChange={saveApplicationConfiguration}
+  onRestartDaemon={restartOwnedDaemon}
   onColorThemeChange={setColorTheme}
   onColorModeChange={setColorMode}
 />

--- a/packages/workbench-app/src/lib/features/settings/components/pages/system/SystemSettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/system/SystemSettingsPage.svelte
@@ -1,40 +1,115 @@
 <script lang="ts">
-import type { Settings, StatusResponse } from "$lib/api";
+import type {
+  ApplicationConfigurationSnapshot,
+  StatusResponse,
+  UpdateApplicationConfigurationRequest,
+} from "$lib/api";
 import {
   SettingsFieldRow,
   SettingsInlineMessage,
   SettingsSection,
+  SettingsSelectRow,
   SettingsStatGrid,
   SettingsToggleRow,
   type SettingsStat,
 } from "$lib/presentation/components/settings";
-import type { SettingsChange } from "../settings-change";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import SelectField from "@nervekit/ui-kit/components/ui/select-field";
 
-type Props = {
-  settingsDraft: Settings;
-  status?: StatusResponse;
-  onSettingsChange?: SettingsChange;
+const ozoneOptions = [
+  { value: "auto", label: "Auto" },
+  { value: "x11", label: "X11" },
+  { value: "wayland", label: "Wayland" },
+];
+const fontOptions = [
+  { value: "system", label: "System" },
+  { value: "none", label: "None" },
+  { value: "slight", label: "Slight" },
+  { value: "medium", label: "Medium" },
+  { value: "full", label: "Full" },
+];
+const logLevelOptions = [
+  { value: "debug", label: "Debug" },
+  { value: "info", label: "Info" },
+  { value: "warn", label: "Warning" },
+  { value: "error", label: "Error" },
+];
+
+type ResolvedLeaf = {
+  activeValue: unknown;
+  savedValue: unknown;
+  editable: boolean;
+  source: { kind: string; name?: string };
+  restartTarget: "none" | "daemon" | "desktop";
+  pendingRestart: boolean;
 };
 
-let { settingsDraft, status, onSettingsChange }: Props = $props();
+type Props = {
+  configuration?: ApplicationConfigurationSnapshot;
+  status?: StatusResponse;
+  daemonCapability?: {
+    mode?: "local" | "remote";
+    owned: boolean;
+    canRestart: boolean;
+  };
+  daemonRestarting?: boolean;
+  onConfigurationChange?: (
+    patch: UpdateApplicationConfigurationRequest,
+  ) => void;
+  onRestartDaemon?: () => void;
+};
 
-function updateHost(value: string): void {
-  settingsDraft.server.host = value;
-  onSettingsChange?.({ server: { host: value } }, { debounceMs: 650 });
+let {
+  configuration,
+  status,
+  daemonCapability,
+  daemonRestarting = false,
+  onConfigurationChange,
+  onRestartDaemon,
+}: Props = $props();
+
+function describe(base: string, setting: ResolvedLeaf): string {
+  if (!setting.editable) {
+    return `${base} Controlled by ${setting.source.name ?? setting.source.kind}. Unset the override to edit it here.`;
+  }
+  if (setting.pendingRestart) {
+    return `${base} Saved value: ${String(setting.savedValue)}. Restart ${setting.restartTarget === "desktop" ? "Nerve" : "the daemon"} to apply.`;
+  }
+  return base;
 }
 
-function updateServerPort(value: string): void {
+function save(patch: UpdateApplicationConfigurationRequest): void {
+  onConfigurationChange?.(patch);
+}
+
+function saveNumber(
+  value: string,
+  minimum: number,
+  apply: (value: number) => UpdateApplicationConfigurationRequest,
+): void {
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return;
-  const port = Math.floor(parsed);
-  settingsDraft.server.port = port;
-  onSettingsChange?.({ server: { port } }, { debounceMs: 650 });
+  if (!Number.isInteger(parsed) || parsed < minimum) return;
+  save(apply(parsed));
 }
 
-function setAllowRemote(checked: boolean): void {
-  settingsDraft.server.allowRemote = checked;
-  onSettingsChange?.({ server: { allowRemote: checked } }, { immediate: true });
-}
+const pendingDaemonRestart = $derived(
+  configuration
+    ? Object.values(configuration.application).some((group) =>
+        Object.values(group).some(
+          (item) => item.pendingRestart && item.restartTarget === "daemon",
+        ),
+      )
+    : false,
+);
+const pendingDesktopRestart = $derived(
+  configuration
+    ? Object.values(configuration.application).some((group) =>
+        Object.values(group).some(
+          (item) => item.pendingRestart && item.restartTarget === "desktop",
+        ),
+      )
+    : false,
+);
 
 const diagnostics = $derived<SettingsStat[]>([
   { label: "Daemon", value: status?.daemonId ?? "not loaded" },
@@ -50,41 +125,330 @@ const diagnostics = $derived<SettingsStat[]>([
     value: status?.storage?.indexHealthy ? "healthy" : "unknown",
   },
   { label: "Data directory", value: status?.dataDir ?? "—", wide: true },
-  {
-    label: "SQLite",
-    value: status?.storage?.sqlitePath ?? "—",
-    wide: true,
-  },
+  { label: "SQLite", value: status?.storage?.sqlitePath ?? "—", wide: true },
 ]);
 </script>
 
-<SettingsSection id="server" title="Server">
-  <div class="grid gap-3 sm:grid-cols-2">
-    <SettingsFieldRow
-      id="settings-server-host"
-      label="Host"
-      value={settingsDraft.server.host}
-      onValueChange={updateHost}
-    />
-    <SettingsFieldRow
-      id="settings-server-port"
-      label="Port"
-      type="number"
-      value={String(settingsDraft.server.port)}
-      onValueChange={updateServerPort}
-    />
-  </div>
-  <SettingsToggleRow
-    label="Allow remote connections"
-    bind:checked={settingsDraft.server.allowRemote}
-    onCheckedChange={setAllowRemote}
-  />
-  <SettingsInlineMessage
-    tone="warning"
-    text="Restart the daemon after changing host, port, or remote access."
-  />
-</SettingsSection>
+{#if configuration}
+  {#if pendingDaemonRestart || pendingDesktopRestart}
+    <div class="flex items-center gap-2">
+      <SettingsInlineMessage
+        class="min-w-0 flex-1"
+        tone="warning"
+        text={`${pendingDaemonRestart ? "Daemon restart required." : ""}${pendingDesktopRestart ? " Restart Nerve to apply desktop changes." : ""}`}
+      />
+      {#if pendingDaemonRestart && daemonCapability?.canRestart}
+        <Button size="xs" disabled={daemonRestarting} onclick={onRestartDaemon}>
+          {daemonRestarting ? "Restarting…" : "Restart daemon"}
+        </Button>
+      {/if}
+    </div>
+  {/if}
 
-<SettingsSection id="diagnostics" title="Diagnostics">
+  <SettingsSection
+    id="network"
+    title="Network"
+    description="Configure the daemon listener and optional LAN/PWA access."
+  >
+    <SettingsToggleRow
+      label="Allow remote connections"
+      description={describe(
+        "Bind to the local network so trusted devices can connect.",
+        configuration.application.network.allowRemote,
+      )}
+      checked={configuration.application.network.allowRemote.activeValue}
+      disabled={!configuration.application.network.allowRemote.editable}
+      onCheckedChange={(allowRemote) =>
+        save({ application: { network: { allowRemote } } })}
+    />
+    <div class="grid gap-3 sm:grid-cols-2">
+      <SettingsFieldRow
+        id="settings-server-host"
+        label="Bind host"
+        value={String(configuration.application.network.host.activeValue)}
+        disabled={!configuration.application.network.host.editable}
+        hint={describe(
+          "Use 127.0.0.1 for local-only or 0.0.0.0 for all interfaces.",
+          configuration.application.network.host,
+        )}
+        onValueChange={(host) => save({ application: { network: { host } } })}
+      />
+      <SettingsFieldRow
+        id="settings-server-port"
+        label="HTTP port"
+        type="number"
+        min={1}
+        max={65535}
+        value={String(configuration.application.network.port.activeValue)}
+        disabled={!configuration.application.network.port.editable}
+        hint={describe(
+          "Port used by the desktop and browser workbench.",
+          configuration.application.network.port,
+        )}
+        onValueChange={(value) =>
+          saveNumber(value, 1, (port) => ({
+            application: { network: { port } },
+          }))}
+      />
+    </div>
+    <SettingsToggleRow
+      label="Mobile HTTPS"
+      description={describe(
+        "Serve a local-CA HTTPS endpoint for installable mobile PWA access.",
+        configuration.application.network.mobileHttps,
+      )}
+      checked={configuration.application.network.mobileHttps.activeValue}
+      disabled={!configuration.application.network.mobileHttps.editable}
+      onCheckedChange={(mobileHttps) =>
+        save({ application: { network: { mobileHttps } } })}
+    />
+    <SettingsFieldRow
+      id="settings-https-port"
+      label="HTTPS port"
+      type="number"
+      min={1}
+      max={65535}
+      value={String(configuration.application.network.httpsPort.activeValue)}
+      disabled={!configuration.application.network.httpsPort.editable}
+      hint={describe(
+        "Used only when Mobile HTTPS is enabled.",
+        configuration.application.network.httpsPort,
+      )}
+      onValueChange={(value) =>
+        saveNumber(value, 1, (httpsPort) => ({
+          application: { network: { httpsPort } },
+        }))}
+    />
+  </SettingsSection>
+
+  <SettingsSection id="diagnostics" title="Diagnostics">
+    <SettingsToggleRow
+      label="Application logging"
+      description={describe(
+        "Write desktop and daemon application logs under the data directory.",
+        configuration.application.diagnostics.loggingEnabled,
+      )}
+      checked={configuration.application.diagnostics.loggingEnabled.activeValue}
+      disabled={!configuration.application.diagnostics.loggingEnabled.editable}
+      onCheckedChange={(loggingEnabled) =>
+        save({ application: { diagnostics: { loggingEnabled } } })}
+    />
+    <SettingsToggleRow
+      label="Performance sampling"
+      description={describe(
+        "Write lightweight local process and subsystem samples for profiling.",
+        configuration.application.diagnostics.performanceEnabled,
+      )}
+      checked={configuration.application.diagnostics.performanceEnabled
+        .activeValue}
+      disabled={!configuration.application.diagnostics.performanceEnabled
+        .editable}
+      onCheckedChange={(performanceEnabled) =>
+        save({ application: { diagnostics: { performanceEnabled } } })}
+    />
+    <SettingsSelectRow
+      label="Log level"
+      description={describe(
+        "Minimum severity written by the daemon logger.",
+        configuration.application.diagnostics.level,
+      )}
+    >
+      {#snippet control(disabled)}
+        <SelectField
+          items={logLevelOptions}
+          value={configuration.application.diagnostics.level.activeValue}
+          ariaLabel="Log level"
+          {disabled}
+          onValueChange={(level) =>
+            save({
+              logging: {
+                level: level as "debug" | "info" | "warn" | "error",
+              },
+            })}
+        />
+      {/snippet}
+    </SettingsSelectRow>
+    <div class="grid gap-3 sm:grid-cols-2">
+      <SettingsFieldRow
+        id="settings-log-retention"
+        label="Log retention"
+        type="number"
+        min={1}
+        suffix="days"
+        value={String(
+          configuration.application.diagnostics.retentionDays.activeValue,
+        )}
+        hint={describe(
+          "How long application log files are retained.",
+          configuration.application.diagnostics.retentionDays,
+        )}
+        onValueChange={(value) =>
+          saveNumber(value, 1, (retentionDays) => ({
+            logging: { retentionDays },
+          }))}
+      />
+      <SettingsFieldRow
+        id="settings-log-buffer"
+        label="Buffered records"
+        type="number"
+        min={1}
+        value={String(
+          configuration.application.diagnostics.maxBufferedLogs.activeValue,
+        )}
+        hint={describe(
+          "Maximum recent records kept available for the Logs view.",
+          configuration.application.diagnostics.maxBufferedLogs,
+        )}
+        onValueChange={(value) =>
+          saveNumber(value, 1, (maxBufferedLogs) => ({
+            logging: { maxBufferedLogs },
+          }))}
+      />
+    </div>
+  </SettingsSection>
+
+  <SettingsSection id="daemon" title="Daemon">
+    <div class="grid gap-3 sm:grid-cols-2">
+      <SettingsFieldRow
+        id="settings-startup-timeout"
+        label="Startup timeout"
+        type="number"
+        min={1}
+        suffix="ms"
+        value={String(
+          configuration.application.daemon.startupTimeoutMs.activeValue,
+        )}
+        disabled={!configuration.application.daemon.startupTimeoutMs.editable}
+        hint={describe(
+          "How long Electron waits for an owned daemon.",
+          configuration.application.daemon.startupTimeoutMs,
+        )}
+        onValueChange={(value) =>
+          saveNumber(value, 1, (startupTimeoutMs) => ({
+            application: { daemon: { startupTimeoutMs } },
+          }))}
+      />
+      <SettingsFieldRow
+        id="settings-daemon-heap"
+        label="Maximum heap"
+        type="number"
+        min={1}
+        suffix="MB"
+        value={String(
+          configuration.application.daemon.maxOldSpaceMb.activeValue,
+        )}
+        disabled={!configuration.application.daemon.maxOldSpaceMb.editable}
+        hint={describe(
+          "Node.js old-space limit for an owned daemon.",
+          configuration.application.daemon.maxOldSpaceMb,
+        )}
+        onValueChange={(value) =>
+          saveNumber(value, 1, (maxOldSpaceMb) => ({
+            application: { daemon: { maxOldSpaceMb } },
+          }))}
+      />
+    </div>
+  </SettingsSection>
+
+  <SettingsSection
+    id="desktop-rendering"
+    title="Desktop rendering"
+    description="Linux Electron startup options. Restart Nerve after changing them."
+  >
+    {#if configuration.context.platform === "linux"}
+      <SettingsSelectRow
+        label="Ozone platform"
+        disabled={!configuration.application.electron.ozonePlatform.editable}
+        description={describe(
+          "Choose automatic, X11, or Wayland rendering.",
+          configuration.application.electron.ozonePlatform,
+        )}
+      >
+        {#snippet control(disabled)}
+          <SelectField
+            items={ozoneOptions}
+            value={configuration.application.electron.ozonePlatform.activeValue}
+            ariaLabel="Ozone platform"
+            {disabled}
+            onValueChange={(ozonePlatform) =>
+              save({
+                application: {
+                  electron: {
+                    ozonePlatform: ozonePlatform as "auto" | "x11" | "wayland",
+                  },
+                },
+              })}
+          />
+        {/snippet}
+      </SettingsSelectRow>
+      <SettingsSelectRow
+        label="Font render hinting"
+        disabled={!configuration.application.electron.fontRenderHinting
+          .editable}
+        description={describe(
+          "Control Chromium font hinting on Linux.",
+          configuration.application.electron.fontRenderHinting,
+        )}
+      >
+        {#snippet control(disabled)}
+          <SelectField
+            items={fontOptions}
+            value={configuration.application.electron.fontRenderHinting
+              .activeValue}
+            ariaLabel="Font render hinting"
+            {disabled}
+            onValueChange={(fontRenderHinting) =>
+              save({
+                application: {
+                  electron: {
+                    fontRenderHinting: fontRenderHinting as
+                      "system" | "none" | "slight" | "medium" | "full",
+                  },
+                },
+              })}
+          />
+        {/snippet}
+      </SettingsSelectRow>
+    {:else}
+      <SettingsInlineMessage
+        text="Electron rendering controls apply only to the Linux desktop app."
+      />
+    {/if}
+  </SettingsSection>
+
+  <SettingsSection id="launch-context" title="Launch context">
+    <SettingsStatGrid
+      items={[
+        {
+          label: "Data directory source",
+          value: configuration.context.dataDirSource,
+        },
+        { label: "Platform", value: configuration.context.platform },
+        {
+          label: "Daemon mode",
+          value: daemonCapability?.mode ?? "browser or unavailable",
+        },
+        {
+          label: "Daemon ownership",
+          value: daemonCapability?.owned ? "owned" : "not owned",
+        },
+        {
+          label: "Web assets",
+          value: configuration.context.webAssetsOverridden
+            ? "overridden"
+            : "bundled/default",
+        },
+        {
+          label: "Proxy",
+          value: configuration.context.proxyConfigured
+            ? "configured"
+            : "not configured",
+        },
+      ]}
+    />
+  </SettingsSection>
+{/if}
+
+<SettingsSection id="system-information" title="System information">
   <SettingsStatGrid items={diagnostics} />
 </SettingsSection>

--- a/packages/workbench-app/src/lib/features/settings/components/pages/system/SystemSettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/system/SystemSettingsPage.svelte
@@ -68,12 +68,28 @@ let {
   onRestartDaemon,
 }: Props = $props();
 
+function formatSettingValue(value: unknown): string {
+  if (typeof value === "boolean") return value ? "On" : "Off";
+  return String(value);
+}
+
+function controlValue<T>(setting: {
+  activeValue: T;
+  savedValue: T;
+  editable: boolean;
+}): T {
+  return setting.editable ? setting.savedValue : setting.activeValue;
+}
+
 function describe(base: string, setting: ResolvedLeaf): string {
   if (!setting.editable) {
-    return `${base} Controlled by ${setting.source.name ?? setting.source.kind}. Unset the override to edit it here.`;
+    const saved = Object.is(setting.activeValue, setting.savedValue)
+      ? ""
+      : ` Saved setting: ${formatSettingValue(setting.savedValue)}.`;
+    return `${base} Controlled by ${setting.source.name ?? setting.source.kind}.${saved} Unset the override to edit it here.`;
   }
   if (setting.pendingRestart) {
-    return `${base} Saved value: ${String(setting.savedValue)}. Restart ${setting.restartTarget === "desktop" ? "Nerve" : "the daemon"} to apply.`;
+    return `${base} Pending restart; currently active: ${formatSettingValue(setting.activeValue)}.`;
   }
   return base;
 }
@@ -135,7 +151,7 @@ const diagnostics = $derived<SettingsStat[]>([
       <SettingsInlineMessage
         class="min-w-0 flex-1"
         tone="warning"
-        text={`${pendingDaemonRestart ? "Daemon restart required." : ""}${pendingDesktopRestart ? " Restart Nerve to apply desktop changes." : ""}`}
+        text={`${pendingDaemonRestart ? "Changes saved. Restart the daemon to apply them." : ""}${pendingDesktopRestart ? " Restart Nerve to apply desktop changes." : ""}`}
       />
       {#if pendingDaemonRestart && daemonCapability?.canRestart}
         <Button size="xs" disabled={daemonRestarting} onclick={onRestartDaemon}>
@@ -156,7 +172,7 @@ const diagnostics = $derived<SettingsStat[]>([
         "Bind to the local network so trusted devices can connect.",
         configuration.application.network.allowRemote,
       )}
-      checked={configuration.application.network.allowRemote.activeValue}
+      checked={controlValue(configuration.application.network.allowRemote)}
       disabled={!configuration.application.network.allowRemote.editable}
       onCheckedChange={(allowRemote) =>
         save({ application: { network: { allowRemote } } })}
@@ -165,7 +181,7 @@ const diagnostics = $derived<SettingsStat[]>([
       <SettingsFieldRow
         id="settings-server-host"
         label="Bind host"
-        value={String(configuration.application.network.host.activeValue)}
+        value={String(controlValue(configuration.application.network.host))}
         disabled={!configuration.application.network.host.editable}
         hint={describe(
           "Use 127.0.0.1 for local-only or 0.0.0.0 for all interfaces.",
@@ -179,7 +195,7 @@ const diagnostics = $derived<SettingsStat[]>([
         type="number"
         min={1}
         max={65535}
-        value={String(configuration.application.network.port.activeValue)}
+        value={String(controlValue(configuration.application.network.port))}
         disabled={!configuration.application.network.port.editable}
         hint={describe(
           "Port used by the desktop and browser workbench.",
@@ -197,7 +213,7 @@ const diagnostics = $derived<SettingsStat[]>([
         "Serve a local-CA HTTPS endpoint for installable mobile PWA access.",
         configuration.application.network.mobileHttps,
       )}
-      checked={configuration.application.network.mobileHttps.activeValue}
+      checked={controlValue(configuration.application.network.mobileHttps)}
       disabled={!configuration.application.network.mobileHttps.editable}
       onCheckedChange={(mobileHttps) =>
         save({ application: { network: { mobileHttps } } })}
@@ -208,7 +224,7 @@ const diagnostics = $derived<SettingsStat[]>([
       type="number"
       min={1}
       max={65535}
-      value={String(configuration.application.network.httpsPort.activeValue)}
+      value={String(controlValue(configuration.application.network.httpsPort))}
       disabled={!configuration.application.network.httpsPort.editable}
       hint={describe(
         "Used only when Mobile HTTPS is enabled.",
@@ -228,7 +244,9 @@ const diagnostics = $derived<SettingsStat[]>([
         "Write desktop and daemon application logs under the data directory.",
         configuration.application.diagnostics.loggingEnabled,
       )}
-      checked={configuration.application.diagnostics.loggingEnabled.activeValue}
+      checked={controlValue(
+        configuration.application.diagnostics.loggingEnabled,
+      )}
       disabled={!configuration.application.diagnostics.loggingEnabled.editable}
       onCheckedChange={(loggingEnabled) =>
         save({ application: { diagnostics: { loggingEnabled } } })}
@@ -239,8 +257,9 @@ const diagnostics = $derived<SettingsStat[]>([
         "Write lightweight local process and subsystem samples for profiling.",
         configuration.application.diagnostics.performanceEnabled,
       )}
-      checked={configuration.application.diagnostics.performanceEnabled
-        .activeValue}
+      checked={controlValue(
+        configuration.application.diagnostics.performanceEnabled,
+      )}
       disabled={!configuration.application.diagnostics.performanceEnabled
         .editable}
       onCheckedChange={(performanceEnabled) =>
@@ -256,7 +275,7 @@ const diagnostics = $derived<SettingsStat[]>([
       {#snippet control(disabled)}
         <SelectField
           items={logLevelOptions}
-          value={configuration.application.diagnostics.level.activeValue}
+          value={controlValue(configuration.application.diagnostics.level)}
           ariaLabel="Log level"
           {disabled}
           onValueChange={(level) =>
@@ -276,7 +295,7 @@ const diagnostics = $derived<SettingsStat[]>([
         min={1}
         suffix="days"
         value={String(
-          configuration.application.diagnostics.retentionDays.activeValue,
+          controlValue(configuration.application.diagnostics.retentionDays),
         )}
         hint={describe(
           "How long application log files are retained.",
@@ -293,7 +312,7 @@ const diagnostics = $derived<SettingsStat[]>([
         type="number"
         min={1}
         value={String(
-          configuration.application.diagnostics.maxBufferedLogs.activeValue,
+          controlValue(configuration.application.diagnostics.maxBufferedLogs),
         )}
         hint={describe(
           "Maximum recent records kept available for the Logs view.",
@@ -316,7 +335,7 @@ const diagnostics = $derived<SettingsStat[]>([
         min={1}
         suffix="ms"
         value={String(
-          configuration.application.daemon.startupTimeoutMs.activeValue,
+          controlValue(configuration.application.daemon.startupTimeoutMs),
         )}
         disabled={!configuration.application.daemon.startupTimeoutMs.editable}
         hint={describe(
@@ -335,7 +354,7 @@ const diagnostics = $derived<SettingsStat[]>([
         min={1}
         suffix="MB"
         value={String(
-          configuration.application.daemon.maxOldSpaceMb.activeValue,
+          controlValue(configuration.application.daemon.maxOldSpaceMb),
         )}
         disabled={!configuration.application.daemon.maxOldSpaceMb.editable}
         hint={describe(
@@ -367,7 +386,9 @@ const diagnostics = $derived<SettingsStat[]>([
         {#snippet control(disabled)}
           <SelectField
             items={ozoneOptions}
-            value={configuration.application.electron.ozonePlatform.activeValue}
+            value={controlValue(
+              configuration.application.electron.ozonePlatform,
+            )}
             ariaLabel="Ozone platform"
             {disabled}
             onValueChange={(ozonePlatform) =>
@@ -393,8 +414,9 @@ const diagnostics = $derived<SettingsStat[]>([
         {#snippet control(disabled)}
           <SelectField
             items={fontOptions}
-            value={configuration.application.electron.fontRenderHinting
-              .activeValue}
+            value={controlValue(
+              configuration.application.electron.fontRenderHinting,
+            )}
             ariaLabel="Font render hinting"
             {disabled}
             onValueChange={(fontRenderHinting) =>

--- a/packages/workbench-app/src/lib/features/settings/registry/settings-pages.ts
+++ b/packages/workbench-app/src/lib/features/settings/registry/settings-pages.ts
@@ -92,8 +92,12 @@ export const settingsPages: SettingsPageDef[] = [
     label: "System",
     icon: Server,
     sections: [
-      { id: "server", label: "Server" },
+      { id: "network", label: "Network" },
       { id: "diagnostics", label: "Diagnostics" },
+      { id: "daemon", label: "Daemon" },
+      { id: "desktop-rendering", label: "Desktop rendering" },
+      { id: "launch-context", label: "Launch context" },
+      { id: "system-information", label: "System information" },
     ],
   },
 ];

--- a/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
+++ b/packages/workbench-app/src/lib/features/settings/state/settings-actions.svelte.ts
@@ -4,13 +4,16 @@ import {
 } from "$lib/presentation/utils/model";
 import type { AgentRecord, ColorMode, ColorTheme, ModelInfo } from "$lib/api";
 import {
+  getApplicationConfiguration,
   getAuthProviders,
   getClientConfig,
   getModels,
   getSettings,
   listAvailableSkills,
   getSubscriptionUsage,
+  type UpdateApplicationConfigurationRequest,
   type UpdateSettingsRequest,
+  updateApplicationConfiguration,
   updateSettings,
 } from "$lib/api";
 import {
@@ -25,6 +28,10 @@ import {
   resolveNewAgentComposerSelection,
 } from "$lib/features/conversations/state/agent-selection-defaults";
 import { conversationState } from "$lib/features/conversations/state/conversation-state.svelte";
+import {
+  getDesktopDaemonCapability,
+  restartDesktopDaemon,
+} from "$lib/features/desktop/state/desktop-bridge.svelte";
 import { notify } from "$lib/features/notifications/notify.svelte";
 import { settingsState } from "$lib/features/settings/state/settings-state.svelte";
 import { usageState } from "$lib/features/usage/state/usage-state.svelte";
@@ -120,12 +127,17 @@ export async function loadSettingsSkills(projectId = selection.projectId) {
 }
 
 async function performCoreSettingsLoad(): Promise<void> {
-  const [settings, modelList, auth] = await Promise.all([
-    getSettings(),
-    getModels(),
-    getAuthProviders(),
-  ]);
+  const [settings, applicationConfiguration, modelList, auth, capability] =
+    await Promise.all([
+      getSettings(),
+      getApplicationConfiguration(),
+      getModels(),
+      getAuthProviders(),
+      getDesktopDaemonCapability(),
+    ]);
   settingsState.settingsDraft = settings;
+  settingsState.applicationConfiguration = applicationConfiguration;
+  settingsState.daemonCapability = capability;
   applyAppearance(settings.ui.theme, settings.ui.colorMode);
   applyZoomLevel(settings.ui.zoomLevel);
   settingsState.models = modelList;
@@ -228,8 +240,43 @@ function mergeSettingsPatch(
   patch: UpdateSettingsRequest,
 ): UpdateSettingsRequest {
   const next: UpdateSettingsRequest = { ...(base ?? {}), ...patch };
-  if (base?.server || patch.server) {
-    next.server = { ...(base?.server ?? {}), ...(patch.server ?? {}) };
+  if (base?.application || patch.application) {
+    next.application = {
+      ...(base?.application ?? {}),
+      ...(patch.application ?? {}),
+      ...(base?.application?.network || patch.application?.network
+        ? {
+            network: {
+              ...(base?.application?.network ?? {}),
+              ...(patch.application?.network ?? {}),
+            },
+          }
+        : {}),
+      ...(base?.application?.diagnostics || patch.application?.diagnostics
+        ? {
+            diagnostics: {
+              ...(base?.application?.diagnostics ?? {}),
+              ...(patch.application?.diagnostics ?? {}),
+            },
+          }
+        : {}),
+      ...(base?.application?.daemon || patch.application?.daemon
+        ? {
+            daemon: {
+              ...(base?.application?.daemon ?? {}),
+              ...(patch.application?.daemon ?? {}),
+            },
+          }
+        : {}),
+      ...(base?.application?.electron || patch.application?.electron
+        ? {
+            electron: {
+              ...(base?.application?.electron ?? {}),
+              ...(patch.application?.electron ?? {}),
+            },
+          }
+        : {}),
+    };
   }
   if (base?.ui || patch.ui) {
     next.ui = { ...(base?.ui ?? {}), ...(patch.ui ?? {}) };
@@ -331,7 +378,9 @@ function mergeSettingsPatch(
 }
 
 function patchTouchesServer(patch: UpdateSettingsRequest | undefined): boolean {
-  return Boolean(patch?.server && Object.keys(patch.server).length > 0);
+  return Boolean(
+    patch?.application && Object.keys(patch.application).length > 0,
+  );
 }
 
 function patchTouchesRuntime(
@@ -436,6 +485,46 @@ export async function flushSettingsSave() {
     if (pendingSettingsPatch && settingsState.settingsSaveStatus !== "error") {
       void flushSettingsSave();
     }
+  }
+}
+
+export async function saveApplicationConfiguration(
+  patch: UpdateApplicationConfigurationRequest,
+): Promise<void> {
+  settingsState.settingsSaveStatus = "saving";
+  settingsState.settingsMessage = "Saving…";
+  try {
+    const snapshot = await updateApplicationConfiguration(patch);
+    settingsState.applicationConfiguration = snapshot;
+    const settings = await getSettings();
+    settingsState.settingsDraft = settings;
+    settingsState.settingsSaveStatus = "saved";
+    settingsState.settingsMessage = "Saved";
+  } catch (caught) {
+    const message = caught instanceof Error ? caught.message : String(caught);
+    settingsState.settingsSaveStatus = "error";
+    settingsState.settingsMessage = message;
+    notify.error("Could not save configuration", { description: message });
+  }
+}
+
+export async function restartOwnedDaemon(): Promise<void> {
+  if (settingsState.daemonRestarting) return;
+  settingsState.daemonRestarting = true;
+  settingsState.settingsMessage = "Restarting daemon…";
+  try {
+    const restarted = await restartDesktopDaemon();
+    if (!restarted) throw new Error("Daemon restart is not available here.");
+    await loadCoreSettings();
+    settingsState.settingsSaveStatus = "saved";
+    settingsState.settingsMessage = "Daemon restarted";
+  } catch (caught) {
+    const message = caught instanceof Error ? caught.message : String(caught);
+    settingsState.settingsSaveStatus = "error";
+    settingsState.settingsMessage = message;
+    notify.error("Could not restart daemon", { description: message });
+  } finally {
+    settingsState.daemonRestarting = false;
   }
 }
 

--- a/packages/workbench-app/src/lib/features/settings/state/settings-events.ts
+++ b/packages/workbench-app/src/lib/features/settings/state/settings-events.ts
@@ -11,7 +11,8 @@ export function registerSettingsEventHandlers(): () => void {
 
 function handleSettingsEvent(event: WorkbenchEvent): void {
   if (
-    shouldRefreshSettings(event.type) &&
+    (event.type === "applicationConfiguration.updated" ||
+      shouldRefreshSettings(event.type)) &&
     !(event.type.startsWith("settings.") && hasPendingSettingsSave())
   ) {
     void loadSettingsPanel();

--- a/packages/workbench-app/src/lib/features/settings/state/settings-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/settings/state/settings-state.svelte.ts
@@ -1,4 +1,5 @@
 import type {
+  ApplicationConfigurationSnapshot,
   AuthProviderMetadata,
   AvailableSkill,
   ModelInfo,
@@ -15,6 +16,18 @@ export const settingsState = $state({
   skillsError: undefined as string | undefined,
   skillsProjectId: undefined as string | null | undefined,
   settingsDraft: undefined as Settings | undefined,
+  applicationConfiguration: undefined as
+    | ApplicationConfigurationSnapshot
+    | undefined,
+  daemonCapability: {
+    owned: false,
+    canRestart: false,
+  } as {
+    mode?: "local" | "remote";
+    owned: boolean;
+    canRestart: boolean;
+  },
+  daemonRestarting: false,
   settingsSaveStatus: "idle" as "idle" | "dirty" | "saving" | "saved" | "error",
   settingsMessage: undefined as string | undefined,
   settingsTabOpen: false,

--- a/packages/workbench-server/src/app/orchestrator-state.ts
+++ b/packages/workbench-server/src/app/orchestrator-state.ts
@@ -6,6 +6,7 @@ import {
 } from "@nervekit/harness";
 import {
   allOperationDefinitions,
+  type ApplicationConfigurationSnapshot,
   createId,
   type DaemonFile,
   type MobileHttpsInfo,
@@ -27,6 +28,7 @@ import {
 } from "../domains/storage/index.js";
 import { LatestReleaseService } from "../domains/status/latest-release-service.js";
 import { SubscriptionUsageService } from "../domains/usage/subscription-usage-service.js";
+import { resolveApplicationConfiguration } from "../infrastructure/configuration/index.js";
 import {
   ApplicationLogger,
   noopPerformanceDiagnostics,
@@ -66,6 +68,7 @@ export interface OrchestratorState {
   subscriptionUsage: SubscriptionUsageService;
   agentBrowserSkills: AgentBrowserSkillCatalog;
   performanceDiagnostics: PerformanceDiagnosticsPort;
+  applicationConfiguration: ApplicationConfigurationSnapshot;
 }
 
 export function createOrchestratorState(
@@ -75,6 +78,7 @@ export function createOrchestratorState(
   options: {
     applicationLogsEnabled?: boolean;
     performanceDiagnosticsEnabled?: boolean;
+    applicationConfiguration?: ApplicationConfigurationSnapshot;
   } = {},
 ): OrchestratorState {
   const index = new IndexStore(storage.paths.sqlitePath);
@@ -212,6 +216,14 @@ export function createOrchestratorState(
     agentBrowserSkills,
     subscriptionUsage,
     performanceDiagnostics,
+    applicationConfiguration:
+      options.applicationConfiguration ??
+      resolveApplicationConfiguration({
+        settings: storage.settings,
+        dataDir: storage.paths.home,
+        env: {},
+        argv: [],
+      }).snapshot,
   };
 }
 

--- a/packages/workbench-server/src/index.ts
+++ b/packages/workbench-server/src/index.ts
@@ -6,6 +6,7 @@ export {
 export { createApp } from "./app/server.js";
 export { version } from "./app/version.js";
 export * from "./infrastructure/network/index.js";
+export * from "./infrastructure/configuration/index.js";
 export {
   inspectWorkbenchHome,
   type LegacyCredentialMigrationStatus,
@@ -15,6 +16,7 @@ export {
   type LegacyHomeMigrationResult,
   migrateLegacyWorkbenchHome,
   initializeStorage,
+  readPersistedSettingsForBootstrap,
   resolveDataDir,
   storagePaths,
   type WorkbenchHomeInspection,

--- a/packages/workbench-server/src/infrastructure/configuration/application-configuration.ts
+++ b/packages/workbench-server/src/infrastructure/configuration/application-configuration.ts
@@ -1,0 +1,504 @@
+import type {
+  ApplicationConfigurationSnapshot,
+  ApplicationSettings,
+  ConfigurationSource,
+  Settings,
+  UpdateApplicationConfigurationRequest,
+} from "@nervekit/contracts";
+
+export interface ResolvedApplicationStartup {
+  snapshot: ApplicationConfigurationSnapshot;
+  values: {
+    host: string;
+    port: number;
+    allowRemote: boolean;
+    mobileHttps: boolean;
+    httpsPort: number;
+    loggingEnabled: boolean;
+    performanceEnabled: boolean;
+    startupTimeoutMs: number;
+    maxOldSpaceMb: number;
+    ozonePlatform: ApplicationSettings["electron"]["ozonePlatform"];
+    fontRenderHinting: ApplicationSettings["electron"]["fontRenderHinting"];
+  };
+}
+
+interface ResolveOptions {
+  settings: Settings;
+  env?: NodeJS.ProcessEnv;
+  argv?: string[];
+  dataDir: string;
+  platform?: string;
+  development?: boolean;
+  packaged?: boolean;
+  activeSnapshot?: ApplicationConfigurationSnapshot;
+}
+
+type RestartTarget = "none" | "daemon" | "desktop";
+
+function commandLineValue(argv: string[], name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = argv.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+function hasFlag(argv: string[], name: string): boolean {
+  return argv.includes(name);
+}
+
+function parseBooleanEnvironment(
+  env: NodeJS.ProcessEnv,
+  name: string,
+): boolean | undefined {
+  const raw = env[name];
+  if (raw === undefined || raw.trim() === "") return undefined;
+  if (raw === "1" || raw.toLowerCase() === "true") return true;
+  if (raw === "0" || raw.toLowerCase() === "false") return false;
+  throw new Error(
+    `Invalid ${name}=${JSON.stringify(raw)}. Expected 1, 0, true, or false.`,
+  );
+}
+
+function parsePositiveInteger(
+  raw: string,
+  source: string,
+  maximum?: number,
+): number {
+  const value = Number(raw);
+  if (
+    !Number.isInteger(value) ||
+    value <= 0 ||
+    (maximum !== undefined && value > maximum)
+  ) {
+    const range = maximum ? `1-${maximum}` : "a positive integer";
+    throw new Error(
+      `Invalid ${source}=${JSON.stringify(raw)}. Expected ${range}.`,
+    );
+  }
+  return value;
+}
+
+function envString(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name]?.trim();
+  return value || undefined;
+}
+
+function source(
+  kind: ConfigurationSource["kind"],
+  name?: string,
+): ConfigurationSource {
+  return name ? { kind, name } : { kind };
+}
+
+function select<T>(input: {
+  saved: T;
+  environment?: { value: T; name: string };
+  commandLine?: { value: T; name: string };
+  developmentDefault?: T;
+}): { value: T; source: ConfigurationSource; editable: boolean } {
+  if (input.commandLine) {
+    return {
+      value: input.commandLine.value,
+      source: source("command_line", input.commandLine.name),
+      editable: false,
+    };
+  }
+  if (input.environment) {
+    return {
+      value: input.environment.value,
+      source: source("environment", input.environment.name),
+      editable: false,
+    };
+  }
+  if (input.developmentDefault !== undefined) {
+    return {
+      value: input.developmentDefault,
+      source: source("development_default"),
+      editable: true,
+    };
+  }
+  return { value: input.saved, source: source("settings"), editable: true };
+}
+
+function leaf<T>(input: {
+  selected: { value: T; source: ConfigurationSource; editable: boolean };
+  saved: T;
+  restartTarget: RestartTarget;
+  active?: T;
+}) {
+  const activeValue = input.active ?? input.selected.value;
+  return {
+    activeValue,
+    savedValue: input.saved,
+    source: input.selected.source,
+    editable: input.selected.editable,
+    restartTarget: input.restartTarget,
+    pendingRestart:
+      input.selected.editable &&
+      input.restartTarget !== "none" &&
+      !Object.is(activeValue, input.saved),
+  };
+}
+
+export function resolveApplicationConfiguration(
+  options: ResolveOptions,
+): ResolvedApplicationStartup {
+  const env = options.env ?? process.env;
+  const argv = options.argv ?? process.argv.slice(2);
+  const saved = options.settings.application;
+
+  const cliAllowRemote = hasFlag(argv, "--allow-remote") ? true : undefined;
+  const envAllowRemote = parseBooleanEnvironment(env, "NERVE_ALLOW_REMOTE");
+  const allowRemote = select({
+    saved: saved.network.allowRemote,
+    commandLine:
+      cliAllowRemote === undefined
+        ? undefined
+        : { value: cliAllowRemote, name: "--allow-remote" },
+    environment:
+      envAllowRemote === undefined
+        ? undefined
+        : { value: envAllowRemote, name: "NERVE_ALLOW_REMOTE" },
+  });
+
+  const cliHost = commandLineValue(argv, "--host");
+  const environmentHost = envString(env, "NERVE_HOST");
+  const impliedRemoteHost =
+    allowRemote.value &&
+    (saved.network.host === "127.0.0.1" || saved.network.host === "localhost")
+      ? "0.0.0.0"
+      : saved.network.host;
+  const host = select({
+    saved: impliedRemoteHost,
+    commandLine: cliHost ? { value: cliHost, name: "--host" } : undefined,
+    environment: environmentHost
+      ? { value: environmentHost, name: "NERVE_HOST" }
+      : undefined,
+  });
+
+  const cliPort = commandLineValue(argv, "--port");
+  const environmentPort = envString(env, "NERVE_PORT");
+  const port = select({
+    saved: saved.network.port,
+    commandLine: cliPort
+      ? {
+          value: parsePositiveInteger(cliPort, "--port", 65_535),
+          name: "--port",
+        }
+      : undefined,
+    environment: environmentPort
+      ? {
+          value: parsePositiveInteger(environmentPort, "NERVE_PORT", 65_535),
+          name: "NERVE_PORT",
+        }
+      : undefined,
+  });
+
+  const cliMobileHttps = hasFlag(argv, "--mobile-https") ? true : undefined;
+  const envMobileHttps = parseBooleanEnvironment(env, "NERVE_MOBILE_HTTPS");
+  const mobileHttps = select({
+    saved: saved.network.mobileHttps,
+    commandLine:
+      cliMobileHttps === undefined
+        ? undefined
+        : { value: cliMobileHttps, name: "--mobile-https" },
+    environment:
+      envMobileHttps === undefined
+        ? undefined
+        : { value: envMobileHttps, name: "NERVE_MOBILE_HTTPS" },
+  });
+
+  const cliHttpsPort = commandLineValue(argv, "--https-port");
+  const environmentHttpsPort = envString(env, "NERVE_HTTPS_PORT");
+  const httpsPort = select({
+    saved: saved.network.httpsPort,
+    commandLine: cliHttpsPort
+      ? {
+          value: parsePositiveInteger(cliHttpsPort, "--https-port", 65_535),
+          name: "--https-port",
+        }
+      : undefined,
+    environment: environmentHttpsPort
+      ? {
+          value: parsePositiveInteger(
+            environmentHttpsPort,
+            "NERVE_HTTPS_PORT",
+            65_535,
+          ),
+          name: "NERVE_HTTPS_PORT",
+        }
+      : undefined,
+  });
+
+  const envLogging = parseBooleanEnvironment(env, "NERVE_LOGGING_ENABLED");
+  const loggingEnabled = select({
+    saved: saved.diagnostics.loggingEnabled,
+    environment:
+      envLogging === undefined
+        ? undefined
+        : { value: envLogging, name: "NERVE_LOGGING_ENABLED" },
+  });
+  const envPerformance = parseBooleanEnvironment(
+    env,
+    "NERVE_PERFORMANCE_DIAGNOSTICS",
+  );
+  const savedPerformance = saved.diagnostics.performanceEnabled;
+  const performanceEnabled = select({
+    saved: savedPerformance ?? false,
+    environment:
+      envPerformance === undefined
+        ? undefined
+        : { value: envPerformance, name: "NERVE_PERFORMANCE_DIAGNOSTICS" },
+    developmentDefault:
+      envPerformance === undefined &&
+      savedPerformance === undefined &&
+      (options.development || env.NERVE_DEVELOPMENT_PERFORMANCE_DEFAULT === "1")
+        ? true
+        : undefined,
+  });
+
+  const envTimeout = envString(env, "NERVE_DAEMON_STARTUP_TIMEOUT_MS");
+  const startupTimeoutMs = select({
+    saved: saved.daemon.startupTimeoutMs,
+    environment: envTimeout
+      ? {
+          value: parsePositiveInteger(
+            envTimeout,
+            "NERVE_DAEMON_STARTUP_TIMEOUT_MS",
+          ),
+          name: "NERVE_DAEMON_STARTUP_TIMEOUT_MS",
+        }
+      : undefined,
+  });
+  const envHeap = envString(env, "NERVE_DAEMON_MAX_OLD_SPACE_MB");
+  const maxOldSpaceMb = select({
+    saved: saved.daemon.maxOldSpaceMb,
+    environment: envHeap
+      ? {
+          value: parsePositiveInteger(envHeap, "NERVE_DAEMON_MAX_OLD_SPACE_MB"),
+          name: "NERVE_DAEMON_MAX_OLD_SPACE_MB",
+        }
+      : undefined,
+  });
+
+  const ozoneEnvironment = envString(env, "NERVE_ELECTRON_OZONE_PLATFORM");
+  if (
+    ozoneEnvironment &&
+    !["auto", "x11", "wayland"].includes(ozoneEnvironment)
+  ) {
+    throw new Error(
+      `Invalid NERVE_ELECTRON_OZONE_PLATFORM=${JSON.stringify(ozoneEnvironment)}. Expected auto, x11, or wayland.`,
+    );
+  }
+  const ozonePlatform = select({
+    saved: saved.electron.ozonePlatform,
+    environment: ozoneEnvironment
+      ? {
+          value:
+            ozoneEnvironment as ApplicationSettings["electron"]["ozonePlatform"],
+          name: "NERVE_ELECTRON_OZONE_PLATFORM",
+        }
+      : undefined,
+  });
+  const fontEnvironment = envString(env, "NERVE_ELECTRON_FONT_RENDER_HINTING");
+  if (
+    fontEnvironment &&
+    !["system", "none", "slight", "medium", "full"].includes(fontEnvironment)
+  ) {
+    throw new Error(
+      `Invalid NERVE_ELECTRON_FONT_RENDER_HINTING=${JSON.stringify(fontEnvironment)}. Expected system, none, slight, medium, or full.`,
+    );
+  }
+  const fontRenderHinting = select({
+    saved: saved.electron.fontRenderHinting,
+    environment: fontEnvironment
+      ? {
+          value:
+            fontEnvironment as ApplicationSettings["electron"]["fontRenderHinting"],
+          name: "NERVE_ELECTRON_FONT_RENDER_HINTING",
+        }
+      : undefined,
+  });
+
+  const active = options.activeSnapshot?.application;
+  const snapshot: ApplicationConfigurationSnapshot = {
+    application: {
+      network: {
+        host: leaf({
+          selected: host,
+          saved: impliedRemoteHost,
+          restartTarget: "daemon",
+          active: active?.network.host.activeValue,
+        }),
+        port: leaf({
+          selected: port,
+          saved: saved.network.port,
+          restartTarget: "daemon",
+          active: active?.network.port.activeValue,
+        }),
+        allowRemote: leaf({
+          selected: allowRemote,
+          saved: saved.network.allowRemote,
+          restartTarget: "daemon",
+          active: active?.network.allowRemote.activeValue,
+        }),
+        mobileHttps: leaf({
+          selected: mobileHttps,
+          saved: saved.network.mobileHttps,
+          restartTarget: "daemon",
+          active: active?.network.mobileHttps.activeValue,
+        }),
+        httpsPort: leaf({
+          selected: httpsPort,
+          saved: saved.network.httpsPort,
+          restartTarget: "daemon",
+          active: active?.network.httpsPort.activeValue,
+        }),
+      },
+      diagnostics: {
+        loggingEnabled: leaf({
+          selected: loggingEnabled,
+          saved: saved.diagnostics.loggingEnabled,
+          restartTarget: "daemon",
+          active: active?.diagnostics.loggingEnabled.activeValue,
+        }),
+        performanceEnabled: leaf({
+          selected: performanceEnabled,
+          saved: savedPerformance ?? false,
+          restartTarget: "daemon",
+          active: active?.diagnostics.performanceEnabled.activeValue,
+        }),
+        level: leaf({
+          selected: select({ saved: options.settings.logging.level }),
+          saved: options.settings.logging.level,
+          restartTarget: "daemon",
+          active: active?.diagnostics.level.activeValue,
+        }),
+        retentionDays: leaf({
+          selected: select({ saved: options.settings.logging.retentionDays }),
+          saved: options.settings.logging.retentionDays,
+          restartTarget: "daemon",
+          active: active?.diagnostics.retentionDays.activeValue,
+        }),
+        maxBufferedLogs: leaf({
+          selected: select({ saved: options.settings.logging.maxBufferedLogs }),
+          saved: options.settings.logging.maxBufferedLogs,
+          restartTarget: "daemon",
+          active: active?.diagnostics.maxBufferedLogs.activeValue,
+        }),
+      },
+      daemon: {
+        startupTimeoutMs: leaf({
+          selected: startupTimeoutMs,
+          saved: saved.daemon.startupTimeoutMs,
+          restartTarget: "desktop",
+          active: active?.daemon.startupTimeoutMs.activeValue,
+        }),
+        maxOldSpaceMb: leaf({
+          selected: maxOldSpaceMb,
+          saved: saved.daemon.maxOldSpaceMb,
+          restartTarget: "daemon",
+          active: active?.daemon.maxOldSpaceMb.activeValue,
+        }),
+      },
+      electron: {
+        ozonePlatform: leaf({
+          selected: ozonePlatform,
+          saved: saved.electron.ozonePlatform,
+          restartTarget: "desktop",
+          active: active?.electron.ozonePlatform.activeValue,
+        }),
+        fontRenderHinting: leaf({
+          selected: fontRenderHinting,
+          saved: saved.electron.fontRenderHinting,
+          restartTarget: "desktop",
+          active: active?.electron.fontRenderHinting.activeValue,
+        }),
+      },
+    },
+    context: {
+      dataDir: options.dataDir,
+      dataDirSource: env.NERVE_HOME?.trim() ? "environment" : "default",
+      platform: options.platform ?? process.platform,
+      packaged: options.packaged,
+      webAssetsOverridden: Boolean(env.NERVE_WEB_DIST?.trim()),
+      proxyConfigured: Boolean(
+        env.HTTPS_PROXY ?? env.https_proxy ?? env.HTTP_PROXY ?? env.http_proxy,
+      ),
+      proxyDebugEnabled: env.NERVE_DEBUG_PROXY === "1",
+    },
+  };
+
+  return {
+    snapshot,
+    values: {
+      host: host.value,
+      port: port.value,
+      allowRemote: allowRemote.value,
+      mobileHttps: mobileHttps.value,
+      httpsPort: httpsPort.value,
+      loggingEnabled: loggingEnabled.value,
+      performanceEnabled: performanceEnabled.value,
+      startupTimeoutMs: startupTimeoutMs.value,
+      maxOldSpaceMb: maxOldSpaceMb.value,
+      ozonePlatform: ozonePlatform.value,
+      fontRenderHinting: fontRenderHinting.value,
+    },
+  };
+}
+
+export function assertApplicationConfigurationEditable(
+  snapshot: ApplicationConfigurationSnapshot,
+  patch: UpdateApplicationConfigurationRequest,
+): void {
+  const checks: Array<
+    [unknown, { editable: boolean; source: ConfigurationSource }]
+  > = [
+    [patch.application?.network?.host, snapshot.application.network.host],
+    [patch.application?.network?.port, snapshot.application.network.port],
+    [
+      patch.application?.network?.allowRemote,
+      snapshot.application.network.allowRemote,
+    ],
+    [
+      patch.application?.network?.mobileHttps,
+      snapshot.application.network.mobileHttps,
+    ],
+    [
+      patch.application?.network?.httpsPort,
+      snapshot.application.network.httpsPort,
+    ],
+    [
+      patch.application?.diagnostics?.loggingEnabled,
+      snapshot.application.diagnostics.loggingEnabled,
+    ],
+    [
+      patch.application?.diagnostics?.performanceEnabled,
+      snapshot.application.diagnostics.performanceEnabled,
+    ],
+    [
+      patch.application?.daemon?.startupTimeoutMs,
+      snapshot.application.daemon.startupTimeoutMs,
+    ],
+    [
+      patch.application?.daemon?.maxOldSpaceMb,
+      snapshot.application.daemon.maxOldSpaceMb,
+    ],
+    [
+      patch.application?.electron?.ozonePlatform,
+      snapshot.application.electron.ozonePlatform,
+    ],
+    [
+      patch.application?.electron?.fontRenderHinting,
+      snapshot.application.electron.fontRenderHinting,
+    ],
+  ];
+  for (const [value, setting] of checks) {
+    if (value === undefined || setting.editable) continue;
+    throw new Error(
+      `This setting is controlled by ${setting.source.name ?? setting.source.kind}. Unset that override before changing it.`,
+    );
+  }
+}

--- a/packages/workbench-server/src/infrastructure/configuration/application-configuration.ts
+++ b/packages/workbench-server/src/infrastructure/configuration/application-configuration.ts
@@ -366,7 +366,7 @@ export function resolveApplicationConfiguration(
         }),
         performanceEnabled: leaf({
           selected: performanceEnabled,
-          saved: savedPerformance ?? false,
+          saved: savedPerformance ?? performanceEnabled.value,
           restartTarget: "daemon",
           active: active?.diagnostics.performanceEnabled.activeValue,
         }),

--- a/packages/workbench-server/src/infrastructure/configuration/index.ts
+++ b/packages/workbench-server/src/infrastructure/configuration/index.ts
@@ -1,0 +1,1 @@
+export * from "./application-configuration.js";

--- a/packages/workbench-server/src/infrastructure/storage/initialize.ts
+++ b/packages/workbench-server/src/infrastructure/storage/initialize.ts
@@ -16,7 +16,10 @@ import {
 } from "./json.js";
 import { resolveDataDir, type StoragePaths, storagePaths } from "./paths.js";
 import { ensureStateLayout } from "./state-layout.js";
-import { migrateLegacyAppearanceSettings } from "./settings-migrations.js";
+import {
+  migrateApplicationConfiguration,
+  migrateLegacyAppearanceSettings,
+} from "./settings-migrations.js";
 
 const dataSubdirs = [
   "auth",
@@ -160,6 +163,43 @@ function migrateRemovedNotificationTones(value: unknown): {
   };
 }
 
+function normalizeSettings(value: unknown): {
+  settings: Settings;
+  changed: boolean;
+} {
+  const normalizedApplication = migrateApplicationConfiguration(value);
+  const normalizedAppearance = migrateLegacyAppearanceSettings(
+    normalizedApplication.value,
+  );
+  const normalizedTools = migrateLegacyToolNames(normalizedAppearance.value);
+  const normalizedImageExplanation = migrateImageExplanationTool(
+    normalizedTools.value,
+  );
+  const normalizedTones = migrateRemovedNotificationTones(
+    normalizedImageExplanation.value,
+  );
+  return {
+    settings: settingsSchema.parse({
+      ...defaultSettings,
+      ...(normalizedTones.value as object),
+    }),
+    changed:
+      normalizedApplication.changed ||
+      normalizedAppearance.changed ||
+      normalizedTools.changed ||
+      normalizedImageExplanation.changed ||
+      normalizedTones.changed,
+  };
+}
+
+export async function readPersistedSettingsForBootstrap(
+  home = resolveDataDir(),
+): Promise<Settings> {
+  const path = storagePaths(home).configPath;
+  if (!(await pathExists(path))) return defaultSettings;
+  return normalizeSettings(await readJsonFile<unknown>(path)).settings;
+}
+
 export async function initializeStorage(
   home = resolveDataDir(),
 ): Promise<InitializedStorage> {
@@ -179,24 +219,9 @@ export async function initializeStorage(
   }
 
   const rawSettings = await readJsonFile<unknown>(paths.configPath);
-  const normalizedAppearance = migrateLegacyAppearanceSettings(rawSettings);
-  const normalizedTools = migrateLegacyToolNames(normalizedAppearance.value);
-  const normalizedImageExplanation = migrateImageExplanationTool(
-    normalizedTools.value,
-  );
-  const normalizedTones = migrateRemovedNotificationTones(
-    normalizedImageExplanation.value,
-  );
-  const settings = settingsSchema.parse({
-    ...defaultSettings,
-    ...(normalizedTones.value as object),
-  });
-  if (
-    normalizedAppearance.changed ||
-    normalizedTools.changed ||
-    normalizedImageExplanation.changed ||
-    normalizedTones.changed
-  ) {
+  const normalized = normalizeSettings(rawSettings);
+  const settings = normalized.settings;
+  if (normalized.changed) {
     await atomicWriteJson(paths.configPath, settings, 0o600);
   }
 
@@ -349,7 +374,26 @@ export async function writeSettings(
     ...(defaultApprovalPolicyPatch
       ? { defaultApprovalPolicy: defaultApprovalPolicyPatch }
       : {}),
-    server: { ...storage.settings.server, ...(patch.server ?? {}) },
+    application: {
+      ...storage.settings.application,
+      ...(patch.application ?? {}),
+      network: {
+        ...storage.settings.application.network,
+        ...(patch.application?.network ?? {}),
+      },
+      diagnostics: {
+        ...storage.settings.application.diagnostics,
+        ...(patch.application?.diagnostics ?? {}),
+      },
+      daemon: {
+        ...storage.settings.application.daemon,
+        ...(patch.application?.daemon ?? {}),
+      },
+      electron: {
+        ...storage.settings.application.electron,
+        ...(patch.application?.electron ?? {}),
+      },
+    },
     ui: { ...storage.settings.ui, ...(patch.ui ?? {}) },
     desktop: { ...storage.settings.desktop, ...(patch.desktop ?? {}) },
     notifications: {

--- a/packages/workbench-server/src/infrastructure/storage/settings-migrations.ts
+++ b/packages/workbench-server/src/infrastructure/storage/settings-migrations.ts
@@ -1,5 +1,75 @@
 const legacyColorModes = new Set(["system", "light", "dark"]);
 
+export function migrateApplicationConfiguration(value: unknown): {
+  value: unknown;
+  changed: boolean;
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { value, changed: false };
+  }
+  const settings = value as Record<string, unknown>;
+  const legacyServer =
+    settings.server &&
+    typeof settings.server === "object" &&
+    !Array.isArray(settings.server)
+      ? (settings.server as Record<string, unknown>)
+      : undefined;
+  if (settings.application !== undefined && !legacyServer) {
+    return { value, changed: false };
+  }
+  const existing =
+    settings.application &&
+    typeof settings.application === "object" &&
+    !Array.isArray(settings.application)
+      ? (settings.application as Record<string, unknown>)
+      : {};
+  const existingNetwork =
+    existing.network &&
+    typeof existing.network === "object" &&
+    !Array.isArray(existing.network)
+      ? (existing.network as Record<string, unknown>)
+      : {};
+  const allowRemote = Boolean(
+    existingNetwork.allowRemote ?? legacyServer?.allowRemote ?? false,
+  );
+  let host = String(existingNetwork.host ?? legacyServer?.host ?? "127.0.0.1");
+  if (allowRemote && (host === "127.0.0.1" || host === "localhost")) {
+    host = "0.0.0.0";
+  }
+  const rest = { ...settings };
+  delete rest.server;
+  return {
+    value: {
+      ...rest,
+      application: {
+        ...existing,
+        network: {
+          host,
+          port: existingNetwork.port ?? legacyServer?.port ?? 3747,
+          allowRemote,
+          mobileHttps: existingNetwork.mobileHttps ?? false,
+          httpsPort: existingNetwork.httpsPort ?? 3748,
+        },
+        diagnostics: {
+          loggingEnabled: false,
+          ...((existing.diagnostics as object | undefined) ?? {}),
+        },
+        daemon: {
+          startupTimeoutMs: 60_000,
+          maxOldSpaceMb: 4096,
+          ...((existing.daemon as object | undefined) ?? {}),
+        },
+        electron: {
+          ozonePlatform: "auto",
+          fontRenderHinting: "slight",
+          ...((existing.electron as object | undefined) ?? {}),
+        },
+      },
+    },
+    changed: true,
+  };
+}
+
 export function migrateLegacyAppearanceSettings(value: unknown): {
   value: unknown;
   changed: boolean;

--- a/packages/workbench-server/src/main.ts
+++ b/packages/workbench-server/src/main.ts
@@ -21,6 +21,7 @@ import {
   writeCrashReportSync,
   writeNodeDiagnosticReport,
 } from "./infrastructure/diagnostics/index.js";
+import { resolveApplicationConfiguration } from "./infrastructure/configuration/index.js";
 import { migrateLegacyEventLogs } from "./infrastructure/events/index.js";
 import {
   isLoopbackHost,
@@ -40,18 +41,6 @@ import {
 } from "./infrastructure/storage/index.js";
 import { ensureMobileHttpsTlsMaterial } from "./infrastructure/tls/lan-certificate.js";
 import { installProtocolWebSocketUpgrade } from "./protocol/protocol-websocket.js";
-
-function readArg(name: string): string | undefined {
-  const prefix = `${name}=`;
-  const value = process.argv.find((arg) => arg.startsWith(prefix));
-  if (value) return value.slice(prefix.length);
-  const index = process.argv.indexOf(name);
-  return index >= 0 ? process.argv[index + 1] : undefined;
-}
-
-function readFlag(name: string): boolean {
-  return process.argv.includes(name);
-}
 
 function prepareEnterpriseNetworkEnvironment(): void {
   const proxyConfigured = Boolean(
@@ -119,36 +108,30 @@ async function main() {
   const storageDurationMs = Math.round(performance.now() - storageStartedAt);
   installNodeDiagnosticReports(dataDir);
   runtimeMonitor = installDaemonRuntimeMonitor(dataDir);
-  const host =
-    readArg("--host") ?? process.env.NERVE_HOST ?? storage.settings.server.host;
-  const allowRemote =
-    readArg("--allow-remote") !== undefined ||
-    process.env.NERVE_ALLOW_REMOTE === "1" ||
-    storage.settings.server.allowRemote;
+  const resolvedConfiguration = resolveApplicationConfiguration({
+    settings: storage.settings,
+    env: process.env,
+    argv: process.argv.slice(2),
+    dataDir,
+  });
+  const {
+    host,
+    port,
+    allowRemote,
+    mobileHttps: mobileHttpsEnabled,
+    httpsPort,
+    loggingEnabled,
+    performanceEnabled: performanceDiagnosticsEnabled,
+  } = resolvedConfiguration.values;
   if (!allowRemote && !isLoopbackHost(host)) {
     throw new Error(
-      `Refusing to bind nerve daemon to ${host}. Use --allow-remote, NERVE_ALLOW_REMOTE=1, or set server.allowRemote=true in config.json to explicitly opt in.`,
+      `Refusing to bind Nerve daemon to ${host}. Enable remote connections in Settings or set NERVE_ALLOW_REMOTE=1.`,
     );
   }
-  const port = Number(
-    readArg("--port") ?? process.env.NERVE_PORT ?? storage.settings.server.port,
-  );
-  const mobileHttpsEnabled =
-    readFlag("--mobile-https") || process.env.NERVE_MOBILE_HTTPS === "1";
-  const httpsPort = Number(
-    readArg("--https-port") ?? process.env.NERVE_HTTPS_PORT ?? port + 1,
-  );
-  if (!Number.isFinite(port) || port <= 0) {
-    throw new Error(`Invalid Nerve daemon port: ${String(port)}`);
-  }
-  if (mobileHttpsEnabled && (!Number.isFinite(httpsPort) || httpsPort <= 0)) {
-    throw new Error(`Invalid Nerve HTTPS port: ${String(httpsPort)}`);
-  }
-  const performanceDiagnosticsEnabled =
-    process.env.NERVE_PERFORMANCE_DIAGNOSTICS === "1";
   const state = createOrchestratorState(storage, host, port, {
-    applicationLogsEnabled: process.env.NERVE_LOGGING_ENABLED === "1",
+    applicationLogsEnabled: loggingEnabled,
     performanceDiagnosticsEnabled,
+    applicationConfiguration: resolvedConfiguration.snapshot,
   });
   const loggerHydrateStartedAt = performance.now();
   await state.logger.hydrate();

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -1,4 +1,7 @@
-import { slashCommandCompletionItems } from "@nervekit/contracts";
+import {
+  slashCommandCompletionItems,
+  type UpdateApplicationConfigurationRequest,
+} from "@nervekit/contracts";
 import type { OrchestratorState } from "../../app/orchestrator-state.js";
 import {
   providerApiKeySecretName,
@@ -10,6 +13,10 @@ import {
   directoryListing,
   projectDirectoryEntries,
 } from "../../domains/filesystem/filesystem.service.js";
+import {
+  assertApplicationConfigurationEditable,
+  resolveApplicationConfiguration,
+} from "../../infrastructure/configuration/index.js";
 import { writeSettings } from "../../infrastructure/storage/index.js";
 import {
   getConversationSnapshotResponse,
@@ -25,6 +32,9 @@ export const platformMethodHandlers = defineWorkbenchMethodHandlers({
   "settings.get": (state) => state.storage.settings,
   "settings.update": (state, params) =>
     updateSettings(state, params as Record<string, unknown>),
+  "applicationConfiguration.get": (state) => state.applicationConfiguration,
+  "applicationConfiguration.update": (state, params) =>
+    updateApplicationConfiguration(state, params),
   "skill.list": (state, params) => {
     const projectDir = params?.projectId
       ? state.registry.getProject(params.projectId).dir
@@ -121,6 +131,12 @@ async function updateSettings(
   state: OrchestratorState,
   patch: Record<string, unknown>,
 ) {
+  if (patch.application) {
+    assertApplicationConfigurationEditable(
+      state.applicationConfiguration,
+      patch as UpdateApplicationConfigurationRequest,
+    );
+  }
   const settings = await writeSettings(state.storage, patch as never);
   if (
     patch.runtime &&
@@ -131,6 +147,56 @@ async function updateSettings(
   }
   await state.events.publish("settings.updated", { settings });
   return { settings };
+}
+
+async function updateApplicationConfiguration(
+  state: OrchestratorState,
+  patch: UpdateApplicationConfigurationRequest,
+) {
+  assertApplicationConfigurationEditable(state.applicationConfiguration, patch);
+  const normalized = normalizeRemoteAccessPatch(state, patch);
+  const settings = await writeSettings(state.storage, normalized);
+  const resolved = resolveApplicationConfiguration({
+    settings,
+    env: process.env,
+    argv: process.argv.slice(2),
+    dataDir: state.storage.paths.home,
+    activeSnapshot: state.applicationConfiguration,
+  });
+  state.applicationConfiguration = resolved.snapshot;
+  await state.events.publish("settings.updated", { settings });
+  await state.events.publish("applicationConfiguration.updated", {
+    snapshot: resolved.snapshot,
+  });
+  return resolved.snapshot;
+}
+
+function normalizeRemoteAccessPatch(
+  state: OrchestratorState,
+  patch: UpdateApplicationConfigurationRequest,
+): UpdateApplicationConfigurationRequest {
+  const allowRemote = patch.application?.network?.allowRemote;
+  if (
+    allowRemote === undefined ||
+    patch.application?.network?.host !== undefined
+  ) {
+    return patch;
+  }
+  const host = state.storage.settings.application.network.host;
+  const nextHost = allowRemote
+    ? host === "127.0.0.1" || host === "localhost"
+      ? "0.0.0.0"
+      : host
+    : host === "0.0.0.0" || host === "::"
+      ? "127.0.0.1"
+      : host;
+  return {
+    ...patch,
+    application: {
+      ...patch.application,
+      network: { ...patch.application?.network, host: nextHost },
+    },
+  };
 }
 
 async function publishProviderCatalogChanged(

--- a/packages/workbench-server/test/application-configuration.test.ts
+++ b/packages/workbench-server/test/application-configuration.test.ts
@@ -52,6 +52,34 @@ describe("application configuration resolution", () => {
     assert.throws(() => resolve({ NERVE_PORT: "70000" }), /NERVE_PORT/);
   });
 
+  it("does not report the unsaved development performance fallback as pending", () => {
+    const settings = structuredClone(defaultSettings);
+    settings.application.diagnostics.performanceEnabled = undefined;
+    const result = resolveApplicationConfiguration({
+      settings,
+      env: {},
+      argv: [],
+      dataDir: "/data/nerve",
+      development: true,
+    });
+    assert.equal(
+      result.snapshot.application.diagnostics.performanceEnabled.activeValue,
+      true,
+    );
+    assert.equal(
+      result.snapshot.application.diagnostics.performanceEnabled.savedValue,
+      true,
+    );
+    assert.equal(
+      result.snapshot.application.diagnostics.performanceEnabled.pendingRestart,
+      false,
+    );
+    assert.equal(
+      result.snapshot.application.diagnostics.performanceEnabled.source.kind,
+      "development_default",
+    );
+  });
+
   it("tracks saved startup changes without changing the active value", () => {
     const initial = resolve();
     const settings = structuredClone(defaultSettings);

--- a/packages/workbench-server/test/application-configuration.test.ts
+++ b/packages/workbench-server/test/application-configuration.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { defaultSettings } from "@nervekit/contracts";
+import {
+  assertApplicationConfigurationEditable,
+  resolveApplicationConfiguration,
+} from "../src/infrastructure/configuration/index.js";
+
+function resolve(env: NodeJS.ProcessEnv = {}, argv: string[] = []) {
+  return resolveApplicationConfiguration({
+    settings: structuredClone(defaultSettings),
+    env,
+    argv,
+    dataDir: "/data/nerve",
+    platform: "linux",
+  });
+}
+
+describe("application configuration resolution", () => {
+  it("uses environment and command-line precedence with source metadata", () => {
+    const result = resolve({ NERVE_PORT: "4000", NERVE_ALLOW_REMOTE: "0" }, [
+      "--port",
+      "5000",
+    ]);
+    assert.equal(result.values.port, 5000);
+    assert.deepEqual(result.snapshot.application.network.port.source, {
+      kind: "command_line",
+      name: "--port",
+    });
+    assert.equal(result.values.allowRemote, false);
+    assert.equal(
+      result.snapshot.application.network.allowRemote.source.name,
+      "NERVE_ALLOW_REMOTE",
+    );
+    assert.equal(
+      result.snapshot.application.network.allowRemote.editable,
+      false,
+    );
+  });
+
+  it("makes a remote opt-in bind to the LAN when no host is supplied", () => {
+    const result = resolve({ NERVE_ALLOW_REMOTE: "1" });
+    assert.equal(result.values.allowRemote, true);
+    assert.equal(result.values.host, "0.0.0.0");
+  });
+
+  it("rejects invalid explicit values", () => {
+    assert.throws(
+      () => resolve({ NERVE_LOGGING_ENABLED: "sometimes" }),
+      /NERVE_LOGGING_ENABLED/,
+    );
+    assert.throws(() => resolve({ NERVE_PORT: "70000" }), /NERVE_PORT/);
+  });
+
+  it("tracks saved startup changes without changing the active value", () => {
+    const initial = resolve();
+    const settings = structuredClone(defaultSettings);
+    settings.application.network.port = 5000;
+    const refreshed = resolveApplicationConfiguration({
+      settings,
+      env: {},
+      argv: [],
+      dataDir: "/data/nerve",
+      activeSnapshot: initial.snapshot,
+    });
+    assert.equal(refreshed.snapshot.application.network.port.activeValue, 3747);
+    assert.equal(refreshed.snapshot.application.network.port.savedValue, 5000);
+    assert.equal(
+      refreshed.snapshot.application.network.port.pendingRestart,
+      true,
+    );
+  });
+
+  it("rejects writes to externally controlled settings", () => {
+    const result = resolve({ NERVE_PORT: "4000" });
+    assert.throws(
+      () =>
+        assertApplicationConfigurationEditable(result.snapshot, {
+          application: { network: { port: 5000 } },
+        }),
+      /NERVE_PORT/,
+    );
+  });
+});

--- a/packages/workbench-server/test/storage-settings-migration.test.ts
+++ b/packages/workbench-server/test/storage-settings-migration.test.ts
@@ -18,6 +18,33 @@ afterEach(async () => {
 });
 
 describe("settings migrations", () => {
+  it("moves legacy server settings into application configuration", async () => {
+    const root = await mkdtemp(join(tmpdir(), "nerve-settings-migration-"));
+    try {
+      await initializeStorage(root);
+      const legacy = {
+        ...defaultSettings,
+        application: undefined,
+        server: { host: "127.0.0.1", port: 4100, allowRemote: true },
+      };
+      await writeFile(join(root, "config.json"), `${JSON.stringify(legacy)}\n`);
+      const storage = await initializeStorage(root);
+      assert.deepEqual(storage.settings.application.network, {
+        host: "0.0.0.0",
+        port: 4100,
+        allowRemote: true,
+        mobileHttps: false,
+        httpsPort: 3748,
+      });
+      const persisted = JSON.parse(
+        await readFile(join(root, "config.json"), "utf8"),
+      ) as Record<string, unknown>;
+      assert.equal("server" in persisted, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   for (const colorMode of ["system", "light", "dark"] as const) {
     it(`migrates the legacy ${colorMode} appearance setting`, async () => {
       const root = await mkdtemp(join(tmpdir(), "nerve-settings-migration-"));

--- a/packages/workbench-server/test/workbench-task-service-foreground.test.ts
+++ b/packages/workbench-server/test/workbench-task-service-foreground.test.ts
@@ -70,45 +70,54 @@ describe("task manager foreground bash auto-promotion", () => {
     );
   });
 
-  it("returns normal bash output and removes the hidden task when it finishes before promotion", async () => {
-    const child = fakeChild();
-    const { supervisor } = fakeSupervisor({ child });
-    const { manager, storage, events } = await createManager(supervisor);
-    const startedEvent = waitForTaskEvent(events, "task.started");
+  it(
+    "returns normal bash output and removes the hidden task when it finishes before promotion",
+    { timeout: 10_000 },
+    async () => {
+      const child = fakeChild();
+      let spawned!: () => void;
+      const didSpawn = new Promise<void>((resolve) => {
+        spawned = resolve;
+      });
+      const { supervisor } = fakeSupervisor({ child, onSpawn: spawned });
+      const { manager, storage, events } = await createManager(supervisor);
+      const startedEvent = waitForTaskEvent(events, "task.started");
 
-    const run = manager.runForegroundBashWithPromotion({
-      command: "node fake.js",
-      cwd: storage.paths.home,
-      projectId: "proj_test",
-      conversationId: "conv_test",
-      agentId: "agent_test",
-      autoPromoteAfterMs: 1000,
-      origin: { kind: "agent_tool", toolCallId: "tool_test" },
-    });
-    const started = await startedEvent;
-    const completedEvent = waitForTaskEvent(
-      events,
-      "task.completed",
-      started.id,
-    );
-    child.stdout.emit("data", "out 1\n");
-    child.stderr.emit("data", "err 1\n");
-    child.stdout.emit("data", "out 2\n");
-    child.emitClose(0, null);
-    await completedEvent;
+      const run = manager.runForegroundBashWithPromotion({
+        command: "node fake.js",
+        cwd: storage.paths.home,
+        projectId: "proj_test",
+        conversationId: "conv_test",
+        agentId: "agent_test",
+        autoPromoteAfterMs: 1000,
+        origin: { kind: "agent_tool", toolCallId: "tool_test" },
+      });
+      const started = await startedEvent;
+      await didSpawn;
+      const completedEvent = waitForTaskEvent(
+        events,
+        "task.completed",
+        started.id,
+      );
+      child.stdout.emit("data", "out 1\n");
+      child.stderr.emit("data", "err 1\n");
+      child.stdout.emit("data", "out 2\n");
+      child.emitClose(0, null);
+      await completedEvent;
 
-    const result = await run;
+      const result = await run;
 
-    assert.equal(result.kind, "completed_foreground");
-    assert.deepEqual(
-      (result.result.details as { execution?: unknown }).execution,
-      { disposition: "completed" },
-    );
-    assert.equal(result.result.stdout, "out 1\nout 2");
-    assert.equal(result.result.stderr, "err 1");
-    assert.equal(result.result.content, "out 1\nerr 1\nout 2\n");
-    assert.throws(() => manager.getTask(started.id), /Task not found/);
-  });
+      assert.equal(result.kind, "completed_foreground");
+      assert.deepEqual(
+        (result.result.details as { execution?: unknown }).execution,
+        { disposition: "completed" },
+      );
+      assert.equal(result.result.stdout, "out 1\nout 2");
+      assert.equal(result.result.stderr, "err 1");
+      assert.equal(result.result.content, "out 1\nerr 1\nout 2\n");
+      assert.throws(() => manager.getTask(started.id), /Task not found/);
+    },
+  );
 
   it("captures output before delayed runtime identity resolves", async () => {
     const child = fakeChild();


### PR DESCRIPTION
## Summary
- add shared application configuration schemas and resolve settings with environment/CLI precedence, source metadata, and restart requirements
- expose editable runtime configuration through the server, desktop bridge, and System settings UI
- migrate legacy server settings and document the updated configuration and diagnostics options

## Testing
- `pnpm fix && pnpm check && pnpm test`