### PR TITLE
feat(workbench): show conversation usage and stabilize system prompt

### DIFF
--- a/packages/ui-kit/src/lib/core/utils/usage.test.ts
+++ b/packages/ui-kit/src/lib/core/utils/usage.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatTokens } from "./usage.js";
+
+describe("formatTokens", () => {
+  it("formats token counts with compact human-readable units", () => {
+    assert.equal(formatTokens(999), "999");
+    assert.equal(formatTokens(1_250), "1.3k");
+    assert.equal(formatTokens(25_400), "25k");
+    assert.equal(formatTokens(1_250_000), "1.3M");
+    assert.equal(formatTokens(25_400_000), "25M");
+    assert.equal(formatTokens(1_250_000_000), "1.3B");
+    assert.equal(formatTokens(25_400_000_000), "25B");
+    assert.equal(formatTokens(1_250_000_000_000), "1.3T");
+    assert.equal(formatTokens(25_400_000_000_000), "25T");
+  });
+});

--- a/packages/ui-kit/src/lib/core/utils/usage.ts
+++ b/packages/ui-kit/src/lib/core/utils/usage.ts
@@ -4,7 +4,12 @@ export function formatTokens(count: number): string {
   if (count < 10_000) return `${(count / 1000).toFixed(1)}k`;
   if (count < 1_000_000) return `${Math.round(count / 1000)}k`;
   if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-  return `${Math.round(count / 1_000_000)}M`;
+  if (count < 1_000_000_000) return `${Math.round(count / 1_000_000)}M`;
+  if (count < 10_000_000_000) return `${(count / 1_000_000_000).toFixed(1)}B`;
+  if (count < 1_000_000_000_000) return `${Math.round(count / 1_000_000_000)}B`;
+  if (count < 10_000_000_000_000)
+    return `${(count / 1_000_000_000_000).toFixed(1)}T`;
+  return `${Math.round(count / 1_000_000_000_000)}T`;
 }
 
 /** Tone for a usage percentage: error >90, warning >70, otherwise neutral. */

--- a/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/PanelViewHost.svelte
@@ -76,6 +76,9 @@ const activeAgent = $derived(conversationSelectors.activeAgent);
 const conversationAgents = $derived(conversationSelectors.conversationAgents);
 const compacting = $derived(conversationSelectors.compacting);
 const contextUsage = $derived(conversationSelectors.activeContextUsage);
+const conversationUsage = $derived(
+  conversationSelectors.activeConversationUsage,
+);
 const contextWindow = $derived(conversationSelectors.activeContextWindow);
 const tasks = $derived(taskSelectors.scopedTasks);
 const selectedTask = $derived(taskSelectors.activeCenterTask);
@@ -131,6 +134,7 @@ function focusTasks() {
   <ContextPanelView
     {status}
     {contextUsage}
+    {conversationUsage}
     {contextWindow}
     {activeProject}
     {activeConversation}

--- a/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/adapters/WorkbenchComposerAdapter.svelte
@@ -42,6 +42,7 @@ let {
   models = [],
   selectedModelKey = "",
   contextUsage,
+  conversationUsage,
   contextWindow = 0,
   todos = [],
   focusToken = 0,
@@ -340,6 +341,7 @@ function handleMicContextMenu(event: MouseEvent) {
     permissionLevel,
     approvalPolicy,
     contextUsage,
+    conversationUsage,
     contextWindow,
     placeholder: pendingApproval
       ? "Approval required before the agent can continue"

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextAgentsTree.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextAgentsTree.svelte
@@ -1,15 +1,10 @@
 <script lang="ts">
 import Bot from "@lucide/svelte/icons/bot";
-import { StatusDot } from "@nervekit/ui-kit/components/ui/status-dot";
 import {
   agentActivityPulse,
   agentActivityTone,
 } from "@nervekit/ui-kit/core/utils/status";
-import {
-  buildPanelItemTree,
-  PanelEmpty,
-  PanelTree,
-} from "$lib/presentation/panel";
+import { PanelEmpty, PanelList, PanelRow } from "$lib/presentation/panel";
 import type { AgentRecord } from "$lib/api";
 import { shortAgentModel } from "$lib/core/utils/project-tree";
 import { permissionLabel } from "./context-session-fields";
@@ -30,6 +25,10 @@ function isAgentLive(agent: AgentRecord): boolean {
 
 function sortAgents(agents: readonly AgentRecord[]): AgentRecord[] {
   return [...agents].sort((a, b) => {
+    const aMain = a.parentAgentId ? 0 : 1;
+    const bMain = b.parentAgentId ? 0 : 1;
+    if (aMain !== bMain) return bMain - aMain;
+
     const aSelected = a.id === activeAgent?.id ? 1 : 0;
     const bSelected = b.id === activeAgent?.id ? 1 : 0;
     if (aSelected !== bSelected) return bSelected - aSelected;
@@ -44,10 +43,6 @@ function sortAgents(agents: readonly AgentRecord[]): AgentRecord[] {
 
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
   });
-}
-
-function agentLabel(agent: AgentRecord): string {
-  return agent.parentAgentId ? "Subagent" : "Main agent";
 }
 
 /** Compact thinking-level suffix rendered next to the model. */
@@ -67,7 +62,7 @@ function agentModelLabel(agent: AgentRecord): string {
 }
 
 function agentDescription(agent: AgentRecord): string {
-  return `${agent.mode} · ${permissionLabel(agent.permissionLevel)} · ${agentModelLabel(agent)}`;
+  return `${agent.mode} · ${permissionLabel(agent.permissionLevel)}`;
 }
 
 function agentTooltip(agent: AgentRecord): string {
@@ -89,13 +84,7 @@ function agentTooltip(agent: AgentRecord): string {
     .join("\n");
 }
 
-const nodes = $derived(
-  buildPanelItemTree(sortAgents(conversationAgents), {
-    getKey: (agent) => agent.id,
-    getParentKey: (agent) => agent.parentAgentId ?? undefined,
-    getLabel: agentLabel,
-  }),
-);
+const agents = $derived(sortAgents(conversationAgents));
 </script>
 
 {#if conversationAgents.length === 0}
@@ -105,24 +94,20 @@ const nodes = $derived(
     description="Agents appear once a run starts."
   />
 {:else}
-  <PanelTree
-    {nodes}
-    ariaLabel="Conversation agents"
-    itemStacked
-    itemMetaMono
-    itemVariant="card"
-    indentItems={false}
-    getItemDescription={agentDescription}
-    getItemMeta={(agent) => agent.id}
-    getItemTitle={agentTooltip}
-    getItemSelected={(agent) => agent.id === activeAgent?.id}
-    onItemActivate={(agent) => onSelectAgent?.(agent)}
-  >
-    {#snippet itemLabelTrailing(agent)}
-      <StatusDot
-        tone={agentActivityTone(agent.status, false, agent.mode)}
+  <PanelList ariaLabel="Conversation agents">
+    {#each agents as agent, index (agent.id)}
+      <PanelRow
+        label={agentModelLabel(agent)}
+        description={agentDescription(agent)}
+        title={agentTooltip(agent)}
+        status={agentActivityTone(agent.status, false, agent.mode)}
         pulse={agentActivityPulse(agent.status)}
+        class={agent.parentAgentId && !agents[index - 1]?.parentAgentId
+          ? "mt-2"
+          : undefined}
+        dense
+        onclick={() => onSelectAgent?.(agent)}
       />
-    {/snippet}
-  </PanelTree>
+    {/each}
+  </PanelList>
 {/if}

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextConversationUsage.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextConversationUsage.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+import { formatTokens } from "@nervekit/ui-kit/core/utils/usage";
+import { PanelPropertyRow, PanelSectionHeader } from "$lib/presentation/panel";
+import {
+  conversationUsageMetrics,
+  type ConversationUsageSummary,
+} from "$lib/presentation/usage/conversation-usage";
+
+let { conversationUsage }: { conversationUsage: ConversationUsageSummary } =
+  $props();
+
+const metrics = $derived(conversationUsageMetrics(conversationUsage));
+const cacheRateLabel = $derived(
+  metrics.cacheRate == null
+    ? "Unavailable"
+    : `${Math.round(metrics.cacheRate)}%`,
+);
+
+function compactTokens(value: number): string {
+  return `${formatTokens(value)} tokens`;
+}
+
+function exactTokens(value: number): string {
+  return `${value.toLocaleString()} tokens`;
+}
+</script>
+
+<div class="flex min-w-0 flex-col">
+  <PanelSectionHeader title="Conversation usage" />
+  {#if metrics.hasUsage}
+    <PanelPropertyRow
+      label="Processed"
+      value={compactTokens(metrics.totalTokens)}
+      title={exactTokens(metrics.totalTokens)}
+      dense
+    />
+    <PanelPropertyRow
+      label="Prompt input"
+      value={compactTokens(metrics.promptTokens)}
+      title={exactTokens(metrics.promptTokens)}
+      dense
+    />
+    <PanelPropertyRow
+      label="Output"
+      value={compactTokens(metrics.output)}
+      title={exactTokens(metrics.output)}
+      dense
+    />
+  {:else}
+    <p class="py-1.5 text-xs text-muted-foreground">
+      Available after the first response.
+    </p>
+  {/if}
+</div>
+
+{#if metrics.hasUsage}
+  <div class="flex min-w-0 flex-col">
+    <PanelSectionHeader title="Prompt cache">
+      {#snippet meta()}{cacheRateLabel}{/snippet}
+    </PanelSectionHeader>
+    <PanelPropertyRow
+      label="Cached input"
+      labelClass="w-24"
+      value={compactTokens(metrics.cachedTokens)}
+      title={`${exactTokens(metrics.cachedTokens)} · ${cacheRateLabel} of prompt input`}
+      dense
+    />
+    <PanelPropertyRow
+      label="Uncached input"
+      labelClass="w-24"
+      value={compactTokens(metrics.uncachedTokens)}
+      title={exactTokens(metrics.uncachedTokens)}
+      dense
+    />
+    <PanelPropertyRow
+      label="Cache writes"
+      labelClass="w-24"
+      value={compactTokens(metrics.cacheWrite)}
+      title={exactTokens(metrics.cacheWrite)}
+      dense
+    />
+    <p class="pt-1 text-xs text-muted-foreground">
+      Provider-reported usage for the selected branch.
+    </p>
+  </div>
+{/if}

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextConversationUsage.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextConversationUsage.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-import { formatTokens } from "@nervekit/ui-kit/core/utils/usage";
-import { PanelPropertyRow, PanelSectionHeader } from "$lib/presentation/panel";
+import { PanelPropertyRow } from "$lib/presentation/panel";
 import {
   conversationUsageMetrics,
   type ConversationUsageSummary,
@@ -16,33 +15,31 @@ const cacheRateLabel = $derived(
     : `${Math.round(metrics.cacheRate)}%`,
 );
 
-function compactTokens(value: number): string {
-  return `${formatTokens(value)} tokens`;
-}
-
 function exactTokens(value: number): string {
   return `${value.toLocaleString()} tokens`;
 }
 </script>
 
 <div class="flex min-w-0 flex-col">
-  <PanelSectionHeader title="Conversation usage" />
   {#if metrics.hasUsage}
     <PanelPropertyRow
-      label="Processed"
-      value={compactTokens(metrics.totalTokens)}
-      title={exactTokens(metrics.totalTokens)}
-      dense
-    />
-    <PanelPropertyRow
-      label="Prompt input"
-      value={compactTokens(metrics.promptTokens)}
+      label="Input"
+      labelClass="w-24"
+      value={exactTokens(metrics.promptTokens)}
       title={exactTokens(metrics.promptTokens)}
       dense
     />
     <PanelPropertyRow
+      label="Cached input"
+      labelClass="w-24"
+      value={`${exactTokens(metrics.cachedTokens)} · ${cacheRateLabel}`}
+      title={`${exactTokens(metrics.cachedTokens)} · ${cacheRateLabel} of all input tokens`}
+      dense
+    />
+    <PanelPropertyRow
       label="Output"
-      value={compactTokens(metrics.output)}
+      labelClass="w-24"
+      value={exactTokens(metrics.output)}
       title={exactTokens(metrics.output)}
       dense
     />
@@ -52,35 +49,3 @@ function exactTokens(value: number): string {
     </p>
   {/if}
 </div>
-
-{#if metrics.hasUsage}
-  <div class="flex min-w-0 flex-col">
-    <PanelSectionHeader title="Prompt cache">
-      {#snippet meta()}{cacheRateLabel}{/snippet}
-    </PanelSectionHeader>
-    <PanelPropertyRow
-      label="Cached input"
-      labelClass="w-24"
-      value={compactTokens(metrics.cachedTokens)}
-      title={`${exactTokens(metrics.cachedTokens)} · ${cacheRateLabel} of prompt input`}
-      dense
-    />
-    <PanelPropertyRow
-      label="Uncached input"
-      labelClass="w-24"
-      value={compactTokens(metrics.uncachedTokens)}
-      title={exactTokens(metrics.uncachedTokens)}
-      dense
-    />
-    <PanelPropertyRow
-      label="Cache writes"
-      labelClass="w-24"
-      value={compactTokens(metrics.cacheWrite)}
-      title={exactTokens(metrics.cacheWrite)}
-      dense
-    />
-    <p class="pt-1 text-xs text-muted-foreground">
-      Provider-reported usage for the selected branch.
-    </p>
-  </div>
-{/if}

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextPanelView.svelte
@@ -18,7 +18,9 @@ import type {
 } from "$lib/api";
 import { writeClipboardText } from "$lib/core/clipboard";
 import { notify } from "$lib/features/notifications/notify.svelte";
+import type { ConversationUsageSummary } from "$lib/presentation/usage/conversation-usage";
 import ContextAgentsTree from "./ContextAgentsTree.svelte";
+import ContextConversationUsage from "./ContextConversationUsage.svelte";
 import ContextExportMenu from "./ContextExportMenu.svelte";
 import ContextSessionSection from "./ContextSessionSection.svelte";
 import ContextUsageStrip from "./ContextUsageStrip.svelte";
@@ -27,6 +29,7 @@ import { sessionFields, sessionFieldsText } from "./context-session-fields";
 type Props = {
   status?: StatusResponse;
   contextUsage?: ContextUsage;
+  conversationUsage: ConversationUsageSummary;
   contextWindow?: number;
   activeProject?: ProjectRecord;
   activeConversation?: ConversationRecord;
@@ -42,6 +45,7 @@ type Props = {
 let {
   status,
   contextUsage,
+  conversationUsage,
   contextWindow = 0,
   activeProject,
   activeConversation,
@@ -111,6 +115,7 @@ async function copySession(): Promise<void> {
           {compacting ? "Compacting…" : "Compact"}
         </Button>
       </ContextUsageStrip>
+      <ContextConversationUsage {conversationUsage} />
       <div class="flex min-w-0 flex-col">
         <ContextSessionSection {fields} />
       </div>

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextPanelView.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextPanelView.svelte
@@ -115,10 +115,10 @@ async function copySession(): Promise<void> {
           {compacting ? "Compacting…" : "Compact"}
         </Button>
       </ContextUsageStrip>
-      <ContextConversationUsage {conversationUsage} />
       <div class="flex min-w-0 flex-col">
         <ContextSessionSection {fields} />
       </div>
+      <ContextConversationUsage {conversationUsage} />
       <ContextAgentsTree {conversationAgents} {activeAgent} {onSelectAgent} />
     </div>
   {/if}

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextSessionSection.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextSessionSection.svelte
@@ -8,6 +8,7 @@ let { fields }: { fields: readonly SessionField[] } = $props();
 {#each fields as field (field.label)}
   <PanelPropertyRow
     label={field.label}
+    labelClass="w-24"
     value={field.value}
     title={field.value}
     mono={field.mono ?? false}

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextUsageStrip.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextUsageStrip.svelte
@@ -2,7 +2,7 @@
 import type { Snippet } from "svelte";
 import type { ContextUsage } from "@nervekit/contracts";
 import { cn } from "@nervekit/ui-kit/core/utils";
-import { formatTokens, usageTone } from "@nervekit/ui-kit/core/utils/usage";
+import { usageTone } from "@nervekit/ui-kit/core/utils/usage";
 
 let {
   contextUsage,
@@ -35,9 +35,9 @@ const percentLabel = $derived(
 );
 const tokensLabel = $derived(
   tokens != null && limit > 0
-    ? `${formatTokens(tokens)} / ${formatTokens(limit)} tokens`
+    ? `${tokens.toLocaleString()} / ${limit.toLocaleString()} tokens`
     : limit > 0
-      ? `${formatTokens(limit)} token window`
+      ? `${limit.toLocaleString()} token window`
       : "Usage unknown",
 );
 const tone = $derived(usageTone(percent));
@@ -63,7 +63,7 @@ const percentClass = $derived(
       viewBox="0 0 120 66"
       class="w-full"
       role="img"
-      aria-label={`Current context window usage: ${percentLabel} of ${tokensLabel}`}
+      aria-label={`Context window usage: ${percentLabel} of ${tokensLabel}`}
     >
       <path
         d={ARC_PATH}

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextUsageStrip.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextUsageStrip.svelte
@@ -63,7 +63,7 @@ const percentClass = $derived(
       viewBox="0 0 120 66"
       class="w-full"
       role="img"
-      aria-label={`Context window usage: ${percentLabel} of ${tokensLabel}`}
+      aria-label={`Current context window usage: ${percentLabel} of ${tokensLabel}`}
     >
       <path
         d={ARC_PATH}

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
@@ -14,6 +14,7 @@ import {
   modelKey,
   scopedUsableModelOptions,
 } from "$lib/presentation/utils/model";
+import { summarizeConversationUsage } from "$lib/presentation/usage/conversation-usage";
 import { settingsState } from "$lib/features/settings/state/settings-state.svelte";
 import WorkbenchConversationAdapter from "$lib/features/conversations/components/WorkbenchConversationAdapter.svelte";
 import {
@@ -222,6 +223,9 @@ const contextWindow = $derived(
     view?.contextUsage?.contextWindow ??
     0,
 );
+const conversationUsage = $derived(
+  summarizeConversationUsage(view?.entries ?? []),
+);
 const builtinSuggestionIcons = {
   "commit-changes": GitCommitHorizontal,
   "commit-on-feature-branch": GitBranchPlus,
@@ -404,6 +408,7 @@ function moveQueuedPromptToComposer(prompt: QueuedPromptRecord) {
   approvalPolicy={selectedApprovalPolicy}
   {slashCompletions}
   contextUsage={view?.contextUsage}
+  {conversationUsage}
   {contextWindow}
   composerFocusToken={composerSignals.focusToken}
   composerEscapeToken={composerSignals.escapeToken}

--- a/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
@@ -51,6 +51,7 @@ let {
   planReviewModelKey = "",
   planReviewThinkingLevel = "off",
   contextUsage,
+  conversationUsage,
   contextWindow = 0,
   composerFocusToken = 0,
   composerEscapeToken = 0,
@@ -247,6 +248,7 @@ function menuForTranscript(
       permissionLevel,
       approvalPolicy,
       contextUsage,
+      conversationUsage,
       contextWindow,
       capabilities: {
         voice: true,
@@ -292,6 +294,7 @@ function menuForTranscript(
       {models}
       {selectedModelKey}
       {contextUsage}
+      {conversationUsage}
       {contextWindow}
       todos={composerTodos}
       focusToken={composerFocusToken}

--- a/packages/workbench-app/src/lib/features/conversations/components/prompt-composer-props.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/prompt-composer-props.ts
@@ -12,6 +12,7 @@ import type {
 } from "$lib/api";
 import type { PendingConversationState } from "$lib/core/types/state-types";
 import type { ComposerSuggestion } from "./composer-suggestion";
+import type { ConversationUsageSummary } from "$lib/presentation/usage/conversation-usage";
 
 export type Mode = AgentRecord["mode"];
 export type PermissionLevel = AgentRecord["permissionLevel"];
@@ -34,6 +35,7 @@ export type PromptComposerProps = {
   models?: ModelInfo[];
   selectedModelKey?: string;
   contextUsage?: ContextUsage;
+  conversationUsage?: ConversationUsageSummary;
   contextWindow?: number;
   todos?: TodoItem[];
   focusToken?: number;

--- a/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
@@ -21,6 +21,7 @@ import type {
   TranscriptItem,
 } from "$lib/core/types/state-types";
 import type { ComposerSuggestion } from "./composer-suggestion";
+import type { ConversationUsageSummary } from "$lib/presentation/usage/conversation-usage";
 
 export type WorkbenchConversationAdapterProps = {
   activeProject?: ProjectRecord;
@@ -49,6 +50,7 @@ export type WorkbenchConversationAdapterProps = {
   planReviewModelKey?: string;
   planReviewThinkingLevel?: AgentRecord["thinkingLevel"];
   contextUsage?: ContextUsage;
+  conversationUsage?: ConversationUsageSummary;
   contextWindow?: number;
   composerFocusToken?: number;
   composerEscapeToken?: number;

--- a/packages/workbench-app/src/lib/features/conversations/state/conversation-selectors.svelte.ts
+++ b/packages/workbench-app/src/lib/features/conversations/state/conversation-selectors.svelte.ts
@@ -4,6 +4,7 @@ import {
   scopedUsableModelOptions,
 } from "$lib/presentation/utils/model";
 import { activeRunStreamingText } from "$lib/presentation/state";
+import { summarizeConversationUsage } from "$lib/presentation/usage/conversation-usage";
 import type { PlanReviewRecord, UserQuestionRecord } from "$lib/api";
 import {
   conversationViewKey,
@@ -149,23 +150,7 @@ const conversationSelectorsValue = {
     return activeView()?.contextUsage?.contextWindow ?? 0;
   },
   get activeConversationUsage() {
-    const totals = {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      cost: 0,
-    };
-
-    for (const entry of activeView()?.entries ?? []) {
-      if (!entry.usage) continue;
-      totals.input += entry.usage.input;
-      totals.output += entry.usage.output;
-      totals.cacheRead += entry.usage.cacheRead;
-      totals.cacheWrite += entry.usage.cacheWrite;
-      totals.cost += entry.usage.cost;
-    }
-    return totals;
+    return summarizeConversationUsage(activeView()?.entries ?? []);
   },
   get usableModels() {
     return scopedUsableModelOptions(

--- a/packages/workbench-app/src/lib/presentation/components/composer/ComposerToolbar.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ComposerToolbar.svelte
@@ -22,6 +22,7 @@ import Switch from "@nervekit/ui-kit/components/ui/switch-field";
 import type { Component } from "svelte";
 import ComposerModelPicker from "./ComposerModelPicker.svelte";
 import ContextProgressBadge from "./ContextProgressBadge.svelte";
+import type { ConversationUsageSummary } from "../../usage/conversation-usage.js";
 import TodoProgressChip from "./TodoProgressChip.svelte";
 
 type PermissionOption = {
@@ -50,6 +51,7 @@ type Props = {
   modeShortcutAria?: string;
   thinkingShortcut?: string;
   contextUsage?: ContextUsage;
+  conversationUsage?: ConversationUsageSummary;
   contextWindow: number;
   compacting?: boolean;
   compactDisabled?: boolean;
@@ -81,6 +83,7 @@ let {
   modeShortcutAria,
   thinkingShortcut,
   contextUsage,
+  conversationUsage,
   contextWindow,
   compacting = false,
   compactDisabled = false,
@@ -224,6 +227,7 @@ function setAutoApproveReadOnly(autoApproveReadOnly: boolean) {
 
   <ContextProgressBadge
     {contextUsage}
+    {conversationUsage}
     {contextWindow}
     {compacting}
     {compactDisabled}

--- a/packages/workbench-app/src/lib/presentation/components/composer/ContextProgressBadge.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ContextProgressBadge.svelte
@@ -136,7 +136,7 @@ function requestCompact(): void {
     {/snippet}
 
     <PopoverBody>
-      <PopoverHeader title="Current context window">
+      <PopoverHeader title="Context window">
         {#snippet action()}
           <span
             class={cn(
@@ -172,37 +172,49 @@ function requestCompact(): void {
             label="Used"
             value={tokens == null
               ? "Unavailable"
+              : `${formatTokens(tokens)} tokens`}
+            title={tokens == null
+              ? undefined
               : `${tokens.toLocaleString()} tokens`}
           />
           <PopoverProperty
             label="Remaining"
             value={remainingTokens == null
               ? "Unavailable"
+              : `${formatTokens(remainingTokens)} tokens`}
+            title={remainingTokens == null
+              ? undefined
               : `${remainingTokens.toLocaleString()} tokens`}
           />
           <PopoverProperty
             label="Window"
             value={contextLimit > 0
-              ? `${contextLimit.toLocaleString()} tokens`
+              ? `${formatTokens(contextLimit)} tokens`
               : "Unknown"}
+            title={contextLimit > 0
+              ? `${contextLimit.toLocaleString()} tokens`
+              : undefined}
           />
         </PopoverProperties>
       </PopoverSection>
 
-      <PopoverSection label="Conversation usage" separated>
+      <PopoverSection label="Token usage" separated>
         {#if conversationMetrics.hasUsage}
           <PopoverProperties>
             <PopoverProperty
-              label="Total processed"
-              value={`${conversationMetrics.totalTokens.toLocaleString()} tokens`}
+              label="Input"
+              value={`${formatTokens(conversationMetrics.promptTokens)} tokens`}
+              title={`${conversationMetrics.promptTokens.toLocaleString()} tokens`}
             />
             <PopoverProperty
-              label="Prompt input"
-              value={`${conversationMetrics.promptTokens.toLocaleString()} tokens`}
+              label="Cached input"
+              value={`${formatTokens(conversationMetrics.cachedTokens)} tokens · ${cacheRateLabel}`}
+              title={`${conversationMetrics.cachedTokens.toLocaleString()} tokens · ${cacheRateLabel} of all input tokens`}
             />
             <PopoverProperty
               label="Output"
-              value={`${conversationMetrics.output.toLocaleString()} tokens`}
+              value={`${formatTokens(conversationMetrics.output)} tokens`}
+              title={`${conversationMetrics.output.toLocaleString()} tokens`}
             />
           </PopoverProperties>
         {:else}
@@ -211,29 +223,6 @@ function requestCompact(): void {
           </p>
         {/if}
       </PopoverSection>
-
-      {#if conversationMetrics.hasUsage}
-        <PopoverSection label="Prompt cache" separated>
-          <PopoverProperties>
-            <PopoverProperty
-              label="Cached input"
-              value={`${conversationMetrics.cachedTokens.toLocaleString()} tokens · ${cacheRateLabel}`}
-              title="Provider-reported cache reads as a share of all prompt input"
-            />
-            <PopoverProperty
-              label="Uncached input"
-              value={`${conversationMetrics.uncachedTokens.toLocaleString()} tokens`}
-            />
-            <PopoverProperty
-              label="Cache writes"
-              value={`${conversationMetrics.cacheWrite.toLocaleString()} tokens`}
-            />
-          </PopoverProperties>
-          <p class="text-muted-foreground">
-            Provider-reported usage for the selected branch.
-          </p>
-        </PopoverSection>
-      {/if}
 
       <Button
         size="xs"

--- a/packages/workbench-app/src/lib/presentation/components/composer/ContextProgressBadge.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/composer/ContextProgressBadge.svelte
@@ -17,9 +17,15 @@ import {
 } from "@nervekit/ui-kit/components/ui/progress-ring";
 import { cn } from "@nervekit/ui-kit/core/utils";
 import { formatTokens, usageTone } from "@nervekit/ui-kit/core/utils/usage";
+import {
+  conversationUsageMetrics,
+  emptyConversationUsage,
+  type ConversationUsageSummary,
+} from "../../usage/conversation-usage.js";
 
 type Props = {
   contextUsage?: ContextUsage;
+  conversationUsage?: ConversationUsageSummary;
   contextWindow?: number;
   compacting?: boolean;
   compactDisabled?: boolean;
@@ -28,6 +34,7 @@ type Props = {
 
 let {
   contextUsage,
+  conversationUsage,
   contextWindow = 0,
   compacting = false,
   compactDisabled = false,
@@ -41,6 +48,14 @@ const contextLimit = $derived(
   contextWindow || contextUsage?.contextWindow || 0,
 );
 const tokens = $derived(contextUsage?.tokens ?? null);
+const conversationMetrics = $derived(
+  conversationUsageMetrics(conversationUsage ?? emptyConversationUsage()),
+);
+const cacheRateLabel = $derived(
+  conversationMetrics.cacheRate == null
+    ? "Unavailable"
+    : `${Math.round(conversationMetrics.cacheRate)}%`,
+);
 const percent = $derived.by(() => {
   if (tokens != null && contextLimit > 0) {
     return (tokens / contextLimit) * 100;
@@ -121,7 +136,7 @@ function requestCompact(): void {
     {/snippet}
 
     <PopoverBody>
-      <PopoverHeader title="Context window">
+      <PopoverHeader title="Current context window">
         {#snippet action()}
           <span
             class={cn(
@@ -173,6 +188,52 @@ function requestCompact(): void {
           />
         </PopoverProperties>
       </PopoverSection>
+
+      <PopoverSection label="Conversation usage" separated>
+        {#if conversationMetrics.hasUsage}
+          <PopoverProperties>
+            <PopoverProperty
+              label="Total processed"
+              value={`${conversationMetrics.totalTokens.toLocaleString()} tokens`}
+            />
+            <PopoverProperty
+              label="Prompt input"
+              value={`${conversationMetrics.promptTokens.toLocaleString()} tokens`}
+            />
+            <PopoverProperty
+              label="Output"
+              value={`${conversationMetrics.output.toLocaleString()} tokens`}
+            />
+          </PopoverProperties>
+        {:else}
+          <p class="text-muted-foreground">
+            Available after the first response.
+          </p>
+        {/if}
+      </PopoverSection>
+
+      {#if conversationMetrics.hasUsage}
+        <PopoverSection label="Prompt cache" separated>
+          <PopoverProperties>
+            <PopoverProperty
+              label="Cached input"
+              value={`${conversationMetrics.cachedTokens.toLocaleString()} tokens · ${cacheRateLabel}`}
+              title="Provider-reported cache reads as a share of all prompt input"
+            />
+            <PopoverProperty
+              label="Uncached input"
+              value={`${conversationMetrics.uncachedTokens.toLocaleString()} tokens`}
+            />
+            <PopoverProperty
+              label="Cache writes"
+              value={`${conversationMetrics.cacheWrite.toLocaleString()} tokens`}
+            />
+          </PopoverProperties>
+          <p class="text-muted-foreground">
+            Provider-reported usage for the selected branch.
+          </p>
+        </PopoverSection>
+      {/if}
 
       <Button
         size="xs"

--- a/packages/workbench-app/src/lib/presentation/components/conversation/agent-composer.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/agent-composer.svelte
@@ -111,6 +111,7 @@ function submit(): void {
       thinkingShortcut={model.thinkingShortcut}
       approvalPolicy={model.approvalPolicy}
       contextUsage={model.contextUsage}
+      conversationUsage={model.conversationUsage}
       contextWindow={model.contextWindow ?? 0}
       compacting={model.compacting}
       compactDisabled={blocked || !actions.onCompact}

--- a/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
@@ -14,6 +14,7 @@ import type {
   UserQuestionRecord,
 } from "@nervekit/contracts";
 import type { TimelineItem } from "../../state/timeline.js";
+import type { ConversationUsageSummary } from "../../usage/conversation-usage.js";
 import type {
   ApprovalWithToolCall,
   PlanReviewResolveOptions,
@@ -57,6 +58,7 @@ export type ConversationComposerModel = {
   permissionLevel: PermissionLevel;
   approvalPolicy: ApprovalPolicy;
   contextUsage?: ContextUsage;
+  conversationUsage?: ConversationUsageSummary;
   contextWindow?: number;
   hint?: string;
   placeholder?: string;

--- a/packages/workbench-app/src/lib/presentation/panel/PanelPropertyRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/panel/PanelPropertyRow.svelte
@@ -7,6 +7,7 @@ let {
   value,
   mono = false,
   dense = false,
+  labelClass,
   title,
   actions,
   children,
@@ -16,6 +17,7 @@ let {
   mono?: boolean;
   /** Tightens the row rhythm for dense property lists. */
   dense?: boolean;
+  labelClass?: string;
   title?: string;
   actions?: Snippet;
   /** Custom value rendering; replaces `value`. */
@@ -33,6 +35,7 @@ let {
     class={cn(
       "shrink-0 truncate text-muted-foreground",
       dense ? "w-20" : "w-24",
+      labelClass,
     )}>{label}</span
   >
   <div class={cn("min-w-0 flex-1 truncate", mono && "font-mono")} {title}>

--- a/packages/workbench-app/src/lib/presentation/usage/conversation-usage.test.ts
+++ b/packages/workbench-app/src/lib/presentation/usage/conversation-usage.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ConversationEntry } from "@nervekit/contracts";
+import {
+  conversationUsageMetrics,
+  emptyConversationUsage,
+  summarizeConversationUsage,
+} from "./conversation-usage.js";
+
+describe("conversation usage", () => {
+  it("returns an explicit empty summary without provider usage", () => {
+    const summary = summarizeConversationUsage([{}]);
+
+    assert.deepEqual(summary, emptyConversationUsage());
+    assert.deepEqual(conversationUsageMetrics(summary), {
+      ...emptyConversationUsage(),
+      hasUsage: false,
+      promptTokens: 0,
+      cachedTokens: 0,
+      uncachedTokens: 0,
+      cacheRate: null,
+    });
+  });
+
+  it("aggregates provider totals and derives cache accounting", () => {
+    const summary = summarizeConversationUsage([
+      entryUsage(100, 20, 300, 40, 460, 1.25),
+      entryUsage(50, 10, 500, 20, 580, 0.75),
+    ]);
+
+    assert.deepEqual(summary, {
+      responseCount: 2,
+      input: 150,
+      output: 30,
+      cacheRead: 800,
+      cacheWrite: 60,
+      totalTokens: 1040,
+      cost: 2,
+    });
+    assert.deepEqual(conversationUsageMetrics(summary), {
+      ...summary,
+      hasUsage: true,
+      promptTokens: 1010,
+      cachedTokens: 800,
+      uncachedTokens: 210,
+      cacheRate: (800 / 1010) * 100,
+    });
+  });
+
+  it("keeps cache rate unavailable when responses report no prompt input", () => {
+    const summary = summarizeConversationUsage([
+      entryUsage(0, 12, 0, 0, 12, 0),
+    ]);
+
+    assert.equal(conversationUsageMetrics(summary).hasUsage, true);
+    assert.equal(conversationUsageMetrics(summary).cacheRate, null);
+  });
+
+  it("does not retain totals between branch entry arrays", () => {
+    const first = summarizeConversationUsage([
+      entryUsage(10, 2, 30, 4, 46, 0.1),
+      {},
+    ]);
+    const second = summarizeConversationUsage([
+      entryUsage(1, 1, 0, 0, 2, 0.01),
+    ]);
+
+    assert.equal(first.totalTokens, 46);
+    assert.equal(first.responseCount, 1);
+    assert.equal(second.totalTokens, 2);
+    assert.equal(second.responseCount, 1);
+  });
+});
+
+function entryUsage(
+  input: number,
+  output: number,
+  cacheRead: number,
+  cacheWrite: number,
+  totalTokens: number,
+  cost: number,
+): Pick<ConversationEntry, "usage"> {
+  return {
+    usage: { input, output, cacheRead, cacheWrite, totalTokens, cost },
+  };
+}

--- a/packages/workbench-app/src/lib/presentation/usage/conversation-usage.ts
+++ b/packages/workbench-app/src/lib/presentation/usage/conversation-usage.ts
@@ -1,0 +1,62 @@
+import type { ConversationEntry } from "@nervekit/contracts";
+
+export interface ConversationUsageSummary {
+  responseCount: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: number;
+}
+
+export interface ConversationUsageMetrics extends ConversationUsageSummary {
+  hasUsage: boolean;
+  promptTokens: number;
+  cachedTokens: number;
+  uncachedTokens: number;
+  cacheRate: number | null;
+}
+
+export function emptyConversationUsage(): ConversationUsageSummary {
+  return {
+    responseCount: 0,
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: 0,
+  };
+}
+
+export function summarizeConversationUsage(
+  entries: readonly Pick<ConversationEntry, "usage">[],
+): ConversationUsageSummary {
+  const summary = emptyConversationUsage();
+  for (const entry of entries) {
+    if (!entry.usage) continue;
+    summary.responseCount += 1;
+    summary.input += entry.usage.input;
+    summary.output += entry.usage.output;
+    summary.cacheRead += entry.usage.cacheRead;
+    summary.cacheWrite += entry.usage.cacheWrite;
+    summary.totalTokens += entry.usage.totalTokens;
+    summary.cost += entry.usage.cost;
+  }
+  return summary;
+}
+
+export function conversationUsageMetrics(
+  usage: ConversationUsageSummary,
+): ConversationUsageMetrics {
+  const promptTokens = usage.input + usage.cacheRead + usage.cacheWrite;
+  return {
+    ...usage,
+    hasUsage: usage.responseCount > 0,
+    promptTokens,
+    cachedTokens: usage.cacheRead,
+    uncachedTokens: usage.input + usage.cacheWrite,
+    cacheRate: promptTokens > 0 ? (usage.cacheRead / promptTokens) * 100 : null,
+  };
+}

--- a/packages/workbench-server/src/domains/agents/prompting/nerve-system-prompt.ts
+++ b/packages/workbench-server/src/domains/agents/prompting/nerve-system-prompt.ts
@@ -11,7 +11,6 @@ export interface BuildNerveSystemPromptOptions {
   planDir?: string;
   contextFiles?: Array<{ path: string; content: string }>;
   skills?: Skill[];
-  activeBackgroundTaskIds?: readonly string[];
 }
 
 export function buildNerveSystemPrompt(
@@ -39,14 +38,7 @@ export function buildNerveSystemPrompt(
     options.mode === "planning"
       ? buildPlanModeInstructions(options.planDir ?? "Nerve plan storage")
       : "";
-  const taskToolsEnabled = tools.some((tool) => tool.startsWith("task_"));
-  const environmentBlock = formatEnvironment({
-    date,
-    cwd,
-    activeBackgroundTaskIds: taskToolsEnabled
-      ? options.activeBackgroundTaskIds
-      : undefined,
-  });
+  const environmentBlock = formatEnvironment({ date, cwd });
 
   return [
     basePrompt,
@@ -175,24 +167,13 @@ function buildPlanModeInstructions(planDir: string): string {
   `;
 }
 
-function formatEnvironment(options: {
-  date: string;
-  cwd: string;
-  activeBackgroundTaskIds?: readonly string[];
-}): string {
-  const lines = [
+function formatEnvironment(options: { date: string; cwd: string }): string {
+  return [
     "<environment>",
     `Current date: ${options.date}`,
     `Current working directory: ${options.cwd}`,
-  ];
-  const taskIds = options.activeBackgroundTaskIds;
-  if (taskIds?.length) {
-    lines.push(
-      `Active background tasks (${taskIds.length}): ${taskIds.join(", ")}`,
-    );
-  }
-  lines.push("</environment>");
-  return lines.join("\n");
+    "</environment>",
+  ].join("\n");
 }
 
 function formatProjectInstructions(

--- a/packages/workbench-server/src/domains/agents/run/system-prompt-builder.ts
+++ b/packages/workbench-server/src/domains/agents/run/system-prompt-builder.ts
@@ -1,11 +1,9 @@
 import type { Skill } from "@nervekit/harness";
 import type {
   AgentRecord,
-  TaskRecord,
   UserConfigurableToolName,
 } from "@nervekit/contracts";
 import { planDirForStorageHome } from "../../plans/plan-paths.js";
-import { activeBackgroundTaskIdsInDirectoryTree } from "../../tasks/index.js";
 import {
   activeToolNamesForAgent,
   toolPromptMetadata,
@@ -29,7 +27,6 @@ export async function buildAgentSystemPrompt(
     agentBrowserSkills?: readonly Skill[];
     jiraEnabled?: boolean;
     confluenceEnabled?: boolean;
-    tasks?: readonly TaskRecord[];
   } = {},
 ): Promise<string> {
   const activeToolNames = activeToolNamesForAgent(agent, {
@@ -54,7 +51,6 @@ export async function buildAgentSystemPrompt(
       planDir: options.storageHome
         ? planDirForStorageHome(options.storageHome)
         : undefined,
-      tasks: options.tasks,
     },
   );
 }
@@ -70,7 +66,6 @@ export function composeAgentSystemPrompt(
   resources: Awaited<ReturnType<typeof loadHarnessResources>>,
   options: {
     planDir?: string;
-    tasks?: readonly TaskRecord[];
   } = {},
 ): string {
   if (agent.systemPrompt) return agent.systemPrompt;
@@ -84,8 +79,5 @@ export function composeAgentSystemPrompt(
     customPrompt: resources.systemPrompt,
     appendSystemPrompt: resources.appendSystemPrompt,
     planDir: options.planDir,
-    activeBackgroundTaskIds: options.tasks
-      ? activeBackgroundTaskIdsInDirectoryTree(options.tasks, agent.projectDir)
-      : undefined,
   });
 }

--- a/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
@@ -147,7 +147,6 @@ export async function executeWorkbenchHarness(
         resources,
         {
           planDir: planDirForStorageHome(this.deps.storage.paths.home),
-          tasks: this.deps.tasks.listTasks(),
         },
       );
     };

--- a/packages/workbench-server/src/domains/tasks/index.ts
+++ b/packages/workbench-server/src/domains/tasks/index.ts
@@ -19,10 +19,7 @@ export {
   inspectRuntimeListeningPorts,
   isSameProcessIdentity,
 } from "./task-port-inspector.js";
-export {
-  activeBackgroundTaskIdsInDirectoryTree,
-  isPathInDirectoryTree,
-} from "./task-scope.js";
+export { isPathInDirectoryTree } from "./task-scope.js";
 export {
   isActiveTaskStatus,
   isOrphanedTaskStatus,

--- a/packages/workbench-server/src/domains/tasks/task-scope.ts
+++ b/packages/workbench-server/src/domains/tasks/task-scope.ts
@@ -1,6 +1,4 @@
 import path from "node:path";
-import type { TaskRecord } from "@nervekit/contracts";
-import { isActiveTaskStatus } from "./task-status.js";
 
 export function isPathInDirectoryTree(
   root: string,
@@ -17,18 +15,4 @@ export function isPathInDirectoryTree(
       !relative.startsWith(`..${flavor.sep}`) &&
       !flavor.isAbsolute(relative))
   );
-}
-
-export function activeBackgroundTaskIdsInDirectoryTree(
-  tasks: readonly TaskRecord[],
-  root: string,
-): string[] {
-  return tasks
-    .filter(
-      (task) =>
-        task.visibility !== "foreground" &&
-        isActiveTaskStatus(task.status) &&
-        isPathInDirectoryTree(root, task.cwd),
-    )
-    .map((task) => task.id);
 }

--- a/packages/workbench-server/src/routes/agent-routes.ts
+++ b/packages/workbench-server/src/routes/agent-routes.ts
@@ -47,7 +47,6 @@ export function createAgentRoutes(state: OrchestratorState): Hono {
         agentBrowserSkills: state.agentBrowserSkills.skills,
         jiraEnabled: state.storage.settings.tools.jira.enabled,
         confluenceEnabled: state.storage.settings.tools.confluence.enabled,
-        tasks: state.registry.tasks.listTasks(),
       });
       return c.body(prompt, 200, {
         "Content-Type": "text/markdown; charset=utf-8",

--- a/packages/workbench-server/test/nerve-system-prompt.test.ts
+++ b/packages/workbench-server/test/nerve-system-prompt.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildNerveSystemPrompt } from "../src/domains/agents/prompting/nerve-system-prompt.js";
+
+describe("Nerve system prompt", () => {
+  it("keeps the environment stable and excludes runtime task state", () => {
+    const options = {
+      cwd: "C:\\workspace\\nerve",
+      selectedTools: ["read", "task_start", "task_status"],
+    };
+
+    const first = buildNerveSystemPrompt(options);
+    const second = buildNerveSystemPrompt(options);
+
+    assert.equal(first, second);
+    assert.match(first, /<environment>\nCurrent date: \d{4}-\d{2}-\d{2}\n/);
+    assert.match(first, /Current working directory: C:\/workspace\/nerve/);
+    assert.doesNotMatch(first, /Current (?:time|timestamp):/i);
+    assert.doesNotMatch(first, /Active background tasks/i);
+  });
+
+  it("changes when intentional cache-prefix inputs change", () => {
+    const coding = buildNerveSystemPrompt({
+      cwd: "/workspace/nerve",
+      mode: "coding",
+      selectedTools: ["read"],
+    });
+    const planning = buildNerveSystemPrompt({
+      cwd: "/workspace/nerve",
+      mode: "planning",
+      selectedTools: ["read", "plan_mode_enter"],
+      planDir: "/tmp/plans",
+    });
+
+    assert.notEqual(coding, planning);
+    assert.doesNotMatch(coding, /<plan_mode active="true"/);
+    assert.match(planning, /<plan_mode active="true"/);
+    assert.match(planning, /plan_dir="\/tmp\/plans"/);
+  });
+});

--- a/packages/workbench-server/test/task-scope.test.ts
+++ b/packages/workbench-server/test/task-scope.test.ts
@@ -1,30 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { TaskRecord, TaskStatus } from "@nervekit/contracts";
-import {
-  activeBackgroundTaskIdsInDirectoryTree,
-  isPathInDirectoryTree,
-} from "../src/domains/tasks/index.js";
+import { isPathInDirectoryTree } from "../src/domains/tasks/index.js";
 
 describe("task directory scope", () => {
-  it("includes active background tasks at the project root and below it", () => {
-    const tasks = [
-      task("task_root", "/workspace/project", "starting"),
-      task("task_running", "/workspace/project/apps/api", "running"),
-      task("task_ready", "/workspace/project/apps/web", "ready"),
-      task("task_stopping", "/workspace/project/tmp", "stopping"),
-      task("task_sibling", "/workspace/project-other", "running"),
-      task("task_parent", "/workspace", "running"),
-      task("task_terminal", "/workspace/project", "completed"),
-      task("task_foreground", "/workspace/project", "running", "foreground"),
-    ];
-
-    assert.deepEqual(
-      activeBackgroundTaskIdsInDirectoryTree(tasks, "/workspace/project"),
-      ["task_root", "task_running", "task_ready", "task_stopping"],
-    );
-  });
-
   it("uses Windows path semantics for Windows project roots", () => {
     assert.equal(
       isPathInDirectoryTree("C:\\Work\\Project", "C:\\Work\\Project"),
@@ -52,25 +30,3 @@ describe("task directory scope", () => {
     );
   });
 });
-
-function task(
-  id: string,
-  cwd: string,
-  status: TaskStatus,
-  visibility: TaskRecord["visibility"] = "background",
-): TaskRecord {
-  return {
-    id,
-    cwd,
-    command: "test command",
-    status,
-    readiness: { outcome: "none" },
-    stdoutPath: "/tmp/stdout.log",
-    stderrPath: "/tmp/stderr.log",
-    logsPath: "/tmp/task.log",
-    startedAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    origin: { kind: "api" },
-    visibility,
-  };
-}


### PR DESCRIPTION
## Summary

Two related improvements to the workbench conversation experience and the agent system prompt.

### Conversation usage in the UI
- New `conversation-usage` module (`packages/workbench-app/src/lib/presentation/usage/conversation-usage.ts`) that summarizes provider usage across transcript entries (response count, input, output, cache read/write, total tokens, cost) and derives cache metrics (prompt tokens, cached/uncached input, cache rate).
- New `ContextConversationUsage` section in the context panel showing total processed / prompt input / output tokens and a prompt-cache breakdown (cached vs uncached input, cache writes, cache rate).
- `ContextProgressBadge` popover expanded with "Conversation usage" and "Prompt cache" sections alongside the existing current context window ring.
- `conversationUsage` is threaded through `ConversationShell` → `WorkbenchConversationAdapter` → `WorkbenchComposerAdapter` → `agent-composer` → `ComposerToolbar` → `ContextProgressBadge`, and into `ContextPanelView` via `PanelViewHost`.
- `PanelPropertyRow` gains an optional `labelClass` prop for the dense property lists.
- Unit tests for `conversation-usage.ts` cover empty summaries, aggregation, cache-rate derivation, and isolation between branch entry arrays.

### Deterministic system prompt
- Removed the runtime "Active background tasks" block from the generated nerve system prompt (`buildNerveSystemPrompt`), so identical inputs now produce identical output and the prompt stays cacheable.
- Removed `activeBackgroundTaskIdsInDirectoryTree` from `task-scope.ts` and its plumbing through `system-prompt-builder`, `workbench-harness-execution`, `agent-routes`, and `tasks/index.ts`.
- New `nerve-system-prompt.test.ts` asserts the prompt is stable across calls, excludes runtime task state, and still reflects intentional inputs (mode, plan dir).

## Validation
- `nerve-system-prompt` and `task-scope` server tests pass.
- `conversation-usage` app tests pass.