### PR TITLE
Fix force-push continuation after tool interruption

### DIFF
--- a/packages/harness/src/agent/loop/tool-execution.ts
+++ b/packages/harness/src/agent/loop/tool-execution.ts
@@ -124,10 +124,6 @@ export async function executeToolCallsSequential(
     await emitToolResultMessage(toolResultMessage, emit);
     finalizedCalls.push(finalized);
     messages.push(toolResultMessage);
-
-    if (signal?.aborted) {
-      break;
-    }
   }
 
   return {
@@ -170,9 +166,6 @@ export async function executeToolCallsParallel(
       } satisfies FinalizedToolCallOutcome;
       await emitToolExecutionEnd(finalized, orderedEmit);
       finalizedCalls.push(finalized);
-      if (signal?.aborted) {
-        break;
-      }
       continue;
     }
 
@@ -193,9 +186,6 @@ export async function executeToolCallsParallel(
       await emitToolExecutionEnd(finalized, orderedEmit);
       return finalized;
     });
-    if (signal?.aborted) {
-      break;
-    }
   }
 
   const orderedFinalizedCalls = await Promise.all(
@@ -357,6 +347,13 @@ async function executePreparedToolCall(
   signal: AbortSignal | undefined,
   emit: AgentEventSink,
 ): Promise<ExecutedToolCallOutcome> {
+  if (signal?.aborted) {
+    return {
+      result: createErrorToolResult("Operation aborted"),
+      isError: true,
+    };
+  }
+
   const updateEvents: Promise<void>[] = [];
 
   try {

--- a/packages/harness/src/agent/loop/turn-loop.ts
+++ b/packages/harness/src/agent/loop/turn-loop.ts
@@ -102,6 +102,11 @@ export async function runLoop(
       };
     }
 
+    if (signal?.aborted) {
+      await emit({ type: "agent_end", messages: newMessages });
+      return;
+    }
+
     pendingMessages = (await config.getSteeringMessages?.()) || [];
     if (pendingMessages.length > 0) continue;
 

--- a/packages/harness/test/agent/loop/turn-loop.test.ts
+++ b/packages/harness/test/agent/loop/turn-loop.test.ts
@@ -12,7 +12,10 @@ import {
   convertToLlm,
   createHarnessMessage,
 } from "../../../src/harness/messages.js";
-import { runAgentLoop } from "../../../src/agent/loop/agent-loop.js";
+import {
+  runAgentLoop,
+  runAgentLoopContinue,
+} from "../../../src/agent/loop/agent-loop.js";
 import type {
   AgentContext,
   AgentTool,
@@ -131,6 +134,130 @@ describe("agent loop follow-up queue", () => {
     assert.match(
       textOf(providerContexts[1]?.messages.at(-1) as Message),
       /continue from checkpoint/,
+    );
+  });
+});
+
+describe("agent loop interruption", () => {
+  it("preserves forced steering until a complete tool batch can continue", async () => {
+    const providerContexts: Context[] = [];
+    let providerCalls = 0;
+    const streamFn: StreamFn = (_model, context) => {
+      providerContexts.push(context);
+      providerCalls += 1;
+      if (providerCalls === 1) {
+        return streamMessage(
+          assistant(
+            [
+              {
+                type: "toolCall",
+                id: "call_active",
+                name: "interrupting-tool",
+                arguments: {},
+              },
+              {
+                type: "toolCall",
+                id: "call_cancelled",
+                name: "interrupting-tool",
+                arguments: {},
+              },
+            ],
+            "toolUse",
+          ),
+        );
+      }
+      return streamMessage(
+        assistant([{ type: "text", text: "continued after force push" }]),
+      );
+    };
+
+    const interruptedTurn = new AbortController();
+    let toolExecutions = 0;
+    const interruptingTool: AgentTool = {
+      name: "interrupting-tool",
+      label: "interrupting-tool",
+      description: "Interrupt the active sequential tool batch",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async () => {
+        toolExecutions += 1;
+        interruptedTurn.abort();
+        throw new Error("Command aborted.");
+      },
+    };
+    const forcedPrompt = {
+      role: "user" as const,
+      content: "forced follow-up",
+      timestamp: Date.now(),
+    };
+    const steeringQueue = [forcedPrompt];
+    let steeringPolls = 0;
+    const getSteeringMessages = async () => {
+      steeringPolls += 1;
+      return steeringPolls === 1 ? [] : steeringQueue.splice(0);
+    };
+
+    const interruptedMessages = await runAgentLoop(
+      [{ role: "user", content: "start", timestamp: Date.now() }],
+      { systemPrompt: "", messages: [], tools: [interruptingTool] },
+      {
+        model,
+        convertToLlm,
+        getSteeringMessages,
+      },
+      async () => undefined,
+      interruptedTurn.signal,
+      streamFn,
+    );
+
+    assert.equal(providerCalls, 1);
+    assert.equal(toolExecutions, 1);
+    assert.equal(steeringPolls, 1);
+    assert.equal(steeringQueue.length, 1);
+    assert.deepEqual(
+      interruptedMessages.map((message) => message.role),
+      ["user", "assistant", "toolResult", "toolResult"],
+    );
+    const toolResults = interruptedMessages.filter(
+      (message) => message.role === "toolResult",
+    );
+    assert.deepEqual(
+      toolResults.map((message) => message.toolCallId),
+      ["call_active", "call_cancelled"],
+    );
+    assert.match(textOf(toolResults[1] as Message), /Operation aborted/);
+
+    const continuation = new AbortController();
+    const continuedMessages = await runAgentLoopContinue(
+      {
+        systemPrompt: "",
+        messages: interruptedMessages,
+        tools: [interruptingTool],
+      },
+      {
+        model,
+        convertToLlm,
+        getSteeringMessages,
+      },
+      async () => undefined,
+      continuation.signal,
+      streamFn,
+    );
+
+    assert.equal(providerCalls, 2);
+    assert.equal(steeringPolls, 3);
+    assert.equal(steeringQueue.length, 0);
+    assert.deepEqual(
+      providerContexts[1]?.messages.map((message) => message.role),
+      ["user", "assistant", "toolResult", "toolResult", "user"],
+    );
+    assert.equal(
+      textOf(providerContexts[1]?.messages.at(-1) as Message),
+      "forced follow-up",
+    );
+    assert.equal(
+      textOf(continuedMessages.at(-1) as Message),
+      "continued after force push",
     );
   });
 });


### PR DESCRIPTION
## Summary
- stop aborted turns before they drain force-pushed prompts or issue another provider request
- emit terminal tool results for every call in interrupted sequential and parallel batches
- add regression coverage for preserving queued prompts and resuming with provider-valid context

## Validation
- `pnpm --filter @nervekit/harness test`
- `pnpm fix && pnpm check && pnpm test`