### PR TITLE
refactor(workbench): consolidate terminal run status checks and tool result persistence

### DIFF
--- a/packages/workbench-server/src/domains/runs/run-terminalization.ts
+++ b/packages/workbench-server/src/domains/runs/run-terminalization.ts
@@ -1,4 +1,5 @@
 import type { RunRecord } from "@nervekit/contracts";
+import { isTerminalRunStatus } from "./runtime/run-transitions.js";
 import type { RunTerminalizationPort } from "./runtime/run-execution.js";
 import type { ToolService } from "../tools/tool-service.js";
 
@@ -14,11 +15,7 @@ export class WorkbenchRunTerminalization implements RunTerminalizationPort {
   constructor(private readonly tools: ToolService) {}
 
   async terminalize(run: RunRecord): Promise<void> {
-    if (
-      run.status !== "completed" &&
-      run.status !== "failed" &&
-      run.status !== "cancelled"
-    ) {
+    if (!isTerminalRunStatus(run.status)) {
       return;
     }
     await this.tools.terminateNonTerminalToolCallsForRun(

--- a/packages/workbench-server/src/domains/runs/runtime/run-transitions.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-transitions.ts
@@ -35,6 +35,15 @@ export const TERMINAL_STATUSES = new Set<RunRecord["status"]>([
   "cancelled",
 ]);
 
+export function isTerminalRunStatus(
+  status: RunRecord["status"],
+): status is Extract<
+  RunRecord["status"],
+  "completed" | "failed" | "cancelled"
+> {
+  return TERMINAL_STATUSES.has(status);
+}
+
 export interface StartRunCommand {
   conversationId: string;
   agentId: string;

--- a/packages/workbench-server/src/domains/runs/workbench-run-projector.ts
+++ b/packages/workbench-server/src/domains/runs/workbench-run-projector.ts
@@ -4,9 +4,10 @@ import type {
   RunRecord,
   RunTransitionRecord,
 } from "@nervekit/contracts";
-import type {
-  RunHydratedState,
-  RunTransitionObserverPort,
+import {
+  isTerminalRunStatus,
+  type RunHydratedState,
+  type RunTransitionObserverPort,
 } from "./runtime/index.js";
 import type { RuntimeState } from "../../runtime/runtime-state.js";
 
@@ -139,7 +140,7 @@ export function agentStatusForRun(
 }
 
 function isActiveRun(run: RunRecord): boolean {
-  return !["completed", "failed", "cancelled"].includes(run.status);
+  return !isTerminalRunStatus(run.status);
 }
 
 function retrySnapshotFromState(

--- a/packages/workbench-server/src/domains/tools/tool-result-bounds.ts
+++ b/packages/workbench-server/src/domains/tools/tool-result-bounds.ts
@@ -38,24 +38,45 @@ export async function prepareToolResult(
   let rawResultPath: string | undefined;
 
   if (bounded.summary.truncated) {
-    rawResultPath = await writeRawResult({
-      storageHome: input.storageHome,
-      toolCallId: input.toolCallId,
+    const persisted = await persistRawResult(
+      prepared,
       result,
-    });
-    prepared = attachRawResultDetails(prepared, rawResultPath, bounded.summary);
+      input,
+      rawResultPath,
+      bounded.summary,
+    );
+    prepared = persisted.value;
+    rawResultPath = persisted.path;
   }
 
   if (resultTruncatesForModel(prepared) && !hasRecoveryRoute(prepared)) {
-    rawResultPath ??= await writeRawResult({
-      storageHome: input.storageHome,
-      toolCallId: input.toolCallId,
+    const persisted = await persistRawResult(
+      prepared,
       result,
-    });
-    prepared = attachRawResultDetails(prepared, rawResultPath);
+      input,
+      rawResultPath,
+    );
+    prepared = persisted.value;
   }
 
   return annotateToolResultModelLimits(prepared);
+}
+
+async function persistRawResult(
+  value: unknown,
+  result: unknown,
+  input: { toolCallId: string; storageHome: string },
+  existingPath: string | undefined,
+  summary?: BoundSummary,
+): Promise<{ value: unknown; path: string }> {
+  const path =
+    existingPath ??
+    (await writeRawResult({
+      storageHome: input.storageHome,
+      toolCallId: input.toolCallId,
+      result,
+    }));
+  return { value: attachRawResultDetails(value, path, summary), path };
 }
 
 function boundValue(value: unknown, path: string[]): BoundValueResult {


### PR DESCRIPTION
## Summary

Two small refactors in the workbench server.

### 1. Consolidate terminal run status checks
Extract a single `isTerminalRunStatus()` type guard in `run-transitions.ts` (backed by the existing `TERMINAL_STATUSES` set) and reuse it in place of duplicated inline `completed`/`failed`/`cancelled` comparisons:
- `run-terminalization.ts`
- `workbench-run-projector.ts` (`isActiveRun`)

This removes repeated string-list checks and keeps the definition of what makes a run terminal in one spot.

### 2. Deduplicate raw tool-result persistence
In `tool-result-bounds.ts`, pull the raw-result write + `attachRawResultDetails` logic out of `prepareToolResult` into a shared `persistRawResult` helper. Previously, when both the truncation path and the model-limit recovery path fired, the raw result could be written twice. Now the persisted path is reused so the raw result is written at most once per tool call.

## Testing
- [x] `pnpm fix && pnpm check && pnpm test`