### PR TITLE
Refresh Files panel from filesystem events

### DIFF
--- a/packages/contracts/src/domains/events/public-event-catalog.schema.ts
+++ b/packages/contracts/src/domains/events/public-event-catalog.schema.ts
@@ -4,6 +4,7 @@ import { runEventDefinitions } from "../agents/run.events.schema.js";
 import { authEventDefinitions } from "../auth/auth.events.schema.js";
 import { conversationLifecycleEventDefinitions } from "../conversations/conversation.events.schema.js";
 import { conversationRuntimeEventDefinitions } from "../conversations/conversation-runtime.events.schema.js";
+import { filesystemEventDefinitions } from "../filesystem/filesystem.events.schema.js";
 import { gitEventDefinitions } from "../git/git.events.schema.js";
 import { planEventDefinitions } from "../plans/plan.events.schema.js";
 import { promptSuggestionEventDefinitions } from "../prompt-suggestions/prompt-suggestion.events.schema.js";
@@ -30,6 +31,7 @@ export type {
 const definitions: PublicEventDefinition[] = [
   ...taskEventDefinitions,
   ...taskDefinitionEventDefinitions,
+  ...filesystemEventDefinitions,
   ...gitEventDefinitions,
   ...conversationLifecycleEventDefinitions,
   ...conversationRuntimeEventDefinitions,

--- a/packages/contracts/src/domains/filesystem/filesystem.events.schema.ts
+++ b/packages/contracts/src/domains/filesystem/filesystem.events.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { definePublicEvent } from "../events/event-definition.schema.js";
+
+export const filesystemEventDefinitions = [
+  definePublicEvent(
+    "filesystem.project.changed",
+    z.object({
+      projectId: z.string().startsWith("proj_"),
+      source: z.literal("filesystem"),
+    }),
+    {
+      delivery: "ephemeral",
+      coalescing: { strategy: "latest_by_scope" },
+      scope: ["projectId"],
+    },
+  ),
+] as const;

--- a/packages/contracts/src/domains/filesystem/index.ts
+++ b/packages/contracts/src/domains/filesystem/index.ts
@@ -1,1 +1,2 @@
+export * from "./filesystem.events.schema.js";
 export * from "./filesystem.schema.js";

--- a/packages/contracts/test/protocol.schema.test.ts
+++ b/packages/contracts/test/protocol.schema.test.ts
@@ -465,6 +465,25 @@ describe("Protocol v1 shared schemas", () => {
       ),
       invalidation,
     );
+    const filesystemChange = {
+      projectId: "proj_test",
+      source: "filesystem",
+    };
+    assert.deepEqual(
+      validatePublicEvent(
+        "filesystem.project.changed",
+        filesystemChange,
+        "workbench_server",
+      ),
+      filesystemChange,
+    );
+    assert.throws(() =>
+      validatePublicEvent(
+        "filesystem.project.changed",
+        { projectId: "test", source: "filesystem" },
+        "workbench_server",
+      ),
+    );
     assert.throws(
       () =>
         parsePublicEventEnvelope(

--- a/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/FilesPanelView.svelte
@@ -44,6 +44,7 @@ import {
   refreshFileExplorerProject,
   setFileExplorerItemExpanded,
 } from "$lib/features/filesystem/state/file-explorer-actions.svelte";
+import { registerFileExplorerEventHandler } from "$lib/features/filesystem/state/file-explorer-events";
 import { startFileExplorerRefreshScheduler } from "$lib/features/filesystem/state/file-explorer-refresh-scheduler";
 import { fileExplorerState } from "$lib/features/filesystem/state/file-explorer-state.svelte";
 import {
@@ -357,9 +358,17 @@ $effect(() => {
     ensureFileExplorerRoot(projectId),
     refreshGitStatus(projectId),
   ]);
-  return startFileExplorerRefreshScheduler({
+  const scheduler = startFileExplorerRefreshScheduler({
     refresh: () => refreshAll(projectId),
   });
+  const unregisterEvents = registerFileExplorerEventHandler(
+    projectId,
+    scheduler.requestRefresh,
+  );
+  return () => {
+    unregisterEvents();
+    scheduler.stop();
+  };
 });
 </script>
 

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-events.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-events.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import type { WorkbenchNotifyEvent } from "$lib/core/events/event-bus";
+import { clearEventHandlers, dispatchEvent } from "$lib/core/events/event-bus";
+import { registerFileExplorerEventHandler } from "./file-explorer-events";
+
+const ts = "2026-08-16T00:00:00.000Z";
+
+function change(data: Record<string, unknown>): WorkbenchNotifyEvent {
+  return {
+    id: "evt_filesystem_change",
+    ts,
+    type: "filesystem.project.changed",
+    data,
+  };
+}
+
+afterEach(() => clearEventHandlers());
+
+test("refreshes only for valid changes to the active project and unregisters", () => {
+  let refreshes = 0;
+  const unregister = registerFileExplorerEventHandler("proj_active", () => {
+    refreshes += 1;
+  });
+
+  dispatchEvent(change({ projectId: "proj_other", source: "filesystem" }));
+  dispatchEvent(change({ projectId: "active", source: "filesystem" }));
+  dispatchEvent(change({ projectId: "proj_active", source: "other" }));
+  assert.equal(refreshes, 0);
+
+  dispatchEvent(change({ projectId: "proj_active", source: "filesystem" }));
+  assert.equal(refreshes, 1);
+
+  unregister();
+  dispatchEvent(change({ projectId: "proj_active", source: "filesystem" }));
+  assert.equal(refreshes, 1);
+});

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-events.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-events.ts
@@ -1,0 +1,21 @@
+import { onEvent, type WorkbenchEvent } from "$lib/core/events/event-bus";
+
+function changedProjectId(event: WorkbenchEvent): string | undefined {
+  if (event.type !== "filesystem.project.changed") return undefined;
+  const projectId = event.data?.projectId;
+  const source = event.data?.source;
+  return typeof projectId === "string" &&
+    projectId.startsWith("proj_") &&
+    source === "filesystem"
+    ? projectId
+    : undefined;
+}
+
+export function registerFileExplorerEventHandler(
+  projectId: string,
+  requestRefresh: () => void,
+): () => void {
+  return onEvent("filesystem.project.changed", (event) => {
+    if (changedProjectId(event) === projectId) requestRefresh();
+  });
+}

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.test.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.test.ts
@@ -2,17 +2,23 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { startFileExplorerRefreshScheduler } from "./file-explorer-refresh-scheduler";
 
-test("refreshes only while visible and cleans up listeners", () => {
+type Timer = { at: number; callback: () => void; cancelled: boolean };
+
+function schedulerHarness(
+  refresh: () => void | Promise<void> = () => undefined,
+) {
   const windowTarget = new EventTarget();
   const documentTarget = new EventTarget();
+  const timers: Timer[] = [];
   let interval: (() => void) | undefined;
   let intervalMs: number | undefined;
+  let intervalCleared = false;
   let visible = true;
-  let refreshes = 0;
-  const stop = startFileExplorerRefreshScheduler({
-    refresh: () => {
-      refreshes += 1;
-    },
+  let now = 0;
+
+  const scheduler = startFileExplorerRefreshScheduler({
+    refresh,
+    now: () => now,
     window: {
       addEventListener: windowTarget.addEventListener.bind(windowTarget),
       removeEventListener: windowTarget.removeEventListener.bind(windowTarget),
@@ -21,7 +27,21 @@ test("refreshes only while visible and cleans up listeners", () => {
         intervalMs = delay;
         return 1;
       }) as Window["setInterval"],
-      clearInterval: (() => undefined) as Window["clearInterval"],
+      clearInterval: (() => {
+        intervalCleared = true;
+      }) as Window["clearInterval"],
+      setTimeout: ((callback: TimerHandler, delay?: number) => {
+        const timer = {
+          at: now + (delay ?? 0),
+          callback: callback as () => void,
+          cancelled: false,
+        };
+        timers.push(timer);
+        return timer as unknown as number;
+      }) as Window["setTimeout"],
+      clearTimeout: ((timer: number) => {
+        (timer as unknown as Timer).cancelled = true;
+      }) as Window["clearTimeout"],
     },
     document: {
       addEventListener: documentTarget.addEventListener.bind(documentTarget),
@@ -33,16 +53,105 @@ test("refreshes only while visible and cleans up listeners", () => {
     },
   });
 
-  assert.equal(intervalMs, 20_000);
-  interval?.();
-  windowTarget.dispatchEvent(new Event("focus"));
+  const advance = (milliseconds: number) => {
+    const target = now + milliseconds;
+    while (true) {
+      const next = timers
+        .filter((timer) => !timer.cancelled && timer.at <= target)
+        .sort((left, right) => left.at - right.at)[0];
+      if (!next) break;
+      next.cancelled = true;
+      now = next.at;
+      next.callback();
+    }
+    now = target;
+  };
+
+  return {
+    scheduler,
+    windowTarget,
+    documentTarget,
+    runInterval: () => interval?.(),
+    intervalMs: () => intervalMs,
+    intervalCleared: () => intervalCleared,
+    setVisible: (value: boolean) => {
+      visible = value;
+    },
+    advance,
+  };
+}
+
+async function flushRefreshes(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+test("coalesces visible lifecycle triggers within the one-second window", async () => {
+  let refreshes = 0;
+  const harness = schedulerHarness(() => {
+    refreshes += 1;
+  });
+  assert.equal(harness.intervalMs(), 20_000);
+
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  harness.documentTarget.dispatchEvent(new Event("visibilitychange"));
+  await flushRefreshes();
+  assert.equal(refreshes, 1);
+
+  harness.advance(999);
+  await flushRefreshes();
+  assert.equal(refreshes, 1);
+  harness.advance(1);
+  await flushRefreshes();
   assert.equal(refreshes, 2);
-  visible = false;
-  interval?.();
-  documentTarget.dispatchEvent(new Event("visibilitychange"));
+});
+
+test("keeps one trailing refresh without overlapping in-flight work", async () => {
+  let refreshes = 0;
+  let resolveRefresh: (() => void) | undefined;
+  const harness = schedulerHarness(
+    () =>
+      new Promise<void>((resolve) => {
+        refreshes += 1;
+        resolveRefresh = resolve;
+      }),
+  );
+
+  harness.scheduler.requestRefresh();
+  await flushRefreshes();
+  assert.equal(refreshes, 1);
+  harness.scheduler.requestRefresh();
+  harness.runInterval();
+  harness.advance(1_000);
+  assert.equal(refreshes, 1);
+
+  resolveRefresh?.();
+  await flushRefreshes();
   assert.equal(refreshes, 2);
-  stop();
-  visible = true;
-  windowTarget.dispatchEvent(new Event("focus"));
-  assert.equal(refreshes, 2);
+});
+
+test("ignores hidden triggers, recovers from rejection, and cleans up", async () => {
+  let refreshes = 0;
+  const harness = schedulerHarness(() => {
+    refreshes += 1;
+    return Promise.reject(new Error("offline"));
+  });
+
+  harness.setVisible(false);
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  harness.runInterval();
+  await flushRefreshes();
+  assert.equal(refreshes, 0);
+
+  harness.setVisible(true);
+  harness.documentTarget.dispatchEvent(new Event("visibilitychange"));
+  await flushRefreshes();
+  assert.equal(refreshes, 1);
+
+  harness.scheduler.stop();
+  assert.equal(harness.intervalCleared(), true);
+  harness.advance(1_000);
+  harness.windowTarget.dispatchEvent(new Event("focus"));
+  harness.documentTarget.dispatchEvent(new Event("visibilitychange"));
+  await flushRefreshes();
+  assert.equal(refreshes, 1);
 });

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-explorer-refresh-scheduler.ts
@@ -1,29 +1,95 @@
 type RefreshWindow = Pick<
   Window,
-  "addEventListener" | "removeEventListener" | "setInterval" | "clearInterval"
+  | "addEventListener"
+  | "removeEventListener"
+  | "setInterval"
+  | "clearInterval"
+  | "setTimeout"
+  | "clearTimeout"
 >;
 type RefreshDocument = Pick<
   Document,
   "addEventListener" | "removeEventListener" | "visibilityState"
 >;
 
+export type FileExplorerRefreshScheduler = {
+  requestRefresh(): void;
+  stop(): void;
+};
+
 export function startFileExplorerRefreshScheduler(options: {
   refresh: () => void | Promise<void>;
   intervalMs?: number;
+  minimumRefreshIntervalMs?: number;
+  now?: () => number;
   window?: RefreshWindow;
   document?: RefreshDocument;
-}): () => void {
+}): FileExplorerRefreshScheduler {
   const targetWindow = options.window ?? window;
   const targetDocument = options.document ?? document;
-  const refresh = (): void => {
-    if (targetDocument.visibilityState === "visible") void options.refresh();
+  const now = options.now ?? Date.now;
+  const minimumRefreshIntervalMs = options.minimumRefreshIntervalMs ?? 1_000;
+  let lastRefreshStartedAt = Number.NEGATIVE_INFINITY;
+  let refreshInFlight = false;
+  let refreshPending = false;
+  let stopped = false;
+  let pendingTimer: ReturnType<Window["setTimeout"]> | undefined;
+
+  const drain = (): void => {
+    if (stopped || refreshInFlight || !refreshPending) return;
+    if (targetDocument.visibilityState !== "visible") {
+      refreshPending = false;
+      return;
+    }
+
+    const delay = minimumRefreshIntervalMs - (now() - lastRefreshStartedAt);
+    if (delay > 0) {
+      pendingTimer ??= targetWindow.setTimeout(() => {
+        pendingTimer = undefined;
+        drain();
+      }, delay);
+      return;
+    }
+
+    if (pendingTimer !== undefined) {
+      targetWindow.clearTimeout(pendingTimer);
+      pendingTimer = undefined;
+    }
+    refreshPending = false;
+    lastRefreshStartedAt = now();
+    refreshInFlight = true;
+    void Promise.resolve()
+      .then(options.refresh)
+      .catch(() => undefined)
+      .finally(() => {
+        refreshInFlight = false;
+        drain();
+      });
   };
-  const timer = targetWindow.setInterval(refresh, options.intervalMs ?? 20_000);
-  targetWindow.addEventListener("focus", refresh);
-  targetDocument.addEventListener("visibilitychange", refresh);
-  return () => {
-    targetWindow.clearInterval(timer);
-    targetWindow.removeEventListener("focus", refresh);
-    targetDocument.removeEventListener("visibilitychange", refresh);
+
+  const requestRefresh = (): void => {
+    if (stopped || targetDocument.visibilityState !== "visible") return;
+    refreshPending = true;
+    drain();
   };
+
+  const interval = targetWindow.setInterval(
+    requestRefresh,
+    options.intervalMs ?? 20_000,
+  );
+  targetWindow.addEventListener("focus", requestRefresh);
+  targetDocument.addEventListener("visibilitychange", requestRefresh);
+
+  const stop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    refreshPending = false;
+    targetWindow.clearInterval(interval);
+    if (pendingTimer !== undefined) targetWindow.clearTimeout(pendingTimer);
+    pendingTimer = undefined;
+    targetWindow.removeEventListener("focus", requestRefresh);
+    targetDocument.removeEventListener("visibilitychange", requestRefresh);
+  };
+
+  return { requestRefresh, stop };
 }

--- a/packages/workbench-server/src/domains/filesystem/project-filesystem-watcher.ts
+++ b/packages/workbench-server/src/domains/filesystem/project-filesystem-watcher.ts
@@ -1,0 +1,202 @@
+import { watch as watchFs, type FSWatcher, type WatchOptions } from "node:fs";
+import { normalize, sep } from "node:path";
+
+export type ProjectFilesystemChange = {
+  readonly projectId: string;
+  readonly source: "filesystem";
+};
+
+export interface ProjectFilesystemChangePublisher {
+  publishBestEffort(
+    type: "filesystem.project.changed",
+    data: ProjectFilesystemChange,
+    context: string,
+  ): void;
+}
+
+type WatchListener = (
+  eventType: string,
+  filename: string | Buffer | null,
+) => void;
+type WatchFunction = (
+  path: string,
+  options: WatchOptions,
+  listener: WatchListener,
+) => FSWatcher;
+
+type Clock = {
+  setTimeout(
+    callback: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+};
+
+type WatchedProject = {
+  projectId: string;
+  projectDir: string;
+  touchedAt: number;
+  watcher: FSWatcher;
+  quietTimer?: ReturnType<typeof setTimeout>;
+  maxTimer?: ReturnType<typeof setTimeout>;
+};
+
+export type ProjectFilesystemWatcherOptions = {
+  readonly watch?: WatchFunction;
+  readonly clock?: Clock;
+  readonly now?: () => number;
+  readonly quietMs?: number;
+  readonly maxWaitMs?: number;
+  readonly maxProjects?: number;
+  readonly onWarning?: (message: string, error: unknown) => void;
+};
+
+const systemClock: Clock = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+export class ProjectFilesystemWatcher {
+  readonly #entries = new Map<string, WatchedProject>();
+  readonly #watch: WatchFunction;
+  readonly #clock: Clock;
+  readonly #now: () => number;
+  readonly #quietMs: number;
+  readonly #maxWaitMs: number;
+  readonly #maxProjects: number;
+  #closed = false;
+
+  constructor(
+    readonly publisher: ProjectFilesystemChangePublisher,
+    readonly options: ProjectFilesystemWatcherOptions = {},
+  ) {
+    this.#watch = options.watch ?? watchFs;
+    this.#clock = options.clock ?? systemClock;
+    this.#now = options.now ?? Date.now;
+    this.#quietMs = options.quietMs ?? 300;
+    this.#maxWaitMs = options.maxWaitMs ?? 2_000;
+    this.#maxProjects = options.maxProjects ?? 16;
+  }
+
+  watch(projectId: string, projectDir: string): void {
+    if (this.#closed) return;
+    const existing = this.#entries.get(projectId);
+    if (existing?.projectDir === projectDir) {
+      existing.touchedAt = this.#now();
+      return;
+    }
+    if (existing) this.#remove(projectId, existing);
+
+    try {
+      const watcher = this.#watch(
+        projectDir,
+        { recursive: true, persistent: false },
+        (_eventType, filename) => {
+          if (shouldInvalidateProjectPath(filename))
+            this.#invalidate(projectId);
+        },
+      );
+      const entry: WatchedProject = {
+        projectId,
+        projectDir,
+        touchedAt: this.#now(),
+        watcher,
+      };
+      watcher.on("error", (error) => {
+        this.options.onWarning?.("Project filesystem watcher failed", error);
+        if (this.#entries.get(projectId) === entry)
+          this.#remove(projectId, entry);
+      });
+      this.#entries.set(projectId, entry);
+      this.#evictOverflow();
+    } catch (error) {
+      this.options.onWarning?.("Could not watch project filesystem", error);
+    }
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const [projectId, entry] of this.#entries)
+      this.#remove(projectId, entry);
+  }
+
+  #invalidate(projectId: string): void {
+    const entry = this.#entries.get(projectId);
+    if (this.#closed || !entry) return;
+    if (entry.quietTimer) this.#clock.clearTimeout(entry.quietTimer);
+    entry.quietTimer = this.#clock.setTimeout(
+      () => this.#flush(entry),
+      this.#quietMs,
+    );
+    entry.maxTimer ??= this.#clock.setTimeout(
+      () => this.#flush(entry),
+      this.#maxWaitMs,
+    );
+  }
+
+  #flush(entry: WatchedProject): void {
+    if (entry.quietTimer) this.#clock.clearTimeout(entry.quietTimer);
+    if (entry.maxTimer) this.#clock.clearTimeout(entry.maxTimer);
+    entry.quietTimer = undefined;
+    entry.maxTimer = undefined;
+    if (this.#closed || this.#entries.get(entry.projectId) !== entry) return;
+    try {
+      this.publisher.publishBestEffort(
+        "filesystem.project.changed",
+        { projectId: entry.projectId, source: "filesystem" },
+        "project filesystem watcher",
+      );
+    } catch (error) {
+      this.options.onWarning?.(
+        "Could not publish project filesystem change",
+        error,
+      );
+    }
+  }
+
+  #evictOverflow(): void {
+    while (this.#entries.size > this.#maxProjects) {
+      const oldest = [...this.#entries.entries()].sort(
+        ([, left], [, right]) => left.touchedAt - right.touchedAt,
+      )[0];
+      if (!oldest) return;
+      this.#remove(oldest[0], oldest[1]);
+    }
+  }
+
+  #remove(projectId: string, entry: WatchedProject): void {
+    if (entry.quietTimer) this.#clock.clearTimeout(entry.quietTimer);
+    if (entry.maxTimer) this.#clock.clearTimeout(entry.maxTimer);
+    entry.watcher.close();
+    this.#entries.delete(projectId);
+  }
+}
+
+function pathText(filename: string | Buffer | null): string | undefined {
+  if (filename === null) return undefined;
+  return normalize(filename.toString()).split(sep).join("/");
+}
+
+export function shouldInvalidateProjectPath(
+  filename: string | Buffer | null,
+): boolean {
+  const path = pathText(filename);
+  if (path === undefined || path === ".git") return true;
+  if (!path.startsWith(".git/")) return true;
+  const gitPath = path.slice(5);
+  if (gitPath.endsWith(".lock")) return false;
+  return (
+    gitPath === "HEAD" ||
+    gitPath === "index" ||
+    gitPath === "packed-refs" ||
+    gitPath === "config" ||
+    gitPath === "MERGE_HEAD" ||
+    gitPath === "CHERRY_PICK_HEAD" ||
+    gitPath === "REVERT_HEAD" ||
+    gitPath.startsWith("refs/") ||
+    gitPath.startsWith("rebase-") ||
+    gitPath.startsWith("sequencer/") ||
+    gitPath.startsWith("BISECT_")
+  );
+}

--- a/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/platform-method-handlers.ts
@@ -121,11 +121,13 @@ export const platformMethodHandlers: WorkbenchMethodHandlerMap =
     }),
     "filesystem.directories.list": (_state, params) =>
       directoryListing(params?.path, params?.showHidden as boolean | undefined),
-    "filesystem.project.entries.list": (state, params) =>
-      projectDirectoryEntries(
+    "filesystem.project.entries.list": (state, params) => {
+      state.registry.watchProjectFilesystem(params.projectId);
+      return projectDirectoryEntries(
         params,
         (projectId) => state.registry.getProject(projectId).dir,
-      ),
+      );
+    },
     "filesystem.project.entries.create": (state, params) =>
       createProjectEntry(
         params,

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -23,6 +23,7 @@ import type { AuthManager } from "../domains/auth/index.js";
 import { WorkbenchExploreAdmission } from "../domains/agents/run/workbench-explore-admission.js";
 import { WorkbenchSubagentExecutions } from "../domains/agents/run/workbench-subagent-executions.js";
 import { FileCompletionService } from "../domains/completions/index.js";
+import { ProjectFilesystemWatcher } from "../domains/filesystem/project-filesystem-watcher.js";
 import { ConversationService } from "../domains/conversations/conversation-service.js";
 import { ConversationHarnessStorage } from "../domains/conversations/conversation-harness-storage.js";
 import {
@@ -106,6 +107,7 @@ export interface RuntimeServices {
   tools: ToolService;
   git: GitService;
   gitRepositoryWatcher: GitRepositoryWatcher;
+  projectFilesystemWatcher: ProjectFilesystemWatcher;
   fileCompletions: FileCompletionService;
   promptSuggestions: PromptSuggestionService;
   taskDefinitions: TaskDefinitionService;
@@ -337,6 +339,12 @@ export function composeRuntime(
   );
   services.projectIcons = new ProjectIconService(getProject);
   services.fileCompletions = new FileCompletionService(getProject);
+  const filesystemLogger = logger.child({ component: "filesystem" });
+  services.projectFilesystemWatcher = new ProjectFilesystemWatcher(events, {
+    onWarning: (message, error) => {
+      void filesystemLogger.warn(message, { error });
+    },
+  });
   services.conversationLifecycle = new ConversationLifecycleService(
     storage,
     events,

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -187,6 +187,7 @@ export class RuntimeRegistry {
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
     this.services.gitRepositoryWatcher.close();
+    this.services.projectFilesystemWatcher.close();
     await this.services.tasks.shutdown();
     this.services.taskNotifications.stop();
     await Promise.allSettled([...this.backgroundOperations]);
@@ -364,6 +365,11 @@ export class RuntimeRegistry {
 
   getProject(projectId: string): ProjectRecord {
     return this.services.projectLifecycle.getProject(projectId);
+  }
+
+  watchProjectFilesystem(projectId: string): void {
+    const project = this.getProject(projectId);
+    this.services.projectFilesystemWatcher.watch(project.id, project.dir);
   }
 
   async createConversation(

--- a/packages/workbench-server/test/project-filesystem-watcher.test.ts
+++ b/packages/workbench-server/test/project-filesystem-watcher.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import type { FSWatcher } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  ProjectFilesystemWatcher,
+  shouldInvalidateProjectPath,
+} from "../src/domains/filesystem/project-filesystem-watcher.js";
+
+type Timer = { at: number; callback: () => void; cancelled: boolean };
+
+class FakeClock {
+  nowMs = 0;
+  timers: Timer[] = [];
+
+  setTimeout(
+    callback: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout> {
+    const timer = { at: this.nowMs + delayMs, callback, cancelled: false };
+    this.timers.push(timer);
+    return timer as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void {
+    (timer as unknown as Timer).cancelled = true;
+  }
+
+  advanceTo(nowMs: number): void {
+    while (true) {
+      const next = this.timers
+        .filter((timer) => !timer.cancelled && timer.at <= nowMs)
+        .sort((left, right) => left.at - right.at)[0];
+      if (!next) break;
+      next.cancelled = true;
+      this.nowMs = next.at;
+      next.callback();
+    }
+    this.nowMs = nowMs;
+  }
+}
+
+class FakeWatcher extends EventEmitter {
+  closed = false;
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function setup(
+  options: { maxProjects?: number; publisherThrows?: boolean } = {},
+) {
+  const clock = new FakeClock();
+  const watches: Array<{
+    path: string;
+    watcher: FakeWatcher;
+    listener: (event: string, filename: string | Buffer | null) => void;
+  }> = [];
+  const publications: unknown[] = [];
+  const warnings: string[] = [];
+  const watcher = new ProjectFilesystemWatcher(
+    {
+      publishBestEffort: (_type, data) => {
+        if (options.publisherThrows) throw new Error("publish failed");
+        publications.push(data);
+      },
+    },
+    {
+      clock,
+      now: () => clock.nowMs,
+      quietMs: 300,
+      maxWaitMs: 2_000,
+      maxProjects: options.maxProjects,
+      watch: (path, _options, listener) => {
+        const target = new FakeWatcher();
+        watches.push({ path, watcher: target, listener });
+        return target as unknown as FSWatcher;
+      },
+      onWarning: (message) => warnings.push(message),
+    },
+  );
+  return { clock, publications, warnings, watcher, watches };
+}
+
+describe("ProjectFilesystemWatcher", () => {
+  it("debounces bursts and filters noisy Git internals", () => {
+    const { clock, publications, watcher, watches } = setup();
+    watcher.watch("proj_one", "/repo");
+    const emit = watches[0]?.listener;
+    assert.ok(emit);
+
+    emit("change", ".git/objects/aa/object");
+    emit("change", ".git/index.lock");
+    clock.advanceTo(1_000);
+    assert.equal(publications.length, 0);
+
+    emit("change", "src/a.ts");
+    clock.advanceTo(1_200);
+    emit("change", "src/b.ts");
+    clock.advanceTo(1_499);
+    assert.equal(publications.length, 0);
+    clock.advanceTo(1_500);
+    assert.deepEqual(publications, [
+      { projectId: "proj_one", source: "filesystem" },
+    ]);
+
+    assert.equal(shouldInvalidateProjectPath(".git/index"), true);
+    assert.equal(shouldInvalidateProjectPath(".git/refs/heads/main"), true);
+    assert.equal(shouldInvalidateProjectPath(null), true);
+  });
+
+  it("flushes continuous changes at the maximum wait", () => {
+    const { clock, publications, watcher, watches } = setup();
+    watcher.watch("proj_one", "/repo");
+    const emit = watches[0]?.listener;
+    assert.ok(emit);
+
+    emit("change", "a.ts");
+    for (let at = 250; at < 2_000; at += 250) {
+      clock.advanceTo(at);
+      emit("change", "a.ts");
+    }
+    clock.advanceTo(2_000);
+    assert.equal(publications.length, 1);
+  });
+
+  it("deduplicates, replaces, and evicts watched projects", () => {
+    const { watcher, watches } = setup({ maxProjects: 1 });
+    watcher.watch("proj_one", "/one");
+    watcher.watch("proj_one", "/one");
+    assert.equal(watches.length, 1);
+
+    watcher.watch("proj_one", "/replacement");
+    assert.equal(watches[0]?.watcher.closed, true);
+    watcher.watch("proj_two", "/two");
+    assert.equal(watches[1]?.watcher.closed, true);
+    watcher.close();
+    assert.equal(watches[2]?.watcher.closed, true);
+  });
+
+  it("contains errors and cancels pending changes on close", () => {
+    const { clock, warnings, watcher, watches } = setup({
+      publisherThrows: true,
+    });
+    watcher.watch("proj_one", "/repo");
+    watches[0]?.listener("change", "a.ts");
+    clock.advanceTo(300);
+    assert.deepEqual(warnings, ["Could not publish project filesystem change"]);
+
+    watches[0]?.listener("change", "b.ts");
+    watcher.close();
+    clock.advanceTo(3_000);
+    assert.equal(warnings.length, 1);
+    assert.equal(watches[0]?.watcher.closed, true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a project-scoped filesystem change event and demand-activated native watcher for Git and non-Git projects
- refresh the visible Files panel from filesystem events with a 1-second throttle and no overlapping requests
- retain focus/visibility refreshes and the 20-second poll as recovery paths
- cover contracts, watcher lifecycle, event filtering, throttling, and cleanup with tests

## Validation
- `pnpm fix && pnpm check && pnpm test`
