### PR TITLE
Fix startup migration for legacy task runtimes

### DIFF
--- a/packages/contracts/src/domains/tasks/task.schema.ts
+++ b/packages/contracts/src/domains/tasks/task.schema.ts
@@ -53,31 +53,34 @@ export const taskRuntimeIdentitySchema = z.discriminatedUnion("kind", [
     kind: z.literal("linux"),
     startTimeTicks: z.number().int().nonnegative(),
   }),
-  z.object({ kind: z.literal("darwin"), startFingerprint: z.string().min(1) }),
-  z.object({ kind: z.literal("win32"), creationDate: z.string().min(1) }),
-  z.object({ kind: z.literal("legacy_unverified") }),
+  z.object({
+    kind: z.literal("darwin"),
+    startFingerprint: z.string().startsWith("darwin:"),
+  }),
+  z.object({
+    kind: z.literal("win32"),
+    creationDate: z.string().startsWith("win32:"),
+  }),
 ]);
 export type TaskRuntimeIdentity = z.infer<typeof taskRuntimeIdentitySchema>;
 
 export const taskRuntimeSchema = z.object({
-  version: z.literal(2).optional(),
+  version: z.literal(2),
   platform: z.string().min(1),
-  childPid: z.number().int().positive().optional(),
+  childPid: z.number().int().positive(),
   processGroupId: z.number().int().positive().optional(),
   detached: z.boolean(),
   shell: z.boolean(),
-  containment: z.enum(["job-object", "process-group", "fallback"]).optional(),
+  containment: z.enum(["job-object", "process-group"]),
   spawnedAt: z.string().datetime(),
-  identity: taskRuntimeIdentitySchema.optional(),
+  identity: taskRuntimeIdentitySchema,
   listeningPorts: z.array(taskListeningPortSchema).optional(),
-  capabilities: z
-    .object({
-      identity: z.boolean(),
-      processTree: z.boolean(),
-      listeningPorts: z.boolean(),
-      detail: z.string().optional(),
-    })
-    .optional(),
+  capabilities: z.object({
+    identity: z.boolean(),
+    processTree: z.boolean(),
+    listeningPorts: z.boolean(),
+    detail: z.string().optional(),
+  }),
 });
 export type TaskRuntime = z.infer<typeof taskRuntimeSchema>;
 

--- a/packages/contracts/test/task.schema.test.ts
+++ b/packages/contracts/test/task.schema.test.ts
@@ -170,19 +170,45 @@ describe("task log paging metadata", () => {
 });
 
 describe("taskRecordSchema runtime metadata", () => {
-  it("rejects invalid runtime PID values", () => {
-    const parsed = taskRecordSchema.safeParse(
-      record({
-        runtime: {
-          platform: "linux",
-          childPid: -1,
-          detached: true,
-          shell: true,
-          spawnedAt: "2026-01-02T03:04:06.000Z",
-        },
-      }),
-    );
+  const runtime = {
+    version: 2 as const,
+    platform: "linux",
+    childPid: 1234,
+    processGroupId: 1234,
+    detached: true,
+    shell: true,
+    containment: "process-group" as const,
+    spawnedAt: "2026-01-02T03:04:06.000Z",
+    identity: { kind: "linux" as const, startTimeTicks: 5678 },
+    capabilities: {
+      identity: true,
+      processTree: true,
+      listeningPorts: true,
+      detail: "native:process-group",
+    },
+  };
 
-    assert.equal(parsed.success, false);
+  it("accepts complete native runtime metadata", () => {
+    assert.equal(taskRecordSchema.safeParse(record({ runtime })).success, true);
+  });
+
+  it("rejects incomplete and legacy runtime metadata", () => {
+    assert.equal(
+      taskRecordSchema.safeParse(
+        record({ runtime: { ...runtime, childPid: -1 } }),
+      ).success,
+      false,
+    );
+    for (const legacy of [
+      { ...runtime, version: undefined },
+      { ...runtime, containment: undefined },
+      { ...runtime, identity: undefined },
+      { ...runtime, identity: { kind: "legacy_unverified" } },
+    ]) {
+      assert.equal(
+        taskRecordSchema.safeParse({ ...record(), runtime: legacy }).success,
+        false,
+      );
+    }
   });
 });

--- a/packages/workbench-server/src/domains/tasks/task-supervisor.ts
+++ b/packages/workbench-server/src/domains/tasks/task-supervisor.ts
@@ -188,46 +188,18 @@ function managedTargetForRuntime(
       error: `Cannot clean up task spawned on ${runtime.platform} from ${process.platform}.`,
     };
   }
-  if (!runtime.childPid) return { error: "Missing managed process root PID" };
-  const identity = nativeIdentityForRuntime(runtime.identity);
-  if (!identity) {
-    return {
-      error:
-        "Persisted task runtime has no native-verifiable process identity; refusing unsafe PID-only cleanup.",
-    };
-  }
-  const containment =
-    runtime.containment === "job-object" ||
-    runtime.containment === "process-group"
-      ? runtime.containment
-      : runtime.platform === "win32"
-        ? "job-object"
-        : "process-group";
   return {
     pid: runtime.childPid,
     processGroupId: runtime.processGroupId,
-    containment,
-    identity,
+    containment: runtime.containment,
+    identity: nativeIdentityForRuntime(runtime.identity),
   };
 }
 
-function nativeIdentityForRuntime(
-  identity: TaskRuntimeIdentity | undefined,
-): string | undefined {
-  if (identity?.kind === "linux") return `linux:${identity.startTimeTicks}`;
-  if (
-    identity?.kind === "darwin" &&
-    identity.startFingerprint.startsWith("darwin:")
-  ) {
-    return identity.startFingerprint;
-  }
-  if (
-    identity?.kind === "win32" &&
-    identity.creationDate.startsWith("win32:")
-  ) {
-    return identity.creationDate;
-  }
-  return undefined;
+function nativeIdentityForRuntime(identity: TaskRuntimeIdentity): string {
+  if (identity.kind === "linux") return `linux:${identity.startTimeTicks}`;
+  if (identity.kind === "darwin") return identity.startFingerprint;
+  return identity.creationDate;
 }
 
 function processEnvironment(

--- a/packages/workbench-server/src/infrastructure/migrations/migrations/0009-native-task-runtimes.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/migrations/0009-native-task-runtimes.ts
@@ -1,0 +1,165 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { taskRecordSchema, taskRuntimeSchema } from "@nervekit/contracts";
+import { z } from "zod";
+import {
+  atomicWriteJson,
+  pathExists,
+  readJsonFile,
+} from "../../storage/json.js";
+import { joinCanonicalPath } from "../canonical-path.js";
+import { migrationChecksum } from "../checksum.js";
+import type { StorageMigration } from "../migration.js";
+
+const markerPath = "migrations/.native-task-runtimes-v1";
+const interruptionError =
+  "Task supervision was interrupted while upgrading to native process management.";
+
+const legacyRuntimeIdentitySchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("linux"),
+    startTimeTicks: z.number().int().nonnegative(),
+  }),
+  z.object({ kind: z.literal("darwin"), startFingerprint: z.string().min(1) }),
+  z.object({ kind: z.literal("win32"), creationDate: z.string().min(1) }),
+  z.object({ kind: z.literal("legacy_unverified") }),
+]);
+
+const legacyTaskRuntimeSchema = z.object({
+  version: z.literal(2).optional(),
+  platform: z.string().min(1),
+  childPid: z.number().int().positive().optional(),
+  processGroupId: z.number().int().positive().optional(),
+  detached: z.boolean(),
+  shell: z.boolean(),
+  containment: z.enum(["job-object", "process-group", "fallback"]).optional(),
+  spawnedAt: z.string().datetime(),
+  identity: legacyRuntimeIdentitySchema.optional(),
+  listeningPorts: z
+    .array(
+      z.object({
+        protocol: z.enum(["tcp", "tcp6"]),
+        address: z.string().min(1),
+        port: z.number().int().positive().max(65_535),
+        pid: z.number().int().positive().optional(),
+        processGroupId: z.number().int().positive().optional(),
+        processStartTimeTicks: z.number().int().nonnegative().optional(),
+        detectedAt: z.string().datetime(),
+      }),
+    )
+    .optional(),
+  capabilities: z
+    .object({
+      identity: z.boolean(),
+      processTree: z.boolean(),
+      listeningPorts: z.boolean(),
+      detail: z.string().optional(),
+    })
+    .optional(),
+});
+
+const legacyTaskRecordSchema = taskRecordSchema.extend({
+  runtime: legacyTaskRuntimeSchema.optional(),
+});
+
+const terminalStatuses = new Set([
+  "completed",
+  "failed",
+  "timed_out",
+  "cancelled",
+  "orphaned",
+  "interrupted",
+]);
+
+type LegacyTaskRecord = z.infer<typeof legacyTaskRecordSchema>;
+
+type LegacyTaskFile = {
+  relativePath: string;
+  record: LegacyTaskRecord;
+};
+
+async function legacyTaskFiles(home: string): Promise<LegacyTaskFile[]> {
+  const root = join(home, "tasks");
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  const files: LegacyTaskFile[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith("task_")) continue;
+    const relativePath = joinCanonicalPath("tasks", entry.name, "task.json");
+    const raw = await readJsonFile<unknown>(join(home, relativePath)).catch(
+      () => undefined,
+    );
+    const parsed = legacyTaskRecordSchema.safeParse(raw);
+    if (
+      !parsed.success ||
+      !parsed.data.runtime ||
+      taskRuntimeSchema.safeParse(parsed.data.runtime).success
+    ) {
+      continue;
+    }
+    files.push({ relativePath, record: parsed.data });
+  }
+  return files.sort((left, right) =>
+    left.relativePath.localeCompare(right.relativePath),
+  );
+}
+
+function migrateRecord(record: LegacyTaskRecord, migratedAt: string) {
+  const withoutRuntime = { ...record };
+  delete withoutRuntime.runtime;
+  const migrated = terminalStatuses.has(record.status)
+    ? withoutRuntime
+    : {
+        ...withoutRuntime,
+        status: "interrupted" as const,
+        error: interruptionError,
+        finishedAt: migratedAt,
+        updatedAt: migratedAt,
+      };
+  return taskRecordSchema.parse(migrated);
+}
+
+export const migration0009: StorageMigration = {
+  id: "0009-native-task-runtimes",
+  description: "Retire pre-native persisted task runtimes",
+  checksum: migrationChecksum(
+    "0009-native-task-runtimes|v1|Retire pre-native persisted task runtimes",
+  ),
+  async detect(context) {
+    return (await pathExists(join(context.paths.home, markerPath)))
+      ? "current"
+      : "pending";
+  },
+  async backup(context) {
+    const files = await legacyTaskFiles(context.paths.home);
+    return {
+      paths: [...files.map((file) => file.relativePath), markerPath],
+    };
+  },
+  async up(context) {
+    const files = await legacyTaskFiles(context.paths.home);
+    const migratedAt = context.now().toISOString();
+    for (const file of files) {
+      await atomicWriteJson(
+        join(context.paths.home, file.relativePath),
+        migrateRecord(file.record, migratedAt),
+        0o600,
+      );
+    }
+    await atomicWriteJson(
+      join(context.paths.home, markerPath),
+      { migratedAt, transformedRecords: files.length },
+      0o600,
+    );
+  },
+  async verify(context) {
+    if (!(await pathExists(join(context.paths.home, markerPath)))) {
+      throw new Error("Native task runtime migration marker is missing.");
+    }
+    const remaining = await legacyTaskFiles(context.paths.home);
+    if (remaining.length > 0) {
+      throw new Error(
+        `Pre-native task runtime remains at '${remaining[0]?.relativePath}'.`,
+      );
+    }
+  },
+};

--- a/packages/workbench-server/src/infrastructure/migrations/registry.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/registry.ts
@@ -9,6 +9,7 @@ import { migration0005 } from "./migrations/0005-current-project-sidecars.js";
 import { migration0006 } from "./migrations/0006-unify-tool-call-lifecycle.js";
 import { migration0007 } from "./migrations/0007-transient-conversation-live-events.js";
 import { migration0008 } from "./migrations/0008-remove-legacy-storage.js";
+import { migration0009 } from "./migrations/0009-native-task-runtimes.js";
 
 export const storageMigrationRegistry: readonly StorageMigration[] =
   Object.freeze([
@@ -20,6 +21,7 @@ export const storageMigrationRegistry: readonly StorageMigration[] =
     migration0006,
     migration0007,
     migration0008,
+    migration0009,
   ]);
 
 export function validateMigrationRegistry(

--- a/packages/workbench-server/test/helpers/workbench-task-service.ts
+++ b/packages/workbench-server/test/helpers/workbench-task-service.ts
@@ -138,13 +138,28 @@ export function fakeChild(pid = 1234): FakeChild {
 export function runtimeMetadata(
   overrides: Partial<TaskRuntime> = {},
 ): TaskRuntime {
+  const identity: TaskRuntime["identity"] =
+    process.platform === "win32"
+      ? { kind: "win32", creationDate: "win32:133801632000000000" }
+      : process.platform === "darwin"
+        ? { kind: "darwin", startFingerprint: "darwin:1234:5678" }
+        : { kind: "linux", startTimeTicks: 5678 };
   return {
+    version: 2,
     platform: process.platform,
     childPid: 1234,
     processGroupId: process.platform === "win32" ? undefined : 1234,
     detached: process.platform !== "win32",
     shell: true,
+    containment: process.platform === "win32" ? "job-object" : "process-group",
     spawnedAt: "2026-01-02T03:04:05.000Z",
+    identity,
+    capabilities: {
+      identity: true,
+      processTree: true,
+      listeningPorts: true,
+      detail: `native:${process.platform === "win32" ? "job-object" : "process-group"}`,
+    },
     ...overrides,
   };
 }

--- a/packages/workbench-server/test/storage-migrations.test.ts
+++ b/packages/workbench-server/test/storage-migrations.test.ts
@@ -12,6 +12,7 @@ import {
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
+import { taskRecordSchema } from "@nervekit/contracts";
 import type {
   MigrationContext,
   StorageMigration,
@@ -26,6 +27,7 @@ import { migration0005 } from "../src/infrastructure/migrations/migrations/0005-
 import { migration0006 } from "../src/infrastructure/migrations/migrations/0006-unify-tool-call-lifecycle.js";
 import { migration0007 } from "../src/infrastructure/migrations/migrations/0007-transient-conversation-live-events.js";
 import { migration0008 } from "../src/infrastructure/migrations/migrations/0008-remove-legacy-storage.js";
+import { migration0009 } from "../src/infrastructure/migrations/migrations/0009-native-task-runtimes.js";
 import { StreamLog } from "../src/infrastructure/events/stream-log.js";
 import {
   ledgerDigest,
@@ -272,6 +274,124 @@ describe("storage migration runner", () => {
 
     const second = await runStorageMigrations(root, {
       registry: [migration0008],
+    });
+    assert.deepEqual(second.executions, []);
+  });
+
+  it("retires pre-native task runtimes before task hydration", async () => {
+    const root = await home();
+    const tasks = join(root, "tasks");
+    const startedAt = "2026-08-17T01:02:03.000Z";
+    const migratedAt = "2026-08-18T04:05:06.000Z";
+    const baseRecord = {
+      cwd: "C:\\Users\\test\\project",
+      command: "pnpm dev",
+      readiness: { outcome: "pending" },
+      stdoutPath: "stdout.log",
+      stderrPath: "stderr.log",
+      logsPath: "events.jsonl",
+      startedAt,
+      updatedAt: startedAt,
+    };
+    const legacyRuntime = {
+      platform: "win32",
+      childPid: 4321,
+      detached: false,
+      shell: true,
+      spawnedAt: startedAt,
+    };
+    const active = {
+      ...baseRecord,
+      id: "task_legacy_active",
+      status: "running",
+      runtime: legacyRuntime,
+    };
+    const terminal = {
+      ...baseRecord,
+      id: "task_legacy_terminal",
+      status: "completed",
+      finishedAt: "2026-08-17T02:02:03.000Z",
+      runtime: { ...legacyRuntime, identity: { kind: "legacy_unverified" } },
+    };
+    const native = {
+      ...baseRecord,
+      id: "task_native",
+      status: "running",
+      runtime: {
+        version: 2,
+        platform: "linux",
+        childPid: 9876,
+        processGroupId: 9876,
+        detached: true,
+        shell: true,
+        containment: "process-group",
+        spawnedAt: startedAt,
+        identity: { kind: "linux", startTimeTicks: 12345 },
+        capabilities: {
+          identity: true,
+          processTree: true,
+          listeningPorts: true,
+          detail: "native:process-group",
+        },
+      },
+    };
+    for (const record of [active, terminal, native]) {
+      const directory = join(tasks, record.id);
+      await mkdir(directory, { recursive: true });
+      await writeFile(
+        join(directory, "task.json"),
+        `${JSON.stringify(record)}\n`,
+      );
+    }
+
+    const backup = await migration0009.backup(migrationContext(root));
+    assert.deepEqual(backup.paths, [
+      "tasks/task_legacy_active/task.json",
+      "tasks/task_legacy_terminal/task.json",
+      "migrations/.native-task-runtimes-v1",
+    ]);
+    assert.ok(backup.paths.every((path) => !path.includes("\\")));
+
+    const report = await runStorageMigrations(root, {
+      registry: [migration0009],
+      now: () => new Date(migratedAt),
+    });
+    assert.equal(report.executions[0]?.execution, "ran");
+    assert.ok(report.backupBytes > 0);
+
+    const readTask = async (id: string) =>
+      JSON.parse(await readFile(join(tasks, id, "task.json"), "utf8")) as {
+        [key: string]: unknown;
+      };
+    const migratedActive = await readTask(active.id);
+    assert.equal(migratedActive.status, "interrupted");
+    assert.equal(migratedActive.finishedAt, migratedAt);
+    assert.equal(migratedActive.updatedAt, migratedAt);
+    assert.match(String(migratedActive.error), /native process management/);
+    assert.equal("runtime" in migratedActive, false);
+    assert.equal(taskRecordSchema.safeParse(migratedActive).success, true);
+
+    const migratedTerminal = await readTask(terminal.id);
+    assert.equal(migratedTerminal.status, "completed");
+    assert.equal(migratedTerminal.finishedAt, terminal.finishedAt);
+    assert.equal(migratedTerminal.updatedAt, startedAt);
+    assert.equal("runtime" in migratedTerminal, false);
+    assert.equal(taskRecordSchema.safeParse(migratedTerminal).success, true);
+
+    assert.deepEqual(await readTask(native.id), native);
+    assert.equal(taskRecordSchema.safeParse(native).success, true);
+    assert.deepEqual(
+      JSON.parse(
+        await readFile(
+          join(root, "migrations", ".native-task-runtimes-v1"),
+          "utf8",
+        ),
+      ),
+      { migratedAt, transformedRecords: 2 },
+    );
+
+    const second = await runStorageMigrations(root, {
+      registry: [migration0009],
     });
     assert.deepEqual(second.executions, []);
   });

--- a/packages/workbench-server/test/task-supervisor.test.ts
+++ b/packages/workbench-server/test/task-supervisor.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { describe, it } from "node:test";
 import type { ChildProcess } from "node:child_process";
-import type { TaskRuntime } from "@nervekit/contracts";
 import {
   defaultTaskSupervisor,
   managedTaskShellCommand,
@@ -64,30 +63,6 @@ describe("task supervisor", () => {
       await defaultTaskSupervisor.terminate(spawned.child, "SIGKILL");
       await spawned.closed;
     }
-  });
-
-  it("refuses an unverified persisted runtime without signaling", async () => {
-    const runtime: TaskRuntime = {
-      version: 2,
-      platform: process.platform,
-      childPid: process.pid,
-      detached: process.platform !== "win32",
-      shell: true,
-      containment:
-        process.platform === "win32" ? "job-object" : "process-group",
-      spawnedAt: new Date().toISOString(),
-      identity: { kind: "legacy_unverified" },
-    };
-    const result = await defaultTaskSupervisor.terminateRuntime(
-      runtime,
-      "SIGKILL",
-    );
-    assert.equal(result.attempted, false);
-    assert.match(result.error ?? "", /refusing unsafe PID-only cleanup/);
-    await assert.rejects(
-      defaultTaskSupervisor.isRuntimeTargetAlive(runtime),
-      /no native-verifiable process identity/,
-    );
   });
 
   it("refuses unmanaged ChildProcess-shaped objects", async () => {


### PR DESCRIPTION
## Summary
- add a storage migration that retires pre-native task runtime metadata before hydration
- mark active legacy tasks as interrupted while preserving task history and logs
- require complete native process identity metadata in current task contracts
- add Windows-style migration and contract regression coverage

## Validation
- `pnpm fix && pnpm check && pnpm test`

Closes #196