### PR TITLE
docs: refresh website for current UI

### DIFF
--- a/packages/website/src/content/docs/guides/background-tasks.md
+++ b/packages/website/src/content/docs/guides/background-tasks.md
@@ -10,7 +10,7 @@ Nerve separates a durable **task definition** from immutable **task runs**. A de
 - `single` (default): launching an active definition focuses its current run.
 - `concurrent`: launching can create another active run.
 
-Use finite Bash for commands that should finish. Use a task for a known server or watcher. Nerve can also promote a command that remains active.
+Use finite Bash for commands that should finish. Use a task for a known server or watcher. Nerve can also promote a command that remains active. A task is separate from an agent todo: tasks supervise processes, while todos describe work inside a conversation.
 
 ## Supervision
 
@@ -32,6 +32,10 @@ A normal **Stop** requests graceful process-tree termination and escalates after
 
 Quitting the desktop app immediately terminates active local task process trees before its owned daemon exits. Closing to the tray leaves tasks running.
 
+## Task controls
+
+The Tasks panel and task-output tab let you switch between sibling runs, restart a saved task, cancel a run, load earlier log output, clean up terminal history, and prune old runs. **Force kill** is available only when Nerve has verified the process identity (or a run is stuck stopping); it is intentionally unavailable for `recovery_unknown` records. Removing a run's history does not remove the durable task definition.
+
 ## Agent notifications
 
 Task terminal changes can become deduplicated `task_event` system entries in the conversation and can wake an agent waiting for completion. This is separate from desktop/browser toast notifications.
@@ -39,4 +43,5 @@ Task terminal changes can become deduplicated `task_event` system entries in the
 ## Next steps
 
 - [Task recovery troubleshooting](/troubleshooting/tasks-and-recovery/)
+- [Configure Settings](/guides/settings/)
 - [Task tool reference](/reference/tools/#background-tasks)

--- a/packages/website/src/content/docs/guides/settings.md
+++ b/packages/website/src/content/docs/guides/settings.md
@@ -1,0 +1,53 @@
+---
+title: Configure Settings
+description: Manage Workbench behavior, models, agents, tools, storage, and system controls.
+sidebar:
+  order: 14
+---
+
+Open **Settings** from the title bar. Settings is organized into focused areas and saves changes through the application state. Some controls are supplied by the daemon or launch environment; those controls show their effective source and can be locked when a CLI flag or environment variable takes precedence.
+
+## Workbench and notifications
+
+**Workbench** contains Appearance and Desktop options, including theme and desktop-specific behavior. **Notifications** separates general notification delivery from sounds. **Shortcuts** shows the current fixed keyboard bindings; bindings are not currently remappable.
+
+## Models and agents
+
+- **Scoped Models** controls the models shown in conversation pickers. An empty scope keeps all authenticated models available.
+- **Agents → Defaults** sets the default mode, permission, model, thinking level, approval behavior, and whether new agents use the last selections.
+- **Agents → Compaction** controls automatic conversation compaction, profile, trigger threshold, and retained recent context.
+- **Agents → Explore agent** configures the separate model and thinking level used for read-only Explore work.
+
+Model availability depends on authentication and provider metadata. Changes to defaults affect new agents; changes made during an active run apply to a later provider request where noted by the UI.
+
+## Suggestions, tools, and skills
+
+**Suggestions** manages reusable prompt chips and their trust settings. **Tools** has separate **Built-in** and **Integrations** sections. Built-in controls include tool enablement, background-task behavior, Python runtime settings, and image explanation. Integration cards appear only when the corresponding module is available and can manage enablement and credentials.
+
+**Skills** lists discovered user and project resources and lets you enable or disable them without deleting their source files. Tool and skill changes apply to subsequent agent runs.
+
+## Storage
+
+**Storage** shows local usage and provides cancellable cleanup. Depending on the selected targets, cleanup can remove old conversations and logs, Explore reports, crash and Node reports, cache and temporary data, and rebuild the search index. Cleanup is asynchronous and reports progress; it does not replace a backup or change authoritative project files unexpectedly.
+
+## System
+
+**System** groups:
+
+- **Network** — remote connections, bind host, daemon ports, and Mobile HTTPS.
+- **Diagnostics** — application logging, performance sampling, log level, retention, and buffered records.
+- **Daemon** — server lifecycle and capability-related controls.
+- **Desktop rendering** — desktop rendering behavior.
+- **Launch context** — information about how the application was started.
+- **System information** — versions and runtime details.
+
+Network, daemon, and diagnostic changes may require a restart. CLI and environment settings take precedence over saved Settings values, and Nerve marks those effective values as locked. Do not put API keys or proxy credentials in shared configuration files.
+
+## Related pages
+
+- [Personalize Nerve](/guides/personalize/)
+- [Select models](/models/selecting-models/)
+- [Configure agent controls](/guides/agent-controls/)
+- [Manage skills and resources](/guides/skills-and-resources/)
+- [Storage and migration](/operations/storage-migration/)
+- [Diagnostics](/operations/diagnostics/)

--- a/packages/website/src/content/docs/guides/workbench.md
+++ b/packages/website/src/content/docs/guides/workbench.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-The desktop layout has a conversation/task dock, a tabbed center workspace, and a secondary dock. Drag resize handles to allocate space. Panel views can move among left, right, and bottom docks or be hidden; Nerve repairs obsolete saved layouts after upgrades.
+The desktop layout has a conversation/task dock, a tabbed center workspace, and a secondary dock. Drag resize handles to allocate space. Panel views can move among left, right, and bottom docks or be hidden; Nerve repairs obsolete saved layouts after upgrades. The title-bar Help button opens the built-in Guides catalog, including a full Workbench tour.
 
 ## Dock views
 
@@ -30,8 +30,14 @@ Below 1024px, Nerve switches to a single center column. Left dock views move int
 
 Layout and active-tab preferences are browser-local. A different browser profile or cleared site storage starts with defaults even though server-side projects and conversations remain.
 
+## Built-in tour
+
+Choose **Help → Guides → Work through the Workbench** for an interactive tour of the composer, review controls, panels, files, Git, tasks, providers, Settings, and status. The tour needs an active project and can be replayed after completion.
+
 ## Next steps
 
 - [Conversations](/guides/conversations/)
 - [Files, context, and notes](/guides/files-context-notes/)
 - [Themes, zoom, and shortcuts](/guides/personalize/)
+- [Configure Settings](/guides/settings/)
+- [Use the built-in Guides](/start/guides/)

--- a/packages/website/src/content/docs/start/first-project.md
+++ b/packages/website/src/content/docs/start/first-project.md
@@ -43,8 +43,14 @@ You will see text and any thinking returned by the provider, plus cards for file
 Below 1024px, dock views become left and right sheets. The phone-density layout begins below 640px, but the same project and conversation data remains available.
 :::
 
+## Use the built-in guide
+
+After opening a project, choose **Help → Guides → Work through the Workbench** for an interactive tour. The catalog also includes provider, voice, model, agent-default, and web-search setup coaches.
+
 ## Next steps
 
 - [Complete a safe first task](/start/first-task/)
+- [Use the built-in Guides](/start/guides/)
 - [Learn the workbench](/guides/workbench/)
+- [Configure Settings](/guides/settings/)
 - [Learn the composer](/guides/composer/)

--- a/packages/website/src/content/docs/start/guides.md
+++ b/packages/website/src/content/docs/start/guides.md
@@ -1,0 +1,39 @@
+---
+title: Use the built-in Guides
+description: Learn Nerve through interactive setup coaches and a guided Workbench tour.
+sidebar:
+  order: 2
+---
+
+Nerve includes interactive Guides for the first steps and the most important Workbench controls. Open **Help → Guides** from the title bar at any time.
+
+## The guide catalog
+
+The catalog currently includes:
+
+- **Open a project** — choose a project folder and open its conversation navigator.
+- **Connect a model provider** — connect a subscription or save an API key.
+- **Enable voice input** — connect OpenAI Codex/ChatGPT OAuth so the composer microphone is available.
+- **Configure scoped models** — choose which authenticated models appear in conversation pickers.
+- **Configure agent defaults** — set the default mode, permission, model, thinking level, and Explore settings.
+- **Set up web search** — configure Tavily under **Settings → Tools → Integrations**.
+- **Work through the Workbench** — a tour of conversations, the composer, reviews, panels, files, Git, tasks, providers, Settings, and status.
+
+Setup entries are short coaches that take you to the relevant screen. The Workbench entry is a guided tour and requires an active project. If you start another guide first, Nerve offers to open a project before continuing.
+
+## Completion and replay
+
+Guides can open automatically during eligible desktop startup when setup remains incomplete. You can dismiss the catalog and return to it from Help. Nerve remembers completed guide versions locally; choose **Replay** when you want to review one again. A guide may appear again after its content is revised.
+
+The catalog reflects the current application state. For example, a connected provider or opened project can satisfy a guide without manually stepping through it. Available integrations and provider choices still depend on your installation and credentials.
+
+Guides are intentionally not shown in phone layouts. The responsive Workbench remains available on phones and tablets, and you can use the full guide experience from a desktop or wider browser window.
+
+## Related guides
+
+- [Open your first project](/start/first-project/)
+- [Connect a model provider](/start/providers/)
+- [Configure models](/models/selecting-models/)
+- [Control agent permissions](/guides/agent-controls/)
+- [Navigate the Workbench](/guides/workbench/)
+- [Configure Settings](/guides/settings/)

--- a/packages/website/src/content/docs/start/providers.md
+++ b/packages/website/src/content/docs/start/providers.md
@@ -9,7 +9,7 @@ Nerve gets its current built-in provider and model catalog through its pi-ai int
 
 ## Add authentication
 
-Open **Settings → Providers** and choose a provider. Depending on provider metadata, Nerve can offer:
+Open **Providers & authentication** from the title bar, then use its **Connections** page to choose a provider. Model defaults and scopes live separately under **Settings**. Depending on provider metadata, Nerve can offer:
 
 - an API key;
 - an OAuth or subscription flow;
@@ -47,6 +47,7 @@ Voice transcription requires OpenAI Codex/ChatGPT OAuth. An ordinary OpenAI API 
 
 ## Next steps
 
+- [Built-in Guides](/start/guides/)
 - [Open a project](/start/first-project/)
 - [Provider and authentication details](/models/providers-and-auth/)
 - [Troubleshoot providers](/troubleshooting/providers/)


### PR DESCRIPTION
## Summary
- document built-in Guides and the current Settings surface
- refresh Workbench, provider, project, and background-task guidance
- add an accessible Mermaid architecture diagram and clarify docs ownership

## Validation
- pnpm fix && pnpm check && pnpm test
- pnpm --filter @nervekit/website build