### PR TITLE
Preserve detached Windows daemon processes

### DIFF
--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -19,7 +19,7 @@ The shared filesystem walker in `native/src/` is an internal primitive for searc
 
 Managed commands retain platform containment while the root process or inherited stdout/stderr pipes remain active. Root exit and pipe closure are separate lifecycle events: `exited` reports that the root was reaped, while `closed` waits for inherited output handles to close.
 
-On Windows, the active tree remains in a kill-on-close Job Object so explicit cancellation, timeout handling, foreground Bash promotion, and daemon shutdown can terminate the complete supervised tree. Natural completion releases the Job Object without terminating descendants only after output pipes close. A correctly detached daemon can therefore survive its launcher across tool calls, matching Unix behavior; a descendant that retains managed pipes remains supervised and keeps `closed` pending until it exits or is terminated.
+On Windows, the active tree remains in a Job Object so explicit cancellation, timeout handling, foreground Bash promotion, and graceful daemon shutdown can terminate the complete supervised tree. Natural completion releases the Job Object without terminating descendants only after output pipes close. A correctly detached daemon can therefore survive its launcher across tool calls, matching Unix behavior; a descendant that retains managed pipes remains supervised and keeps `closed` pending until it exits or is terminated.
 
 ## Git boundary
 

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -15,6 +15,12 @@ Keep `native/src/lib.rs` limited to module wiring and boundary re-exports. Featu
 
 The shared filesystem walker in `native/src/` is an internal primitive for search and find, not a generic exported operation. Watchers remain a separate long-lived feature.
 
+## Managed process boundary
+
+Managed commands retain platform containment while the root process or inherited stdout/stderr pipes remain active. Root exit and pipe closure are separate lifecycle events: `exited` reports that the root was reaped, while `closed` waits for inherited output handles to close.
+
+On Windows, the active tree remains in a kill-on-close Job Object so explicit cancellation, timeout handling, foreground Bash promotion, and daemon shutdown can terminate the complete supervised tree. Natural completion releases the Job Object without terminating descendants only after output pipes close. A correctly detached daemon can therefore survive its launcher across tool calls, matching Unix behavior; a descendant that retains managed pipes remains supervised and keeps `closed` pending until it exits or is terminated.
+
 ## Git boundary
 
 The native Git API is deliberately narrow and structured. It supports repository metadata, worktree/index status, refs and branch upstreams, remotes, ahead/behind ancestry, recent commits, stash listing, revision resolution, branch-name validation, and bounded revision/index/worktree document reads. Every potentially expensive repository operation is an N-API worker task rather than main-thread work.

--- a/packages/native/native/src/process/managed.rs
+++ b/packages/native/native/src/process/managed.rs
@@ -53,16 +53,19 @@ impl ManagedProcess {
     }
 
     pub(crate) fn terminate(&self, signal: &str) -> TerminationResult {
-        if self.state.exited.load(Ordering::Acquire) {
-            return TerminationResult::not_attempted(TerminationMethod::None, None);
-        }
         let guard = self
             .state
             .containment_guard
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if let Some(result) = guard.as_ref().and_then(ContainmentGuard::terminate) {
+        if let Some(result) = guard
+            .as_ref()
+            .and_then(|guard| guard.terminate(&self.state.target, signal))
+        {
             return result;
+        }
+        if self.state.exited.load(Ordering::Acquire) {
+            return TerminationResult::not_attempted(TerminationMethod::None, None);
         }
         sys_process::terminate(&self.state.target, signal)
     }
@@ -113,15 +116,16 @@ pub(crate) fn spawn(
         };
         wait_state.exited.store(true, Ordering::Release);
         (events.exit)(result.clone());
-        // Closing the kill-on-close Windows Job after the root exits prevents
-        // descendants from keeping inherited pipes open forever. The Unix guard
-        // is deliberately inert because process groups do not own a handle.
-        let _ = wait_state
-            .containment_guard
-            .lock()
-            .map(|mut guard| guard.take());
         for output_thread in output_threads {
             let _ = output_thread.join();
+        }
+        let guard = wait_state
+            .containment_guard
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(guard) = guard {
+            guard.release();
         }
         (events.close)(result);
     });

--- a/packages/native/native/src/sys/process/mod.rs
+++ b/packages/native/native/src/sys/process/mod.rs
@@ -43,10 +43,7 @@ impl ContainmentGuard {
         }
     }
 
-    pub(crate) fn release(self) {
-        #[cfg(windows)]
-        self.0.release();
-    }
+    pub(crate) fn release(self) {}
 }
 
 pub(crate) fn capabilities() -> Vec<String> {

--- a/packages/native/native/src/sys/process/mod.rs
+++ b/packages/native/native/src/sys/process/mod.rs
@@ -27,15 +27,25 @@ pub(crate) struct ContainmentGuard;
 pub(crate) struct ContainmentGuard(windows::OwnedJob);
 
 impl ContainmentGuard {
-    pub(crate) fn terminate(&self) -> Option<TerminationResult> {
+    pub(crate) fn terminate(
+        &self,
+        target: &ManagedTarget,
+        signal: &str,
+    ) -> Option<TerminationResult> {
         #[cfg(unix)]
         {
-            None
+            Some(signal_target(target, signal))
         }
         #[cfg(windows)]
         {
+            let _ = (target, signal);
             Some(self.0.terminate())
         }
+    }
+
+    pub(crate) fn release(self) {
+        #[cfg(windows)]
+        self.0.release();
     }
 }
 

--- a/packages/native/native/src/sys/process/windows.rs
+++ b/packages/native/native/src/sys/process/windows.rs
@@ -59,6 +59,15 @@ impl OwnedJob {
             TerminationResult::failed(TerminationMethod::JobObject, error.to_string())
         }
     }
+
+    pub(crate) fn release(self) {
+        if configure_kill_on_close(self.0, false).is_err() {
+            // Releasing a kill-on-close job after natural completion must never
+            // kill detached descendants. Keep the handle until process exit if
+            // Windows unexpectedly refuses the limit update.
+            std::mem::forget(self);
+        }
+    }
 }
 
 enum OpenedProcess {
@@ -240,11 +249,18 @@ fn create_job() -> Result<OwnedJob, String> {
         return Err(std::io::Error::last_os_error().to_string());
     }
     let job = OwnedJob(handle);
+    configure_kill_on_close(job.0, true)?;
+    Ok(job)
+}
+
+fn configure_kill_on_close(handle: HANDLE, enabled: bool) -> Result<(), String> {
     let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    if enabled {
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    }
     let configured = unsafe {
         SetInformationJobObject(
-            job.0,
+            handle,
             JobObjectExtendedLimitInformation,
             &limits as *const _ as *const c_void,
             size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
@@ -253,7 +269,7 @@ fn create_job() -> Result<OwnedJob, String> {
     if configured == 0 {
         return Err(std::io::Error::last_os_error().to_string());
     }
-    Ok(job)
+    Ok(())
 }
 
 fn resume_process_thread(pid: u32) -> Result<(), String> {

--- a/packages/native/native/src/sys/process/windows.rs
+++ b/packages/native/native/src/sys/process/windows.rs
@@ -1,6 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::ffi::c_void;
-use std::mem::size_of;
 use std::os::windows::io::AsRawHandle;
 use std::os::windows::process::CommandExt;
 use std::process::{Child, Command};
@@ -11,9 +9,7 @@ use windows_sys::Win32::System::Diagnostics::ToolHelp::{
     TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
 };
 use windows_sys::Win32::System::JobObjects::{
-    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
-    SetInformationJobObject, TerminateJobObject,
+    AssignProcessToJobObject, CreateJobObjectW, TerminateJobObject,
 };
 use windows_sys::Win32::System::Threading::{
     CREATE_NO_WINDOW, CREATE_SUSPENDED, GetExitCodeProcess, GetProcessTimes, OpenProcess,
@@ -57,15 +53,6 @@ impl OwnedJob {
         } else {
             let error = std::io::Error::last_os_error();
             TerminationResult::failed(TerminationMethod::JobObject, error.to_string())
-        }
-    }
-
-    pub(crate) fn release(self) {
-        if configure_kill_on_close(self.0, false).is_err() {
-            // Releasing a kill-on-close job after natural completion must never
-            // kill detached descendants. Keep the handle until process exit if
-            // Windows unexpectedly refuses the limit update.
-            std::mem::forget(self);
         }
     }
 }
@@ -248,28 +235,7 @@ fn create_job() -> Result<OwnedJob, String> {
     if handle.is_null() {
         return Err(std::io::Error::last_os_error().to_string());
     }
-    let job = OwnedJob(handle);
-    configure_kill_on_close(job.0, true)?;
-    Ok(job)
-}
-
-fn configure_kill_on_close(handle: HANDLE, enabled: bool) -> Result<(), String> {
-    let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-    if enabled {
-        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-    }
-    let configured = unsafe {
-        SetInformationJobObject(
-            handle,
-            JobObjectExtendedLimitInformation,
-            &limits as *const _ as *const c_void,
-            size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-        )
-    };
-    if configured == 0 {
-        return Err(std::io::Error::last_os_error().to_string());
-    }
-    Ok(())
+    Ok(OwnedJob(handle))
 }
 
 fn resume_process_thread(pid: u32) -> Result<(), String> {

--- a/packages/native/test/managed-process.test.ts
+++ b/packages/native/test/managed-process.test.ts
@@ -147,6 +147,59 @@ describe("native managed process facade", () => {
   });
 
   it(
+    "preserves detached descendants after the root exits",
+    { timeout: 5_000 },
+    async () => {
+      const managed = spawnManagedProcess(node, [
+        "-e",
+        `const { spawn } = require("node:child_process");
+       const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+       console.log(child.pid);
+       child.unref();`,
+      ]);
+      const childPid = await firstOutputNumber(managed.stdout);
+      try {
+        assert.equal((await managed.closed).exitCode, 0);
+        assert.equal(await processIsAlive(childPid), true);
+      } finally {
+        try {
+          process.kill(childPid, "SIGKILL");
+        } catch {
+          // The descendant may have exited independently.
+        }
+        await waitForProcessExit(childPid);
+      }
+    },
+  );
+
+  it(
+    "terminates inherited-pipe descendants after the root exits",
+    { timeout: 5_000 },
+    async () => {
+      const managed = spawnManagedProcess(node, [
+        "-e",
+        `const { spawn } = require("node:child_process");
+       const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: ["ignore", 1, 2] });
+       console.log(child.pid);
+       child.unref();`,
+      ]);
+      const childPid = await firstOutputNumber(managed.stdout);
+      let closed = false;
+      void managed.closed.then(() => {
+        closed = true;
+      });
+
+      await managed.exited;
+      assert.equal(closed, false);
+      const result = await managed.terminate("SIGKILL");
+      assert.equal(result.attempted, true);
+      assert.ok(["job-object", "process-group"].includes(result.method));
+      await managed.closed;
+      await waitForProcessExit(childPid);
+    },
+  );
+
+  it(
     "terminates a managed process tree promptly",
     { timeout: 5_000 },
     async () => {

--- a/packages/native/test/managed-process.test.ts
+++ b/packages/native/test/managed-process.test.ts
@@ -179,7 +179,7 @@ describe("native managed process facade", () => {
       const managed = spawnManagedProcess(node, [
         "-e",
         `const { spawn } = require("node:child_process");
-       const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: ["ignore", 1, 2] });
+       const child = spawn(process.execPath, ["-e", "setInterval(() => process.stdout.write('alive\\n'), 20)"], { stdio: ["ignore", "inherit", "inherit"] });
        console.log(child.pid);
        child.unref();`,
       ]);

--- a/packages/native/test/managed-process.test.ts
+++ b/packages/native/test/managed-process.test.ts
@@ -153,7 +153,7 @@ describe("native managed process facade", () => {
       const managed = spawnManagedProcess(node, [
         "-e",
         `const { spawn } = require("node:child_process");
-       const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+       const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore", detached: process.platform === "win32" });
        console.log(child.pid);
        child.unref();`,
       ]);
@@ -179,7 +179,7 @@ describe("native managed process facade", () => {
       const managed = spawnManagedProcess(node, [
         "-e",
         `const { spawn } = require("node:child_process");
-       const child = spawn(process.execPath, ["-e", "setInterval(() => process.stdout.write('alive\\n'), 20)"], { stdio: ["ignore", "inherit", "inherit"] });
+       const child = spawn(process.execPath, ["-e", "setInterval(() => process.stdout.write('alive\\n'), 20)"], { stdio: ["ignore", "inherit", "inherit"], detached: process.platform === "win32" });
        console.log(child.pid);
        child.unref();`,
       ]);

--- a/packages/workbench-server/test/workbench-task-service-foreground.test.ts
+++ b/packages/workbench-server/test/workbench-task-service-foreground.test.ts
@@ -69,6 +69,63 @@ describe("task manager foreground bash auto-promotion", () => {
     );
   });
 
+  it("keeps a promoted task supervised for explicit cancellation", async () => {
+    const child = fakeChild();
+    const { supervisor, terminateSignals } = fakeSupervisor({
+      child,
+      onTerminate(signal) {
+        child.emitClose(null, signal);
+      },
+    });
+    const { manager, storage } = await createManager(supervisor);
+
+    const result = await manager.runForegroundBashWithPromotion({
+      command: "long-running command",
+      cwd: storage.paths.home,
+      projectId: "proj_test",
+      conversationId: "conv_test",
+      agentId: "agent_test",
+      autoPromoteAfterMs: 10,
+      origin: { kind: "agent_tool", toolCallId: "tool_test" },
+    });
+    assert.equal(result.kind, "promoted");
+
+    const cancelled = await manager.cancelTask(result.task.id, {
+      signal: "SIGKILL",
+      reason: "Stopped from the task panel.",
+    });
+
+    assert.deepEqual(terminateSignals, ["SIGKILL"]);
+    assert.equal(cancelled.status, "cancelled");
+  });
+
+  it("force-kills a promoted active task during shutdown", async () => {
+    const child = fakeChild();
+    const { supervisor, terminateSignals } = fakeSupervisor({
+      child,
+      onTerminate(signal) {
+        child.emitClose(null, signal);
+      },
+    });
+    const { manager, storage } = await createManager(supervisor);
+
+    const result = await manager.runForegroundBashWithPromotion({
+      command: "long-running command",
+      cwd: storage.paths.home,
+      projectId: "proj_test",
+      conversationId: "conv_test",
+      agentId: "agent_test",
+      autoPromoteAfterMs: 10,
+      origin: { kind: "agent_tool", toolCallId: "tool_test" },
+    });
+    assert.equal(result.kind, "promoted");
+
+    await manager.shutdown();
+
+    assert.deepEqual(terminateSignals, ["SIGKILL"]);
+    assert.equal(manager.getTask(result.task.id).status, "cancelled");
+  });
+
   it(
     "returns normal bash output and removes the hidden task when it finishes before promotion",
     { timeout: 10_000 },


### PR DESCRIPTION
## Summary
- retain managed containment until inherited stdout and stderr pipes close
- release naturally completed Windows Job Objects without terminating detached daemon descendants
- keep process-tree termination available after root exit and across foreground Bash promotion
- verify promoted-task cancellation and shutdown cleanup

## Validation
- `pnpm build:native`
- `pnpm --filter @nervekit/native test`
- `pnpm --filter @nervekit/workbench-server test:native`
- `pnpm fix && pnpm check && pnpm test`

## Platform note
Windows Job Object behavior is covered by the native-host Windows CI matrix.