### PR TITLE
fix(workbench): align startup progress width

### DIFF
--- a/packages/workbench-app/index.html
+++ b/packages/workbench-app/index.html
@@ -120,7 +120,7 @@
       }
       #startup-bootstrap-progress {
         width: 100%;
-        max-width: 12rem;
+        max-width: 24rem;
         margin-top: 1.5rem;
       }
       #startup-bootstrap-status {
@@ -131,7 +131,9 @@
       }
       #startup-bootstrap-track {
         width: 100%;
+        max-width: 16rem;
         height: 0.25rem;
+        margin-inline: auto;
         overflow: hidden;
         border-radius: 999px;
         background: var(--startup-border);


### PR DESCRIPTION
## Summary
- align the pre-stylesheet workbench bootstrap progress track with the Electron and mounted Svelte splash stages
- keep the status region wide while centering the responsive 16rem progress track

## Validation
- `pnpm fix && pnpm check && pnpm test`