### PR TITLE
chore(ci): gate heavy check/test steps by changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Fast baseline (format, lint, boundaries, scripts tests)
-        run: oxfmt --check && eslint . && pnpm check:boundaries && pnpm test:scripts
+        run: pnpm exec oxfmt --check && pnpm exec eslint . && pnpm check:boundaries && pnpm test:scripts
 
       - name: Typecheck and check all packages
         if: github.event_name != 'pull_request' || needs.paths.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,56 @@ permissions:
   contents: read
 
 jobs:
+  paths:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      testable: ${{ steps.filter.outputs.testable }}
+      workbench: ${{ steps.filter.outputs.workbench }}
+
+    steps:
+      - name: Classify changed files
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          predicate-quantifier: "some-with-excludes"
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!README.md'
+              - '!NOTICE'
+            testable:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!README.md'
+              - '!NOTICE'
+              - '!packages/website/**'
+            workbench:
+              - 'packages/workbench-server/**'
+              - 'packages/workbench-app/**'
+              - 'packages/ui-kit/**'
+              - 'packages/contracts/**'
+              - 'packages/protocol/**'
+              - 'packages/harness/**'
+              - 'packages/tools/**'
+              - 'packages/native/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig*.json'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+
   validate:
     name: Check and test (Ubuntu)
     runs-on: ubuntu-latest
+    needs: paths
 
     steps:
       - name: Check out repository
@@ -35,14 +82,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check formatting, lint, and packages
-        run: pnpm check
+      - name: Fast baseline (format, lint, boundaries, scripts tests)
+        run: oxfmt --check && eslint . && pnpm check:boundaries && pnpm test:scripts
+
+      - name: Typecheck and check all packages
+        if: github.event_name != 'pull_request' || needs.paths.outputs.code == 'true'
+        run: pnpm -r check
 
       - name: Run complete test suite
+        if: github.event_name != 'pull_request' || needs.paths.outputs.testable == 'true'
         run: pnpm test
 
       - name: Build workbench runtime
+        if: github.event_name != 'pull_request' || needs.paths.outputs.workbench == 'true'
         run: pnpm build:workbench-runtime
 
       - name: Smoke built workbench HTTP and WebSocket parity
+        if: github.event_name != 'pull_request' || needs.paths.outputs.workbench == 'true'
         run: pnpm release:smoke:workbench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Classify changed files
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           base: ${{ github.event_name == 'push' && github.event.before || '' }}
           predicate-quantifier: "some-with-excludes"


### PR DESCRIPTION
## Summary

Reduce wasted CI work on PRs by making the expensive steps of the always-on `validate` job in `.github/workflows/ci.yml` run only when the PR actually touches relevant code.

### What changed
- Added a `paths` detection job using `dorny/paths-filter@v3` that classifies changed files into three outputs:
  - `code` — true unless the PR is docs-only (`.md` / `docs/**` / `NOTICE`)
  - `testable` — `code` minus `packages/website/**`
  - `workbench` — server/app/ui/contracts/protocol/harness/tools/native + root config/Cargo files
- `validate` now `needs: paths` and gates its heavy steps:
  - Per-package typecheck incl. native clippy → gated by `code`
  - Full test suite → gated by `testable`
  - Workbench runtime build + HTTP/WS smoke → gated by `workbench`
- Added a fast always-on baseline (format, lint, package boundaries, script tests) so every PR still gets a reliable quality signal.
- Kept the **full** suite on `push` to `main` (gates bypassed when not a PR), so release-blocking validation is unchanged.

### Resulting behavior
| PR contents | Runs |
|---|---|
| Docs-only / `.md` only | Fast baseline only |
| Website-only | baseline + typechecks |
| Code (typical) | baseline + typecheck + tests + workbench build/smoke (same as today) |
| Push to main | Full suite always |

### Notes / out of scope
- `native-host.yml` was already path-gated and is left unchanged.
- **CodeQL** (3 always-on jobs, GitHub-managed default setup) is NOT addressed by this repo change; it should be trimmed in **Settings → Code security and analysis → CodeQL**.
- Subtle but important: negation-only `dorny` filters never match (exclusion is final), so the filters use a `'**'` catch-all with `predicate-quantifier: 'some-with-excludes'` to make exclusions work correctly.

Local validation: `pnpm fix && pnpm check && pnpm test` all pass; only `ci.yml` was modified.