### PR TITLE
Fix cross-platform canonical path handling

### DIFF
--- a/packages/harness/src/harness/path-utils.ts
+++ b/packages/harness/src/harness/path-utils.ts
@@ -39,8 +39,12 @@ function toPosixPath(path: string): string {
   return end === 0 ? normalized : normalized.slice(0, end);
 }
 
-function isWindowsDrivePath(path: string): boolean {
-  return WINDOWS_DRIVE_PATH_RE.test(path) || /^[A-Za-z]:\//u.test(path);
+function isWindowsLikePath(path: string): boolean {
+  return (
+    WINDOWS_DRIVE_PATH_RE.test(path) ||
+    /^[A-Za-z]:\//u.test(path) ||
+    path.startsWith("//")
+  );
 }
 
 function makeRelativeIgnorePath(path: string): string {
@@ -92,7 +96,7 @@ export function relativeEnvPath(root: string, path: string): string {
   const normalizedRoot = toPosixPath(root);
   const normalizedPath = toPosixPath(path);
   const windowsComparison =
-    isWindowsDrivePath(normalizedRoot) || isWindowsDrivePath(normalizedPath);
+    isWindowsLikePath(normalizedRoot) || isWindowsLikePath(normalizedPath);
   const compareRoot = windowsComparison
     ? normalizedRoot.toLowerCase()
     : normalizedRoot;

--- a/packages/harness/test/harness/path-utils.test.ts
+++ b/packages/harness/test/harness/path-utils.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { relativeEnvPath } from "../../src/harness/path-utils.js";
+
+describe("execution environment path helpers", () => {
+  it("compares Windows drive and UNC paths case-insensitively", () => {
+    assert.equal(
+      relativeEnvPath(
+        String.raw`C:\Users\Alice\Skills`,
+        String.raw`c:\users\alice\skills\Category\SKILL.md`,
+      ),
+      "Category/SKILL.md",
+    );
+    assert.equal(
+      relativeEnvPath(
+        String.raw`\\SERVER\Share\Skills`,
+        String.raw`\\server\share\skills\Category\SKILL.md`,
+      ),
+      "Category/SKILL.md",
+    );
+  });
+
+  it("does not confuse UNC sibling prefixes", () => {
+    assert.equal(
+      relativeEnvPath(
+        String.raw`\\server\share\skills`,
+        String.raw`\\server\share\skills-old\SKILL.md`,
+      ),
+      "server/share/skills-old/SKILL.md",
+    );
+  });
+
+  it("keeps POSIX path comparisons case-sensitive", () => {
+    assert.equal(
+      relativeEnvPath("/Users/alice/skills", "/users/alice/skills/SKILL.md"),
+      "users/alice/skills/SKILL.md",
+    );
+  });
+});

--- a/packages/tools/src/safety/command-policy-wrappers.ts
+++ b/packages/tools/src/safety/command-policy-wrappers.ts
@@ -1,3 +1,5 @@
+import { win32 } from "node:path";
+
 export function stripEnvVarAssignments(tokens: string[]): string[] {
   let index = 0;
   while (
@@ -10,7 +12,7 @@ export function stripEnvVarAssignments(tokens: string[]): string[] {
 }
 
 export function normalizeCommandName(command: string): string {
-  return (command.split("/").pop() ?? command).trim();
+  return win32.basename(command.trim());
 }
 
 function stripLeadingOptions(tokens: string[]): string[] {

--- a/packages/tools/test/command-policy.test.ts
+++ b/packages/tools/test/command-policy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isAllowedPlanModeBashCommand } from "../src/index.js";
+import { normalizeCommandName } from "../src/safety/command-policy-wrappers.js";
 
 function expectAllowed(commands: string[]): void {
   for (const command of commands) {
@@ -19,6 +20,12 @@ function expectBlocked(commands: string[]): void {
 }
 
 describe("plan-mode bash command guard", () => {
+  it("normalizes POSIX, Windows, and mixed command paths", () => {
+    assert.equal(normalizeCommandName("/usr/bin/rg"), "rg");
+    assert.equal(normalizeCommandName(String.raw`C:\Tools\rg.exe`), "rg.exe");
+    assert.equal(normalizeCommandName(String.raw`C:\Tools/rg.exe`), "rg.exe");
+  });
+
   describe("allows inspection commands, including unknown roots", () => {
     expectAllowed([
       'rg "foo" src',
@@ -79,6 +86,8 @@ describe("plan-mode bash command guard", () => {
       "nohup rm file >/dev/null 2>&1",
       "rg foo src | xargs rm",
       "rg foo src | xargs -I{} git checkout {}",
+      String.raw`'C:\Windows\System32\rm' -rf dist`,
+      String.raw`'C:\Windows\System32\env' rm -rf dist`,
     ]);
   });
 

--- a/packages/ui-kit/src/lib/core/utils/path-links.test.ts
+++ b/packages/ui-kit/src/lib/core/utils/path-links.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   localPathDirectory,
   parseLocalFileHref,
+  relativePathForDisplay,
   resolveDisplayPath,
   splitPathLineSuffix,
 } from "./path-links";
@@ -19,6 +20,23 @@ describe("path link helpers", () => {
         "C:\\Users\\me\\repo",
       ),
       "C:\\Users\\me\\repo\\src\\App.svelte",
+    );
+  });
+
+  it("compares UNC paths case-insensitively without matching siblings", () => {
+    assert.equal(
+      relativePathForDisplay(
+        String.raw`\\server\share\repo\src\App.svelte`,
+        String.raw`\\SERVER\Share\Repo`,
+      ),
+      "src/App.svelte",
+    );
+    assert.equal(
+      relativePathForDisplay(
+        String.raw`\\server\share\repo-old\App.svelte`,
+        String.raw`\\server\share\repo`,
+      ),
+      "//server/share/repo-old/App.svelte",
     );
   });
 

--- a/packages/ui-kit/src/lib/core/utils/path-links.ts
+++ b/packages/ui-kit/src/lib/core/utils/path-links.ts
@@ -69,11 +69,17 @@ export function relativePathForDisplay(
   if (!path) return undefined;
   const normalizedPath = normalizePathForCompare(path);
   const normalizedCwd = normalizePathForCompare(cwd);
-  if (normalizedPath === normalizedCwd) return ".";
-  const prefix = normalizedCwd.endsWith("/")
-    ? normalizedCwd
-    : `${normalizedCwd}/`;
-  if (normalizedPath.startsWith(prefix)) {
+  const windowsComparison =
+    isWindowsLikePath(normalizedPath) || isWindowsLikePath(normalizedCwd);
+  const comparePath = windowsComparison
+    ? normalizedPath.toLowerCase()
+    : normalizedPath;
+  const compareCwd = windowsComparison
+    ? normalizedCwd.toLowerCase()
+    : normalizedCwd;
+  if (comparePath === compareCwd) return ".";
+  const prefix = compareCwd.endsWith("/") ? compareCwd : `${compareCwd}/`;
+  if (comparePath.startsWith(prefix)) {
     return normalizedPath.slice(prefix.length);
   }
   return path.replace(/\\/g, "/");

--- a/packages/workbench-app/src/lib/core/utils/path.test.ts
+++ b/packages/workbench-app/src/lib/core/utils/path.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isPathInDirectory, pathKey, samePath, tildePath } from "./path";
+
+describe("workbench path helpers", () => {
+  it("compares Windows drive and UNC paths case-insensitively", () => {
+    assert.equal(samePath("C:\\Users\\Alice", "c:\\users\\alice"), true);
+    assert.equal(
+      samePath(
+        String.raw`\\SERVER\Share\Repo`,
+        String.raw`\\server\share\repo`,
+      ),
+      true,
+    );
+    assert.equal(
+      pathKey(String.raw`\\SERVER\Share\Repo`),
+      "//server/share/repo",
+    );
+  });
+
+  it("handles UNC containment without accepting sibling prefixes", () => {
+    const root = String.raw`\\SERVER\Share\Repo`;
+    assert.equal(
+      isPathInDirectory(String.raw`\\server\share\repo\src`, root),
+      true,
+    );
+    assert.equal(
+      isPathInDirectory(String.raw`\\server\share\repo-old`, root),
+      false,
+    );
+    assert.equal(tildePath(String.raw`\\server\share\repo\src`, root), "~/src");
+  });
+
+  it("keeps POSIX comparisons case-sensitive", () => {
+    assert.equal(samePath("/Users/Alice", "/users/alice"), false);
+    assert.equal(isPathInDirectory("/repo-old", "/repo"), false);
+  });
+});

--- a/packages/workbench-app/src/lib/core/utils/path.ts
+++ b/packages/workbench-app/src/lib/core/utils/path.ts
@@ -43,7 +43,7 @@ function normalizeDisplayPath(path: string): string {
 
 function comparablePath(path: string): string {
   const normalized = normalizeDisplayPath(path);
-  return /^[A-Za-z]:\//.test(normalized)
+  return /^[A-Za-z]:\//.test(normalized) || normalized.startsWith("//")
     ? normalized.toLowerCase()
     : normalized;
 }
@@ -90,8 +90,8 @@ export function tildePath(dir?: string, home?: string): string {
 }
 
 /**
- * Stable, case-correct key for a filesystem path. Drive-letter (Windows) paths
- * are lower-cased for case-insensitive matching; POSIX paths stay case-sensitive.
+ * Stable, case-correct key for a filesystem path. Drive-letter and UNC Windows
+ * paths are lower-cased for case-insensitive matching; POSIX paths stay case-sensitive.
  */
 export function pathKey(path: string): string {
   return comparablePath(path);

--- a/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.test.ts
+++ b/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.test.ts
@@ -23,6 +23,20 @@ describe("project entry drag payload", () => {
     );
   });
 
+  it("canonicalizes Windows and mixed relative separators", () => {
+    const windowsEntries: ProjectEntryDragItem[] = [
+      { path: "src\\main.ts", kind: "file" },
+      { path: "src\\components/button.svelte", kind: "file" },
+    ];
+    assert.deepEqual(
+      parseProjectEntryDrag(serializeProjectEntryDrag(windowsEntries)),
+      [
+        { path: "src/main.ts", kind: "file" },
+        { path: "src/components/button.svelte", kind: "file" },
+      ],
+    );
+  });
+
   it("formats file and directory references", () => {
     assert.deepEqual(formatProjectEntryReferences(entries), [
       "@src/main.ts",
@@ -58,7 +72,9 @@ describe("project entry drag payload", () => {
       "/etc/passwd",
       "../secret",
       "src/../secret",
+      "src//secret",
       "C:\\secret",
+      "\\\\server\\share\\secret",
     ])
       assert.equal(
         parseProjectEntryDrag(

--- a/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.ts
+++ b/packages/workbench-app/src/lib/presentation/dnd/project-entry-drag.ts
@@ -10,34 +10,53 @@ type ProjectEntryDragPayload = {
   entries: readonly ProjectEntryDragItem[];
 };
 
-function isRelativeProjectPath(path: string): boolean {
-  if (!path || path.startsWith("/") || path.startsWith("\\")) return false;
-  if (/^[a-zA-Z]:[\\/]/.test(path)) return false;
-  const segments = path.replaceAll("\\", "/").split("/");
+function normalizeRelativeProjectPath(path: string): string | undefined {
+  const normalized = path.replaceAll("\\", "/");
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    /^[a-zA-Z]:\//.test(normalized)
+  ) {
+    return undefined;
+  }
+  const segments = normalized.split("/");
   return segments.every(
     (segment) => segment !== "" && segment !== "." && segment !== "..",
-  );
+  )
+    ? normalized
+    : undefined;
 }
 
-function isProjectEntryDragItem(value: unknown): value is ProjectEntryDragItem {
-  if (!value || typeof value !== "object") return false;
+function normalizeProjectEntryDragItem(
+  value: unknown,
+): ProjectEntryDragItem | undefined {
+  if (!value || typeof value !== "object") return undefined;
   const item = value as Partial<ProjectEntryDragItem>;
-  return (
-    (item.kind === "file" || item.kind === "directory") &&
-    typeof item.path === "string" &&
-    isRelativeProjectPath(item.path)
-  );
+  if (
+    (item.kind !== "file" && item.kind !== "directory") ||
+    typeof item.path !== "string"
+  ) {
+    return undefined;
+  }
+  const path = normalizeRelativeProjectPath(item.path);
+  return path ? { path, kind: item.kind } : undefined;
 }
 
 export function serializeProjectEntryDrag(
   entries: readonly ProjectEntryDragItem[],
 ): string {
-  if (entries.length === 0 || !entries.every(isProjectEntryDragItem)) {
+  const normalized = entries.map(normalizeProjectEntryDragItem);
+  if (
+    normalized.length === 0 ||
+    !normalized.every(
+      (entry): entry is ProjectEntryDragItem => entry !== undefined,
+    )
+  ) {
     throw new Error("Project entry drag payload contains invalid entries.");
   }
   return JSON.stringify({
     version: 1,
-    entries,
+    entries: normalized,
   } satisfies ProjectEntryDragPayload);
 }
 
@@ -50,12 +69,16 @@ export function parseProjectEntryDrag(
     if (
       payload.version !== 1 ||
       !Array.isArray(payload.entries) ||
-      payload.entries.length === 0 ||
-      !payload.entries.every(isProjectEntryDragItem)
+      payload.entries.length === 0
     ) {
       return undefined;
     }
-    return payload.entries;
+    const entries = payload.entries.map(normalizeProjectEntryDragItem);
+    return entries.every(
+      (entry): entry is ProjectEntryDragItem => entry !== undefined,
+    )
+      ? entries
+      : undefined;
   } catch {
     return undefined;
   }
@@ -68,8 +91,11 @@ export function hasProjectEntryDragType(types: readonly string[]): boolean {
 export function formatProjectEntryReference(
   entry: ProjectEntryDragItem,
 ): string {
-  const normalizedPath = entry.path.replaceAll("\\", "/");
-  const reference = `@${normalizedPath}${entry.kind === "directory" ? "/" : ""}`;
+  const normalized = normalizeProjectEntryDragItem(entry);
+  if (!normalized) {
+    throw new Error("Project entry reference contains an invalid path.");
+  }
+  const reference = `@${normalized.path}${normalized.kind === "directory" ? "/" : ""}`;
   if (!/[\s"]/.test(reference)) return reference;
   return `"${reference.replaceAll('"', '\\"')}"`;
 }

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -31,7 +31,7 @@
     "check": "tsc -b --pretty false",
     "dev": "tsx src/main.ts",
     "test": "tsx --test test/*.test.ts",
-    "test:native": "tsx --test test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/storage-json.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts"
+    "test:native": "tsx --test test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/static-files.test.ts test/storage-json.test.ts test/storage-migrations.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "0.84.2",

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -31,7 +31,7 @@
     "check": "tsc -b --pretty false",
     "dev": "tsx src/main.ts",
     "test": "tsx --test test/*.test.ts",
-    "test:native": "tsx --test test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/static-files.test.ts test/storage-json.test.ts test/storage-migrations.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts"
+    "test:native": "tsx --test test/file-idempotency-store.test.ts test/file-mutations.test.ts test/legacy-home-migration.test.ts test/policy.test.ts test/process-runtime-driver.test.ts test/protocol-websocket.test.ts test/storage-json.test.ts test/storage-settings-migration.test.ts test/task-port-inspector.test.ts test/task-scope.test.ts test/task-service.contract.test.ts test/task-supervisor.test.ts test/workbench-task-service-foreground.test.ts test/workbench-task-service-launch-env.test.ts test/workbench-task-service-lifecycle.test.ts test/workbench-task-service-orphan.test.ts test/workbench-task-service-readiness.test.ts && tsx --test test/static-files.test.ts test/storage-migrations.test.ts"
   },
   "dependencies": {
     "@earendil-works/pi-ai": "0.84.2",

--- a/packages/workbench-server/src/http/static-files.ts
+++ b/packages/workbench-server/src/http/static-files.ts
@@ -1,6 +1,14 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { dirname, extname, join, resolve } from "node:path";
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
 import { fileURLToPath } from "node:url";
 import type { OrchestratorState } from "../app/orchestrator-state.js";
 import { cookieHeader } from "./auth-middleware.js";
@@ -57,7 +65,7 @@ export async function serveStatic(
   const webDist = resolveWebDistPath();
   const requestedPath = pathname === "/" ? "/index.html" : pathname;
   const normalizedPath = resolve(webDist, `.${requestedPath}`);
-  const finalPath = normalizedPath.startsWith(webDist)
+  const finalPath = isPathInside(webDist, normalizedPath)
     ? normalizedPath
     : join(webDist, "index.html");
 
@@ -150,6 +158,16 @@ function isLoopbackHost(host: string): boolean {
     normalized === "::1" ||
     normalized.startsWith("127.") ||
     normalized.startsWith("::ffff:127.")
+  );
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === "" ||
+    (pathFromRoot !== ".." &&
+      !pathFromRoot.startsWith(`..${sep}`) &&
+      !isAbsolute(pathFromRoot))
   );
 }
 

--- a/packages/workbench-server/src/infrastructure/migrations/canonical-path.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/canonical-path.ts
@@ -1,0 +1,37 @@
+import { isAbsolute, posix, relative, resolve, sep } from "node:path";
+import { MigrationError } from "./migration.js";
+
+export function assertCanonicalRelativePath(path: string): string {
+  if (
+    !path ||
+    posix.isAbsolute(path) ||
+    path.includes("\\") ||
+    posix.normalize(path) !== path ||
+    path
+      .split("/")
+      .some((segment) => !segment || segment === "." || segment === "..")
+  ) {
+    throw new MigrationError(`Unsafe migration backup path '${path}'.`);
+  }
+  return path;
+}
+
+export function joinCanonicalPath(...parts: string[]): string {
+  return assertCanonicalRelativePath(posix.join(...parts));
+}
+
+export function resolveCanonicalPath(root: string, path: string): string {
+  assertCanonicalRelativePath(path);
+  const resolvedRoot = resolve(root);
+  const target = resolve(resolvedRoot, path);
+  const pathFromRoot = relative(resolvedRoot, target);
+  if (
+    pathFromRoot === "" ||
+    pathFromRoot === ".." ||
+    pathFromRoot.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromRoot)
+  ) {
+    throw new MigrationError(`Unsafe migration backup path '${path}'.`);
+  }
+  return target;
+}

--- a/packages/workbench-server/src/infrastructure/migrations/migration.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/migration.ts
@@ -4,7 +4,7 @@ import type { StoragePaths } from "../storage/paths.js";
 export type MigrationDetection = "current" | "pending";
 
 export interface MigrationBackupSpec {
-  /** Canonical paths relative to NERVE_HOME. */
+  /** Normalized POSIX-style identifiers relative to NERVE_HOME, not native filesystem paths. */
   paths: string[];
 }
 

--- a/packages/workbench-server/src/infrastructure/migrations/migrations/0004-dense-event-stream-layout.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/migrations/0004-dense-event-stream-layout.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { pathExists } from "../../storage/json.js";
 import type { StorageMigration } from "../migration.js";
+import { joinCanonicalPath } from "../canonical-path.js";
 import { migrationChecksum } from "../checksum.js";
 
 const markerPath = "logs/.dense-streams-v1";
@@ -16,7 +17,7 @@ async function legacyPaths(home: string): Promise<string[]> {
       name === "workspace-events.jsonl" ||
       name === "workspace-events.meta.json"
     )
-      paths.push(join("logs", name));
+      paths.push(joinCanonicalPath("logs", name));
   }
   const conversations = await readdir(join(home, "conversations"), {
     withFileTypes: true,
@@ -24,7 +25,11 @@ async function legacyPaths(home: string): Promise<string[]> {
   for (const conversation of conversations) {
     if (!conversation.isDirectory()) continue;
     for (const name of ["events.jsonl", "events.meta.json"]) {
-      const relative = join("conversations", conversation.name, name);
+      const relative = joinCanonicalPath(
+        "conversations",
+        conversation.name,
+        name,
+      );
       if (await pathExists(join(home, relative))) paths.push(relative);
     }
   }

--- a/packages/workbench-server/src/infrastructure/migrations/migrations/0005-current-project-sidecars.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/migrations/0005-current-project-sidecars.ts
@@ -14,6 +14,7 @@ import {
   readJsonFile,
 } from "../../storage/json.js";
 import type { StorageMigration } from "../migration.js";
+import { joinCanonicalPath } from "../canonical-path.js";
 import { migrationChecksum } from "../checksum.js";
 
 const legacyScratchNoteSchema = z.object({
@@ -33,12 +34,12 @@ async function projectIds(home: string): Promise<string[]> {
 }
 
 function paths(projectId: string) {
-  const root = join("projects", projectId);
+  const root = joinCanonicalPath("projects", projectId);
   return {
-    tasks: join(root, "task-definitions.json"),
-    legacyTasks: join(root, "pinned-commands.json"),
-    notes: join(root, "scratch-notes.json"),
-    legacyNote: join(root, "scratch-note.json"),
+    tasks: joinCanonicalPath(root, "task-definitions.json"),
+    legacyTasks: joinCanonicalPath(root, "pinned-commands.json"),
+    notes: joinCanonicalPath(root, "scratch-notes.json"),
+    legacyNote: joinCanonicalPath(root, "scratch-note.json"),
   };
 }
 

--- a/packages/workbench-server/src/infrastructure/migrations/migrations/0006-unify-tool-call-lifecycle.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/migrations/0006-unify-tool-call-lifecycle.ts
@@ -16,6 +16,7 @@ import {
   rewriteJsonLines,
 } from "../../storage/json.js";
 import type { StorageMigration } from "../migration.js";
+import { joinCanonicalPath } from "../canonical-path.js";
 import { migrationChecksum } from "../checksum.js";
 
 type LegacyRecord = Record<string, unknown>;
@@ -523,7 +524,9 @@ export const migration0006: StorageMigration = {
       "run-runtime",
     ];
     for (const conversationId of await conversationIds(context.paths.home)) {
-      paths.push(join("conversations", conversationId, "tool-calls"));
+      paths.push(
+        joinCanonicalPath("conversations", conversationId, "tool-calls"),
+      );
     }
     paths.push(archiveRoot);
     return { paths };

--- a/packages/workbench-server/src/infrastructure/migrations/migrations/0007-transient-conversation-live-events.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/migrations/0007-transient-conversation-live-events.ts
@@ -4,6 +4,7 @@ import { eventEnvelopeSchema } from "@nervekit/contracts";
 import { atomicWriteFile } from "../../storage/file-mutations.js";
 import { pathExists } from "../../storage/json.js";
 import type { StorageMigration } from "../migration.js";
+import { joinCanonicalPath } from "../canonical-path.js";
 import { migrationChecksum } from "../checksum.js";
 
 const markerPath = "logs/.transient-conversation-live-events-v1";
@@ -25,9 +26,9 @@ async function discover(home: string): Promise<StreamFiles[]> {
   );
   for (const entry of conversations) {
     if (!entry.isDirectory() || !entry.name.startsWith("conv_")) continue;
-    const relativeRoot = join("conversations", entry.name);
-    const journal = join(relativeRoot, "events.jsonl");
-    const metadata = join(relativeRoot, "events.meta.json");
+    const relativeRoot = joinCanonicalPath("conversations", entry.name);
+    const journal = joinCanonicalPath(relativeRoot, "events.jsonl");
+    const metadata = joinCanonicalPath(relativeRoot, "events.meta.json");
     const hasJournal = await pathExists(join(home, journal));
     const hasMetadata = await pathExists(join(home, metadata));
     if (!hasJournal && !hasMetadata) continue;

--- a/packages/workbench-server/src/infrastructure/migrations/rollback-bundle.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/rollback-bundle.ts
@@ -8,8 +8,9 @@ import {
   readFile,
   rm,
 } from "node:fs/promises";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, join } from "node:path";
 import { atomicWriteJson, pathExists } from "../storage/json.js";
+import { resolveCanonicalPath } from "./canonical-path.js";
 import { MigrationError } from "./migration.js";
 import { invalidateDerivedDatabase } from "./sqlite.js";
 
@@ -45,7 +46,7 @@ export async function createRollbackBundle(input: {
   await mkdir(directory, { recursive: true, mode: 0o700 });
   const entries: BackupEntry[] = [];
   for (const path of [...new Set(input.paths)].sort()) {
-    const source = safeCanonicalPath(input.home, path);
+    const source = resolveCanonicalPath(input.home, path);
     const existed = await pathExists(source);
     const bytes = existed
       ? await copyCanonical(source, join(directory, "files", path))
@@ -107,7 +108,7 @@ export async function recoverInterruptedBatch(
     return false;
   }
   for (const entry of manifest.entries) {
-    const target = safeCanonicalPath(home, entry.path);
+    const target = resolveCanonicalPath(home, entry.path);
     await rm(target, { recursive: true, force: true });
     if (entry.existed) {
       await copyCanonical(join(directory, "files", entry.path), target);
@@ -124,19 +125,6 @@ export async function discardRollbackBundle(
 ): Promise<void> {
   await rm(bundle.activePath, { force: true });
   await rm(bundle.directory, { recursive: true, force: true });
-}
-
-function safeCanonicalPath(home: string, path: string): string {
-  if (!path || path.startsWith("/") || path.includes("\\")) {
-    throw new MigrationError(`Unsafe migration backup path '${path}'.`);
-  }
-  const root = resolve(home);
-  const target = resolve(root, path);
-  const rel = relative(root, target);
-  if (rel === ".." || rel.startsWith(`..${sep}`) || rel === "") {
-    throw new MigrationError(`Unsafe migration backup path '${path}'.`);
-  }
-  return target;
 }
 
 async function copyCanonical(source: string, target: string): Promise<number> {

--- a/packages/workbench-server/test/static-files.test.ts
+++ b/packages/workbench-server/test/static-files.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import type { OrchestratorState } from "../src/app/orchestrator-state.js";
+import { serveStatic } from "../src/http/static-files.js";
+
+const roots: string[] = [];
+const originalWebDist = process.env.NERVE_WEB_DIST;
+
+before(() => {
+  delete process.env.NERVE_WEB_DIST;
+});
+
+after(async () => {
+  if (originalWebDist === undefined) delete process.env.NERVE_WEB_DIST;
+  else process.env.NERVE_WEB_DIST = originalWebDist;
+  await Promise.all(
+    roots.map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "nerve-static-files-"));
+  roots.push(root);
+  const webDist = join(root, "web");
+  const sibling = join(root, "web-evil");
+  await mkdir(join(webDist, "assets"), { recursive: true });
+  await mkdir(sibling);
+  await writeFile(join(webDist, "index.html"), "safe index");
+  await writeFile(join(webDist, "assets", "app.js"), "safe asset");
+  await writeFile(join(sibling, "secret.txt"), "outside secret");
+  process.env.NERVE_WEB_DIST = webDist;
+  return { webDist, sibling };
+}
+
+const state = {
+  host: "127.0.0.1",
+  storage: { localToken: "test-token" },
+} as OrchestratorState;
+
+describe("static file serving", () => {
+  it("serves nested assets inside the configured distribution", async () => {
+    await fixture();
+    const response = await serveStatic("/assets/app.js", state);
+    assert.equal(await response.text(), "safe asset");
+  });
+
+  it("does not accept sibling paths that share the distribution prefix", async () => {
+    const { webDist, sibling } = await fixture();
+    const traversal = `/../${basename(sibling)}/secret.txt`;
+    assert.equal(dirname(webDist), dirname(sibling));
+
+    const response = await serveStatic(traversal, state);
+
+    assert.notEqual(await response.text(), "outside secret");
+  });
+
+  it("preserves the SPA fallback for missing routes", async () => {
+    await fixture();
+    const response = await serveStatic("/conversation/conv_test", state);
+    assert.equal(await response.text(), "safe index");
+  });
+});

--- a/packages/workbench-server/test/storage-migrations.test.ts
+++ b/packages/workbench-server/test/storage-migrations.test.ts
@@ -295,10 +295,12 @@ describe("storage migration runner", () => {
     assert.equal(first.executions[0]?.execution, "detected");
     const second = await runStorageMigrations(root, { registry });
     assert.equal(second.executions.length, 0);
-    assert.equal(
-      (await stat(join(root, "migrations", "ledger.json"))).mode & 0o777,
-      0o600,
-    );
+    if (process.platform !== "win32") {
+      assert.equal(
+        (await stat(join(root, "migrations", "ledger.json"))).mode & 0o777,
+        0o600,
+      );
+    }
   });
 
   it("creates one batch bundle, restores on failure, and leaves the ledger unchanged", async () => {

--- a/packages/workbench-server/test/storage-migrations.test.ts
+++ b/packages/workbench-server/test/storage-migrations.test.ts
@@ -12,9 +12,18 @@ import {
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
-import type { StorageMigration } from "../src/infrastructure/migrations/index.js";
+import type {
+  MigrationContext,
+  StorageMigration,
+} from "../src/infrastructure/migrations/migration.js";
+import {
+  assertCanonicalRelativePath,
+  joinCanonicalPath,
+} from "../src/infrastructure/migrations/canonical-path.js";
 import { migrationChecksum } from "../src/infrastructure/migrations/checksum.js";
 import { migration0004 } from "../src/infrastructure/migrations/migrations/0004-dense-event-stream-layout.js";
+import { migration0005 } from "../src/infrastructure/migrations/migrations/0005-current-project-sidecars.js";
+import { migration0006 } from "../src/infrastructure/migrations/migrations/0006-unify-tool-call-lifecycle.js";
 import { migration0007 } from "../src/infrastructure/migrations/migrations/0007-transient-conversation-live-events.js";
 import { migration0008 } from "../src/infrastructure/migrations/migrations/0008-remove-legacy-storage.js";
 import { StreamLog } from "../src/infrastructure/events/stream-log.js";
@@ -34,6 +43,10 @@ async function home() {
   roots.push(value);
   return value;
 }
+function migrationContext(root: string): MigrationContext {
+  return { paths: { home: root } } as unknown as MigrationContext;
+}
+
 function migration(
   id: string,
   behavior: Partial<StorageMigration> = {},
@@ -51,6 +64,96 @@ function migration(
 }
 
 describe("storage migration runner", () => {
+  it("constructs and validates normalized canonical backup paths", () => {
+    assert.equal(
+      joinCanonicalPath("conversations", "conv_test", "tool-calls"),
+      "conversations/conv_test/tool-calls",
+    );
+    for (const path of [
+      "",
+      ".",
+      "../state.txt",
+      "nested/../state.txt",
+      "nested/./state.txt",
+      "nested//state.txt",
+      "/state.txt",
+      "nested\\state.txt",
+    ]) {
+      assert.throws(() => assertCanonicalRelativePath(path), /unsafe/i);
+    }
+  });
+
+  it("rejects unsafe rollback scopes at the canonical/native boundary", async () => {
+    const root = await home();
+    for (const path of [
+      "../state.txt",
+      "nested/../state.txt",
+      "/state.txt",
+      "nested\\state.txt",
+    ]) {
+      await assert.rejects(
+        createRollbackBundle({
+          home: root,
+          migrationsDir: join(root, "migrations"),
+          id: "unsafe-path-test",
+          ledgerDigest: "digest",
+          paths: [path],
+        }),
+        /unsafe/i,
+      );
+    }
+  });
+
+  it("keeps every dynamically discovered backup path canonical", async () => {
+    const root = await home();
+    await mkdir(join(root, "logs"), { recursive: true });
+    await writeFile(join(root, "logs", "events.jsonl.1"), "");
+
+    const conversation = join(root, "conversations", "conv_test");
+    await mkdir(join(conversation, "tool-calls"), { recursive: true });
+    await writeFile(join(conversation, "events.jsonl"), "");
+    await writeFile(
+      join(conversation, "events.meta.json"),
+      JSON.stringify({ lastSeq: 0 }),
+    );
+
+    const project = join(root, "projects", "proj_test");
+    await mkdir(project, { recursive: true });
+    await writeFile(join(project, "pinned-commands.json"), "[]");
+
+    const context = migrationContext(root);
+    const specs = await Promise.all(
+      [migration0004, migration0005, migration0006, migration0007].map(
+        (entry) => entry.backup(context),
+      ),
+    );
+    const paths = specs.flatMap((spec) => spec.paths);
+
+    assert.ok(paths.includes("logs/events.jsonl.1"));
+    assert.ok(paths.includes("projects/proj_test/pinned-commands.json"));
+    assert.ok(paths.includes("conversations/conv_test/tool-calls"));
+    assert.ok(paths.includes("conversations/conv_test/events.jsonl"));
+    assert.ok(paths.every((path) => !path.includes("\\")));
+    assert.doesNotThrow(() => paths.forEach(assertCanonicalRelativePath));
+
+    const bundle = await createRollbackBundle({
+      home: root,
+      migrationsDir: join(root, "migrations"),
+      id: "canonical-paths-test",
+      ledgerDigest: "digest",
+      paths,
+    });
+    const manifest = JSON.parse(
+      await readFile(join(bundle.directory, "manifest.json"), "utf8"),
+    ) as { entries: Array<{ path: string }> };
+    assert.ok(manifest.entries.every((entry) => !entry.path.includes("\\")));
+    assert.doesNotThrow(() =>
+      manifest.entries.forEach((entry) =>
+        assertCanonicalRelativePath(entry.path),
+      ),
+    );
+  });
+
   it("accepts active dense journals after their layout marker exists", async () => {
     const root = await home();
     await mkdir(join(root, "logs"), { recursive: true });


### PR DESCRIPTION
## Summary
- separate canonical migration identifiers from native filesystem paths and fix migrations 0004–0007 on Windows
- harden rollback validation, static asset containment, Windows command parsing, drag payload paths, and UNC comparisons
- add cross-platform regression coverage and include storage/static tests in the native host suite

## Validation
- `pnpm fix && pnpm check && pnpm test`

Closes #189