### PR TITLE
Fix orphaned tool cards in conversation timelines

### DIFF
--- a/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
+++ b/packages/workbench-app/src/lib/features/conversations/components/WorkbenchConversationAdapter.svelte
@@ -150,7 +150,6 @@ const committed = $derived.by(() =>
     entries: rendered.entries,
     optimisticMessages: rendered.optimisticMessages,
     toolCalls: rendered.toolCalls,
-    includeUnanchoredTerminalToolCalls: !rendered.activeRun,
   }),
 );
 const liveItems = $derived.by(() =>

--- a/packages/workbench-app/src/lib/presentation/state/render.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/render.test.ts
@@ -296,7 +296,7 @@ describe("conversation render projection", () => {
     );
   });
 
-  it("keeps terminal recovered tool calls visible after activeRun clears", () => {
+  it("keeps terminal tool calls visible at their durable transcript anchor", () => {
     const state: ConversationRenderState = {
       conversationId: "conv_workbench",
       entries: [
@@ -310,8 +310,23 @@ describe("conversation render projection", () => {
           text: "Run the tool",
           createdAt: ts,
         },
+        {
+          id: "entry_result",
+          conversationId: "conv_workbench",
+          agentId: "agent_workbench",
+          runId: "run_workbench",
+          role: "system",
+          kind: "message",
+          text: "[Tool result: bash]",
+          details: {
+            toolCallId: "call_bash",
+            toolRecordId: "tool_bash",
+            toolName: "bash",
+          },
+          createdAt: ts,
+        },
       ],
-      activeEntryIds: ["entry_user"],
+      activeEntryIds: ["entry_user", "entry_result"],
       toolCalls: [toolCall()],
       cursorSeq: 0,
     };

--- a/packages/workbench-app/src/lib/presentation/state/render.ts
+++ b/packages/workbench-app/src/lib/presentation/state/render.ts
@@ -38,8 +38,7 @@ export function buildConversationRenderProjection(
   const toolCalls = state.toolCalls ?? [];
   const committed = buildCommittedTimeline(transcript, toolCalls, {
     includeHiddenToolCalls: state.retainHiddenToolCalls,
-    includeUnanchoredTerminalToolCalls:
-      state.retainHiddenToolCalls || !state.activeRun,
+    includeUnanchoredTerminalToolCalls: Boolean(state.retainHiddenToolCalls),
   });
   const liveItems = buildActiveRunTimeline(
     state.activeRun,

--- a/packages/workbench-app/src/lib/presentation/state/timeline-projection.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline-projection.test.ts
@@ -6,7 +6,6 @@ const emptyInput = {
   entries: [],
   optimisticMessages: [],
   toolCalls: [],
-  includeUnanchoredTerminalToolCalls: false,
 };
 
 describe("CommittedTimelineProjection", () => {

--- a/packages/workbench-app/src/lib/presentation/state/timeline-projection.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline-projection.ts
@@ -10,7 +10,6 @@ export type CommittedTimelineProjectionInput = {
   entries: ConversationEntry[];
   optimisticMessages: TranscriptItem[];
   toolCalls: ToolCallTranscriptRecord[];
-  includeUnanchoredTerminalToolCalls: boolean;
 };
 
 /**
@@ -24,7 +23,6 @@ export class CommittedTimelineProjection {
   private entries?: ConversationEntry[];
   private optimisticMessages?: TranscriptItem[];
   private toolCalls?: ToolCallTranscriptRecord[];
-  private includeUnanchoredTerminalToolCalls?: boolean;
   private committed?: CommittedTimeline;
 
   project(input: CommittedTimelineProjectionInput): CommittedTimeline {
@@ -32,9 +30,7 @@ export class CommittedTimelineProjection {
       this.committed &&
       this.entries === input.entries &&
       this.optimisticMessages === input.optimisticMessages &&
-      this.toolCalls === input.toolCalls &&
-      this.includeUnanchoredTerminalToolCalls ===
-        input.includeUnanchoredTerminalToolCalls
+      this.toolCalls === input.toolCalls
     ) {
       return this.committed;
     }
@@ -42,15 +38,10 @@ export class CommittedTimelineProjection {
     this.entries = input.entries;
     this.optimisticMessages = input.optimisticMessages;
     this.toolCalls = input.toolCalls;
-    this.includeUnanchoredTerminalToolCalls =
-      input.includeUnanchoredTerminalToolCalls;
     this.committed = buildCommittedTimeline(
       [...entriesToTranscript(input.entries), ...input.optimisticMessages],
       input.toolCalls,
-      {
-        includeUnanchoredTerminalToolCalls:
-          input.includeUnanchoredTerminalToolCalls,
-      },
+      { includeUnanchoredTerminalToolCalls: false },
     );
     return this.committed;
   }

--- a/packages/workbench-app/src/lib/presentation/state/timeline.committed.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline.committed.test.ts
@@ -23,6 +23,23 @@ describe("buildConversationTimeline committed transcript", () => {
     assert.equal(child.items[0]?.kind, "tool");
   });
 
+  it("does not append unmatched terminal tools to a primary conversation", () => {
+    const terminal = toolCall(
+      "tool_orphaned",
+      "2026-01-01T00:00:01.000Z",
+      "bash",
+      undefined,
+      { status: "failed", runId: "run_failed" },
+    );
+
+    const timeline = buildConversationTimeline(
+      [{ id: "entry_final", role: "assistant", text: "All done." }],
+      [terminal],
+    );
+
+    assert.deepEqual(keys(timeline), ["entry_final"]);
+  });
+
   it("anchors historical tool cards at matching tool-result entries", () => {
     const transcript: TranscriptItem[] = [
       {

--- a/packages/workbench-app/src/lib/presentation/state/timeline.live-tools.test.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline.live-tools.test.ts
@@ -92,7 +92,7 @@ describe("buildConversationTimeline live tools", () => {
         "2026-01-01T00:01:01.000Z",
         "bash",
         undefined,
-        { status: "completed", runId: "run_old" },
+        { status: "completed", runId: "run_active" },
       ),
     ];
 
@@ -280,9 +280,9 @@ describe("buildConversationTimeline live tools", () => {
       [
         ...transcript,
         {
-          id: "entry_assistant",
-          role: "assistant",
-          text: "[Tool call: bash]",
+          id: "entry_result",
+          role: "system",
+          text: "[Tool result: bash]",
           toolRecordId: "tool_real",
         },
       ],
@@ -340,13 +340,33 @@ describe("buildConversationTimeline live tools", () => {
     assert.deepEqual(timeline.filter((item) => item.kind === "tool").length, 1);
   });
 
+  it("does not render orphaned live-status tools without an active owner", () => {
+    const timeline = buildConversationTimeline(
+      [{ id: "entry_final", role: "assistant", text: "All done." }],
+      [
+        toolCall(
+          "tool_orphaned",
+          "2026-01-01T00:00:01.000Z",
+          "bash",
+          undefined,
+          { status: "running", runId: "run_failed" },
+        ),
+      ],
+    );
+
+    assert.deepEqual(keys(timeline), ["entry_final"]);
+  });
+
   it("attaches live output to the matching tool card", () => {
     const running = toolCall(
       "tool_bash",
       "2026-01-01T00:00:01.000Z",
       "bash",
       undefined,
-      { status: "running" },
+      {
+        status: "running",
+        runId: "run_01H00000000000000000000000",
+      },
     );
     const timeline = buildConversationTimeline(
       [{ id: "entry_user", role: "user", text: "Run command" }],

--- a/packages/workbench-app/src/lib/presentation/state/timeline.ts
+++ b/packages/workbench-app/src/lib/presentation/state/timeline.ts
@@ -131,15 +131,11 @@ function shouldAppendUnanchoredToolCall(
   liveOutput: ConversationLiveToolOutputSnapshot | undefined,
   activeRun: ConversationActiveRunSnapshot | undefined,
 ): boolean {
-  // Tools actively streaming output always belong in the live tail.
-  if (liveOutput) return true;
-  // During an active run, only that run's tool calls belong in the live tail;
-  // a stale live-status call from a finished run must not be pinned below the
-  // current run's streaming content.
-  if (activeRun) return toolCall.runId === activeRun.runId;
-  // No active run: surface genuinely live tool calls. Stale ones are
-  // terminalized by the orchestrator so they are no longer live-status here.
-  return isLiveToolCall(toolCall);
+  // A live timeline is an overlay owned by one active run. Persisted live
+  // statuses without that owner are stale/recovery data, not tail content.
+  if (!activeRun || toolCall.runId !== activeRun.runId) return false;
+  // Output and lifecycle status both remain scoped to the active owner.
+  return Boolean(liveOutput) || isLiveToolCall(toolCall);
 }
 
 function runStatusTimelineKey(
@@ -327,7 +323,7 @@ export function buildCommittedTimeline(
   );
 
   const unanchoredTerminalToolCalls =
-    (options.includeUnanchoredTerminalToolCalls ?? true) &&
+    options.includeUnanchoredTerminalToolCalls === true &&
     liveCandidateToolCalls.length === 0
       ? orderedToolCalls.filter(
           (toolCall) =>
@@ -750,7 +746,7 @@ export function buildConversationTimeline(
   transient?: ConversationTransientState,
 ): TimelineItem[] {
   const committed = buildCommittedTimeline(transcript, toolCalls, {
-    includeUnanchoredTerminalToolCalls: !activeRun,
+    includeUnanchoredTerminalToolCalls: false,
   });
   const liveItems = buildActiveRunTimeline(
     activeRun,

--- a/packages/workbench-server/src/domains/runs/run-composition.ts
+++ b/packages/workbench-server/src/domains/runs/run-composition.ts
@@ -28,6 +28,7 @@ import { WorkbenchLiveExecutions } from "./run-live-executions.js";
 import { WorkbenchRunReferences } from "./run-references.js";
 import { WorkbenchRunUnitOfWork } from "./run-transition.repository.js";
 import { WorkbenchRunProjector } from "./workbench-run-projector.js";
+import { WorkbenchRunTerminalization } from "./run-terminalization.js";
 
 export interface WorkbenchRunRuntime {
   coordinator: RunCoordinator;
@@ -78,6 +79,7 @@ export function createWorkbenchRunRuntime(input: {
     input.subagentExecutions,
     unitOfWork,
   );
+  const terminalization = new WorkbenchRunTerminalization(input.tools);
   const adapter =
     typeof input.execution === "function"
       ? input.execution(references)
@@ -97,6 +99,7 @@ export function createWorkbenchRunRuntime(input: {
     execution,
     references,
     cancellation,
+    terminalization,
     clock: { now: () => new Date() },
     ids: { next: () => randomUUID() },
     integrity,

--- a/packages/workbench-server/src/domains/runs/run-terminalization.ts
+++ b/packages/workbench-server/src/domains/runs/run-terminalization.ts
@@ -1,0 +1,29 @@
+import type { RunRecord } from "@nervekit/contracts";
+import type { RunTerminalizationPort } from "./runtime/run-execution.js";
+import type { ToolService } from "../tools/tool-service.js";
+
+const TERMINAL_TOOL_MESSAGES = {
+  completed:
+    "Tool execution ended without a terminal result before the run completed.",
+  failed: "Tool execution was interrupted because the run failed.",
+  cancelled: "Tool execution was interrupted because the run was cancelled.",
+} satisfies Record<"completed" | "failed" | "cancelled", string>;
+
+/** Enforces that a terminal run cannot leave run-owned tool calls live. */
+export class WorkbenchRunTerminalization implements RunTerminalizationPort {
+  constructor(private readonly tools: ToolService) {}
+
+  async terminalize(run: RunRecord): Promise<void> {
+    if (
+      run.status !== "completed" &&
+      run.status !== "failed" &&
+      run.status !== "cancelled"
+    ) {
+      return;
+    }
+    await this.tools.terminateNonTerminalToolCallsForRun(
+      run.runId,
+      TERMINAL_TOOL_MESSAGES[run.status],
+    );
+  }
+}

--- a/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
@@ -45,6 +45,7 @@ import {
   type RunExecutionFactoryPort,
   type RunExecutionSink,
   type RunIntegrityPort,
+  type RunTerminalizationPort,
 } from "./run-execution.js";
 import {
   ACTIVE_STATUSES,
@@ -78,6 +79,7 @@ export interface RunCoordinatorPorts {
   execution: RunExecutionFactoryPort;
   references: RunCheckpointReferencePort;
   cancellation: RunCancellationPort;
+  terminalization: RunTerminalizationPort;
   clock: ClockPort;
   ids: IdPort;
   integrity: RunIntegrityPort;
@@ -1120,6 +1122,12 @@ export class RunCoordinator {
     changes: TransitionChanges = {},
   ): Promise<void> {
     const expectedRevision = previous?.run.revision ?? 0;
+    const becomingTerminal =
+      TERMINAL_STATUSES.has(run.status) &&
+      (!previous || !TERMINAL_STATUSES.has(previous.run.status));
+    if (becomingTerminal) {
+      await this.ports.terminalization.terminalize(run);
+    }
     const transition = buildTransition(
       run,
       kind,

--- a/packages/workbench-server/src/domains/runs/runtime/run-execution.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-execution.ts
@@ -83,6 +83,11 @@ export interface RunCancellationPort {
   cancelInteraction(run: RunRecord): Promise<"confirmed" | "not_running">;
 }
 
+/** Reconciles run-owned resources before a terminal run transition commits. */
+export interface RunTerminalizationPort {
+  terminalize(run: RunRecord): Promise<void>;
+}
+
 export interface RunIntegrityPort {
   checksum(value: unknown): string;
 }

--- a/packages/workbench-server/test/run-coordinator.contract.test.ts
+++ b/packages/workbench-server/test/run-coordinator.contract.test.ts
@@ -6,6 +6,7 @@ import {
   type PeerRole,
   type RunEventDeliveryRecord,
   type RunPublicEventIntent,
+  type RunRecord,
   type RunTransitionRecord,
 } from "@nervekit/contracts";
 import {
@@ -132,6 +133,7 @@ function fixture(
     beforeFlushEvents?: (transition: RunTransitionRecord) => Promise<void>;
     retryDelay?: (delayMs: number, signal: AbortSignal) => Promise<void>;
     removeQueuedPrompt?: (promptId: string) => boolean | Promise<boolean>;
+    terminalizationFails?: boolean;
   } = {},
 ) {
   const unitOfWork = new MemoryUnitOfWork();
@@ -148,6 +150,7 @@ function fixture(
   const notifyEvents: RunProgressEvent[] = [];
   const executionInputs: Parameters<RunExecution["execute"]>[0][] = [];
   const observed: RunTransitionRecord[] = [];
+  const terminalized: RunRecord[] = [];
   let id = 0;
   let finishExecution!: (value: { status: "completed" }) => void;
   const executeResult = new Promise<{ status: "completed" }>((resolve) => {
@@ -245,6 +248,14 @@ function fixture(
       cancelInteraction: async () =>
         options.cancelTarget?.("interaction") ?? "not_running",
     },
+    terminalization: {
+      terminalize: async (run) => {
+        terminalized.push(run);
+        if (options.terminalizationFails) {
+          throw new Error("terminalization unavailable");
+        }
+      },
+    },
     clock: {
       now: () =>
         new Date(`2026-07-12T00:00:${String(id).padStart(2, "0")}.000Z`),
@@ -284,6 +295,7 @@ function fixture(
     notifyEvents,
     executionInputs,
     observed,
+    terminalized,
     finishExecution,
     flushEvents: () => delivery.flush(),
     setTranscript(value: typeof transcript) {
@@ -376,6 +388,49 @@ test("keeps accepted prompts queued until the execution reports delivery", async
       .filter((event) => event.type === "conversation.prompt.dequeued").length,
     2,
   );
+});
+
+test("terminalizes run-owned resources before committing completion", async () => {
+  const harness = fixture();
+  const run = await start(harness.coordinator);
+
+  harness.finishExecution({ status: "completed" });
+  await waitUntil(
+    async () =>
+      (await harness.coordinator.get(run.runId))?.run.status === "completed",
+  );
+
+  assert.equal(harness.terminalized.length, 1);
+  assert.equal(harness.terminalized[0]?.runId, run.runId);
+  assert.equal(harness.terminalized[0]?.status, "completed");
+  const completedIndex = harness.observed.findIndex(
+    (transition) => transition.kind === "completed",
+  );
+  assert.notEqual(completedIndex, -1);
+});
+
+test("terminalizes run-owned resources before committing hard failure", async () => {
+  const harness = fixture({
+    retryPolicy: { enabled: false, maxRetries: 0, baseDelayMs: 0 },
+    execute: async () => ({
+      status: "failed",
+      failure: {
+        code: "EXECUTION_FAILED",
+        message: "broken",
+        retryable: false,
+      },
+    }),
+  });
+  const run = await start(harness.coordinator);
+
+  await waitUntil(
+    async () =>
+      (await harness.coordinator.get(run.runId))?.run.status === "failed",
+  );
+
+  assert.equal(harness.terminalized.length, 1);
+  assert.equal(harness.terminalized[0]?.runId, run.runId);
+  assert.equal(harness.terminalized[0]?.status, "failed");
 });
 
 test("re-enqueues accepted prompts when a new execution is launched", async () => {

--- a/packages/workbench-server/test/run-runtime.test.ts
+++ b/packages/workbench-server/test/run-runtime.test.ts
@@ -189,6 +189,9 @@ function fixture(
       cancelSubagents: async () => "not_running",
       cancelInteraction: async () => "not_running",
     },
+    terminalization: {
+      terminalize: async () => undefined,
+    },
     clock: { now: () => new Date("2026-07-12T00:00:59.000Z") },
     ids: { next: () => String(++id) },
     integrity: { checksum },

--- a/packages/workbench-server/test/run-terminalization.test.ts
+++ b/packages/workbench-server/test/run-terminalization.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { RunRecord } from "@nervekit/contracts";
+import { WorkbenchRunTerminalization } from "../src/domains/runs/run-terminalization.js";
+
+function run(status: RunRecord["status"]): RunRecord {
+  return { runId: "run_test", status } as RunRecord;
+}
+
+describe("WorkbenchRunTerminalization", () => {
+  it("reconciles tools for every terminal run status", async () => {
+    const calls: Array<{ runId: string; message: string }> = [];
+    const terminalization = new WorkbenchRunTerminalization({
+      terminateNonTerminalToolCallsForRun: async (
+        runId: string,
+        message: string,
+      ) => {
+        calls.push({ runId, message });
+        return [];
+      },
+    } as never);
+
+    await terminalization.terminalize(run("completed"));
+    await terminalization.terminalize(run("failed"));
+    await terminalization.terminalize(run("cancelled"));
+
+    assert.deepEqual(
+      calls.map((call) => call.runId),
+      ["run_test", "run_test", "run_test"],
+    );
+    assert.match(calls[0]!.message, /run completed/);
+    assert.match(calls[1]!.message, /run failed/);
+    assert.match(calls[2]!.message, /run was cancelled/);
+  });
+
+  it("does not reconcile resumable run statuses", async () => {
+    let calls = 0;
+    const terminalization = new WorkbenchRunTerminalization({
+      terminateNonTerminalToolCallsForRun: async () => {
+        calls += 1;
+        return [];
+      },
+    } as never);
+
+    for (const status of [
+      "running",
+      "retrying",
+      "waiting",
+      "suspended",
+      "interrupted",
+    ] as const) {
+      await terminalization.terminalize(run(status));
+    }
+
+    assert.equal(calls, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- reconcile non-terminal tool calls before their owning run reaches a terminal state
- render live tool cards only for the current active run and durable cards only at transcript anchors
- keep incomplete-transcript fallback explicit and add server/UI regression coverage

## Validation
- pnpm fix && pnpm check && pnpm test