### PR TITLE
fix: system prompt download in desktop shell

### DIFF
--- a/packages/workbench-app/src/lib/features/conversations/components/ContextExportMenu.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextExportMenu.svelte
@@ -65,7 +65,8 @@ function download(entry: ExportEntry): void {
   if (!entry.href) return;
   const anchor = document.createElement("a");
   anchor.href = entry.href;
-  if (entry.filename) anchor.download = entry.filename;
+  // An empty value still marks this as a download before desktop navigation guards run.
+  anchor.download = entry.filename ?? "";
   anchor.rel = "noopener";
   document.body.append(anchor);
   anchor.click();


### PR DESCRIPTION
## Summary

The "System prompt" entry in the context panel export menu silently did nothing in the desktop app, while JSON/Markdown/HTML conversation exports worked.

## Root cause

`ContextExportMenu.svelte` created a temporary anchor for every export. The conversation export entries set an explicit `download` filename, but the system-prompt entry had no client-side filename, so no `download` attribute was set. Without it, the click was ordinary same-origin navigation to `/api/agents/:agentId/system-prompt`, which the desktop shell's navigation guard cancels (it only allows the daemon root path), so the server's `Content-Disposition: attachment` never got a chance to start a download.

## Fix

Always mark the anchor as a download (`anchor.download = entry.filename ?? ""`). Explicit filenames are preserved for conversation exports; the empty value still classifies the click as a download before the guard runs, and the server-provided `system-prompt-<agentId>.md` filename from the response header is used for the system prompt.

## Validation

- `pnpm fix && pnpm check && pnpm test` passes.
- The server endpoint, desktop navigation policy, and component props are unchanged.