### PR TITLE
Fix interactive Mermaid diagrams in transcripts

### DIFF
--- a/packages/ui-kit/src/lib/core/components/Markdown.svelte
+++ b/packages/ui-kit/src/lib/core/components/Markdown.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { tick, untrack } from "svelte";
+import { mount, tick, unmount, untrack } from "svelte";
 import { writeClipboardText } from "@nervekit/ui-kit/core/clipboard";
 import {
   decorateMarkdownHtml,
@@ -19,10 +19,7 @@ import {
   resolveDisplayPath,
   splitPathLineSuffix,
 } from "@nervekit/ui-kit/core/utils/path-links";
-import {
-  enhanceMermaidBlocks,
-  type MermaidEnhancement,
-} from "./mermaid-render.js";
+import MermaidDiagram from "./MermaidDiagram.svelte";
 
 type Props = {
   text: string;
@@ -137,17 +134,44 @@ function copyButtonHandler(node: HTMLDivElement) {
   };
 }
 
-type MermaidActionValue = { html: string; enabled: boolean };
+type MermaidEnhancement = { destroy: () => void };
 
-function mermaidHandler(node: HTMLDivElement, value: MermaidActionValue) {
+function enhanceMermaidBlocks(root: HTMLElement): MermaidEnhancement {
+  const components: Record<string, unknown>[] = [];
+  for (const host of root.querySelectorAll<HTMLElement>(
+    "[data-mermaid-diagram]",
+  )) {
+    const source = host.querySelector("pre > code")?.textContent ?? "";
+    if (!source.trim()) continue;
+    const ariaLabel = host.getAttribute("aria-label") ?? "Mermaid diagram";
+    host.replaceChildren();
+    components.push(
+      mount(MermaidDiagram, {
+        target: host,
+        props: {
+          source,
+          ariaLabel,
+          class: "h-full w-full",
+        },
+      }),
+    );
+  }
+  return {
+    destroy() {
+      for (const component of components) void unmount(component);
+    },
+  };
+}
+
+function mermaidHandler(node: HTMLDivElement, value: string) {
   let generation = 0;
   let enhancement: MermaidEnhancement | undefined;
 
-  async function update(next: MermaidActionValue) {
+  async function update(nextHtml: string) {
     const current = ++generation;
     enhancement?.destroy();
     enhancement = undefined;
-    if (!next.enabled || !next.html.includes("data-mermaid-diagram")) return;
+    if (!nextHtml.includes("data-mermaid-diagram")) return;
     await tick();
     if (current !== generation) return;
     enhancement = enhanceMermaidBlocks(node);
@@ -260,7 +284,7 @@ $effect(() => () => streamingScheduler.destroy());
   <div
     class="markdown"
     use:copyButtonHandler
-    use:mermaidHandler={{ html: streamingPrefixHtml, enabled: false }}
+    use:mermaidHandler={streamingPrefixHtml}
   >
     <!-- eslint-disable-next-line svelte/no-at-html-tags -- the prefix uses the sanitized Markdown pipeline. -->
     {@html streamingPrefixHtml}
@@ -269,11 +293,7 @@ $effect(() => () => streamingScheduler.destroy());
     {/if}
   </div>
 {:else}
-  <div
-    class="markdown"
-    use:copyButtonHandler
-    use:mermaidHandler={{ html, enabled: true }}
-  >
+  <div class="markdown" use:copyButtonHandler use:mermaidHandler={html}>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -- renderMarkdown applies rehype-sanitize before producing markup. -->
     {@html html}
   </div>
@@ -449,31 +469,11 @@ $effect(() => () => streamingScheduler.destroy());
 }
 
 .markdown :global(.mermaid-block) {
-  display: grid;
-  place-items: center;
   min-width: 0;
-  overflow: auto;
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--card);
-  padding: 1rem;
-}
-
-.markdown :global(.mermaid-block[data-state="loading"] pre) {
-  opacity: 0.7;
-}
-
-.markdown :global(.mermaid-block svg) {
-  display: block;
-  max-width: 100%;
-  height: auto;
-}
-
-.markdown :global(.mermaid-block .mermaid-error) {
-  justify-self: stretch;
-  margin: 0.5rem 0 0;
-  color: var(--destructive);
-  font-size: var(--text-xs);
 }
 
 .markdown :global(pre) {

--- a/packages/ui-kit/src/lib/core/components/markdown-render.ts
+++ b/packages/ui-kit/src/lib/core/components/markdown-render.ts
@@ -117,7 +117,7 @@ function wrapCodeBlock(pre: Element): Element {
 
 function wrapMermaidBlock(pre: Element): Element {
   const shell = document.createElement("div");
-  shell.className = "mermaid-block";
+  shell.className = "mermaid-block h-80 min-h-64 max-h-96";
   shell.dataset.mermaidDiagram = "";
   shell.setAttribute("aria-label", "Mermaid diagram");
   shell.append(pre.cloneNode(true));

--- a/packages/ui-kit/src/lib/core/components/mermaid-render.test.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-render.test.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
-import { mermaidThemeVariables, type MermaidTheme } from "./mermaid-render";
+import {
+  mermaidThemeVariables,
+  rewriteMermaidSvgIdReferences,
+  type MermaidTheme,
+} from "./mermaid-render";
 
 const theme: MermaidTheme = {
   fingerprint: "dark-theme",
@@ -15,6 +19,23 @@ const theme: MermaidTheme = {
   strongBorder: "#777777",
   mutedForeground: "#aaaaaa",
 };
+
+describe("Mermaid SVG ID references", () => {
+  it("scopes fragment references without confusing ID prefixes", () => {
+    const ids = new Map([
+      ["arrow", "mount-1-arrow"],
+      ["arrowhead", "mount-1-arrowhead"],
+    ]);
+
+    assert.equal(
+      rewriteMermaidSvgIdReferences(
+        "marker-end: url(#arrowhead); fill: url(#arrow); href: #arrow",
+        ids,
+      ),
+      "marker-end: url(#mount-1-arrowhead); fill: url(#mount-1-arrow); href: #mount-1-arrow",
+    );
+  });
+});
 
 describe("Mermaid theme variables", () => {
   it("uses themed surfaces for alternating ER attribute rows", () => {

--- a/packages/ui-kit/src/lib/core/components/mermaid-render.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-render.ts
@@ -1,3 +1,5 @@
+import { LruCache } from "@nervekit/ui-kit/core/utils/lru-cache";
+
 export type MermaidTheme = {
   fingerprint: string;
   dark: boolean;
@@ -16,7 +18,11 @@ export type MermaidRenderResult =
   | { ok: true; svg: string; themeFingerprint: string }
   | { ok: false; themeFingerprint: string };
 
+const MERMAID_RENDER_CACHE_MAX = 100;
+const renderCache = new LruCache<string, string>(MERMAID_RENDER_CACHE_MAX);
+const renderInflight = new Map<string, Promise<string | undefined>>();
 let renderSequence = 0;
+let mountSequence = 0;
 let renderQueue = Promise.resolve();
 
 function cssColor(
@@ -181,27 +187,125 @@ async function renderWithTheme(
   return sanitizeSvg(svg);
 }
 
-export function renderMermaid(
+function renderCacheKey(source: string, theme: MermaidTheme): string {
+  return `${theme.fingerprint}\0${source}`;
+}
+
+function renderCachedMermaid(
   source: string,
-  element: Element,
-): Promise<MermaidRenderResult> {
-  const theme = readMermaidTheme(element);
-  const run = async (): Promise<MermaidRenderResult> => {
-    try {
-      const svg = await renderWithTheme(source, theme);
-      return svg
-        ? { ok: true, svg, themeFingerprint: theme.fingerprint }
-        : { ok: false, themeFingerprint: theme.fingerprint };
-    } catch {
-      return { ok: false, themeFingerprint: theme.fingerprint };
-    }
-  };
+  theme: MermaidTheme,
+): Promise<string | undefined> {
+  const key = renderCacheKey(source, theme);
+  const cached = renderCache.get(key);
+  if (cached !== undefined) return Promise.resolve(cached);
+  const pending = renderInflight.get(key);
+  if (pending) return pending;
+
+  const run = () => renderWithTheme(source, theme);
   const result = renderQueue.then(run, run);
   renderQueue = result.then(
     () => undefined,
     () => undefined,
   );
+  renderInflight.set(key, result);
+  void result.then(
+    (svg) => {
+      if (svg) renderCache.set(key, svg);
+      if (renderInflight.get(key) === result) renderInflight.delete(key);
+    },
+    () => {
+      if (renderInflight.get(key) === result) renderInflight.delete(key);
+    },
+  );
   return result;
+}
+
+export async function renderMermaid(
+  source: string,
+  element: Element,
+): Promise<MermaidRenderResult> {
+  const theme = readMermaidTheme(element);
+  try {
+    const svg = await renderCachedMermaid(source, theme);
+    return svg
+      ? { ok: true, svg, themeFingerprint: theme.fingerprint }
+      : { ok: false, themeFingerprint: theme.fingerprint };
+  } catch {
+    return { ok: false, themeFingerprint: theme.fingerprint };
+  }
+}
+
+export function rewriteMermaidSvgIdReferences(
+  value: string,
+  ids: ReadonlyMap<string, string>,
+): string {
+  let rewritten = value;
+  const entries = Array.from(ids).sort(
+    ([first], [second]) => second.length - first.length,
+  );
+  for (const [original, scoped] of entries) {
+    rewritten = rewritten.replaceAll(`#${original}`, `#${scoped}`);
+  }
+  return rewritten;
+}
+
+function rewriteIdList(
+  value: string,
+  ids: ReadonlyMap<string, string>,
+): string {
+  return value
+    .split(/(\s+)/u)
+    .map((part) => ids.get(part) ?? part)
+    .join("");
+}
+
+function rewriteTimingReferences(
+  value: string,
+  ids: ReadonlyMap<string, string>,
+): string {
+  return value
+    .split(";")
+    .map((part) => {
+      const match = part.match(/^(\s*)([^.]+)(\..*)$/u);
+      if (!match) return part;
+      const scoped = ids.get(match[2]!);
+      return scoped ? `${match[1]}${scoped}${match[3]}` : part;
+    })
+    .join(";");
+}
+
+function scopeMermaidSvgIds(svg: SVGSVGElement): void {
+  const prefix = `nerve-mermaid-mount-${++mountSequence}`;
+  const elements = [svg, ...Array.from(svg.querySelectorAll("*"))];
+  const ids = new Map<string, string>();
+  for (const element of elements) {
+    if (element.id) ids.set(element.id, `${prefix}-${element.id}`);
+  }
+  if (ids.size === 0) return;
+
+  for (const element of elements) {
+    const originalId = element.id;
+    if (originalId) element.id = ids.get(originalId) ?? originalId;
+    for (const attribute of Array.from(element.attributes)) {
+      if (attribute.name === "id") continue;
+      let value = rewriteMermaidSvgIdReferences(attribute.value, ids);
+      if (
+        attribute.name === "aria-labelledby" ||
+        attribute.name === "aria-describedby"
+      ) {
+        value = rewriteIdList(value, ids);
+      } else if (attribute.name === "begin" || attribute.name === "end") {
+        value = rewriteTimingReferences(value, ids);
+      }
+      if (value !== attribute.value)
+        element.setAttribute(attribute.name, value);
+    }
+  }
+  for (const style of svg.querySelectorAll("style")) {
+    if (style.textContent) {
+      style.textContent = rewriteMermaidSvgIdReferences(style.textContent, ids);
+    }
+  }
 }
 
 export function mountMermaidSvg(host: HTMLElement, svg: string): boolean {
@@ -211,7 +315,9 @@ export function mountMermaidSvg(host: HTMLElement, svg: string): boolean {
     parsed.documentElement.tagName !== "svg"
   )
     return false;
-  const mounted = host.ownerDocument.importNode(parsed.documentElement, true);
+  const parsedSvg = parsed.documentElement as unknown as SVGSVGElement;
+  scopeMermaidSvgIds(parsedSvg);
+  const mounted = host.ownerDocument.importNode(parsedSvg, true);
   mounted.setAttribute("role", "img");
   mounted.setAttribute(
     "aria-label",
@@ -219,59 +325,4 @@ export function mountMermaidSvg(host: HTMLElement, svg: string): boolean {
   );
   host.replaceChildren(mounted);
   return true;
-}
-
-export type MermaidEnhancement = { destroy: () => void };
-
-export function enhanceMermaidBlocks(root: HTMLElement): MermaidEnhancement {
-  let generation = 0;
-  const records = Array.from(
-    root.querySelectorAll<HTMLElement>("[data-mermaid-diagram]"),
-  ).map((host) => {
-    const code = host.querySelector("pre > code");
-    return {
-      host,
-      source: code?.textContent ?? "",
-      fallback: host.cloneNode(true) as HTMLElement,
-    };
-  });
-
-  const renderAll = () => {
-    const current = ++generation;
-    for (const record of records) {
-      if (!record.source || !record.host.isConnected) continue;
-      record.host.dataset.state = "loading";
-      void renderMermaid(record.source, record.host).then((result) => {
-        if (
-          current !== generation ||
-          !record.host.isConnected ||
-          !root.contains(record.host)
-        )
-          return;
-        if (result.ok && mountMermaidSvg(record.host, result.svg)) {
-          record.host.dataset.state = "rendered";
-          return;
-        }
-        const fallback = record.fallback.cloneNode(true) as HTMLElement;
-        const status = document.createElement("p");
-        status.className = "mermaid-error";
-        status.textContent = "Diagram could not be rendered";
-        record.host.replaceChildren(...Array.from(fallback.childNodes), status);
-        record.host.dataset.state = "error";
-      });
-    }
-  };
-
-  renderAll();
-  const observer = new MutationObserver(renderAll);
-  observer.observe(root.ownerDocument.documentElement, {
-    attributes: true,
-    attributeFilter: ["class", "data-theme"],
-  });
-  return {
-    destroy() {
-      generation += 1;
-      observer.disconnect();
-    },
-  };
 }

--- a/packages/ui-kit/src/lib/core/components/streaming-markdown.test.ts
+++ b/packages/ui-kit/src/lib/core/components/streaming-markdown.test.ts
@@ -30,6 +30,14 @@ describe("splitStreamingMarkdown", () => {
       tail: "Next",
     });
   });
+
+  it("moves a completed Mermaid fence into the renderable prefix", () => {
+    const diagram = "```mermaid\nflowchart TD\n  A --> B\n```\n\n";
+    assert.deepEqual(splitStreamingMarkdown(`${diagram}Still streaming`), {
+      prefix: diagram,
+      tail: "Still streaming",
+    });
+  });
 });
 
 describe("appendedNewline", () => {


### PR DESCRIPTION
## Summary
- render completed Mermaid fences while assistant messages are still streaming
- reuse the interactive Mermaid viewport for transcript and Markdown embeds with zoom, pan, fit, and bounded dimensions
- reserve diagram layout to prevent transcript jumps and cache successful source/theme renders with mount-safe SVG IDs

## Validation
- pnpm fix && pnpm check && pnpm test
- smoke-tested transcript, Markdown file, and standalone Mermaid previews with Agent Browser