### PR TITLE
Harden daemon resilience for heavy command output

### DIFF
--- a/packages/contracts/src/domains/tasks/task.schema.ts
+++ b/packages/contracts/src/domains/tasks/task.schema.ts
@@ -132,6 +132,20 @@ export const taskNotificationStateSchema = z.object({
 });
 export type TaskNotificationState = z.infer<typeof taskNotificationStateSchema>;
 
+export const taskOutputRetentionSchema = z.object({
+  totalBytes: z.number().int().nonnegative(),
+  retainedBytes: z.number().int().nonnegative(),
+  omittedBytes: z.number().int().nonnegative(),
+  totalLines: z.number().int().nonnegative(),
+  retainedLines: z.number().int().nonnegative(),
+  omittedLines: z.number().int().nonnegative(),
+  headMaxBytes: z.number().int().positive(),
+  tailMaxBytes: z.number().int().positive(),
+  truncated: z.boolean(),
+  tailPath: z.string().min(1).optional(),
+});
+export type TaskOutputRetention = z.infer<typeof taskOutputRetentionSchema>;
+
 export const taskRecordSchema = z.object({
   id: z.string().startsWith("task_"),
   definitionId: z.string().startsWith("taskdef_").optional(),
@@ -167,6 +181,7 @@ export const taskRecordSchema = z.object({
   origin: taskOriginSchema.default({ kind: "api" }),
   completion: taskCompletionInjectionSchema.optional(),
   notifications: taskNotificationStateSchema.optional(),
+  outputRetention: taskOutputRetentionSchema.optional(),
   visibility: taskVisibilitySchema.default("background"),
 });
 export type TaskRecord = z.infer<typeof taskRecordSchema>;
@@ -238,5 +253,6 @@ export const taskLogQueryResponseSchema = z.object({
   mode: z.string(),
   previewPath: z.string().min(1).optional(),
   truncated: z.boolean().optional(),
+  outputRetention: taskOutputRetentionSchema.optional(),
 });
 export type TaskLogQueryResponse = z.infer<typeof taskLogQueryResponseSchema>;

--- a/packages/contracts/src/domains/tools/tool.operations.schema.ts
+++ b/packages/contracts/src/domains/tools/tool.operations.schema.ts
@@ -21,6 +21,12 @@ const toolCallListParamsSchema = z
     projectId: z.string().startsWith("proj_").optional(),
     runId: z.string().startsWith("run_").optional(),
     limit: z.number().int().positive().max(1_000).optional(),
+    cursor: z
+      .object({
+        updatedAt: z.string().datetime(),
+        id: toolCallIdSchema,
+      })
+      .optional(),
   })
   .optional();
 const toolCallGetParamsSchema = z.object({
@@ -92,7 +98,15 @@ export const toolsOperationDefinitions = [
   defineOperation(
     "toolCall.list",
     toolCallListParamsSchema,
-    z.object({ toolCalls: z.array(toolCallTranscriptRecordSchema) }),
+    z.object({
+      toolCalls: z.array(toolCallTranscriptRecordSchema),
+      nextCursor: z
+        .object({
+          updatedAt: z.string().datetime(),
+          id: toolCallIdSchema,
+        })
+        .optional(),
+    }),
     "read",
     "none",
     ["workbench_server"] as const,

--- a/packages/tools/src/execution/common/bounded-process-output.ts
+++ b/packages/tools/src/execution/common/bounded-process-output.ts
@@ -1,0 +1,131 @@
+export const PROCESS_CAPTURE_HEAD_MAX_BYTES = 32 * 1024 * 1024;
+export const PROCESS_CAPTURE_TAIL_MAX_BYTES = 512 * 1024;
+
+export type ProcessOutputChunk = {
+  stream: "stdout" | "stderr";
+  data: Buffer;
+};
+
+export type BoundedProcessOutputSnapshot = {
+  stdoutChunks: Buffer[];
+  stderrChunks: Buffer[];
+  combinedChunks: Buffer[];
+  totalBytes: number;
+  retainedBytes: number;
+  omittedBytes: number;
+  truncated: boolean;
+};
+
+/**
+ * Retains a generous process-output head and a small rolling tail. Memory is
+ * bounded independently of child output volume; callers still own pipe
+ * backpressure and durable task logging.
+ */
+function streamChunks(
+  head: ProcessOutputChunk[],
+  tail: ProcessOutputChunk[],
+  stream: "stdout" | "stderr",
+  marker?: Buffer,
+): Buffer[] {
+  const headChunks = head
+    .filter((chunk) => chunk.stream === stream)
+    .map((chunk) => chunk.data);
+  const tailChunks = tail
+    .filter((chunk) => chunk.stream === stream)
+    .map((chunk) => chunk.data);
+  return [
+    ...headChunks,
+    ...(marker && headChunks.length > 0 && tailChunks.length > 0
+      ? [marker]
+      : []),
+    ...tailChunks,
+  ];
+}
+
+export class BoundedProcessOutput {
+  readonly #head: ProcessOutputChunk[] = [];
+  readonly #tail: ProcessOutputChunk[] = [];
+  #headBytes = 0;
+  #tailBytes = 0;
+  #totalBytes = 0;
+
+  constructor(
+    private readonly headMaxBytes = PROCESS_CAPTURE_HEAD_MAX_BYTES,
+    private readonly tailMaxBytes = PROCESS_CAPTURE_TAIL_MAX_BYTES,
+  ) {}
+
+  push(stream: "stdout" | "stderr", chunk: Buffer): void {
+    if (chunk.length === 0) return;
+    this.#totalBytes += chunk.length;
+    const available = Math.max(0, this.headMaxBytes - this.#headBytes);
+    const headLength = Math.min(available, chunk.length);
+    if (headLength > 0) {
+      const retained = Buffer.from(chunk.subarray(0, headLength));
+      this.#head.push({ stream, data: retained });
+      this.#headBytes += retained.length;
+    }
+    if (headLength < chunk.length) {
+      this.#pushTail(stream, chunk.subarray(headLength));
+    }
+  }
+
+  snapshot(): BoundedProcessOutputSnapshot {
+    const selected = [...this.#head, ...this.#tail];
+    const retainedBytes = selected.reduce(
+      (total, chunk) => total + chunk.data.length,
+      0,
+    );
+    const omittedBytes = Math.max(0, this.#totalBytes - retainedBytes);
+    const marker = Buffer.from(
+      `\n[${omittedBytes} output bytes omitted by process retention]\n`,
+    );
+    const stdoutChunks = streamChunks(
+      this.#head,
+      this.#tail,
+      "stdout",
+      omittedBytes > 0 ? marker : undefined,
+    );
+    const stderrChunks = streamChunks(
+      this.#head,
+      this.#tail,
+      "stderr",
+      omittedBytes > 0 ? marker : undefined,
+    );
+    const combinedChunks = [
+      ...this.#head.map((chunk) => chunk.data),
+      ...(omittedBytes > 0 ? [marker] : []),
+      ...this.#tail.map((chunk) => chunk.data),
+    ];
+    return {
+      stdoutChunks,
+      stderrChunks,
+      combinedChunks,
+      totalBytes: this.#totalBytes,
+      retainedBytes,
+      omittedBytes,
+      truncated: omittedBytes > 0,
+    };
+  }
+
+  #pushTail(stream: "stdout" | "stderr", chunk: Buffer): void {
+    const retained = Buffer.from(
+      chunk.length > this.tailMaxBytes
+        ? chunk.subarray(chunk.length - this.tailMaxBytes)
+        : chunk,
+    );
+    this.#tail.push({ stream, data: retained });
+    this.#tailBytes += retained.length;
+    while (this.#tailBytes > this.tailMaxBytes && this.#tail.length > 0) {
+      const first = this.#tail[0];
+      if (!first) break;
+      const excess = this.#tailBytes - this.tailMaxBytes;
+      if (first.data.length <= excess) {
+        this.#tail.shift();
+        this.#tailBytes -= first.data.length;
+      } else {
+        first.data = first.data.subarray(excess);
+        this.#tailBytes -= excess;
+      }
+    }
+  }
+}

--- a/packages/tools/src/execution/shell/bash.ts
+++ b/packages/tools/src/execution/shell/bash.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import type { ToolExecutionContext, ToolExecutionResult } from "../../types.js";
 import { numberArg } from "../common/args.js";
 import { resolveCommandCwd } from "../common/command-cwd.js";
+import { BoundedProcessOutput } from "../common/bounded-process-output.js";
 import { LiveOutputDelivery } from "../common/live-output.js";
 import { forceKillProcessTree } from "../common/process-tree.js";
 import { buildProcessResult } from "../common/process-result.js";
@@ -32,9 +33,7 @@ export async function executeBash(
     typeof args.timeout === "number"
       ? Math.max(0, numberArg(args.timeout, 0))
       : undefined;
-  const stdoutChunks: Buffer[] = [];
-  const stderrChunks: Buffer[] = [];
-  const combinedChunks: Buffer[] = [];
+  const output = new BoundedProcessOutput();
   const startedAt = performance.now();
 
   return await new Promise<ToolExecutionResult>((resolve, reject) => {
@@ -120,13 +119,11 @@ export async function executeBash(
     }
 
     child.stdout?.on("data", (chunk: Buffer) => {
-      stdoutChunks.push(chunk);
-      combinedChunks.push(chunk);
+      output.push("stdout", chunk);
       liveOutput.write("stdout", chunk, child.stdout ?? undefined);
     });
     child.stderr?.on("data", (chunk: Buffer) => {
-      stderrChunks.push(chunk);
-      combinedChunks.push(chunk);
+      output.push("stderr", chunk);
       liveOutput.write("stderr", chunk, child.stderr ?? undefined);
     });
     child.on("error", (error) => {
@@ -142,23 +139,15 @@ export async function executeBash(
       void liveOutput
         .end()
         .then(() =>
-          buildResult(
-            stdoutChunks,
-            stderrChunks,
-            combinedChunks,
-            code,
-            signal,
-            context.dataDir,
-            {
-              durationMs: Math.round(performance.now() - startedAt),
-              timedOut,
-              timeoutKilled,
-              timeoutMessage:
-                timeoutSeconds !== undefined
-                  ? `Command timed out after ${timeoutSeconds}s and ${timeoutKilled ? "was killed" : "was not killed"}.`
-                  : undefined,
-            },
-          ),
+          buildResult(output.snapshot(), code, signal, context.dataDir, {
+            durationMs: Math.round(performance.now() - startedAt),
+            timedOut,
+            timeoutKilled,
+            timeoutMessage:
+              timeoutSeconds !== undefined
+                ? `Command timed out after ${timeoutSeconds}s and ${timeoutKilled ? "was killed" : "was not killed"}.`
+                : undefined,
+          }),
         )
         .then(resolve)
         .catch(reject);
@@ -167,9 +156,7 @@ export async function executeBash(
 }
 
 async function buildResult(
-  stdoutChunks: Buffer[],
-  stderrChunks: Buffer[],
-  combinedChunks: Buffer[],
+  output: ReturnType<BoundedProcessOutput["snapshot"]>,
   code: number | null,
   signal: NodeJS.Signals | null,
   dataDir: string | undefined,
@@ -181,9 +168,9 @@ async function buildResult(
   } = {},
 ): Promise<ToolExecutionResult> {
   return buildProcessResult({
-    stdoutChunks,
-    stderrChunks,
-    combinedChunks,
+    stdoutChunks: output.stdoutChunks,
+    stderrChunks: output.stderrChunks,
+    combinedChunks: output.combinedChunks,
     code,
     signal,
     outputFilePrefix: "nerve-bash",
@@ -193,5 +180,18 @@ async function buildResult(
     timedOut: options.timedOut,
     timeoutKilled: options.timeoutKilled,
     timeoutMessage: options.timeoutMessage,
+    details: {
+      outputRetention: {
+        totalBytes: output.totalBytes,
+        retainedBytes: output.retainedBytes,
+        omittedBytes: output.omittedBytes,
+        truncated: output.truncated,
+      },
+    },
+    contentFooterLines: output.truncated
+      ? [
+          `${output.omittedBytes} output bytes were omitted by process retention.`,
+        ]
+      : [],
   });
 }

--- a/packages/tools/test/bounded-process-output.test.ts
+++ b/packages/tools/test/bounded-process-output.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { BoundedProcessOutput } from "../src/execution/common/bounded-process-output.js";
+
+describe("BoundedProcessOutput", () => {
+  it("retains a bounded head and rolling tail with exact omission counts", () => {
+    const output = new BoundedProcessOutput(8, 4);
+    output.push("stdout", Buffer.from("abcdefgh"));
+    output.push("stderr", Buffer.from("ijkl"));
+    output.push("stdout", Buffer.from("mnop"));
+
+    const snapshot = output.snapshot();
+
+    assert.equal(snapshot.totalBytes, 16);
+    assert.equal(snapshot.retainedBytes, 12);
+    assert.equal(snapshot.omittedBytes, 4);
+    assert.equal(snapshot.truncated, true);
+    const combined = Buffer.concat(snapshot.combinedChunks).toString();
+    assert.match(combined, /^abcdefgh/);
+    assert.match(combined, /4 output bytes omitted/);
+    assert.match(combined, /mnop$/);
+    assert.match(
+      Buffer.concat(snapshot.stdoutChunks).toString(),
+      /4 output bytes omitted/,
+    );
+    assert.equal(Buffer.concat(snapshot.stderrChunks).toString(), "");
+  });
+
+  it("does not duplicate a tail while output remains inside the head", () => {
+    const output = new BoundedProcessOutput(16, 4);
+    output.push("stdout", Buffer.from("small"));
+
+    const snapshot = output.snapshot();
+
+    assert.equal(Buffer.concat(snapshot.combinedChunks).toString(), "small");
+    assert.equal(snapshot.truncated, false);
+    assert.equal(snapshot.omittedBytes, 0);
+  });
+});

--- a/packages/workbench-server/src/domains/agents/subagent-transcript.service.ts
+++ b/packages/workbench-server/src/domains/agents/subagent-transcript.service.ts
@@ -22,7 +22,6 @@ import {
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { ConversationHarnessStorage } from "../conversations/conversation-harness-storage.js";
 import type { ToolService } from "../tools/tool-service.js";
-import { toToolCallTranscriptRecord } from "../tools/tool-call-transcript-preview.js";
 import { projectHarnessMessageEntry } from "./run/message-mirror.js";
 import type { SubagentTranscriptLiveService } from "./subagent-transcript-live.service.js";
 
@@ -221,16 +220,15 @@ export class SubagentTranscriptService {
         }
 
         const allToolCalls = this.deps.tools
-          .listToolCalls()
-          .filter((toolCall) => toolCall.agentId === child.id)
+          .listToolCallPreviews({ agentId: child.id, limit: 1_000 })
           .sort((a, b) =>
             a.createdAt === b.createdAt
               ? a.id.localeCompare(b.id)
               : a.createdAt.localeCompare(b.createdAt),
           );
-        const toolCalls = allToolCalls
-          .slice(-SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS)
-          .map(toToolCallTranscriptRecord);
+        const toolCalls = allToolCalls.slice(
+          -SUBAGENT_TRANSCRIPT_MAX_TOOL_CALLS,
+        );
         const entries = boundedTail(projected);
         const updatedAt = [
           child.updatedAt,

--- a/packages/workbench-server/src/domains/conversations/conversation-query.service.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-query.service.ts
@@ -5,12 +5,10 @@ import {
   ConversationEntry,
   ConversationSnapshot,
   ConversationTree,
-  ToolCallRecord,
   ToolCallTranscriptRecord,
 } from "@nervekit/contracts";
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { RuntimeState } from "../../runtime/runtime-state.js";
-import { toToolCallTranscriptRecord } from "../tools/tool-call-transcript-preview.js";
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object"
@@ -47,7 +45,7 @@ export interface ConversationQueryServiceDeps {
   getConversationEntries: (conversationId: string) => ConversationEntry[];
   getConversationTree: (conversationId: string) => ConversationTree;
   getContextUsage: (conversationId: string) => Promise<ContextUsage>;
-  listToolCalls: () => ToolCallRecord[];
+  listToolCallPreviews: (conversationId: string) => ToolCallTranscriptRecord[];
   getActiveRun: (
     conversationId: string,
   ) => Promise<ConversationActiveRunSnapshot | undefined>;
@@ -94,23 +92,20 @@ export class ConversationQueryService {
       entries.flatMap((entry) => (entry.runId ? [entry.runId] : [])),
     );
     const toolIds = toolRecordIdsFromEntries(entries);
-    return this.deps
-      .listToolCalls()
-      .filter((toolCall) => {
-        if (toolCall.conversationId !== conversationId) return false;
-        if (toolCall.hidden) return false;
-        if (activeRunId && toolCall.runId === activeRunId) return true;
-        if (toolCall.runId && runIds.has(toolCall.runId)) return true;
-        if (toolIds.has(toolCall.id)) return true;
-        if (toolCall.sourceToolCallId && toolIds.has(toolCall.sourceToolCallId))
-          return true;
-        if (
-          toolCall.providerToolCallId &&
-          toolIds.has(toolCall.providerToolCallId)
-        )
-          return true;
-        return false;
-      })
-      .map(toToolCallTranscriptRecord);
+    return this.deps.listToolCallPreviews(conversationId).filter((toolCall) => {
+      if (toolCall.conversationId !== conversationId) return false;
+      if (toolCall.hidden) return false;
+      if (activeRunId && toolCall.runId === activeRunId) return true;
+      if (toolCall.runId && runIds.has(toolCall.runId)) return true;
+      if (toolIds.has(toolCall.id)) return true;
+      if (toolCall.sourceToolCallId && toolIds.has(toolCall.sourceToolCallId))
+        return true;
+      if (
+        toolCall.providerToolCallId &&
+        toolIds.has(toolCall.providerToolCallId)
+      )
+        return true;
+      return false;
+    });
   }
 }

--- a/packages/workbench-server/src/domains/plans/plan-service.ts
+++ b/packages/workbench-server/src/domains/plans/plan-service.ts
@@ -53,41 +53,47 @@ export class PlanService {
     // Canonical review state is hydrated from tool-call interactions.
   }
 
-  hydrateFromToolCalls(toolCalls: readonly ToolCallRecord[]): void {
+  resetToolCallHydration(): void {
     this.planReviews.clear();
-    for (const toolCall of toolCalls) {
-      for (const interaction of toolCall.interactions) {
-        if (interaction.kind !== "plan_review") continue;
-        const action = interaction.resolution?.action;
-        const reviewStatus: PlanReviewStatus =
-          interaction.status === "pending"
-            ? "pending"
-            : action === "accept"
-              ? "accepted"
-              : action === "accept_in_new_chat"
-                ? "accepted_in_new_chat"
-                : action === "request_changes" || action === "reject"
-                  ? "changes_requested"
-                  : "discarded";
-        const review: PlanReviewRecord = {
-          id: `plan_review_${toolCall.id}_${interaction.ordinal}`,
-          toolCallId: toolCall.id,
-          agentId: toolCall.agentId,
-          conversationId: toolCall.conversationId,
-          projectId: toolCall.projectId,
-          slug: interaction.request.slug,
-          title: interaction.request.title,
-          summary: interaction.request.summary,
-          planPath: interaction.request.planPath,
-          status: reviewStatus,
-          feedback: interaction.resolution?.feedback,
-          requestedAt: interaction.requestedAt,
-          resolvedAt: interaction.resolvedAt,
-          updatedAt: interaction.updatedAt,
-        };
-        this.planReviews.set(review.id, review);
-      }
+  }
+
+  hydrateFromToolCall(toolCall: ToolCallRecord): void {
+    for (const interaction of toolCall.interactions) {
+      if (interaction.kind !== "plan_review") continue;
+      const action = interaction.resolution?.action;
+      const reviewStatus: PlanReviewStatus =
+        interaction.status === "pending"
+          ? "pending"
+          : action === "accept"
+            ? "accepted"
+            : action === "accept_in_new_chat"
+              ? "accepted_in_new_chat"
+              : action === "request_changes" || action === "reject"
+                ? "changes_requested"
+                : "discarded";
+      const review: PlanReviewRecord = {
+        id: `plan_review_${toolCall.id}_${interaction.ordinal}`,
+        toolCallId: toolCall.id,
+        agentId: toolCall.agentId,
+        conversationId: toolCall.conversationId,
+        projectId: toolCall.projectId,
+        slug: interaction.request.slug,
+        title: interaction.request.title,
+        summary: interaction.request.summary,
+        planPath: interaction.request.planPath,
+        status: reviewStatus,
+        feedback: interaction.resolution?.feedback,
+        requestedAt: interaction.requestedAt,
+        resolvedAt: interaction.resolvedAt,
+        updatedAt: interaction.updatedAt,
+      };
+      this.planReviews.set(review.id, review);
     }
+  }
+
+  hydrateFromToolCalls(toolCalls: readonly ToolCallRecord[]): void {
+    this.resetToolCallHydration();
+    for (const toolCall of toolCalls) this.hydrateFromToolCall(toolCall);
   }
 
   listPlanReviews(status?: PlanReviewStatus): PlanReviewRecord[] {

--- a/packages/workbench-server/src/domains/tasks/task-log.service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-log.service.ts
@@ -1,8 +1,9 @@
-import { appendFile } from "node:fs/promises";
+import { appendFile, readFile } from "node:fs/promises";
 import type {
   TaskLogEvent,
   TaskLogQuery,
   TaskLogQueryResponse,
+  TaskOutputRetention,
   TaskRecord,
 } from "@nervekit/contracts";
 import { taskLogEventSchema } from "@nervekit/contracts";
@@ -11,17 +12,35 @@ import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { PerformanceDiagnosticsPort } from "../../core/ports.js";
 import {
   appendJsonLine,
+  atomicWriteJson,
   readJsonLines,
 } from "../../infrastructure/storage/index.js";
 
 export type TaskLogStream = "stdout" | "stderr";
 
 export const MAX_BUFFERED_LOG_LINE_CHARS = 256 * 1024;
+export const TASK_OUTPUT_HEAD_MAX_BYTES = 32 * 1024 * 1024;
+export const TASK_OUTPUT_TAIL_MAX_BYTES = 512 * 1024;
+const TAIL_PERSIST_INTERVAL_BYTES = 64 * 1024;
+
+export type TaskOutputTailChunk = {
+  stream: TaskLogStream;
+  text: string;
+};
 
 export interface TaskLogCursor {
   logSeq: number;
   lineBuffers: Record<TaskLogStream, string>;
   logQueue: Promise<void>;
+  totalBytes: number;
+  retainedBytes: number;
+  omittedBytes: number;
+  totalLines: number;
+  retainedLines: number;
+  omittedLines: number;
+  tailChunks: TaskOutputTailChunk[];
+  tailBytes: number;
+  tailDirtyBytes: number;
 }
 
 export function createTaskLogCursor(logSeq = 0): TaskLogCursor {
@@ -29,6 +48,15 @@ export function createTaskLogCursor(logSeq = 0): TaskLogCursor {
     logSeq,
     lineBuffers: { stdout: "", stderr: "" },
     logQueue: Promise.resolve(),
+    totalBytes: 0,
+    retainedBytes: 0,
+    omittedBytes: 0,
+    totalLines: 0,
+    retainedLines: 0,
+    omittedLines: 0,
+    tailChunks: [],
+    tailBytes: 0,
+    tailDirtyBytes: 0,
   };
 }
 
@@ -45,10 +73,25 @@ export class TaskLogService {
     task: TaskRecord,
     query: TaskLogQuery = {},
   ): Promise<TaskLogQueryResponse> {
-    const allEvents = await this.readLogEvents(task.logsPath);
+    const headEvents = await this.readLogEvents(task.logsPath);
+    const tailEvents = task.outputRetention?.tailPath
+      ? await this.tailLogEvents(
+          task,
+          (headEvents.at(-1)?.seq ?? 0) +
+            (task.outputRetention.truncated ? 2 : 1),
+        )
+      : [];
+    const allEvents = task.outputRetention?.truncated
+      ? [
+          ...headEvents,
+          omissionEvent(headEvents, task.outputRetention.omittedBytes),
+          ...tailEvents,
+        ]
+      : [...headEvents, ...tailEvents];
     return {
       task,
       ...queryTaskLogEvents(allEvents, query),
+      outputRetention: task.outputRetention,
     };
   }
 
@@ -67,7 +110,7 @@ export class TaskLogService {
       diagnostics.count("task.outputBytes", Buffer.byteLength(text));
     }
     return this.enqueue(cursor, () =>
-      this.captureOutputNow(record, cursor, stream, text, onLog),
+      this.captureBoundedOutputNow(record, cursor, stream, text, onLog),
     ).finally(() => {
       if (startedAt !== undefined)
         diagnostics?.duration(
@@ -96,7 +139,67 @@ export class TaskLogService {
     return this.enqueue(cursor, async () => {
       await this.flushOutputNow(record, cursor, "stdout", onLog);
       await this.flushOutputNow(record, cursor, "stderr", onLog);
+      await this.persistTail(record, cursor);
     });
+  }
+
+  async persistTailSnapshot(
+    record: TaskRecord,
+    cursor: TaskLogCursor,
+  ): Promise<void> {
+    await this.enqueue(cursor, () => this.persistTail(record, cursor));
+  }
+
+  retention(record: TaskRecord, cursor: TaskLogCursor): TaskOutputRetention {
+    ensureLogCursorState(cursor);
+    const retainedTailBytes = cursor.tailBytes;
+    const omittedBytes = Math.max(
+      0,
+      cursor.totalBytes - cursor.retainedBytes - retainedTailBytes,
+    );
+    return {
+      totalBytes: cursor.totalBytes,
+      retainedBytes: cursor.retainedBytes + retainedTailBytes,
+      omittedBytes,
+      totalLines: cursor.totalLines,
+      retainedLines: cursor.retainedLines,
+      omittedLines: omittedBytes > 0 ? cursor.omittedLines : 0,
+      headMaxBytes: TASK_OUTPUT_HEAD_MAX_BYTES,
+      tailMaxBytes: TASK_OUTPUT_TAIL_MAX_BYTES,
+      truncated: omittedBytes > 0,
+      tailPath: cursor.tailBytes > 0 ? this.tailPath(record) : undefined,
+    };
+  }
+
+  async readTail(record: TaskRecord): Promise<TaskOutputTailChunk[]> {
+    const parsed = await readFile(this.tailPath(record), "utf8")
+      .then((raw) => JSON.parse(raw) as unknown)
+      .catch(() => []);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isTailChunk);
+  }
+
+  private async tailLogEvents(
+    record: TaskRecord,
+    firstSeq: number,
+  ): Promise<TaskLogEvent[]> {
+    const events: TaskLogEvent[] = [];
+    let seq = firstSeq;
+    for (const chunk of await this.readTail(record)) {
+      for (const line of chunk.text.split(/\r?\n/)) {
+        const cleaned = line.trimEnd();
+        if (!cleaned) continue;
+        events.push({
+          seq,
+          ts: record.finishedAt ?? record.updatedAt,
+          stream: chunk.stream,
+          level: classifyLogLevel(chunk.stream, cleaned),
+          line: cleaned,
+        });
+        seq += 1;
+      }
+    }
+    return events;
   }
 
   async latestLogSeq(logsPath: string): Promise<number> {
@@ -121,6 +224,43 @@ export class TaskLogService {
     const queued = cursor.logQueue.catch(() => undefined).then(task);
     cursor.logQueue = queued.catch(() => undefined);
     return queued;
+  }
+
+  private async captureBoundedOutputNow(
+    record: TaskRecord,
+    cursor: TaskLogCursor,
+    stream: TaskLogStream,
+    text: string,
+    onLog: (event: TaskLogEvent) => Promise<void>,
+  ): Promise<void> {
+    ensureLogCursorState(cursor);
+    const bytes = Buffer.byteLength(text);
+    const lines = countOutputLines(text);
+    cursor.totalBytes += bytes;
+    cursor.totalLines += lines;
+    const available = Math.max(
+      0,
+      TASK_OUTPUT_HEAD_MAX_BYTES - cursor.retainedBytes,
+    );
+    const retained = truncateUtf8Head(text, available);
+    if (retained.length > 0) {
+      const retainedBytes = Buffer.byteLength(retained);
+      const retainedLines = countOutputLines(retained);
+      cursor.retainedBytes += retainedBytes;
+      cursor.retainedLines += retainedLines;
+      await this.captureOutputNow(record, cursor, stream, retained, onLog);
+    }
+
+    const omittedText = text.slice(retained.length);
+    const omittedBytes = bytes - Buffer.byteLength(retained);
+    if (omittedBytes > 0) {
+      appendRollingTail(cursor, stream, omittedText);
+      cursor.omittedBytes += omittedBytes;
+      cursor.omittedLines += countOutputLines(omittedText);
+      if (cursor.tailDirtyBytes >= TAIL_PERSIST_INTERVAL_BYTES) {
+        await this.persistTail(record, cursor);
+      }
+    }
   }
 
   private async captureOutputNow(
@@ -167,6 +307,19 @@ export class TaskLogService {
     await this.emitLogLine(record, cursor, stream, line, onLog);
   }
 
+  private tailPath(record: TaskRecord): string {
+    return `${record.logsPath}.tail.json`;
+  }
+
+  private async persistTail(
+    record: TaskRecord,
+    cursor: TaskLogCursor,
+  ): Promise<void> {
+    if (cursor.omittedBytes === 0 || cursor.tailDirtyBytes === 0) return;
+    await atomicWriteJson(this.tailPath(record), cursor.tailChunks, 0o600);
+    cursor.tailDirtyBytes = 0;
+  }
+
   private async emitLogLine(
     record: TaskRecord,
     cursor: TaskLogCursor,
@@ -204,6 +357,80 @@ function ensureLogCursorState(cursor: TaskLogCursor): void {
   cursor.lineBuffers.stdout ??= "";
   cursor.lineBuffers.stderr ??= "";
   cursor.logQueue ??= Promise.resolve();
+  cursor.totalBytes ??= 0;
+  cursor.retainedBytes ??= 0;
+  cursor.omittedBytes ??= 0;
+  cursor.totalLines ??= 0;
+  cursor.retainedLines ??= 0;
+  cursor.omittedLines ??= 0;
+  cursor.tailChunks ??= [];
+  cursor.tailBytes ??= 0;
+  cursor.tailDirtyBytes ??= 0;
+}
+
+function appendRollingTail(
+  cursor: TaskLogCursor,
+  stream: TaskLogStream,
+  text: string,
+): void {
+  if (text.length === 0) return;
+  const bounded = truncateUtf8Tail(text, TASK_OUTPUT_TAIL_MAX_BYTES);
+  const bytes = Buffer.byteLength(bounded);
+  cursor.tailChunks.push({ stream, text: bounded });
+  cursor.tailBytes += bytes;
+  cursor.tailDirtyBytes += bytes;
+
+  while (
+    cursor.tailBytes > TASK_OUTPUT_TAIL_MAX_BYTES &&
+    cursor.tailChunks.length > 0
+  ) {
+    const first = cursor.tailChunks[0];
+    if (!first) break;
+    const excess = cursor.tailBytes - TASK_OUTPUT_TAIL_MAX_BYTES;
+    const firstBytes = Buffer.byteLength(first.text);
+    if (firstBytes <= excess) {
+      cursor.tailChunks.shift();
+      cursor.tailBytes -= firstBytes;
+      continue;
+    }
+    const kept = truncateUtf8Tail(first.text, firstBytes - excess);
+    cursor.tailBytes -= firstBytes - Buffer.byteLength(kept);
+    first.text = kept;
+  }
+}
+
+function truncateUtf8Head(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (Buffer.byteLength(text) <= maxBytes) return text;
+  const buffer = Buffer.from(text);
+  let end = Math.min(maxBytes, buffer.length);
+  while (end > 0 && (buffer[end] & 0xc0) === 0x80) end -= 1;
+  return buffer.subarray(0, end).toString("utf8");
+}
+
+function truncateUtf8Tail(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (Buffer.byteLength(text) <= maxBytes) return text;
+  const buffer = Buffer.from(text);
+  let start = Math.max(0, buffer.length - maxBytes);
+  while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) start += 1;
+  return buffer.subarray(start).toString("utf8");
+}
+
+function countOutputLines(text: string): number {
+  if (text.length === 0) return 0;
+  let lines = 0;
+  for (const character of text) if (character === "\n") lines += 1;
+  return lines;
+}
+
+function isTailChunk(value: unknown): value is TaskOutputTailChunk {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.stream === "stdout" || record.stream === "stderr") &&
+    typeof record.text === "string"
+  );
 }
 
 function appendChunkAndTakeCompleteLines(
@@ -234,6 +461,20 @@ const stdoutErrorPattern = new RegExp(
   ].join("|"),
   "i",
 );
+
+function omissionEvent(
+  headEvents: TaskLogEvent[],
+  omittedBytes: number,
+): TaskLogEvent {
+  const last = headEvents.at(-1);
+  return {
+    seq: (last?.seq ?? 0) + 1,
+    ts: last?.ts ?? new Date(0).toISOString(),
+    stream: "stdout",
+    level: "info",
+    line: `[${omittedBytes} output bytes omitted by task retention]`,
+  };
+}
 
 function classifyLogLevel(
   stream: TaskLogStream,

--- a/packages/workbench-server/src/domains/tasks/task-notification.service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-notification.service.ts
@@ -200,7 +200,14 @@ export class TaskNotificationService {
     if (this.delivering.has(key)) return;
     this.delivering.add(key);
     try {
-      const task = this.deps.tasks.getTask(taskSnapshot.id);
+      let task: TaskRecord;
+      try {
+        task = this.deps.tasks.getTask(taskSnapshot.id);
+      } catch {
+        // Foreground tasks can finish and be removed before a delayed ready
+        // notification fires. Their terminal tool result is already durable.
+        return;
+      }
       if (!this.shouldDeliver(task, event)) return;
       const existing = this.findExistingTaskEventEntry(task, event);
       if (existing) {

--- a/packages/workbench-server/src/domains/tasks/task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-service.ts
@@ -4,6 +4,7 @@ import type {
   StartTaskRequest,
   TaskLogQuery,
   TaskLogQueryResponse,
+  TaskOutputRetention,
   TaskRecord,
 } from "@nervekit/contracts";
 import {
@@ -76,6 +77,7 @@ export interface TaskLogPort {
     text: string,
   ): Promise<void>;
   remove(task: TaskRecord): Promise<void>;
+  retention?(task: TaskRecord): TaskOutputRetention | undefined;
   paths?(taskId: string): {
     stdoutPath: string;
     stderrPath: string;
@@ -750,6 +752,7 @@ export class TaskService {
       task.finishedAt = exit.exitedAt;
       task.updatedAt = exit.exitedAt;
       task.status = status;
+      task.outputRetention = this.ports.logs.retention?.(task);
       if (reason) task.error = reason;
       else if (status === "timed_out")
         task.error = "Task exceeded maximum runtime.";

--- a/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
@@ -262,8 +262,19 @@ export function createWorkbenchTaskResources(
           async () => undefined,
         );
       },
-      query: (task, query) => logs.queryLogs(task, query),
+      query: async (task, query) => {
+        const state = managed.get(task.id);
+        if (state) await logs.persistTailSnapshot(task, state);
+        const outputRetention = state
+          ? logs.retention(task, state)
+          : task.outputRetention;
+        return await logs.queryLogs({ ...task, outputRetention }, query);
+      },
       remove: async () => undefined,
+      retention: (task) => {
+        const state = managed.get(task.id);
+        return state ? logs.retention(task, state) : task.outputRetention;
+      },
     },
     readiness: {
       wait: (task, request) => readiness.wait(task, request),

--- a/packages/workbench-server/src/domains/tasks/workbench-task-service-foreground.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-service-foreground.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { open } from "node:fs/promises";
 import {
   buildProcessResult,
   buildProcessTextResult,
@@ -17,17 +17,49 @@ export async function buildForegroundBashResult(
   taskId: string,
 ): Promise<ToolExecutionResult> {
   const task = this.getTask(taskId);
-  const [stdout, stderr, combinedFromFile] = await Promise.all([
-    readFile(task.stdoutPath).catch(() => Buffer.alloc(0)),
-    readFile(task.stderrPath).catch(() => Buffer.alloc(0)),
+  const retention = task.outputRetention;
+  const tailChunks = retention?.tailPath
+    ? await this.taskLogs.readTail(task)
+    : [];
+  const [stdoutHead, stderrHead, combinedHead] = await Promise.all([
+    readBoundedFile(task.stdoutPath),
+    readBoundedFile(task.stderrPath),
     task.combinedPath
-      ? readFile(task.combinedPath).catch(() => Buffer.alloc(0))
+      ? readBoundedFile(task.combinedPath)
       : Promise.resolve(Buffer.alloc(0)),
   ]);
-  const combined =
-    combinedFromFile.length > 0
-      ? combinedFromFile
-      : Buffer.concat([stdout, stderr]);
+  const omission = retention?.truncated
+    ? Buffer.from(
+        `\n[${retention.omittedBytes} output bytes omitted by task retention]\n`,
+      )
+    : tailChunks.length > 0
+      ? Buffer.from(
+          "\n[output middle omitted from inline result; retained in task logs]\n",
+        )
+      : Buffer.alloc(0);
+  const stdout = combineSnapshot(
+    stdoutHead,
+    omission,
+    tailChunks
+      .filter((chunk) => chunk.stream === "stdout")
+      .map((chunk) => chunk.text)
+      .join(""),
+  );
+  const stderr = combineSnapshot(
+    stderrHead,
+    omission,
+    tailChunks
+      .filter((chunk) => chunk.stream === "stderr")
+      .map((chunk) => chunk.text)
+      .join(""),
+  );
+  const combined = combineSnapshot(
+    combinedHead.length > 0
+      ? combinedHead
+      : Buffer.concat([stdoutHead, stderrHead]),
+    omission,
+    tailChunks.map((chunk) => chunk.text).join(""),
+  );
   const timedOut = task.status === "timed_out";
   return buildProcessResult({
     stdoutChunks: stdout.length > 0 ? [stdout] : [],
@@ -41,8 +73,57 @@ export async function buildForegroundBashResult(
     timedOut,
     timeoutKilled: timedOut,
     timeoutMessage: task.error,
-    details: { execution: { disposition: "completed" } },
+    details: {
+      execution: { disposition: "completed" },
+      ...(retention ? { outputRetention: retention } : {}),
+    },
+    contentFooterLines:
+      retention && retention.totalBytes > combined.length
+        ? ["Output preview is bounded; use task_logs for retained diagnostics."]
+        : [],
   });
+}
+
+const RESULT_HEAD_MAX_BYTES = 16 * 1024;
+const RESULT_TAIL_MAX_BYTES = 16 * 1024;
+const RESULT_FILE_MAX_BYTES = RESULT_HEAD_MAX_BYTES + RESULT_TAIL_MAX_BYTES;
+
+async function readBoundedFile(path: string): Promise<Buffer> {
+  const handle = await open(path, "r").catch(() => undefined);
+  if (!handle) return Buffer.alloc(0);
+  try {
+    const stat = await handle.stat();
+    if (stat.size <= RESULT_FILE_MAX_BYTES) {
+      const buffer = Buffer.alloc(stat.size);
+      const { bytesRead } = await handle.read(buffer, 0, stat.size, 0);
+      return buffer.subarray(0, bytesRead);
+    }
+    const head = Buffer.alloc(RESULT_HEAD_MAX_BYTES);
+    const tail = Buffer.alloc(RESULT_TAIL_MAX_BYTES);
+    const [headRead, tailRead] = await Promise.all([
+      handle.read(head, 0, head.length, 0),
+      handle.read(tail, 0, tail.length, Math.max(0, stat.size - tail.length)),
+    ]);
+    return Buffer.concat([
+      head.subarray(0, headRead.bytesRead),
+      Buffer.from(
+        `\n[${stat.size - headRead.bytesRead - tailRead.bytesRead} bytes omitted from inline result; retained in task logs]\n`,
+      ),
+      tail.subarray(0, tailRead.bytesRead),
+    ]);
+  } finally {
+    await handle.close();
+  }
+}
+
+function combineSnapshot(head: Buffer, omission: Buffer, tail: string): Buffer {
+  if (omission.length === 0) return head;
+  const tailBuffer = Buffer.from(tail);
+  const boundedTail =
+    tailBuffer.length > RESULT_TAIL_MAX_BYTES
+      ? tailBuffer.subarray(tailBuffer.length - RESULT_TAIL_MAX_BYTES)
+      : tailBuffer;
+  return Buffer.concat([head, omission, boundedTail]);
 }
 
 function commandDisplayName(command: string): string {

--- a/packages/workbench-server/src/domains/tools/todo-state.service.ts
+++ b/packages/workbench-server/src/domains/tools/todo-state.service.ts
@@ -4,23 +4,32 @@ export type TodoItem = { todo: string; done: boolean };
 
 export class TodoStateService {
   private readonly todoLists = new Map<string, TodoItem[]>();
+  private readonly hydratedVersions = new Map<string, string>();
+
+  resetToolCallHydration(): void {
+    this.todoLists.clear();
+    this.hydratedVersions.clear();
+  }
+
+  hydrateFromToolCall(toolCall: ToolCallRecord): void {
+    if (toolCall.toolName !== "todos_set" || toolCall.status !== "completed") {
+      return;
+    }
+    const version = `${toolCall.updatedAt}:${toolCall.id}`;
+    if ((this.hydratedVersions.get(toolCall.agentId) ?? "") >= version) return;
+    const resultRecord = recordFromUnknown(toolCall.result);
+    const details = recordFromUnknown(resultRecord.details);
+    const items =
+      parseTodoItems(details.todos) ??
+      parseTodoItems(recordFromUnknown(toolCall.args).todos);
+    if (!items) return;
+    this.set(toolCall.agentId, items);
+    this.hydratedVersions.set(toolCall.agentId, version);
+  }
 
   hydrateFromToolCalls(toolCalls: ToolCallRecord[]): void {
-    const completedTodoSets = toolCalls
-      .filter(
-        (toolCall) =>
-          toolCall.toolName === "todos_set" && toolCall.status === "completed",
-      )
-      .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
-
-    for (const toolCall of completedTodoSets) {
-      const resultRecord = recordFromUnknown(toolCall.result);
-      const details = recordFromUnknown(resultRecord.details);
-      const items =
-        parseTodoItems(details.todos) ??
-        parseTodoItems(recordFromUnknown(toolCall.args).todos);
-      if (items) this.set(toolCall.agentId, items);
-    }
+    this.resetToolCallHydration();
+    for (const toolCall of toolCalls) this.hydrateFromToolCall(toolCall);
   }
 
   set(agentId: string, items: TodoItem[]): void {
@@ -33,6 +42,7 @@ export class TodoStateService {
 
   delete(agentId: string): void {
     this.todoLists.delete(agentId);
+    this.hydratedVersions.delete(agentId);
   }
 }
 

--- a/packages/workbench-server/src/domains/tools/tool-call.repository.ts
+++ b/packages/workbench-server/src/domains/tools/tool-call.repository.ts
@@ -1,16 +1,27 @@
-import { open, readdir } from "node:fs/promises";
+import { open, readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { toolCallRecordSchema, type ToolCallRecord } from "@nervekit/contracts";
-import type { IndexStore } from "../../infrastructure/index-store/index-store.js";
+import {
+  toolCallRecordSchema,
+  type ToolCallRecord,
+  type ToolCallTranscriptRecord,
+} from "@nervekit/contracts";
+import type {
+  IndexStore,
+  ToolCallPreviewQuery,
+} from "../../infrastructure/index-store/index-store.js";
 import {
   atomicWriteJson,
   type InitializedStorage,
 } from "../../infrastructure/storage/index.js";
+import { toToolCallTranscriptRecord } from "./tool-call-transcript-preview.js";
+
+const TERMINAL_CACHE_MAX_BYTES = 16 * 1024 * 1024;
 
 export interface ToolCallHydrationStats {
   rowCount: number;
   uniqueCount: number;
   fileBytes: number;
+  activeCount: number;
   source: "files";
 }
 
@@ -27,13 +38,24 @@ export class ToolCallRevisionConflictError extends Error {
   }
 }
 
+/**
+ * Canonical tool calls live in per-conversation JSON files. Only mutable calls
+ * remain resident; immutable terminal details are loaded lazily into a
+ * byte-bounded cache. SQLite contains disposable, bounded transcript previews.
+ */
 export class ToolCallRepository {
   readonly records: Map<string, ToolCallRecord> = new Map();
+  private readonly terminalCache = new Map<
+    string,
+    { record: ToolCallRecord; bytes: number }
+  >();
+  private terminalCacheBytes = 0;
   private readonly mutations = new Map<string, Promise<void>>();
   private hydrationStats: ToolCallHydrationStats = {
     rowCount: 0,
     uniqueCount: 0,
     fileBytes: 0,
+    activeCount: 0,
     source: "files",
   };
 
@@ -42,83 +64,154 @@ export class ToolCallRepository {
     private readonly index: IndexStore,
   ) {}
 
-  async hydrate(): Promise<ToolCallRecord[]> {
+  async hydrate(
+    onRecord?: (record: ToolCallRecord) => void,
+  ): Promise<ToolCallRecord[]> {
     this.records.clear();
+    this.terminalCache.clear();
+    this.terminalCacheBytes = 0;
     let fileBytes = 0;
-    const conversations = await readdir(
-      join(this.storage.paths.home, "conversations"),
-      { withFileTypes: true },
-    ).catch(() => []);
-    for (const conversation of conversations.sort((a, b) =>
-      a.name.localeCompare(b.name),
-    )) {
-      if (!conversation.isDirectory() || !validId(conversation.name, "conv_"))
-        continue;
-      const directory = join(
-        this.storage.paths.home,
-        "conversations",
-        conversation.name,
-        "tool-calls",
-      );
-      const files = await readdir(directory, { withFileTypes: true }).catch(
-        () => [],
-      );
-      for (const file of files.sort((a, b) => a.name.localeCompare(b.name))) {
-        if (!file.isFile() || !file.name.endsWith(".json")) continue;
-        const id = file.name.slice(0, -5);
-        if (!validId(id, "tool_"))
-          throw new Error(
-            `Invalid canonical tool-call filename '${file.name}'.`,
-          );
-        const raw = await import("node:fs/promises").then(({ readFile }) =>
-          readFile(join(directory, file.name), "utf8"),
+    let rowCount = 0;
+    const ids = new Set<string>();
+    this.index.beginToolCallRebuild();
+    try {
+      const conversations = await readdir(
+        join(this.storage.paths.home, "conversations"),
+        { withFileTypes: true },
+      ).catch(() => []);
+      for (const conversation of conversations.sort((a, b) =>
+        a.name.localeCompare(b.name),
+      )) {
+        if (!conversation.isDirectory() || !validId(conversation.name, "conv_"))
+          continue;
+        const directory = join(
+          this.storage.paths.home,
+          "conversations",
+          conversation.name,
+          "tool-calls",
         );
-        fileBytes += Buffer.byteLength(raw);
-        const record = toolCallRecordSchema.parse(JSON.parse(raw));
-        if (record.id !== id || record.conversationId !== conversation.name) {
-          throw new Error(
-            `Canonical tool-call path identity mismatch for '${id}'.`,
+        const files = await readdir(directory, { withFileTypes: true }).catch(
+          () => [],
+        );
+        for (const file of files.sort((a, b) => a.name.localeCompare(b.name))) {
+          if (!file.isFile() || !file.name.endsWith(".json")) continue;
+          const id = file.name.slice(0, -5);
+          if (!validId(id, "tool_"))
+            throw new Error(
+              `Invalid canonical tool-call filename '${file.name}'.`,
+            );
+          const raw = await readFile(join(directory, file.name), "utf8");
+          fileBytes += Buffer.byteLength(raw);
+          const record = toolCallRecordSchema.parse(JSON.parse(raw));
+          if (record.id !== id || record.conversationId !== conversation.name) {
+            throw new Error(
+              `Canonical tool-call path identity mismatch for '${id}'.`,
+            );
+          }
+          if (ids.has(id))
+            throw new Error(`Duplicate canonical tool call '${id}'.`);
+          ids.add(id);
+          rowCount += 1;
+          this.index.appendToolCallRebuild(
+            record,
+            toToolCallTranscriptRecord(record),
           );
+          if (!isTerminal(record.status)) this.records.set(id, record);
+          onRecord?.(record);
         }
-        if (this.records.has(id))
-          throw new Error(`Duplicate canonical tool call '${id}'.`);
-        this.records.set(id, record);
-        this.index.upsertToolCall(record);
       }
+      this.index.finishToolCallRebuild();
+    } catch (error) {
+      this.index.rollbackToolCallRebuild();
+      throw error;
     }
     this.hydrationStats = {
-      rowCount: this.records.size,
-      uniqueCount: this.records.size,
+      rowCount,
+      uniqueCount: rowCount,
       fileBytes,
+      activeCount: this.records.size,
       source: "files",
     };
-    return this.list();
+    return this.listActive();
   }
 
   get hydrationSource(): "files" {
     return "files";
   }
+
   get hydrationStatsValue(): ToolCallHydrationStats {
     return { ...this.hydrationStats };
   }
 
-  list(): ToolCallRecord[] {
-    return [...this.records.values()].sort((a, b) =>
-      b.updatedAt.localeCompare(a.updatedAt),
-    );
+  residentStats(): {
+    activeRecords: number;
+    cachedTerminalRecords: number;
+    cachedTerminalBytes: number;
+  } {
+    return {
+      activeRecords: this.records.size,
+      cachedTerminalRecords: this.terminalCache.size,
+      cachedTerminalBytes: this.terminalCacheBytes,
+    };
+  }
+
+  count(): number {
+    return this.index.countToolCalls();
+  }
+
+  listActive(): ToolCallRecord[] {
+    return [...this.records.values()].sort(compareUpdatedDescending);
+  }
+
+  listPreviews(query: ToolCallPreviewQuery = {}): ToolCallTranscriptRecord[] {
+    return this.index.listToolCallPreviews(query);
+  }
+
+  queryPreviews(query: ToolCallPreviewQuery = {}) {
+    return this.index.queryToolCallPreviews(query);
   }
 
   get(toolCallId: string): ToolCallRecord {
-    const toolCall = this.records.get(toolCallId);
-    if (!toolCall) throw new Error("Tool call not found.");
-    return toolCall;
+    const active = this.records.get(toolCallId);
+    if (active) return active;
+    const cached = this.terminalCache.get(toolCallId);
+    if (!cached)
+      throw new Error("Tool call is not active; load it asynchronously.");
+    this.terminalCache.delete(toolCallId);
+    this.terminalCache.set(toolCallId, cached);
+    return cached.record;
+  }
+
+  async getCanonical(toolCallId: string): Promise<ToolCallRecord> {
+    const active = this.records.get(toolCallId);
+    if (active) return active;
+    const cached = this.terminalCache.get(toolCallId);
+    if (cached) {
+      this.terminalCache.delete(toolCallId);
+      this.terminalCache.set(toolCallId, cached);
+      return cached.record;
+    }
+    const conversationId = this.index.toolCallConversationId(toolCallId);
+    if (!conversationId) throw new Error("Tool call not found.");
+    const raw = await readFile(
+      this.path({ id: toolCallId, conversationId }),
+      "utf8",
+    );
+    const record = toolCallRecordSchema.parse(JSON.parse(raw));
+    if (record.id !== toolCallId || record.conversationId !== conversationId)
+      throw new Error("Canonical tool-call identity mismatch.");
+    this.cacheTerminal(record, Buffer.byteLength(raw));
+    return record;
   }
 
   findByProviderToolCallId(
     providerToolCallId: string | undefined,
   ): ToolCallRecord | undefined {
     if (!providerToolCallId) return undefined;
-    return [...this.records.values()].find(
+    return [
+      ...this.records.values(),
+      ...[...this.terminalCache.values()].map((cached) => cached.record),
+    ].find(
       (toolCall) =>
         toolCall.providerToolCallId === providerToolCallId ||
         toolCall.sourceToolCallId === providerToolCallId,
@@ -141,8 +234,12 @@ export class ToolCallRepository {
       } finally {
         await handle.close();
       }
-      this.records.set(record.id, record);
-      this.index.upsertToolCall(record);
+      if (isTerminal(record.status)) {
+        this.cacheTerminal(record, Buffer.byteLength(JSON.stringify(record)));
+      } else {
+        this.records.set(record.id, record);
+      }
+      this.index.upsertToolCall(record, toToolCallTranscriptRecord(record));
       return record;
     });
   }
@@ -170,9 +267,14 @@ export class ToolCallRepository {
         revision: current.revision + 1,
       });
       await atomicWriteJson(this.path(next), next, 0o600);
-      this.records.set(next.id, next);
+      if (isTerminal(next.status)) {
+        this.records.delete(next.id);
+        this.cacheTerminal(next, Buffer.byteLength(JSON.stringify(next)));
+      } else {
+        this.records.set(next.id, next);
+      }
       try {
-        this.index.upsertToolCall(next);
+        this.index.upsertToolCall(next, toToolCallTranscriptRecord(next));
       } catch {
         /* Canonical file remains authoritative. */
       }
@@ -185,6 +287,32 @@ export class ToolCallRepository {
       if (!conversationIds.has(record.conversationId)) continue;
       this.records.delete(id);
       this.index.deleteToolCall(id);
+    }
+    for (const [id, cached] of [...this.terminalCache]) {
+      if (!conversationIds.has(cached.record.conversationId)) continue;
+      this.terminalCache.delete(id);
+      this.terminalCacheBytes -= cached.bytes;
+      this.index.deleteToolCall(id);
+    }
+  }
+
+  private cacheTerminal(record: ToolCallRecord, bytes: number): void {
+    if (!isTerminal(record.status) || bytes > TERMINAL_CACHE_MAX_BYTES) return;
+    const existing = this.terminalCache.get(record.id);
+    if (existing) {
+      this.terminalCache.delete(record.id);
+      this.terminalCacheBytes -= existing.bytes;
+    }
+    this.terminalCache.set(record.id, { record, bytes });
+    this.terminalCacheBytes += bytes;
+    while (this.terminalCacheBytes > TERMINAL_CACHE_MAX_BYTES) {
+      const oldestId = this.terminalCache.keys().next().value as
+        | string
+        | undefined;
+      if (!oldestId) break;
+      const oldest = this.terminalCache.get(oldestId);
+      this.terminalCache.delete(oldestId);
+      this.terminalCacheBytes -= oldest?.bytes ?? 0;
     }
   }
 
@@ -239,6 +367,7 @@ const immutableKeys = [
   "cwd",
   "createdAt",
 ] as const;
+
 function assertImmutableIdentity(
   current: ToolCallRecord,
   next: ToolCallRecord,
@@ -248,9 +377,21 @@ function assertImmutableIdentity(
       throw new Error(`Tool-call identity field '${key}' is immutable.`);
   }
 }
+
 function validId(value: string, prefix: string): boolean {
   return value.startsWith(prefix) && /^[A-Za-z0-9_-]+$/.test(value);
 }
+
 function isTerminal(status: ToolCallRecord["status"]): boolean {
   return ["completed", "denied", "failed", "cancelled"].includes(status);
+}
+
+function compareUpdatedDescending(
+  left: ToolCallRecord,
+  right: ToolCallRecord,
+): number {
+  return (
+    right.updatedAt.localeCompare(left.updatedAt) ||
+    right.id.localeCompare(left.id)
+  );
 }

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -18,6 +18,7 @@ import {
   type TaskRecord,
   type ThinkingLevel,
   type ToolCallRecord,
+  type ToolCallTranscriptRecord,
   type ToolInteraction,
   type ToolName,
   toolCallTransitions,
@@ -228,10 +229,13 @@ export class ToolService {
   }
 
   async hydrate(): Promise<void> {
-    await this.toolCallRepository.hydrate();
-    this.plans.hydrateFromToolCalls?.(this.toolCallRepository.list());
+    this.plans.resetToolCallHydration();
+    this.todoState.resetToolCallHydration();
+    await this.toolCallRepository.hydrate((toolCall) => {
+      this.plans.hydrateFromToolCall(toolCall);
+      this.todoState.hydrateFromToolCall(toolCall);
+    });
     await this.reconcileInterruptedToolCallsOnStartup();
-    this.todoState.hydrateFromToolCalls(this.toolCallRepository.list());
   }
 
   listTools() {
@@ -239,7 +243,23 @@ export class ToolService {
   }
 
   listToolCalls(): ToolCallRecord[] {
-    return this.toolCallRepository.list();
+    return this.toolCallRepository.listActive();
+  }
+
+  listToolCallPreviews(
+    query: Parameters<ToolCallRepository["listPreviews"]>[0] = {},
+  ): ToolCallTranscriptRecord[] {
+    return this.toolCallRepository.listPreviews(query);
+  }
+
+  queryToolCallPreviews(
+    query: Parameters<ToolCallRepository["queryPreviews"]>[0] = {},
+  ): ReturnType<ToolCallRepository["queryPreviews"]> {
+    return this.toolCallRepository.queryPreviews(query);
+  }
+
+  countToolCalls(): number {
+    return this.toolCallRepository.count();
   }
 
   /** Whether the tool-call records were loaded from the persisted snapshot. */
@@ -258,7 +278,11 @@ export class ToolService {
   private projectApprovals(
     status?: ApprovalRecord["status"],
   ): ApprovalRecord[] {
-    return this.listToolCalls()
+    const toolCalls =
+      status === "pending"
+        ? this.listToolCalls()
+        : this.listToolCallPreviews({ limit: 1_000 });
+    return toolCalls
       .flatMap((toolCall) =>
         toolCall.interactions.flatMap((interaction) =>
           interaction.kind === "approval"
@@ -270,7 +294,7 @@ export class ToolService {
   }
 
   private projectApproval(
-    toolCall: ToolCallRecord,
+    toolCall: ToolCallRecord | ToolCallTranscriptRecord,
     ordinal: number,
   ): ApprovalRecord {
     const interaction = toolCall.interactions[ordinal];
@@ -297,7 +321,11 @@ export class ToolService {
   }
 
   private projectQuestions(status?: UserQuestionStatus): UserQuestionRecord[] {
-    return this.listToolCalls()
+    const toolCalls =
+      status === "pending"
+        ? this.listToolCalls()
+        : this.listToolCallPreviews({ limit: 1_000 });
+    return toolCalls
       .flatMap((toolCall) =>
         toolCall.interactions.flatMap((interaction) => {
           if (interaction.kind !== "user_input") return [];
@@ -596,7 +624,7 @@ export class ToolService {
   ): Promise<ToolCallRecord[]> {
     if (!runId) return [];
     const stale = this.toolCallRepository
-      .list()
+      .listActive()
       .filter(
         (toolCall) => toolCall.runId === runId && !isTerminalToolCall(toolCall),
       );
@@ -622,7 +650,7 @@ export class ToolService {
 
   private async reconcileInterruptedToolCallsOnStartup(): Promise<void> {
     const interrupted = this.toolCallRepository
-      .list()
+      .listActive()
       .filter(
         (toolCall) =>
           toolCall.status === "committed" || toolCall.status === "running",
@@ -813,6 +841,10 @@ export class ToolService {
 
   getToolCall(toolCallId: string): ToolCallRecord {
     return this.toolCallRepository.get(toolCallId);
+  }
+
+  async getToolCallDetails(toolCallId: string): Promise<ToolCallRecord> {
+    return await this.toolCallRepository.getCanonical(toolCallId);
   }
 
   private async updateToolCall(

--- a/packages/workbench-server/src/infrastructure/index-store/index-store.ts
+++ b/packages/workbench-server/src/infrastructure/index-store/index-store.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Disposable index lifecycle and transactional table operations remain centralized. */
 import { existsSync, renameSync, rmSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import type {
@@ -6,6 +7,8 @@ import type {
   ProjectRecord,
   TaskRecord,
   ToolCallRecord,
+  ToolCallStatus,
+  ToolCallTranscriptRecord,
   WorkerRecord,
 } from "@nervekit/contracts";
 import { INDEX_STORE_SCHEMA_SQL } from "./schema.js";
@@ -36,7 +39,22 @@ export interface RebuildIndexInput {
   agents: AgentRecord[];
   tasks?: TaskRecord[];
   workers?: WorkerRecord[];
-  toolCalls?: ToolCallRecord[];
+}
+
+export interface ToolCallPreviewQuery {
+  status?: ToolCallStatus;
+  pendingInteractionKind?: "approval" | "user_input" | "plan_review";
+  conversationId?: string;
+  projectId?: string;
+  agentId?: string;
+  runId?: string;
+  limit?: number;
+  cursor?: { updatedAt: string; id: string };
+}
+
+export interface ToolCallPreviewPage {
+  toolCalls: ToolCallTranscriptRecord[];
+  nextCursor?: { updatedAt: string; id: string };
 }
 
 export interface IndexReplacementToken {
@@ -47,6 +65,7 @@ export class IndexStore {
   private db: DatabaseSync;
   private healthy = true;
   private updatesDeferred = false;
+  private toolCallPreviewSchemaReady = false;
 
   constructor(readonly path: string) {
     this.recoverReplacementFiles();
@@ -72,9 +91,11 @@ export class IndexStore {
   initialize(): void {
     this.guard(() => {
       this.db.exec("PRAGMA journal_mode = WAL");
+      this.resetLegacyToolCallIndex();
       this.db.exec("PRAGMA synchronous = NORMAL");
       this.db.exec("PRAGMA wal_autocheckpoint = 1000");
       this.db.exec(INDEX_STORE_SCHEMA_SQL);
+      this.toolCallPreviewSchemaReady = true;
     });
     // Drain any oversized WAL left by a previous large rebuild. A passive
     // autocheckpoint reuses the WAL file in place and never shrinks it, so an
@@ -296,36 +317,113 @@ export class IndexStore {
     });
   }
 
-  upsertToolCall(toolCall: ToolCallRecord): void {
+  upsertToolCall(
+    toolCall: ToolCallRecord,
+    preview: ToolCallTranscriptRecord,
+  ): void {
     if (this.updatesDeferred) return;
+    this.writeToolCallPreview(toolCall, preview, true);
+  }
+
+  beginToolCallRebuild(): void {
     this.guard(() => {
-      this.db
-        .prepare(
-          `INSERT INTO tool_calls (
-             id, conversation_id, project_id, run_id, status,
-             pending_interaction_kind, revision, json
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(id) DO UPDATE SET
-             conversation_id = excluded.conversation_id,
-             project_id = excluded.project_id,
-             run_id = excluded.run_id,
-             status = excluded.status,
-             pending_interaction_kind = excluded.pending_interaction_kind,
-             revision = excluded.revision,
-             json = excluded.json`,
-        )
-        .run(
-          toolCall.id,
-          toolCall.conversationId,
-          toolCall.projectId,
-          toolCall.runId ?? null,
-          toolCall.status,
-          toolCall.interactions.find(
-            (interaction) => interaction.status === "pending",
-          )?.kind ?? null,
-          toolCall.revision,
-          JSON.stringify(toolCall),
+      this.ensureToolCallPreviewTable();
+      this.db.exec("BEGIN IMMEDIATE");
+      this.db.exec("DELETE FROM tool_calls");
+    });
+  }
+
+  appendToolCallRebuild(
+    toolCall: ToolCallRecord,
+    preview: ToolCallTranscriptRecord,
+  ): void {
+    this.writeToolCallPreview(toolCall, preview, false);
+  }
+
+  finishToolCallRebuild(): void {
+    this.guard(() => this.db.exec("COMMIT"));
+  }
+
+  rollbackToolCallRebuild(): void {
+    try {
+      this.db.exec("ROLLBACK");
+    } catch {
+      // No active transaction after an earlier SQLite failure.
+    }
+  }
+
+  countToolCalls(): number {
+    return this.guard(() => {
+      this.ensureToolCallPreviewTable();
+      const row = this.db
+        .prepare("SELECT COUNT(*) AS count FROM tool_calls")
+        .get() as { count: number } | undefined;
+      return row?.count ?? 0;
+    });
+  }
+
+  listToolCallPreviews(
+    query: ToolCallPreviewQuery = {},
+  ): ToolCallTranscriptRecord[] {
+    return this.queryToolCallPreviews(query).toolCalls;
+  }
+
+  queryToolCallPreviews(query: ToolCallPreviewQuery = {}): ToolCallPreviewPage {
+    return this.guard(() => {
+      this.ensureToolCallPreviewTable();
+      const clauses: string[] = [];
+      const values: Array<string | number> = [];
+      const filters = [
+        ["status", query.status],
+        ["pending_interaction_kind", query.pendingInteractionKind],
+        ["conversation_id", query.conversationId],
+        ["project_id", query.projectId],
+        ["agent_id", query.agentId],
+        ["run_id", query.runId],
+      ] as const;
+      for (const [column, value] of filters) {
+        if (value === undefined) continue;
+        clauses.push(`${column} = ?`);
+        values.push(value);
+      }
+      if (query.cursor) {
+        clauses.push("(updated_at < ? OR (updated_at = ? AND id < ?))");
+        values.push(
+          query.cursor.updatedAt,
+          query.cursor.updatedAt,
+          query.cursor.id,
         );
+      }
+      const limit = Math.min(Math.max(query.limit ?? 200, 1), 1_000);
+      values.push(limit + 1);
+      const rows = this.db
+        .prepare(
+          `SELECT preview_json FROM tool_calls${
+            clauses.length > 0 ? ` WHERE ${clauses.join(" AND ")}` : ""
+          } ORDER BY updated_at DESC, id DESC LIMIT ?`,
+        )
+        .all(...values) as Array<{ preview_json: string }>;
+      const toolCalls = rows
+        .slice(0, limit)
+        .map((row) => JSON.parse(row.preview_json) as ToolCallTranscriptRecord);
+      const last = toolCalls.at(-1);
+      return {
+        toolCalls,
+        nextCursor:
+          rows.length > limit && last
+            ? { updatedAt: last.updatedAt, id: last.id }
+            : undefined,
+      };
+    });
+  }
+
+  toolCallConversationId(id: string): string | undefined {
+    return this.guard(() => {
+      this.ensureToolCallPreviewTable();
+      const row = this.db
+        .prepare("SELECT conversation_id FROM tool_calls WHERE id = ?")
+        .get(id) as { conversation_id: string } | undefined;
+      return row?.conversation_id;
     });
   }
 
@@ -443,17 +541,10 @@ export class IndexStore {
           "conversations",
           "projects",
         ];
-        tables.push("tool_calls");
         for (const table of tables) {
           this.db.exec(`DELETE FROM ${table};`);
         }
 
-        const upsertToolCall = this.db.prepare(
-          `INSERT INTO tool_calls (
-             id, conversation_id, project_id, run_id, status,
-             pending_interaction_kind, revision, json
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        );
         const upsertWorker = this.db.prepare(
           `INSERT INTO workers (
              id, kind, name, status, created_at, updated_at, json
@@ -521,20 +612,6 @@ export class IndexStore {
              updated_at = excluded.updated_at,
              json = excluded.json`,
         );
-        for (const toolCall of input.toolCalls ?? []) {
-          upsertToolCall.run(
-            toolCall.id,
-            toolCall.conversationId,
-            toolCall.projectId,
-            toolCall.runId ?? null,
-            toolCall.status,
-            toolCall.interactions.find(
-              (interaction) => interaction.status === "pending",
-            )?.kind ?? null,
-            toolCall.revision,
-            JSON.stringify(toolCall),
-          );
-        }
         for (const worker of input.workers ?? []) {
           upsertWorker.run(
             worker.id,
@@ -634,6 +711,7 @@ export class IndexStore {
       }
       this.db = new DatabaseSync(this.path);
       this.healthy = true;
+      this.toolCallPreviewSchemaReady = false;
       this.initialize();
       return { backupPath };
     } catch (error) {
@@ -661,10 +739,70 @@ export class IndexStore {
     this.restoreReplacementFiles(token.backupPath);
     this.db = new DatabaseSync(this.path);
     this.healthy = true;
+    this.toolCallPreviewSchemaReady = false;
   }
 
   close(): void {
     this.db.close();
+  }
+
+  private ensureToolCallPreviewTable(): void {
+    if (this.toolCallPreviewSchemaReady) return;
+    this.resetLegacyToolCallIndex();
+    this.db.exec(INDEX_STORE_SCHEMA_SQL);
+    this.toolCallPreviewSchemaReady = true;
+  }
+
+  private resetLegacyToolCallIndex(): void {
+    const columns = this.db
+      .prepare("PRAGMA table_info(tool_calls)")
+      .all() as Array<{ name: string }>;
+    if (columns.length === 0) return;
+    if (columns.some((column) => column.name === "preview_json")) return;
+    this.db.exec("DROP TABLE IF EXISTS tool_calls");
+  }
+
+  private writeToolCallPreview(
+    toolCall: ToolCallRecord,
+    preview: ToolCallTranscriptRecord,
+    guarded: boolean,
+  ): void {
+    const operation = () => {
+      if (guarded) this.ensureToolCallPreviewTable();
+      this.db
+        .prepare(
+          `INSERT INTO tool_calls (
+             id, conversation_id, project_id, agent_id, run_id, status,
+             pending_interaction_kind, revision, updated_at, preview_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             conversation_id = excluded.conversation_id,
+             project_id = excluded.project_id,
+             agent_id = excluded.agent_id,
+             run_id = excluded.run_id,
+             status = excluded.status,
+             pending_interaction_kind = excluded.pending_interaction_kind,
+             revision = excluded.revision,
+             updated_at = excluded.updated_at,
+             preview_json = excluded.preview_json`,
+        )
+        .run(
+          toolCall.id,
+          toolCall.conversationId,
+          toolCall.projectId,
+          toolCall.agentId,
+          toolCall.runId ?? null,
+          toolCall.status,
+          toolCall.interactions.find(
+            (interaction) => interaction.status === "pending",
+          )?.kind ?? null,
+          toolCall.revision,
+          toolCall.updatedAt,
+          JSON.stringify(preview),
+        );
+    };
+    if (guarded) this.guard(operation);
+    else operation();
   }
 
   private recoverReplacementFiles(): void {

--- a/packages/workbench-server/src/infrastructure/index-store/schema.ts
+++ b/packages/workbench-server/src/infrastructure/index-store/schema.ts
@@ -62,13 +62,19 @@ export const INDEX_STORE_SCHEMA_SQL = `
     id TEXT PRIMARY KEY,
     conversation_id TEXT NOT NULL,
     project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
     run_id TEXT,
     status TEXT NOT NULL,
     pending_interaction_kind TEXT,
     revision INTEGER NOT NULL,
-    json TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    preview_json TEXT NOT NULL
   );
   CREATE INDEX IF NOT EXISTS tool_calls_conversation ON tool_calls(conversation_id);
+  CREATE INDEX IF NOT EXISTS tool_calls_project ON tool_calls(project_id);
+  CREATE INDEX IF NOT EXISTS tool_calls_run ON tool_calls(run_id);
+  CREATE INDEX IF NOT EXISTS tool_calls_status ON tool_calls(status);
+  CREATE INDEX IF NOT EXISTS tool_calls_updated ON tool_calls(updated_at DESC, id DESC);
   CREATE INDEX IF NOT EXISTS tool_calls_project ON tool_calls(project_id);
   CREATE INDEX IF NOT EXISTS tool_calls_run ON tool_calls(run_id);
   CREATE INDEX IF NOT EXISTS tool_calls_status ON tool_calls(status);

--- a/packages/workbench-server/src/protocol/method-handlers/interaction-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/interaction-method-handlers.ts
@@ -1,4 +1,3 @@
-import { toToolCallTranscriptRecord } from "../../domains/tools/tool-call-transcript-preview.js";
 import {
   defineWorkbenchMethodHandlers,
   type WorkbenchMethodHandlerMap,
@@ -7,39 +6,20 @@ import {
 export const interactionMethodHandlers: WorkbenchMethodHandlerMap =
   defineWorkbenchMethodHandlers({
     "tool.list": (state) => ({ tools: state.registry.tools.listTools() }),
-    "toolCall.list": (state, params) => {
-      let toolCalls = state.registry.tools.listToolCalls();
-      if (params?.status)
-        toolCalls = toolCalls.filter(
-          (toolCall) => toolCall.status === params.status,
-        );
-      if (params?.pendingInteractionKind) {
-        toolCalls = toolCalls.filter((toolCall) =>
-          toolCall.interactions.some(
-            (interaction) =>
-              interaction.status === "pending" &&
-              interaction.kind === params.pendingInteractionKind,
-          ),
-        );
-      }
-      if (params?.conversationId)
-        toolCalls = toolCalls.filter(
-          (toolCall) => toolCall.conversationId === params.conversationId,
-        );
-      if (params?.projectId)
-        toolCalls = toolCalls.filter(
-          (toolCall) => toolCall.projectId === params.projectId,
-        );
-      if (params?.runId)
-        toolCalls = toolCalls.filter(
-          (toolCall) => toolCall.runId === params.runId,
-        );
-      if (params?.limit !== undefined)
-        toolCalls = toolCalls.slice(0, params.limit);
-      return { toolCalls: toolCalls.map(toToolCallTranscriptRecord) };
-    },
-    "toolCall.get": (state, params) => ({
-      toolCall: state.registry.tools.getToolCall(params.toolCallId),
+    "toolCall.list": (state, params) =>
+      state.registry.tools.queryToolCallPreviews({
+        status: params?.status,
+        pendingInteractionKind: params?.pendingInteractionKind,
+        conversationId: params?.conversationId,
+        projectId: params?.projectId,
+        runId: params?.runId,
+        limit: params?.limit,
+        cursor: params?.cursor,
+      }),
+    "toolCall.get": async (state, params) => ({
+      toolCall: await state.registry.tools.getToolCallDetails(
+        params.toolCallId,
+      ),
     }),
     "toolCall.interaction.resolve": async (state, params) => ({
       ...(await state.registry.resolveToolInteraction(params)),

--- a/packages/workbench-server/src/protocol/snapshots.ts
+++ b/packages/workbench-server/src/protocol/snapshots.ts
@@ -6,7 +6,6 @@ import {
   WORKSPACE_STREAM,
 } from "@nervekit/contracts";
 import type { OrchestratorState } from "../app/orchestrator-state.js";
-import { toToolCallTranscriptRecord } from "../domains/tools/tool-call-transcript-preview.js";
 
 export async function getWorkspaceSnapshotResponse(
   state: OrchestratorState,
@@ -18,10 +17,10 @@ export async function getWorkspaceSnapshotResponse(
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
     agents: state.registry.listAgents(),
     tasks: state.registry.listTasks(),
-    pendingToolCalls: state.registry.tools
-      .listToolCalls()
-      .filter((toolCall) => toolCall.status === "waiting")
-      .map(toToolCallTranscriptRecord),
+    pendingToolCalls: state.registry.tools.listToolCallPreviews({
+      status: "waiting",
+      limit: 1_000,
+    }),
     workers: state.registry.listWorkers(),
   }));
   return {

--- a/packages/workbench-server/src/routes/tool-routes.ts
+++ b/packages/workbench-server/src/routes/tool-routes.ts
@@ -4,7 +4,6 @@ import {
 } from "@nervekit/contracts";
 import { Hono } from "hono";
 import type { OrchestratorState } from "../app/orchestrator-state.js";
-import { toToolCallTranscriptRecord } from "../domains/tools/tool-call-transcript-preview.js";
 import { routeHandler } from "../http/responses.js";
 import { routeParam } from "../http/route-params.js";
 
@@ -21,27 +20,31 @@ export function createToolRoutes(state: OrchestratorState): Hono {
       Number.isFinite(requestedLimit) && requestedLimit > 0
         ? Math.min(requestedLimit, MAX_TOOL_CALL_LIST_LIMIT)
         : undefined;
-    let toolCalls = state.registry.tools.listToolCalls();
-    if (status.success)
-      toolCalls = toolCalls.filter(
-        (toolCall) => toolCall.status === status.data,
-      );
-    if (pendingKind)
-      toolCalls = toolCalls.filter((toolCall) =>
-        toolCall.interactions.some(
-          (interaction) =>
-            interaction.status === "pending" &&
-            interaction.kind === pendingKind,
-        ),
-      );
-    if (limit !== undefined) toolCalls = toolCalls.slice(0, limit);
-    return c.json({ toolCalls: toolCalls.map(toToolCallTranscriptRecord) });
+    const cursorUpdatedAt = c.req.query("cursorUpdatedAt");
+    const cursorId = c.req.query("cursorId");
+    const page = state.registry.tools.queryToolCallPreviews({
+      status: status.success ? status.data : undefined,
+      pendingInteractionKind:
+        pendingKind === "approval" ||
+        pendingKind === "user_input" ||
+        pendingKind === "plan_review"
+          ? pendingKind
+          : undefined,
+      limit,
+      cursor:
+        cursorUpdatedAt && cursorId
+          ? { updatedAt: cursorUpdatedAt, id: cursorId }
+          : undefined,
+    });
+    return c.json(page);
   });
   app.get(
     "/tool-calls/:toolCallId",
     routeHandler(async (c) =>
       c.json({
-        toolCall: state.registry.tools.getToolCall(routeParam(c, "toolCallId")),
+        toolCall: await state.registry.tools.getToolCallDetails(
+          routeParam(c, "toolCallId"),
+        ),
       }),
     ),
   );

--- a/packages/workbench-server/src/runtime/runtime-composition.ts
+++ b/packages/workbench-server/src/runtime/runtime-composition.ts
@@ -200,7 +200,6 @@ export function composeRuntime(
       agents: listAgents(),
       tasks: services.tasks.listTasks(),
       workers: services.workers.listWorkers(),
-      toolCalls: services.tools.listToolCalls(),
     });
   };
 
@@ -364,7 +363,8 @@ export function composeRuntime(
       services.conversationLifecycle.getConversationTree(conversationId),
     getContextUsage: (conversationId) =>
       services.workbenchRun.getContextUsage(conversationId),
-    listToolCalls: () => services.tools.listToolCalls(),
+    listToolCallPreviews: (conversationId) =>
+      services.tools.listToolCallPreviews({ conversationId, limit: 1_000 }),
     getActiveRun: (conversationId) =>
       services.runQuery.activeForConversation(conversationId),
   });

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -272,7 +272,7 @@ export class RuntimeRegistry {
         conversations: this.listConversations().length,
         agents: this.listAgents().length,
         tasks: this.tasks.listTasks().length,
-        toolCalls: this.tools.listToolCalls().length,
+        toolCalls: this.tools.countToolCalls(),
         runMetadata: runRecords.length,
         activeRuns: activeStates.length,
       };
@@ -351,7 +351,6 @@ export class RuntimeRegistry {
       agents: this.listAgents(),
       tasks: this.tasks.listTasks(),
       workers: this.workers.listWorkers(),
-      toolCalls: this.tools.listToolCalls(),
     });
   }
 

--- a/packages/workbench-server/test/explore-subagent-isolation.test.ts
+++ b/packages/workbench-server/test/explore-subagent-isolation.test.ts
@@ -114,9 +114,10 @@ describe("explore subagent transcript isolation", () => {
       );
       assert.match(childHarness, /temporary project is isolated/i);
 
-      const childToolCalls = orchestrator.registry.tools
-        .listToolCalls()
-        .filter((toolCall) => toolCall.agentId === child.id);
+      const childToolCalls = orchestrator.registry.tools.listToolCallPreviews({
+        agentId: child.id,
+        limit: 10,
+      });
       assert.equal(childToolCalls.length, 1);
       assert.equal(childToolCalls[0]?.toolName, "ls");
       assert.equal(childToolCalls[0]?.status, "completed");

--- a/packages/workbench-server/test/task-log.service.test.ts
+++ b/packages/workbench-server/test/task-log.service.test.ts
@@ -4,13 +4,15 @@ import {
   type TaskRecord,
 } from "@nervekit/contracts";
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
 import {
   createTaskLogCursor,
   MAX_BUFFERED_LOG_LINE_CHARS,
+  TASK_OUTPUT_HEAD_MAX_BYTES,
+  TASK_OUTPUT_TAIL_MAX_BYTES,
   TaskLogService,
 } from "../src/domains/tasks/task-log.service.js";
 import { StreamLogRegistry } from "../src/infrastructure/events/index.js";
@@ -146,6 +148,39 @@ describe("task log service line buffering", () => {
       [3, 4],
     );
     assert.equal(older.hasMoreBefore, true);
+  });
+
+  it("bounds retained task output and preserves a rolling tail", async () => {
+    const { record, service, cursor, onLog } = await createFixture();
+    const overflowBytes = 1024 * 1024;
+    const text = `${"x".repeat(
+      TASK_OUTPUT_HEAD_MAX_BYTES + overflowBytes - 1,
+    )}z`;
+
+    await service.captureOutput(record, cursor, "stdout", text, onLog);
+    await service.flushOutputBuffers(record, cursor, onLog);
+
+    const retention = service.retention(record, cursor);
+    assert.equal(retention.totalBytes, Buffer.byteLength(text));
+    assert.equal(
+      retention.retainedBytes,
+      TASK_OUTPUT_HEAD_MAX_BYTES + TASK_OUTPUT_TAIL_MAX_BYTES,
+    );
+    assert.equal(
+      retention.omittedBytes,
+      overflowBytes - TASK_OUTPUT_TAIL_MAX_BYTES,
+    );
+    assert.equal(retention.truncated, true);
+    assert.equal(
+      (await stat(record.stdoutPath)).size,
+      TASK_OUTPUT_HEAD_MAX_BYTES,
+    );
+    const tail = await service.readTail(record);
+    assert.ok(
+      Buffer.byteLength(tail.map((chunk) => chunk.text).join("")) <=
+        TASK_OUTPUT_TAIL_MAX_BYTES,
+    );
+    assert.equal(tail.at(-1)?.text.endsWith("z"), true);
   });
 
   it("caps large newline-less buffers", async () => {

--- a/packages/workbench-server/test/tool-call.repository.test.ts
+++ b/packages/workbench-server/test/tool-call.repository.test.ts
@@ -81,4 +81,73 @@ describe("canonical ToolCallRepository", () => {
     );
     value.index.close();
   });
+
+  it("hydrates terminal history into previews without retaining full records", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-repository-"));
+    roots.push(home);
+    const first = await repository(home);
+    for (let index = 0; index < 50; index += 1) {
+      await first.repository.create({
+        ...toolCall(`tool_terminal_${index}`),
+        status: "completed",
+        result: { content: "x".repeat(64 * 1024) },
+        settledAt: "2026-07-25T00:00:00.000Z",
+      });
+    }
+    await first.repository.create(toolCall("tool_active"));
+    first.index.close();
+
+    const second = await repository(home);
+    await second.repository.hydrate();
+
+    assert.deepEqual(second.repository.residentStats(), {
+      activeRecords: 1,
+      cachedTerminalRecords: 0,
+      cachedTerminalBytes: 0,
+    });
+    assert.equal(second.repository.count(), 51);
+    assert.equal(second.repository.listPreviews({ limit: 100 }).length, 51);
+    assert.throws(() => second.repository.get("tool_terminal_0"), /not active/);
+    assert.equal(
+      (await second.repository.getCanonical("tool_terminal_0")).status,
+      "completed",
+    );
+    assert.equal(second.repository.residentStats().cachedTerminalRecords, 1);
+    second.index.close();
+  });
+
+  it("pages previews stably by updated time and id", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-repository-"));
+    roots.push(home);
+    const value = await repository(home);
+    for (let index = 0; index < 5; index += 1) {
+      await value.repository.create({
+        ...toolCall(`tool_page_${index}`),
+        status: "completed",
+        result: "ok",
+        settledAt: "2026-07-25T00:00:00.000Z",
+      });
+    }
+    const first = value.repository.queryPreviews({ limit: 2 });
+    assert.equal(first.toolCalls.length, 2);
+    assert.ok(first.nextCursor);
+    const second = value.repository.queryPreviews({
+      limit: 2,
+      cursor: first.nextCursor,
+    });
+    assert.equal(second.toolCalls.length, 2);
+    assert.equal(
+      new Set([...first.toolCalls, ...second.toolCalls].map((call) => call.id))
+        .size,
+      4,
+    );
+    assert.ok(second.nextCursor);
+    const third = value.repository.queryPreviews({
+      limit: 2,
+      cursor: second.nextCursor,
+    });
+    assert.equal(third.toolCalls.length, 1);
+    assert.equal(third.nextCursor, undefined);
+    value.index.close();
+  });
 });

--- a/packages/workbench-server/test/workbench-task-service-foreground.test.ts
+++ b/packages/workbench-server/test/workbench-task-service-foreground.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { describe, it } from "node:test";
 import {
   createManager,
@@ -118,6 +119,48 @@ describe("task manager foreground bash auto-promotion", () => {
       assert.throws(() => manager.getTask(started.id), /Task not found/);
     },
   );
+
+  it("builds a bounded head-tail result for large foreground output", async () => {
+    const child = fakeChild();
+    let spawned!: () => void;
+    const didSpawn = new Promise<void>((resolve) => {
+      spawned = resolve;
+    });
+    const { supervisor } = fakeSupervisor({ child, onSpawn: spawned });
+    const { manager, storage, events } = await createManager(supervisor);
+    const started = waitForTaskEvent(events, "task.started");
+    const run = manager.runForegroundBashWithPromotion({
+      command: "node noisy.js",
+      cwd: storage.paths.home,
+      projectId: "proj_test",
+      conversationId: "conv_test",
+      agentId: "agent_test",
+      origin: { kind: "agent_tool", toolCallId: "tool_test" },
+    });
+    await started;
+    await didSpawn;
+    child.stdout.emit(
+      "data",
+      Buffer.from(`BEGIN-${"x".repeat(64 * 1024)}-END`),
+    );
+    child.emitClose(0, null);
+
+    const result = await run;
+
+    assert.equal(result.kind, "completed_foreground");
+    assert.match(result.result.content ?? "", /BEGIN-/);
+    assert.match(
+      result.result.content ?? "",
+      /bytes omitted from inline result/,
+    );
+    const details = result.result.details as { fullOutputPath?: string };
+    assert.ok(details.fullOutputPath);
+    assert.match(await readFile(details.fullOutputPath, "utf8"), /-END/);
+    assert.match(
+      result.result.content ?? "",
+      /use task_logs for retained diagnostics/i,
+    );
+  });
 
   it("captures output before delayed runtime identity resolves", async () => {
     const child = fakeChild();


### PR DESCRIPTION
## Summary
- Bound direct bash and managed-task output capture with explicit head/tail retention metadata and omission diagnostics.
- Replace eager historical tool-call retention with active records, a byte-bounded terminal cache, lazy canonical reads, and paginated SQLite previews.
- Stream hydration into plan/todo reducers and update snapshots, routes, transcripts, and notification handling.
- Add regression coverage for high-volume output, bounded foreground results, lazy history hydration, and stable pagination.

## Validation
- `pnpm fix && pnpm check && pnpm test`
- `git diff --check`

## Scope
This implements Option A application-level resilience. OS-level containment for hostile memory, fork, CPU, or filesystem exhaustion remains separate.
