### PR TITLE
feat(workbench): add force push for queued prompts

### DIFF
--- a/packages/contracts/src/domains/agents/agent.operations.schema.ts
+++ b/packages/contracts/src/domains/agents/agent.operations.schema.ts
@@ -36,6 +36,11 @@ const agentPromptQueueParamsSchema = agentIdParamsSchema;
 const agentPromptQueueCancelParamsSchema = agentIdParamsSchema.extend({
   queuedPromptId: queuedPromptIdSchema,
 });
+const agentPromptQueueForcePushResultSchema = z.object({
+  accepted: z.literal(true),
+  runId: z.string().startsWith("run_"),
+  queuedPromptIds: z.array(queuedPromptIdSchema),
+});
 const agentRequestToolParamsSchema = agentIdParamsSchema.merge(
   executeToolRequestSchema,
 );
@@ -103,6 +108,15 @@ export const agentsOperationDefinitions = [
     "recommended",
     ["workbench_server"] as const,
     "operation.agent.promptQueue.cancel",
+  ),
+  defineOperation(
+    "agent.promptQueue.forcePush",
+    agentPromptQueueParamsSchema,
+    agentPromptQueueForcePushResultSchema,
+    "mutation",
+    "recommended",
+    ["workbench_server"] as const,
+    "operation.agent.promptQueue.forcePush",
   ),
   defineOperation(
     "agent.requestTool",

--- a/packages/harness/src/agent/loop/agent-loop.ts
+++ b/packages/harness/src/agent/loop/agent-loop.ts
@@ -120,15 +120,32 @@ export async function runAgentLoopContinue(
     throw new Error("Cannot continue: no messages in context");
   }
 
-  if (context.messages[context.messages.length - 1].role === "assistant") {
-    throw new Error("Cannot continue from message role: assistant");
-  }
-
   const newMessages: AgentMessage[] = [];
-  const currentContext: AgentContext = { ...context };
+  const currentContext: AgentContext = {
+    ...context,
+    messages: [...context.messages],
+  };
 
   await emit({ type: "agent_start" });
   await emit({ type: "turn_start" });
+
+  if (context.messages[context.messages.length - 1].role === "assistant") {
+    const steering = (await config.getSteeringMessages?.()) ?? [];
+    const followUps =
+      steering.length === 0
+        ? ((await config.getFollowUpMessages?.()) ?? [])
+        : [];
+    const queued = steering.length > 0 ? steering : followUps;
+    if (queued.length === 0) {
+      throw new Error("Cannot continue from message role: assistant");
+    }
+    currentContext.messages.push(...queued);
+    newMessages.push(...queued);
+    for (const message of queued) {
+      await emit({ type: "message_start", message });
+      await emit({ type: "message_end", message });
+    }
+  }
 
   await runLoop(currentContext, newMessages, config, signal, emit, streamFn);
   return newMessages;

--- a/packages/harness/src/harness/agent-harness.ts
+++ b/packages/harness/src/harness/agent-harness.ts
@@ -32,6 +32,7 @@ import type {
 import {
   abortHarnessRun,
   getHarnessActiveTools,
+  interruptHarnessRun,
   type HarnessConfigurationState,
   setHarnessActiveTools,
   setHarnessModel,
@@ -68,6 +69,7 @@ import {
   hasQueuedHarnessInput,
   type HarnessQueueState,
   type InboundQueuedMessage,
+  promoteAllQueuedHarnessMessages,
   removeQueuedHarnessMessage,
   steerHarness,
 } from "./queue/operations.js";
@@ -117,6 +119,7 @@ export class AgentHarness<
   private steeringQueueMode: QueueMode;
   private followUpQueue: InboundQueuedMessage[] = [];
   private followUpQueueMode: QueueMode;
+  private forceDrainAll = false;
   private nextTurnQueue: AgentMessage[] = [];
   private readonly queuedMessageWrites = new WeakMap<
     AgentMessage,
@@ -329,8 +332,14 @@ export class AgentHarness<
           thinkingLevel: nextTurnState.thinkingLevel,
         };
       },
-      getSteeringMessages: async () =>
-        this.drainQueuedMessages(this.steerQueue, this.steeringQueueMode),
+      getSteeringMessages: async () => {
+        const forceDrainAll = this.forceDrainAll;
+        this.forceDrainAll = false;
+        return this.drainQueuedMessages(
+          this.steerQueue,
+          forceDrainAll ? "all" : this.steeringQueueMode,
+        );
+      },
       getFollowUpMessages: async () =>
         this.drainQueuedMessages(this.followUpQueue, this.followUpQueueMode),
     };
@@ -665,7 +674,20 @@ export class AgentHarness<
     this.streamOptions = cloneStreamOptions(streamOptions);
   }
 
+  forcePush(): Promise<void> {
+    if (promoteAllQueuedHarnessMessages(this.queueState()) === 0) {
+      throw new AgentHarnessError(
+        "invalid_state",
+        "No queued messages to force push",
+      );
+    }
+    this.forceDrainAll = true;
+    interruptHarnessRun(this.configurationState());
+    return Promise.resolve();
+  }
+
   async abort(): Promise<AbortResult> {
+    this.forceDrainAll = false;
     return abortHarnessRun(this.configurationState());
   }
 

--- a/packages/harness/src/harness/configuration/operations.ts
+++ b/packages/harness/src/harness/configuration/operations.ts
@@ -189,6 +189,14 @@ export async function setHarnessResources<
   });
 }
 
+export function interruptHarnessRun<
+  TSkill extends Skill,
+  TPromptTemplate extends PromptTemplate,
+  TTool extends AgentTool,
+>(state: HarnessConfigurationState<TSkill, TPromptTemplate, TTool>): void {
+  state.runAbortController?.abort();
+}
+
 export async function abortHarnessRun<
   TSkill extends Skill,
   TPromptTemplate extends PromptTemplate,

--- a/packages/harness/src/harness/queue/operations.ts
+++ b/packages/harness/src/harness/queue/operations.ts
@@ -139,6 +139,18 @@ export function hasQueuedHarnessInput(state: HarnessQueueState): boolean {
   );
 }
 
+/** Promote every queued user message to the next steering drain in FIFO order. */
+export function promoteAllQueuedHarnessMessages(
+  state: HarnessQueueState,
+): number {
+  const promoted = [...state.steerQueue, ...state.followUpQueue].sort((a, b) =>
+    a.enqueuedAt.localeCompare(b.enqueuedAt),
+  );
+  state.steerQueue = promoted;
+  state.followUpQueue = [];
+  return promoted.length;
+}
+
 export async function removeQueuedHarnessMessage(
   state: HarnessQueueState,
   id: string,

--- a/packages/harness/test/harness/queue/agent-harness-queue.test.ts
+++ b/packages/harness/test/harness/queue/agent-harness-queue.test.ts
@@ -31,6 +31,12 @@ type QueueTestHarness = {
     queue: InboundQueuedMessage[],
     mode: QueueMode,
   ): Promise<AgentMessage[]>;
+  createLoopConfig(
+    getTurnState: () => unknown,
+    setTurnState: (state: unknown) => void,
+  ): {
+    getSteeringMessages?: () => Promise<AgentMessage[]>;
+  };
 };
 
 function createHarness(): AgentHarness {
@@ -84,6 +90,31 @@ describe("AgentHarness queued message lifecycle", () => {
       "one-at-a-time",
     );
     assert.equal(messages.length, 1);
+  });
+
+  it("force pushes all follow-ups through the next steering drain", async () => {
+    const harness = createHarness();
+    const internal = harness as unknown as QueueTestHarness;
+    internal.phase = "turn";
+    const drained: string[][] = [];
+    harness.subscribe((event) => {
+      if (event.type === "queue_drained") drained.push(event.messageIds);
+    });
+
+    await harness.followUp("first", { id: "promptq_first" });
+    await harness.followUp("second", { id: "promptq_second" });
+    await harness.forcePush();
+
+    assert.equal(internal.followUpQueue.length, 0);
+    assert.equal(internal.steerQueue.length, 2);
+    const config = internal.createLoopConfig(
+      () => ({ model, thinkingLevel: "off" }),
+      () => undefined,
+    );
+    const messages = await config.getSteeringMessages?.();
+    assert.equal(messages?.length, 1);
+    assert.deepEqual(drained, [["promptq_first", "promptq_second"]]);
+    assert.equal(internal.steerQueue.length, 0);
   });
 
   it("does not drain a queued prompt removed by id", async () => {

--- a/packages/website/src/content/docs/guides/composer.md
+++ b/packages/website/src/content/docs/guides/composer.md
@@ -11,7 +11,7 @@ The composer is the main control surface for a conversation. It combines a Markd
 
 `Enter` and `Ctrl/Cmd+Enter` submit unless a completion menu is open. A new idle conversation starts a run. During an active turn, a normal prompt becomes a steering message and appears as a queued row in the transcript.
 
-A queued prompt can be discarded or **Cancel & Edit**-ed back into the composer. Inline command prompts cannot queue. Stop targets the exact active run; Nerve suppresses duplicate stops and reconciles late completion events.
+A queued prompt can be discarded, **Cancel & Edit**-ed back into the composer, or **Force Push**-ed. Force Push interrupts the current provider request or foreground tool, then flushes every queued prompt immediately in FIFO order without cancelling the overall run. Inline command prompts cannot queue. Stop targets the exact active run; Nerve suppresses duplicate stops and reconciles late completion events.
 
 ## Completions
 

--- a/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/ConversationShell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { type QueuedPromptRecord } from "$lib/api";
+import { SvelteSet } from "svelte/reactivity";
 import { protocolRequest } from "@nervekit/protocol";
 import { workspaceState } from "$lib/features/workspace/state/workspace-state.svelte";
 import { workspaceSelectors } from "$lib/features/workspace/state/workspace-selectors.svelte";
@@ -336,6 +337,38 @@ function sendSuggestion(suggestion: { prompt: string }) {
   );
 }
 
+const forcePushesInFlight = new SvelteSet<string>();
+
+function forcePushQueuedPrompts(prompt: QueuedPromptRecord): Promise<void> {
+  return runActivePaneAction(async () => {
+    const key = prompt.runId ?? prompt.agentId;
+    if (forcePushesInFlight.has(key)) return;
+    forcePushesInFlight.add(key);
+    try {
+      const { result } = await protocolRequest(
+        "agent.promptQueue.forcePush",
+        { agentId: prompt.agentId },
+        { idempotencyKey: crypto.randomUUID() },
+      );
+      const pushedIds = new Set(result.queuedPromptIds);
+      const targetView = ensureConversationView(prompt.conversationId);
+      targetView.queuedPrompts = targetView.queuedPrompts.filter(
+        (candidate) => !pushedIds.has(candidate.id),
+      );
+      notify.success(
+        result.queuedPromptIds.length === 1
+          ? "Queued prompt force pushed"
+          : `${result.queuedPromptIds.length} queued prompts force pushed`,
+      );
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      notify.error("Queued prompt action failed", { description: message });
+    } finally {
+      forcePushesInFlight.delete(key);
+    }
+  });
+}
+
 async function cancelQueuedPrompt(
   prompt: QueuedPromptRecord,
 ): Promise<boolean> {
@@ -456,6 +489,7 @@ function moveQueuedPromptToComposer(prompt: QueuedPromptRecord) {
   onContinueFromFailure={(runId) => {
     void runActivePaneAction(() => continueFromFailure(runId));
   }}
+  onForcePushQueuedPrompts={forcePushQueuedPrompts}
   onDiscardQueuedPrompt={discardQueuedPrompt}
   onMoveQueuedPromptToComposer={moveQueuedPromptToComposer}
   onNavigateToEntry={(entryId, summarize) => {

--- a/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
@@ -84,6 +84,7 @@ let {
   onAcceptPlanReviewInNewChat,
   onRejectPlanReview,
   onContinueFromFailure,
+  onForcePushQueuedPrompts,
   onDiscardQueuedPrompt,
   onMoveQueuedPromptToComposer,
   onNavigateToEntry,
@@ -272,6 +273,7 @@ function menuForTranscript(
     onAcceptPlanReviewInNewChat,
     onRejectPlanReview,
     onContinueFromFailure,
+    onForcePushQueuedPrompts,
     onDiscardQueuedPrompt,
     onMoveQueuedPromptToComposer,
   }}

--- a/packages/workbench-app/src/lib/features/conversations/components/conversation-menu-model.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/conversation-menu-model.ts
@@ -182,6 +182,11 @@ export function transcriptMenuModel(
   if (target.kind === "queued_prompt") {
     actionGroup.push(
       {
+        label: "Force push all queued prompts",
+        disabled: target.busy || !target.canForcePush,
+        onSelect: target.onForcePush,
+      },
+      {
         label: "Edit prompt",
         disabled: target.busy || !target.canEdit,
         onSelect: target.onEdit,

--- a/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
+++ b/packages/workbench-app/src/lib/features/conversations/components/workbench-conversation-adapter-props.ts
@@ -94,6 +94,9 @@ export type WorkbenchConversationAdapterProps = {
     options?: PlanReviewResolveOptions,
   ) => void | Promise<void>;
   onRejectPlanReview?: (id: string) => void | Promise<void>;
+  onForcePushQueuedPrompts?: (
+    prompt: QueuedPromptRecord,
+  ) => void | Promise<void>;
   onDiscardQueuedPrompt?: (prompt: QueuedPromptRecord) => void | Promise<void>;
   onMoveQueuedPromptToComposer?: (
     prompt: QueuedPromptRecord,

--- a/packages/workbench-app/src/lib/presentation/components/conversation/conversation-pane.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/conversation-pane.svelte
@@ -119,6 +119,7 @@ const scroll = createConversationScrollController({
           onAcceptPlanReviewInNewChat={actions.onAcceptPlanReviewInNewChat}
           onRejectPlanReview={actions.onRejectPlanReview}
           onContinueFromFailure={actions.onContinueFromFailure}
+          onForcePushQueuedPrompts={actions.onForcePushQueuedPrompts}
           onDiscardQueuedPrompt={actions.onDiscardQueuedPrompt}
           onMoveQueuedPromptToComposer={actions.onMoveQueuedPromptToComposer}
           transcriptMenu={menus.transcriptMenu}

--- a/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
@@ -141,6 +141,9 @@ export type ConversationPaneActions = {
   ) => void | Promise<void>;
   onRejectPlanReview?: (id: string) => void | Promise<void>;
   onContinueFromFailure?: (runId: string) => void;
+  onForcePushQueuedPrompts?: (
+    prompt: QueuedPromptRecord,
+  ) => void | Promise<void>;
   onDiscardQueuedPrompt?: (prompt: QueuedPromptRecord) => void | Promise<void>;
   onMoveQueuedPromptToComposer?: (
     prompt: QueuedPromptRecord,
@@ -163,8 +166,10 @@ export type TranscriptMenuTarget =
       kind: "queued_prompt";
       prompt: QueuedPromptRecord;
       busy: boolean;
+      canForcePush: boolean;
       canEdit: boolean;
       canDiscard: boolean;
+      onForcePush: () => void;
       onEdit: () => void;
       onDiscard: () => void;
     };

--- a/packages/workbench-app/src/lib/presentation/components/transcript/QueuedPromptRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/QueuedPromptRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import ArrowUpToLine from "@lucide/svelte/icons/arrow-up-to-line";
 import ListPlus from "@lucide/svelte/icons/list-plus";
 import Pencil from "@lucide/svelte/icons/pencil";
 import Trash2 from "@lucide/svelte/icons/trash-2";
@@ -11,19 +12,27 @@ import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 
 type Props = {
   prompt: QueuedPromptRecord;
+  onForcePush?: (prompt: QueuedPromptRecord) => void | Promise<void>;
   onDiscard?: (prompt: QueuedPromptRecord) => void | Promise<void>;
   onMoveToComposer?: (prompt: QueuedPromptRecord) => void | Promise<void>;
   transcriptMenu: ConversationMenuBuilders["transcriptMenu"];
 };
 
-let { prompt, onDiscard, onMoveToComposer, transcriptMenu }: Props = $props();
-let pendingAction = $state<"edit" | "discard" | undefined>();
+let {
+  prompt,
+  onForcePush,
+  onDiscard,
+  onMoveToComposer,
+  transcriptMenu,
+}: Props = $props();
+let pendingAction = $state<"force-push" | "edit" | "discard" | undefined>();
 
-async function runAction(action: "edit" | "discard") {
+async function runAction(action: "force-push" | "edit" | "discard") {
   if (pendingAction) return;
   pendingAction = action;
   try {
-    if (action === "edit") await onMoveToComposer?.(prompt);
+    if (action === "force-push") await onForcePush?.(prompt);
+    else if (action === "edit") await onMoveToComposer?.(prompt);
     else await onDiscard?.(prompt);
   } catch {
     // Host actions own user-facing error reporting.
@@ -36,8 +45,10 @@ const menuTarget = $derived({
   kind: "queued_prompt" as const,
   prompt,
   busy: Boolean(pendingAction),
+  canForcePush: Boolean(onForcePush),
   canEdit: Boolean(onMoveToComposer),
   canDiscard: Boolean(onDiscard),
+  onForcePush: () => void runAction("force-push"),
   onEdit: () => void runAction("edit"),
   onDiscard: () => void runAction("discard"),
 });
@@ -58,6 +69,25 @@ const menuTarget = $derived({
     </div>
     <div class="queued-actions" role="group" aria-label="Queued prompt actions">
       <Tooltip.Provider delayDuration={300} disableHoverableContent>
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            {#snippet child({ props })}
+              <Button
+                {...props}
+                variant="ghost"
+                size="icon-xs"
+                disabled={!onForcePush || Boolean(pendingAction)}
+                ariaLabel="Force push all queued prompts"
+                onclick={() => void runAction("force-push")}
+              >
+                <ArrowUpToLine aria-hidden="true" />
+              </Button>
+            {/snippet}
+          </Tooltip.Trigger>
+          <Tooltip.Content sideOffset={4}>
+            Force push all queued prompts
+          </Tooltip.Content>
+        </Tooltip.Root>
         <Tooltip.Root>
           <Tooltip.Trigger>
             {#snippet child({ props })}

--- a/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
@@ -84,6 +84,9 @@ type Props = {
   ) => void | Promise<void>;
   onRejectPlanReview?: (id: string) => void | Promise<void>;
   onContinueFromFailure?: (runId: string) => void;
+  onForcePushQueuedPrompts?: (
+    prompt: QueuedPromptRecord,
+  ) => void | Promise<void>;
   onDiscardQueuedPrompt?: (prompt: QueuedPromptRecord) => void | Promise<void>;
   onMoveQueuedPromptToComposer?: (
     prompt: QueuedPromptRecord,
@@ -137,6 +140,7 @@ let {
   onAcceptPlanReviewInNewChat,
   onRejectPlanReview,
   onContinueFromFailure,
+  onForcePushQueuedPrompts,
   onDiscardQueuedPrompt,
   onMoveQueuedPromptToComposer,
   transcriptMenu,
@@ -467,6 +471,7 @@ $effect(() => {
         {:else}
           <QueuedPromptRow
             prompt={item.prompt}
+            onForcePush={onForcePushQueuedPrompts}
             onDiscard={onDiscardQueuedPrompt}
             onMoveToComposer={onMoveQueuedPromptToComposer}
             {transcriptMenu}

--- a/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
@@ -627,6 +627,7 @@ export async function executeWorkbenchHarness(
         provider: model.provider,
       },
     });
+    let forcePushGeneration = 0;
     const abort = async () => {
       abortRequested = true;
       toolDraftProgressScheduler.clear();
@@ -675,6 +676,11 @@ export async function executeWorkbenchHarness(
           images: prompt.images,
         });
       },
+      forcePush: async () => {
+        forcePushGeneration += 1;
+        toolDraftProgressScheduler.clear();
+        await harness.forcePush();
+      },
       continue: async () => undefined,
       cancel: abort,
       removeQueuedPrompt: harness.removeQueuedMessage.bind(harness),
@@ -690,65 +696,81 @@ export async function executeWorkbenchHarness(
     };
 
     const promptRequest = await expandBlocks(request.text, request.images);
-    const runAssistant = await this.runHarnessAttempt({
-      harness,
-      conversation: harnessConversation,
-      request: promptRequest,
-      continue: options.continue === true,
-      runId,
-      agent,
-      signal: runAbortController.signal,
-    });
-    const branch = await storage.getPathToRoot(await storage.getLeafId());
-    const messages = convertToLlm(buildConversationContext(branch).messages);
-    this.deps.conversationService.setForAgent(agent.id, messages);
-    const assistantEntry = lastAssistantEntry;
-    if (!assistantEntry) {
-      throw new Error("Agent run completed without an assistant entry.");
-    }
-    if (
-      runAssistant.stopReason === "error" ||
-      runAssistant.stopReason === "aborted"
-    ) {
-      const aborted = runAssistant.stopReason === "aborted" || abortRequested;
-      const retryable = !aborted && isRetryableAssistantError(runAssistant);
-      // Automatic retry policy and manual recovery are intentionally separate:
-      // billing/auth failures should not spin, but users can change models and
-      // resume from the provider boundary.
-      const continuable = !aborted;
-      if (continuable) {
-        const leafId = await harnessConversation.getLeafId();
-        const leaf = leafId
-          ? await harnessConversation.getEntry(leafId)
-          : undefined;
-        if (leaf?.parentId !== undefined) {
-          await harnessConversation.moveTo(leaf.parentId);
+    let continueAttempt = options.continue === true;
+    let handledForcePushGeneration = 0;
+    while (true) {
+      const runAssistant = await this.runHarnessAttempt({
+        harness,
+        conversation: harnessConversation,
+        request: promptRequest,
+        continue: continueAttempt,
+        runId,
+        agent,
+        signal: runAbortController.signal,
+      });
+      const branch = await storage.getPathToRoot(await storage.getLeafId());
+      const messages = convertToLlm(buildConversationContext(branch).messages);
+      this.deps.conversationService.setForAgent(agent.id, messages);
+      if (forcePushGeneration > handledForcePushGeneration) {
+        handledForcePushGeneration = forcePushGeneration;
+        continueAttempt = true;
+        continue;
+      }
+      const assistantEntry = lastAssistantEntry;
+      if (!assistantEntry) {
+        throw new Error("Agent run completed without an assistant entry.");
+      }
+      if (
+        runAssistant.stopReason === "error" ||
+        runAssistant.stopReason === "aborted"
+      ) {
+        const aborted = runAssistant.stopReason === "aborted" || abortRequested;
+        const retryable = !aborted && isRetryableAssistantError(runAssistant);
+        const continuable = !aborted;
+        if (continuable) {
+          const leafId = await harnessConversation.getLeafId();
+          const leaf = leafId
+            ? await harnessConversation.getEntry(leafId)
+            : undefined;
+          if (leaf?.parentId !== undefined) {
+            await harnessConversation.moveTo(leaf.parentId);
+          }
+          await coordinator.sink.checkpoint(
+            await coordinator.checkpointCommand("before_provider_request"),
+          );
         }
-        await coordinator.sink.checkpoint(
-          await coordinator.checkpointCommand("before_provider_request"),
-        );
+        if (forcePushGeneration > handledForcePushGeneration) {
+          handledForcePushGeneration = forcePushGeneration;
+          continueAttempt = true;
+          continue;
+        }
+        return {
+          status: aborted ? "interrupted" : "failed",
+          ...(aborted
+            ? { message: "Agent run aborted." }
+            : {
+                failure: {
+                  code: "MODEL_REQUEST_FAILED",
+                  message: runAssistant.errorMessage ?? "Agent run failed.",
+                  retryable,
+                  continuable,
+                },
+              }),
+        } as RunExecutionOutcome;
+      }
+      await coordinator.sink.checkpoint(
+        await coordinator.checkpointCommand("after_provider_response"),
+      );
+      if (forcePushGeneration > handledForcePushGeneration) {
+        handledForcePushGeneration = forcePushGeneration;
+        continueAttempt = true;
+        continue;
       }
       return {
-        status: aborted ? "interrupted" : "failed",
-        ...(aborted
-          ? { message: "Agent run aborted." }
-          : {
-              failure: {
-                code: "MODEL_REQUEST_FAILED",
-                message: runAssistant.errorMessage ?? "Agent run failed.",
-                retryable,
-                continuable,
-              },
-            }),
-      } as RunExecutionOutcome;
+        status: "completed",
+        result: { finalEntryId: assistantEntry.id },
+      };
     }
-    await coordinator.sink.checkpoint(
-      await coordinator.checkpointCommand("after_provider_response"),
-    );
-    return {
-      status: "completed",
-      result: { finalEntryId: assistantEntry.id },
-    };
   } catch (error) {
     if (isAgentToolSuspension(error)) {
       await waitForSequentialToolInteractionBatch({

--- a/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
@@ -182,6 +182,27 @@ export class RunCoordinator {
     return this.prompts.cancel(runId, promptId);
   }
 
+  async forcePush(runId: string): Promise<readonly RunPromptRecord[]> {
+    return this.exclusive(`run:${runId}`, async () => {
+      const state = await this.require(runId);
+      if (!ACTIVE_STATUSES.has(state.run.status)) {
+        throw invalid(state.run, "force push");
+      }
+      const prompts = state.prompts
+        .filter((prompt) => ["queued", "accepted"].includes(prompt.status))
+        .sort((left, right) => left.ordinal - right.ordinal);
+      if (prompts.length === 0) {
+        throw new InvalidRunStateError("No queued prompts to force push");
+      }
+      const execution = this.live.get(runId)?.execution;
+      if (!execution) {
+        throw new InvalidRunStateError("Run has no live execution");
+      }
+      await execution.control.forcePush();
+      return prompts;
+    });
+  }
+
   async continue(runId: string): Promise<RunRecord> {
     return this.exclusive(`run:${runId}`, async () => {
       const state = await this.require(runId);

--- a/packages/workbench-server/src/domains/runs/runtime/run-execution.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-execution.ts
@@ -43,6 +43,8 @@ export interface RunExecutionControl {
   steer(prompt: RunPromptRecord): Promise<void>;
   followUp(prompt: RunPromptRecord): Promise<void>;
   removeQueuedPrompt(promptId: string): Promise<boolean>;
+  /** Interrupt the active turn, preserve queued prompts, and drain them immediately. */
+  forcePush(): Promise<void>;
   continue(): Promise<void>;
   cancel(reason?: string): Promise<void>;
 }

--- a/packages/workbench-server/src/domains/runs/workbench-agent-execution.ts
+++ b/packages/workbench-server/src/domains/runs/workbench-agent-execution.ts
@@ -23,6 +23,7 @@ export class WorkbenchAgentExecutionAdapter implements WorkbenchRunExecutionAdap
   async create(run: RunRecord, sink: RunExecutionSink): Promise<RunExecution> {
     let installed: WorkbenchLiveExecutionControl | undefined;
     let cancelled = false;
+    let forcePushRequested = false;
     const pending: Array<{
       method: "steer" | "followUp";
       prompt: RunPromptRecord;
@@ -44,6 +45,12 @@ export class WorkbenchAgentExecutionAdapter implements WorkbenchRunExecutionAdap
       installed = control;
       if (cancelled) void control.cancel("run cancelled before harness start");
       for (const queued of pending.splice(0)) forward(control, queued);
+      if (forcePushRequested) {
+        forcePushRequested = false;
+        void Promise.all(forwarding.values())
+          .then(() => control.forcePush())
+          .catch(() => undefined);
+      }
     };
 
     const control: WorkbenchLiveExecutionControl = {
@@ -55,9 +62,18 @@ export class WorkbenchAgentExecutionAdapter implements WorkbenchRunExecutionAdap
         if (installed) return installed.followUp(prompt);
         pending.push({ method: "followUp", prompt });
       },
+      forcePush: async () => {
+        if (!installed) {
+          forcePushRequested = true;
+          return;
+        }
+        await Promise.all(forwarding.values());
+        await installed.forcePush();
+      },
       continue: async () => installed?.continue(),
       cancel: async (reason) => {
         cancelled = true;
+        forcePushRequested = false;
         pending.length = 0;
         await installed?.cancel(reason);
       },

--- a/packages/workbench-server/src/domains/runs/workbench-run.service.ts
+++ b/packages/workbench-server/src/domains/runs/workbench-run.service.ts
@@ -81,6 +81,24 @@ export class WorkbenchRunService {
     return this.coordinator.cancelPrompt(state.run.runId, promptId);
   }
 
+  async forcePushQueuedPrompts(agentId: string) {
+    const agent = this.requireAgent(agentId);
+    const state = await this.unitOfWork.findActive(this.scopeId(agent));
+    if (!state) {
+      throw new ApplicationError(
+        409,
+        "AGENT_NOT_RUNNING",
+        "Agent has no active run.",
+      );
+    }
+    const prompts = await this.coordinator.forcePush(state.run.runId);
+    return {
+      accepted: true as const,
+      runId: state.run.runId,
+      queuedPromptIds: prompts.map((prompt) => prompt.id),
+    };
+  }
+
   async promptAgent(agentId: string, request: PromptRequest): Promise<void> {
     const agent = this.requireAgent(agentId);
     if (agent.parentAgentId) {

--- a/packages/workbench-server/src/protocol/method-handlers/conversation-agent-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/conversation-agent-method-handlers.ts
@@ -65,6 +65,8 @@ export const conversationAgentMethodHandlers = defineWorkbenchMethodHandlers({
       params.queuedPromptId,
     ),
   }),
+  "agent.promptQueue.forcePush": (state, params) =>
+    state.registry.forcePushQueuedPrompts(params.agentId),
   "agent.requestTool": (state, params) =>
     state.registry.requestTool(
       params.agentId,

--- a/packages/workbench-server/src/routes/agent-routes.ts
+++ b/packages/workbench-server/src/routes/agent-routes.ts
@@ -84,6 +84,14 @@ export function createAgentRoutes(state: OrchestratorState): Hono {
       }),
     ),
   );
+  app.post(
+    "/agents/:agentId/prompt-queue/force-push",
+    routeHandler(async (c) =>
+      c.json(
+        await state.registry.forcePushQueuedPrompts(routeParam(c, "agentId")),
+      ),
+    ),
+  );
   app.delete(
     "/agents/:agentId/prompt-queue/:queuedPromptId",
     routeHandler(async (c) =>

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -951,6 +951,10 @@ export class RuntimeRegistry {
     return this.workbenchRun.cancelQueuedPrompt(agentId, queuedPromptId);
   }
 
+  async forcePushQueuedPrompts(agentId: string) {
+    return this.workbenchRun.forcePushQueuedPrompts(agentId);
+  }
+
   async promptAgent(agentId: string, request: PromptRequest): Promise<void> {
     return this.workbenchRun.promptAgent(agentId, request);
   }

--- a/packages/workbench-server/test/run-coordinator.contract.test.ts
+++ b/packages/workbench-server/test/run-coordinator.contract.test.ts
@@ -141,6 +141,7 @@ function fixture(
   const controlPrompts: import("@nervekit/contracts").RunPromptRecord[] = [];
   const controlContinues: number[] = [];
   const controlCancels: Array<string | undefined> = [];
+  const forcePushAttempts: number[] = [];
   const removedPromptIds: string[] = [];
   const executions: RunExecution[] = [];
   const sinks: RunExecutionSink[] = [];
@@ -196,6 +197,9 @@ function fixture(
               return options.removeQueuedPrompt
                 ? options.removeQueuedPrompt(promptId)
                 : true;
+            },
+            forcePush: async () => {
+              forcePushAttempts.push(attempt);
             },
             continue: async () => {
               controlContinues.push(attempt);
@@ -273,6 +277,7 @@ function fixture(
     controlPrompts,
     controlContinues,
     controlCancels,
+    forcePushAttempts,
     removedPromptIds,
     executions,
     sinks,
@@ -453,6 +458,58 @@ test("preserves images on start, steer, and follow-up delivery", async () => {
     ),
     [[image], [image]],
   );
+});
+
+test("force pushes every queued prompt without cancelling the run", async () => {
+  const harness = fixture();
+  const run = await start(harness.coordinator);
+  const first = await harness.coordinator.followUp(run.runId, "first");
+  const second = await harness.coordinator.followUp(run.runId, "second");
+
+  const pushed = await harness.coordinator.forcePush(run.runId);
+  assert.deepEqual(
+    pushed.map((prompt) => prompt.id),
+    [first.id, second.id],
+  );
+  assert.deepEqual(harness.forcePushAttempts, [1]);
+
+  let state = await harness.coordinator.get(run.runId);
+  assert.deepEqual(
+    state?.prompts.map((prompt) => prompt.status),
+    ["accepted", "accepted"],
+  );
+  assert.equal(state?.run.status, "running");
+
+  await harness.sinks[0]?.promptDelivered(first.id);
+  await harness.sinks[0]?.promptDelivered(second.id);
+  state = await harness.coordinator.get(run.runId);
+  assert.deepEqual(
+    state?.prompts.map((prompt) => prompt.status),
+    ["delivered", "delivered"],
+  );
+  const eventTypes = state?.transitions.flatMap((transition) =>
+    transition.events.map((event) => event.type),
+  );
+  assert.equal(
+    eventTypes?.filter((type) => type === "run.cancelled").length,
+    0,
+  );
+  assert.equal(
+    eventTypes?.filter((type) => type === "conversation.prompt.dequeued")
+      .length,
+    2,
+  );
+});
+
+test("rejects force push when the queue is empty", async () => {
+  const harness = fixture();
+  const run = await start(harness.coordinator);
+
+  await assert.rejects(
+    harness.coordinator.forcePush(run.runId),
+    /No queued prompts to force push/,
+  );
+  assert.deepEqual(harness.forcePushAttempts, []);
 });
 
 test("commits prompt dequeue and cancellation intents exactly once", async () => {

--- a/packages/workbench-server/test/run-execution-explore-admission.test.ts
+++ b/packages/workbench-server/test/run-execution-explore-admission.test.ts
@@ -22,6 +22,7 @@ function factoryFor(
         steer: async () => undefined,
         followUp: async () => undefined,
         removeQueuedPrompt: async () => false,
+        forcePush: async () => undefined,
         continue: async () => undefined,
         cancel: async () => undefined,
       },

--- a/packages/workbench-server/test/run-runtime.test.ts
+++ b/packages/workbench-server/test/run-runtime.test.ts
@@ -161,6 +161,7 @@ function fixture(
             steer: async () => {},
             followUp: async () => {},
             removeQueuedPrompt: async () => true,
+            forcePush: async () => {},
             continue: async () => {},
             cancel: async () => {},
           },


### PR DESCRIPTION
## Summary

Add a **Force Push** action to queued prompt cards. Force Push interrupts the current provider request or foreground tool **without cancelling the run**, then flushes every queued prompt immediately in FIFO order on the same live execution.

## Changes

- **Protocol/API**: new `agent.promptQueue.forcePush` operation (recommended idempotency) plus `POST /agents/:agentId/prompt-queue/force-push` HTTP route, wired through the run service, registry, and method handlers.
- **Runtime**: coordinator-level `forcePush` under the run lock that captures queued/accepted prompts in ordinal order and delegates to the live execution control; existing `conversation.prompt.dequeued` events remain the canonical delivery projection — no new run state or migration.
- **Harness**: queue-preserving interrupt that promotes steering + follow-up entries to the next steering drain (draining all together), aborts the active turn signal, and allows continuation from an assistant turn so the forced batch runs before the execution settles. Normal `abort()` still clears queues.
- **Workbench execution**: force-interrupted attempts continue in the same execution via `harness.continue()`, with a generation counter to distinguish Force Push aborts from real aborts.
- **UI**: per-card Force Push button (`arrow-up-to-line` icon) and "Force push all queued prompts" context-menu entry, optimistic clearing of the queue after acknowledgment, duplicate-click suppression, and error handling consistent with existing queued-prompt actions.
- **Docs**: composer guide describes Force Push semantics.

## Tests

- Harness: force push preserves queued IDs, promotes follow-ups through the next steering drain in FIFO order, and leaves normal abort clearing intact.
- Coordinator: force push delivers all prompts without a `run.cancelled` transition, rejects empty queues, and keeps prompt statuses queued/accepted until delivery.
- `pnpm fix && pnpm check && pnpm test` passes.