### PR TITLE
feat(workbench): enrich context panel agent details

### DIFF
--- a/packages/contracts/src/domains/agents/agent.schema.ts
+++ b/packages/contracts/src/domains/agents/agent.schema.ts
@@ -59,6 +59,8 @@ export const agentRecordSchema = z.object({
   approvalPolicy: approvalPolicySchema.default(defaultApprovalPolicy),
   workspaceScope: workspaceScopeSchema,
   systemPrompt: z.string().min(1).optional(),
+  /** Subagent work description; present on child agents spawned by orchestration tools. */
+  task: z.string().optional(),
   budget: agentBudgetSchema.default({
     depth: 0,
     maxDepth: 3,

--- a/packages/contracts/test/agent.schema.test.ts
+++ b/packages/contracts/test/agent.schema.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { agentRecordSchema } from "../src/domains/agents/agent.schema.js";
+
+function baseAgent(): Record<string, unknown> {
+  return {
+    id: "agent_01H00000000000000000000000",
+    conversationId: "conv_01H00000000000000000000000",
+    projectId: "proj_01H00000000000000000000000",
+    projectDir: "/home/user/project",
+    rootAgentId: "agent_01H00000000000000000000000",
+    mode: "coding",
+    permissionLevel: "read_only",
+    workspaceScope: { roots: ["/home/user/project"] },
+    status: "idle",
+    createdAt: "2026-08-16T00:00:00.000Z",
+    updatedAt: "2026-08-16T00:00:00.000Z",
+  };
+}
+
+describe("agent record schema", () => {
+  it("parses records without a task (legacy agents)", () => {
+    const agent = agentRecordSchema.parse(baseAgent());
+    assert.equal(agent.task, undefined);
+  });
+
+  it("round-trips an optional subagent task", () => {
+    const agent = agentRecordSchema.parse({
+      ...baseAgent(),
+      parentAgentId: "agent_01H00000000000000000000001",
+      task: "Explore the repo for auth patterns",
+    });
+    assert.equal(agent.task, "Explore the repo for auth patterns");
+  });
+});

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextAgentsTree.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextAgentsTree.svelte
@@ -1,13 +1,30 @@
 <script lang="ts">
 import Bot from "@lucide/svelte/icons/bot";
+import Brain from "@lucide/svelte/icons/brain";
+import ClipboardList from "@lucide/svelte/icons/clipboard-list";
+import Code from "@lucide/svelte/icons/code";
+import Eye from "@lucide/svelte/icons/eye";
+import Glasses from "@lucide/svelte/icons/glasses";
+import HatGlasses from "@lucide/svelte/icons/hat-glasses";
+import Shield from "@lucide/svelte/icons/shield";
+import ShieldCheck from "@lucide/svelte/icons/shield-check";
+import Telescope from "@lucide/svelte/icons/telescope";
+import User from "@lucide/svelte/icons/user";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
+import { cn } from "@nervekit/ui-kit/core/utils";
 import {
   agentActivityPulse,
   agentActivityTone,
+  type StatusTone,
 } from "@nervekit/ui-kit/core/utils/status";
-import { PanelEmpty, PanelList, PanelRow } from "$lib/presentation/panel";
+import {
+  PanelEmpty,
+  PanelList,
+  PanelRow,
+  PanelSectionHeader,
+} from "$lib/presentation/panel";
 import type { AgentRecord } from "$lib/api";
 import { shortAgentModel } from "$lib/core/utils/project-tree";
-import { permissionLabel } from "./context-session-fields";
 
 let {
   conversationAgents = [],
@@ -61,8 +78,53 @@ function agentModelLabel(agent: AgentRecord): string {
   return thinking ? `${model} (${thinking})` : model;
 }
 
-function agentDescription(agent: AgentRecord): string {
-  return `${agent.mode} · ${permissionLabel(agent.permissionLevel)}`;
+/**
+ * Second line carries the subagent's task text only; the status dot already
+ * conveys the live status, so rows stay single-line without a task.
+ */
+function agentDescription(agent: AgentRecord): string | undefined {
+  return agent.task?.trim() || undefined;
+}
+
+type AgentIndicator = {
+  icon: typeof Code;
+  label: string;
+};
+
+const PERMISSION_INDICATORS: Record<string, AgentIndicator["icon"]> = {
+  autonomous: ShieldCheck,
+  supervised: Shield,
+  read_only: Eye,
+};
+
+const PERMISSION_LABELS: Record<string, string> = {
+  autonomous: "Autonomous",
+  supervised: "Supervised",
+  read_only: "Read only",
+};
+
+function agentIndicators(agent: AgentRecord): AgentIndicator[] {
+  const indicators: AgentIndicator[] = [
+    {
+      icon: agent.parentAgentId ? Bot : User,
+      label: agent.parentAgentId ? "Subagent" : "Main agent",
+    },
+  ];
+  if (agent.thinkingLevel && agent.thinkingLevel !== "off") {
+    indicators.push({
+      icon: Brain,
+      label: `Thinking: ${agent.thinkingLevel}`,
+    });
+  }
+  indicators.push({
+    icon: agent.mode === "planning" ? ClipboardList : Code,
+    label: agent.mode === "planning" ? "Planning mode" : "Coding mode",
+  });
+  indicators.push({
+    icon: PERMISSION_INDICATORS[agent.permissionLevel] ?? Shield,
+    label: PERMISSION_LABELS[agent.permissionLevel] ?? agent.permissionLevel,
+  });
+  return indicators;
 }
 
 function agentTooltip(agent: AgentRecord): string {
@@ -76,12 +138,33 @@ function agentTooltip(agent: AgentRecord): string {
   return [
     agent.id,
     `status: ${agent.status}`,
-    `mode: ${agent.mode} · ${permissionLabel(agent.permissionLevel)}`,
+    `mode: ${agent.mode} · ${PERMISSION_LABELS[agent.permissionLevel] ?? agent.permissionLevel}`,
     `model: ${model}`,
     thinking,
+    agent.task?.trim(),
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+/** Leading status indicator: a role icon tinted by the activity tone. */
+function agentStatusIcon(agent: AgentRecord): typeof HatGlasses {
+  if (!agent.parentAgentId) return HatGlasses;
+  if (agent.permissionLevel === "supervised") return Glasses;
+  return Telescope;
+}
+
+const STATUS_TONE_TEXT: Record<StatusTone, string> = {
+  neutral: "text-muted-foreground",
+  accent: "text-foreground",
+  running: "text-info",
+  good: "text-success",
+  warn: "text-warning",
+  danger: "text-destructive",
+};
+
+function agentStatusIconClass(agent: AgentRecord): string {
+  return STATUS_TONE_TEXT[agentActivityTone(agent.status, false, agent.mode)];
 }
 
 const agents = $derived(sortAgents(conversationAgents));
@@ -94,20 +177,62 @@ const agents = $derived(sortAgents(conversationAgents));
     description="Agents appear once a run starts."
   />
 {:else}
-  <PanelList ariaLabel="Conversation agents">
-    {#each agents as agent, index (agent.id)}
-      <PanelRow
-        label={agentModelLabel(agent)}
-        description={agentDescription(agent)}
-        title={agentTooltip(agent)}
-        status={agentActivityTone(agent.status, false, agent.mode)}
-        pulse={agentActivityPulse(agent.status)}
-        class={agent.parentAgentId && !agents[index - 1]?.parentAgentId
-          ? "mt-2"
-          : undefined}
-        dense
-        onclick={() => onSelectAgent?.(agent)}
-      />
-    {/each}
-  </PanelList>
+  <div class="flex min-w-0 flex-col">
+    <PanelSectionHeader title="Agents" count={conversationAgents.length} />
+    <Tooltip.Provider delayDuration={300}>
+      <PanelList ariaLabel="Conversation agents">
+        {#each agents as agent (agent.id)}
+          {@const StatusIcon = agentStatusIcon(agent)}
+          {@const statusColor = agentStatusIconClass(agent)}
+          <PanelRow
+            label={agentModelLabel(agent)}
+            description={agentDescription(agent)}
+            title={agentTooltip(agent)}
+            class="min-h-6 py-0.5"
+            stacked
+            onclick={() => onSelectAgent?.(agent)}
+          >
+            {#snippet leading()}
+              <span
+                class={cn(
+                  "flex shrink-0 items-center",
+                  statusColor,
+                  agentActivityPulse(agent.status) && "status-pulse",
+                )}
+                aria-label={agent.parentAgentId
+                  ? "Subagent status"
+                  : "Main agent status"}
+              >
+                <StatusIcon class="size-3.5" aria-hidden="true" />
+              </span>
+            {/snippet}
+            {#snippet labelTrailing()}
+              <span
+                class="flex shrink-0 items-center gap-1 text-muted-foreground"
+              >
+                {#each agentIndicators(agent) as indicator (indicator.label)}
+                  <Tooltip.Root>
+                    <Tooltip.Trigger>
+                      {#snippet child({ props })}
+                        <span
+                          {...props}
+                          class="inline-flex rounded-sm"
+                          aria-label={indicator.label}
+                        >
+                          <indicator.icon class="size-3" aria-hidden="true" />
+                        </span>
+                      {/snippet}
+                    </Tooltip.Trigger>
+                    <Tooltip.Content side="top">
+                      {indicator.label}
+                    </Tooltip.Content>
+                  </Tooltip.Root>
+                {/each}
+              </span>
+            {/snippet}
+          </PanelRow>
+        {/each}
+      </PanelList>
+    </Tooltip.Provider>
+  </div>
 {/if}

--- a/packages/workbench-app/src/lib/features/conversations/components/ContextUsageStrip.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ContextUsageStrip.svelte
@@ -2,7 +2,7 @@
 import type { Snippet } from "svelte";
 import type { ContextUsage } from "@nervekit/contracts";
 import { cn } from "@nervekit/ui-kit/core/utils";
-import { usageTone } from "@nervekit/ui-kit/core/utils/usage";
+import { formatTokens, usageTone } from "@nervekit/ui-kit/core/utils/usage";
 
 let {
   contextUsage,
@@ -33,12 +33,19 @@ const clampedPercent = $derived(
 const percentLabel = $derived(
   percent == null ? "—" : `${Math.round(percent)}%`,
 );
+/** Compact gauge caption, e.g. "153k / 1M tokens". */
 const tokensLabel = $derived(
   tokens != null && limit > 0
-    ? `${tokens.toLocaleString()} / ${limit.toLocaleString()} tokens`
+    ? `${formatTokens(tokens)} / ${formatTokens(limit)} tokens`
     : limit > 0
-      ? `${limit.toLocaleString()} token window`
+      ? `${formatTokens(limit)} token window`
       : "Usage unknown",
+);
+/** Exact numbers for the aria-label and hover tooltip. */
+const tokensLabelFull = $derived(
+  tokens != null && limit > 0
+    ? `${tokens.toLocaleString()} / ${limit.toLocaleString()} tokens`
+    : tokensLabel,
 );
 const tone = $derived(usageTone(percent));
 const arcClass = $derived(
@@ -63,7 +70,7 @@ const percentClass = $derived(
       viewBox="0 0 120 66"
       class="w-full"
       role="img"
-      aria-label={`Context window usage: ${percentLabel} of ${tokensLabel}`}
+      aria-label={`Context window usage: ${percentLabel} of ${tokensLabelFull}`}
     >
       <path
         d={ARC_PATH}
@@ -90,7 +97,10 @@ const percentClass = $derived(
       <span class={cn("text-xl leading-none font-semibold", percentClass)}>
         {percentLabel}
       </span>
-      <span class="max-w-full truncate text-xs text-muted-foreground">
+      <span
+        class="max-w-full truncate text-xs text-muted-foreground"
+        title={tokensLabelFull}
+      >
         {tokensLabel}
       </span>
       {#if children}

--- a/packages/workbench-server/src/domains/agents/agent-lifecycle.service.ts
+++ b/packages/workbench-server/src/domains/agents/agent-lifecycle.service.ts
@@ -133,6 +133,7 @@ export class AgentLifecycleService {
       approvalPolicy,
       workspaceScope: request.workspaceScope ?? { roots: [projectDir] },
       systemPrompt: request.systemPrompt,
+      task: request.task,
       budget: agentBudget(parent, request.budget),
       model,
       thinkingLevel: clampAgentThinkingLevel(model, thinkingLevel),


### PR DESCRIPTION
## Summary

Improves the Context panel's agent list and gauge caption in the workbench.

### Agent list (`ContextAgentsTree.svelte`)
- Rows are now compact stacked rows: model + thinking level on line 1, and the subagent's task description on line 2 when one exists.
- Icon-only indicators with tooltips for role (main/subagent), thinking level, mode, and permission — smaller icons, no wasted space.
- Status is shown by **colored role icons** using the existing activity tone coding (idle = muted, running = info + pulse, awaiting = warning): `HatGlasses` for the main agent, `Telescope` for read-only subagents, `Glasses` for supervised subagents.
- Static `Agents` header with the agent count (the `1 main · 5 sub` meta was removed per review).
- No selected-row background; no gap between the main agent and subagents.

### Data
- Persist the subagent `task` string on `AgentRecord` (optional, backward compatible) so the panel can show what each subagent is doing. New field flows through agent.json, the index store, snapshots, and `agent.created`/status events.
- New contracts test covering the optional task field.

### Gauge caption (`ContextUsageStrip.svelte`)
- Token caption shortened to the compact format (e.g. `160k / 1.0M tokens`); exact figures preserved in the svg `aria-label` and a hover tooltip.

## Validation
- `pnpm fix`, `pnpm check`, `pnpm test` all pass.
- Visually verified in the running UI in dark and light themes.