### PR TITLE
Fix release workflow cache-poisoning alerts

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,137 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact SemVer without v (for example, 1.2.3 or 1.2.3-rc.1)
+        required: true
+        type: string
+
+concurrency:
+  group: prepare-release-v${{ inputs.version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-release:
+    name: Bump version and create tag
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+
+    steps:
+      - name: Check out default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Bump workspace versions
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: node scripts/bump-release-version.mjs "${RELEASE_VERSION}"
+
+      - name: Verify and push release commit and tag
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_AUTHOR_ID: ${{ github.actor_id }}
+          RELEASE_AUTHOR_NAME: ${{ github.actor }}
+          RELEASE_GPG_FINGERPRINT: ${{ secrets.RELEASE_GPG_FINGERPRINT }}
+          RELEASE_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
+          RELEASE_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          release_tag="v${RELEASE_VERSION}"
+          node scripts/verify-release-tag.mjs "${release_tag}"
+
+          git add package.json packages/*/package.json
+          if git diff --cached --quiet; then
+            echo "Workspace is already at ${release_tag}; reusing the current commit"
+          else
+            # A new release commit must be signed with the configured release key.
+            if [ -z "${RELEASE_GPG_PRIVATE_KEY}" ] ||
+               [ -z "${RELEASE_GPG_PASSPHRASE}" ] ||
+               [ -z "${RELEASE_GPG_FINGERPRINT}" ]; then
+              echo "Release signing secrets are not configured" >&2
+              exit 1
+            fi
+
+            export GNUPGHOME="${RUNNER_TEMP}/release-gnupg"
+            gpg_wrapper="${RUNNER_TEMP}/release-gpg-sign"
+            cleanup_signing_material() {
+              rm -rf "${GNUPGHOME}" "${gpg_wrapper}"
+            }
+            trap cleanup_signing_material EXIT
+            mkdir -m 700 "${GNUPGHOME}"
+
+            printf '%s' "${RELEASE_GPG_PRIVATE_KEY}" | gpg --batch --import >/dev/null 2>&1
+            expected_fingerprint="$(printf '%s' "${RELEASE_GPG_FINGERPRINT}" | tr -d '[:space:]')"
+            mapfile -t imported_fingerprints < <(
+              gpg --batch --with-colons --list-secret-keys |
+                awk -F: '$1 == "sec" { primary = 1; next } primary && $1 == "fpr" { print $10; primary = 0 }'
+            )
+            if [ "${#imported_fingerprints[@]}" -ne 1 ] ||
+               [ "${imported_fingerprints[0]}" != "${expected_fingerprint}" ]; then
+              echo "Imported release key does not match RELEASE_GPG_FINGERPRINT" >&2
+              exit 1
+            fi
+
+            printf '%s\n' \
+              '#!/usr/bin/env bash' \
+              'set -euo pipefail' \
+              'exec gpg --batch --yes --pinentry-mode loopback --passphrase "${RELEASE_GPG_PASSPHRASE}" "$@"' \
+              >"${gpg_wrapper}"
+            chmod 700 "${gpg_wrapper}"
+
+            git config user.name "Nerve Release Bot"
+            git config user.email "41065538+ThilinaTLM@users.noreply.github.com"
+            git config user.signingkey "${expected_fingerprint}"
+            git config gpg.program "${gpg_wrapper}"
+            git config commit.gpgsign true
+            git commit -S \
+              --author="${RELEASE_AUTHOR_NAME} <${RELEASE_AUTHOR_ID}+${RELEASE_AUTHOR_NAME}@users.noreply.github.com>" \
+              -m "chore(release): bump version to ${release_tag}"
+          fi
+
+          # The release commit must carry a GPG signature. It does not have to be
+          # signed with the configured release key: a manual dispatch may reuse a
+          # commit that a developer signed with their own key.
+          if ! git cat-file commit HEAD | grep -q "^gpgsig"; then
+            echo "Release commit is not signed" >&2
+            exit 1
+          fi
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "${release_tag}")"
+            head_sha="$(git rev-parse HEAD)"
+            if [ "${tag_sha}" != "${head_sha}" ]; then
+              echo "Tag ${release_tag} already points to ${tag_sha}, not ${head_sha}" >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already points to the release commit"
+          else
+            git tag -a "${release_tag}" -m "Release ${release_tag}"
+          fi
+
+          git push --atomic origin \
+            "HEAD:refs/heads/${DEFAULT_BRANCH}" \
+            "refs/tags/${release_tag}"
+
+      - name: Dispatch release workflow at tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: gh workflow run release.yml --ref "v${RELEASE_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,198 +8,42 @@ on:
       # Pre-releases: v1.2.3-rc.1, v1.2.3-beta.2, etc.
       - "v[0-9]+.[0-9]+.[0-9]+-*"
   workflow_dispatch:
-    inputs:
-      version:
-        description: Exact SemVer without v (for example, 1.2.3 or 1.2.3-rc.1)
-        required: true
-        type: string
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  prepare-release:
-    name: Bump version and create tag
+  verify-tag:
+    name: Verify release tag
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      release_tag: ${{ steps.context.outputs.release_tag }}
-      release_sha: ${{ steps.sha.outputs.release_sha }}
 
     steps:
-      - name: Resolve release context
-        id: context
+      - name: Require a tag ref
         shell: bash
         env:
-          PUSHED_TAG: ${{ github.ref_name }}
-          INPUT_VERSION: ${{ inputs.version }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
         run: |
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "Release triggered by tag push ${PUSHED_TAG}"
-            echo "release_tag=${PUSHED_TAG}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "Manual release for v${INPUT_VERSION}"
-            echo "release_tag=v${INPUT_VERSION}" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Check out default branch
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 0
-
-      - name: Set up Node.js
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Bump workspace versions
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: node scripts/bump-release-version.mjs "${RELEASE_VERSION}"
-
-      - name: Verify and push release commit and tag
-        if: github.event_name == 'workflow_dispatch'
-        shell: bash
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          RELEASE_AUTHOR_ID: ${{ github.actor_id }}
-          RELEASE_AUTHOR_NAME: ${{ github.actor }}
-          RELEASE_GPG_FINGERPRINT: ${{ secrets.RELEASE_GPG_FINGERPRINT }}
-          RELEASE_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
-          RELEASE_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          release_tag="v${RELEASE_VERSION}"
-          node scripts/verify-release-tag.mjs "${release_tag}"
-
-          git add package.json packages/*/package.json
-          if git diff --cached --quiet; then
-            echo "Workspace is already at ${release_tag}; reusing the current commit"
-          else
-            # A new release commit must be signed with the configured release key.
-            if [ -z "${RELEASE_GPG_PRIVATE_KEY}" ] ||
-               [ -z "${RELEASE_GPG_PASSPHRASE}" ] ||
-               [ -z "${RELEASE_GPG_FINGERPRINT}" ]; then
-              echo "Release signing secrets are not configured" >&2
-              exit 1
-            fi
-
-            export GNUPGHOME="${RUNNER_TEMP}/release-gnupg"
-            gpg_wrapper="${RUNNER_TEMP}/release-gpg-sign"
-            cleanup_signing_material() {
-              rm -rf "${GNUPGHOME}" "${gpg_wrapper}"
-            }
-            trap cleanup_signing_material EXIT
-            mkdir -m 700 "${GNUPGHOME}"
-
-            printf '%s' "${RELEASE_GPG_PRIVATE_KEY}" | gpg --batch --import >/dev/null 2>&1
-            expected_fingerprint="$(printf '%s' "${RELEASE_GPG_FINGERPRINT}" | tr -d '[:space:]')"
-            mapfile -t imported_fingerprints < <(
-              gpg --batch --with-colons --list-secret-keys |
-                awk -F: '$1 == "sec" { primary = 1; next } primary && $1 == "fpr" { print $10; primary = 0 }'
-            )
-            if [ "${#imported_fingerprints[@]}" -ne 1 ] ||
-               [ "${imported_fingerprints[0]}" != "${expected_fingerprint}" ]; then
-              echo "Imported release key does not match RELEASE_GPG_FINGERPRINT" >&2
-              exit 1
-            fi
-
-            printf '%s\n' \
-              '#!/usr/bin/env bash' \
-              'set -euo pipefail' \
-              'exec gpg --batch --yes --pinentry-mode loopback --passphrase "${RELEASE_GPG_PASSPHRASE}" "$@"' \
-              >"${gpg_wrapper}"
-            chmod 700 "${gpg_wrapper}"
-
-            git config user.name "Nerve Release Bot"
-            git config user.email "41065538+ThilinaTLM@users.noreply.github.com"
-            git config user.signingkey "${expected_fingerprint}"
-            git config gpg.program "${gpg_wrapper}"
-            git config commit.gpgsign true
-            git commit -S \
-              --author="${RELEASE_AUTHOR_NAME} <${RELEASE_AUTHOR_ID}+${RELEASE_AUTHOR_NAME}@users.noreply.github.com>" \
-              -m "chore(release): bump version to ${release_tag}"
-          fi
-
-          # The release commit must carry a GPG signature. It does not have to be
-          # signed with the configured release key: a manual dispatch may reuse a
-          # commit that a developer signed with their own key.
-          if ! git cat-file commit HEAD | grep -q "^gpgsig"; then
-            echo "Release commit is not signed" >&2
+          if [ "${RELEASE_REF_TYPE}" != "tag" ]; then
+            echo "Release must run against a tag ref" >&2
             exit 1
           fi
 
-          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
-            tag_sha="$(git rev-list -n 1 "${release_tag}")"
-            head_sha="$(git rev-parse HEAD)"
-            if [ "${tag_sha}" != "${head_sha}" ]; then
-              echo "Tag ${release_tag} already points to ${tag_sha}, not ${head_sha}" >&2
-              exit 1
-            fi
-            echo "Tag ${release_tag} already points to the release commit"
-          else
-            git tag -a "${release_tag}" -m "Release ${release_tag}"
-          fi
-
-          git push --atomic origin \
-            "HEAD:refs/heads/${DEFAULT_BRANCH}" \
-            "refs/tags/${release_tag}"
-
-      - name: Set release SHA
-        id: sha
-        shell: bash
-        env:
-          PUSHED_SHA: ${{ github.sha }}
-        run: |
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "release_sha=${PUSHED_SHA}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "release_sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-          fi
-
-  verify-tag:
-    name: Verify release tag
-    needs: prepare-release
-    runs-on: ubuntu-latest
-    outputs:
-      release_tag: ${{ steps.context.outputs.release_tag }}
-      release_sha: ${{ steps.context.outputs.release_sha }}
-
-    steps:
       - name: Check out release commit
         uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.prepare-release.outputs.release_sha || github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
 
-      - name: Resolve release context
-        id: context
-        shell: bash
-        env:
-          PREPARED_TAG: ${{ needs.prepare-release.outputs.release_tag }}
-          PREPARED_SHA: ${{ needs.prepare-release.outputs.release_sha }}
-          PUSHED_TAG: ${{ github.ref_name }}
-          PUSHED_SHA: ${{ github.sha }}
-        run: |
-          echo "release_tag=${PREPARED_TAG:-${PUSHED_TAG}}" >> "${GITHUB_OUTPUT}"
-          echo "release_sha=${PREPARED_SHA:-${PUSHED_SHA}}" >> "${GITHUB_OUTPUT}"
-
       - name: Verify release tag
-        run: node scripts/verify-release-tag.mjs "${{ steps.context.outputs.release_tag }}"
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/verify-release-tag.mjs "${RELEASE_TAG}"
 
   quality-and-package:
     name: Check, test, build, and package (Ubuntu)
@@ -210,8 +54,6 @@ jobs:
     steps:
       - name: Check out release commit
         uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.verify-tag.outputs.release_sha }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -268,8 +110,6 @@ jobs:
     steps:
       - name: Check out release commit
         uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.verify-tag.outputs.release_sha }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -344,7 +184,7 @@ jobs:
       - name: Publish npm tarball
         shell: bash
         env:
-          RELEASE_TAG: ${{ needs.verify-tag.outputs.release_tag }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           name="@nervekit/desktop"
@@ -386,7 +226,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ needs.verify-tag.outputs.release_tag }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"

--- a/docs/release.md
+++ b/docs/release.md
@@ -39,6 +39,14 @@ pnpm --filter @nervekit/desktop-shell package:dir
 pnpm release:smoke:desktop-package
 ```
 
+## Automated release flow
+
+Run the **Prepare Release** workflow manually with the exact version to publish. It updates all workspace versions on protected `main`, creates the signed release commit and annotated `v<version>` tag, atomically pushes both refs, and dispatches the **Release** workflow at that immutable tag.
+
+The **Release** workflow validates the tag, runs the Linux, Windows, and macOS quality and packaging gates, publishes to npm through OIDC, and creates the GitHub release. It rejects manual dispatches from branch refs. Direct pushes of matching SemVer tags also start Release automatically.
+
+If preparation pushes the commit and tag but the dispatch step fails, rerun **Release** manually and select the existing tag. Do not recreate or move the tag.
+
 ## State reset before testing an incompatible development store
 
 Stop all Nerve processes first, then remove the complete `NERVE_HOME` (default `~/.nerve`). Its marker is `nerve-workbench-state` version 2. Clear browser site local and session storage when testing the browser workbench independently.
@@ -47,7 +55,7 @@ The deterministic workbench error is `Incompatible Nerve state at <path>...`, en
 
 ## Release commit signing
 
-The manual release workflow creates its version-bump commit on protected `main`, so it must use the dedicated `Nerve Release Bot` GPG key registered on the `ThilinaTLM` GitHub account. The initiating maintainer remains the commit author; `Nerve Release Bot <41065538+ThilinaTLM@users.noreply.github.com>` is the signing committer.
+The manually dispatched **Prepare Release** workflow creates its version-bump commit on protected `main`, so it must use the dedicated `Nerve Release Bot` GPG key registered on the `ThilinaTLM` GitHub account. The initiating maintainer remains the commit author; `Nerve Release Bot <41065538+ThilinaTLM@users.noreply.github.com>` is the signing committer.
 
 Configure these repository Actions secrets together:
 
@@ -55,7 +63,7 @@ Configure these repository Actions secrets together:
 - `RELEASE_GPG_PASSPHRASE`: the private-key passphrase
 - `RELEASE_GPG_FINGERPRINT`: the full primary-key fingerprint
 
-The matching public key must remain registered with GitHub. The workflow imports the private key into an ephemeral keyring and fails before its atomic push if a secret is missing, the fingerprint differs, the key cannot be unlocked, or the release commit does not verify against that fingerprint.
+The matching public key must remain registered with GitHub. Prepare Release imports the private key into an ephemeral keyring and fails before its atomic push if a secret is missing, the fingerprint differs, the key cannot be unlocked, or the release commit does not verify against that fingerprint.
 
 The current automation key expires on 2028-08-10. Rotate it before expiry by generating and registering a replacement key, replacing all three secrets together, validating a release, and then removing the old public key. If the key may be compromised, remove it from GitHub and replace the secrets before another release.
 


### PR DESCRIPTION
## Summary
- split signed version/tag preparation into a dedicated manually dispatched workflow
- run publication only from a trusted tag context without cross-job SHA outputs
- document the updated preparation and release flow

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/prepare-release.yml .github/workflows/release.yml`
- `pnpm fix && pnpm check && pnpm test`