### PR TITLE
Allow selecting tool call transcript text

### DIFF
--- a/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptRow.svelte
@@ -152,7 +152,7 @@ $effect(() => {
             }}
         menu={transcriptMenu}
         disabled={!node.toolCall}
-        triggerClass="block min-w-0"
+        triggerClass="block min-w-0 select-text"
       >
         <ToolCallCard
           draft={node.draft}


### PR DESCRIPTION
## Summary
- make tool-call transcript rows opt into text selection
- preserve existing context-menu and interactive control behavior

## Validation
- `pnpm fix && pnpm check && pnpm test`