### PR TITLE
Improve Mermaid rendering and zoom controls

### DIFF
--- a/packages/ui-kit/src/lib/core/components/Markdown.svelte
+++ b/packages/ui-kit/src/lib/core/components/Markdown.svelte
@@ -23,6 +23,7 @@ import {
   resolveDisplayPath,
   splitPathLineSuffix,
 } from "@nervekit/ui-kit/core/utils/path-links";
+import { observeMermaidVisibility } from "./mermaid-visibility.js";
 import MermaidDiagram from "./MermaidDiagram.svelte";
 
 type Props = {
@@ -142,7 +143,10 @@ function copyButtonHandler(node: HTMLDivElement) {
   };
 }
 
-type MermaidEnhancement = { destroy: () => void };
+type MermaidEnhancement = {
+  destroy: () => void;
+  matches: (root: HTMLElement, value: MermaidHandlerValue) => boolean;
+};
 type MermaidHandlerValue = {
   html: string;
   source: string;
@@ -150,39 +154,111 @@ type MermaidHandlerValue = {
   onOpenMermaid?: (block: MermaidMarkdownBlock) => void;
 };
 
+type MermaidHostValue = {
+  host: HTMLElement;
+  source: string;
+  ariaLabel: string;
+  extracted?: MermaidMarkdownBlock;
+};
+
+function nearestVerticalScrollRoot(root: HTMLElement): Element | null {
+  const document = root.ownerDocument;
+  for (let parent = root.parentElement; parent; parent = parent.parentElement) {
+    if (parent === document.body || parent === document.documentElement) break;
+    const overflowY = getComputedStyle(parent).overflowY;
+    if (
+      /^(auto|overlay|scroll)$/u.test(overflowY) &&
+      parent.scrollHeight > parent.clientHeight
+    )
+      return parent;
+  }
+  return null;
+}
+
+function createMermaidPlaceholder(host: HTMLElement): void {
+  const placeholder = host.ownerDocument.createElement("div");
+  placeholder.className =
+    "grid h-full place-items-center p-4 text-sm text-muted-foreground";
+  placeholder.textContent = "Mermaid diagram";
+  placeholder.setAttribute("aria-hidden", "true");
+  host.setAttribute("aria-busy", "true");
+  host.replaceChildren(placeholder);
+}
+
 function enhanceMermaidBlocks(
   root: HTMLElement,
   value: MermaidHandlerValue,
 ): MermaidEnhancement {
   const components: Record<string, unknown>[] = [];
-  const blocks = value.onOpenMermaid
-    ? extractMermaidMarkdownBlocks(value.source, value.sourceLineStart)
-    : [];
-  const hosts = root.querySelectorAll<HTMLElement>("[data-mermaid-diagram]");
-  for (const [index, host] of [...hosts].entries()) {
+  const blocks = extractMermaidMarkdownBlocks(
+    value.source,
+    value.sourceLineStart,
+  );
+  const hosts = [
+    ...root.querySelectorAll<HTMLElement>("[data-mermaid-diagram]"),
+  ];
+  const hostValues: MermaidHostValue[] = [];
+  let active = true;
+
+  for (const [index, host] of hosts.entries()) {
     const extracted = blocks[index];
     const source =
       extracted?.source ?? host.querySelector("pre > code")?.textContent ?? "";
     if (!source.trim()) continue;
-    const ariaLabel = host.getAttribute("aria-label") ?? "Mermaid diagram";
-    host.replaceChildren();
-    components.push(
-      mount(MermaidDiagram, {
-        target: host,
-        props: {
-          source,
-          ariaLabel,
-          class: "h-full w-full",
-          onOpenStandalone:
-            extracted && value.onOpenMermaid
-              ? () => value.onOpenMermaid?.(extracted)
-              : undefined,
-        },
-      }),
-    );
+    hostValues.push({
+      host,
+      source,
+      extracted,
+      ariaLabel: host.getAttribute("aria-label") ?? "Mermaid diagram",
+    });
+    createMermaidPlaceholder(host);
   }
+
+  const stopObserving = observeMermaidVisibility(
+    hostValues.map((value) => value.host),
+    {
+      root: nearestVerticalScrollRoot(root),
+      mount: (target) => {
+        const host = target as HTMLElement;
+        const hostValue = hostValues.find((value) => value.host === host);
+        if (!active || !host.isConnected || !hostValue) return;
+        host.removeAttribute("aria-busy");
+        host.replaceChildren();
+        components.push(
+          mount(MermaidDiagram, {
+            target: host,
+            props: {
+              source: hostValue.source,
+              ariaLabel: hostValue.ariaLabel,
+              class: "h-full w-full",
+              onOpenStandalone:
+                hostValue.extracted && value.onOpenMermaid
+                  ? () => value.onOpenMermaid?.(hostValue.extracted!)
+                  : undefined,
+            },
+          }),
+        );
+      },
+    },
+  );
+
   return {
+    matches(nextRoot, nextValue) {
+      if (
+        nextValue.source !== value.source ||
+        nextValue.sourceLineStart !== value.sourceLineStart ||
+        nextValue.onOpenMermaid !== value.onOpenMermaid
+      )
+        return false;
+      const nextHosts = nextRoot.querySelectorAll("[data-mermaid-diagram]");
+      return (
+        nextHosts.length === hosts.length &&
+        hosts.every((host, index) => nextHosts[index] === host)
+      );
+    },
     destroy() {
+      active = false;
+      stopObserving();
       for (const component of components) void unmount(component);
     },
   };
@@ -194,11 +270,14 @@ function mermaidHandler(node: HTMLDivElement, value: MermaidHandlerValue) {
 
   async function update(nextValue: MermaidHandlerValue) {
     const current = ++generation;
-    enhancement?.destroy();
-    enhancement = undefined;
-    if (!nextValue.html.includes("data-mermaid-diagram")) return;
+    if (!nextValue.html.includes("data-mermaid-diagram")) {
+      enhancement?.destroy();
+      enhancement = undefined;
+      return;
+    }
     await tick();
-    if (current !== generation) return;
+    if (current !== generation || enhancement?.matches(node, nextValue)) return;
+    enhancement?.destroy();
     enhancement = enhanceMermaidBlocks(node, nextValue);
   }
 

--- a/packages/ui-kit/src/lib/core/components/MermaidDiagram.svelte
+++ b/packages/ui-kit/src/lib/core/components/MermaidDiagram.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+import { untrack } from "svelte";
 import ExternalLink from "@lucide/svelte/icons/external-link";
 import Maximize from "@lucide/svelte/icons/maximize";
+import Mouse from "@lucide/svelte/icons/mouse";
 import ZoomIn from "@lucide/svelte/icons/zoom-in";
 import ZoomOut from "@lucide/svelte/icons/zoom-out";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
@@ -11,6 +13,7 @@ type Props = {
   source: string;
   ariaLabel?: string;
   class?: string;
+  defaultWheelZoomEnabled?: boolean;
   onOpenStandalone?: () => void;
 };
 
@@ -23,6 +26,7 @@ let {
   source,
   ariaLabel = "Mermaid diagram",
   class: className = "",
+  defaultWheelZoomEnabled = false,
   onOpenStandalone,
 }: Props = $props();
 
@@ -35,6 +39,7 @@ let offsetY = $state(0);
 let diagramWidth = $state(0);
 let diagramHeight = $state(0);
 let automaticFit = $state(true);
+let wheelZoomEnabled = $state(untrack(() => defaultWheelZoomEnabled));
 let dragging = $state(false);
 let activePointerId: number | undefined;
 let dragStartX = 0;
@@ -96,7 +101,8 @@ function zoomAt(nextScale: number, clientX?: number, clientY?: number) {
 }
 
 function handleWheel(event: WheelEvent) {
-  if (renderState !== "rendered") return;
+  if ((!wheelZoomEnabled && !event.ctrlKey) || renderState !== "rendered")
+    return;
   event.preventDefault();
   zoomAt(scale * Math.exp(-event.deltaY * 0.001), event.clientX, event.clientY);
 }
@@ -227,50 +233,65 @@ $effect(() => {
 
   {#if renderState === "rendered"}
     <div
-      class="absolute right-3 top-3 z-10 flex items-center gap-0.5 rounded-md border border-border bg-popover/90 p-1 text-popover-foreground shadow-sm backdrop-blur-sm"
+      class="absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-md border border-border bg-popover/90 p-0.5 text-popover-foreground shadow-sm backdrop-blur-sm"
       role="toolbar"
-      aria-label="Diagram zoom controls"
+      aria-label="Diagram controls"
       tabindex="-1"
       onpointerdown={(event) => event.stopPropagation()}
     >
       <Button
         variant="ghost"
-        size="icon-sm"
+        size="icon-xs"
+        pressed={wheelZoomEnabled}
+        active={wheelZoomEnabled}
+        ariaLabel={wheelZoomEnabled
+          ? "Disable mouse wheel zoom"
+          : "Enable mouse wheel zoom; hold Control for temporary zoom"}
+        title={wheelZoomEnabled
+          ? "Disable mouse wheel zoom"
+          : "Enable mouse wheel zoom (Ctrl+wheel temporarily)"}
+        onclick={() => (wheelZoomEnabled = !wheelZoomEnabled)}
+      >
+        <Mouse class="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-xs"
         ariaLabel="Zoom out"
         title="Zoom out"
         disabled={scale <= MIN_SCALE}
         onclick={() => zoomAt(scale / ZOOM_STEP)}
       >
-        <ZoomOut class="size-4" />
+        <ZoomOut class="size-3" />
       </Button>
       <Button
         variant="ghost"
-        size="icon-sm"
+        size="icon-xs"
         ariaLabel="Zoom in"
         title="Zoom in"
         disabled={scale >= MAX_SCALE}
         onclick={() => zoomAt(scale * ZOOM_STEP)}
       >
-        <ZoomIn class="size-4" />
+        <ZoomIn class="size-3" />
       </Button>
       <Button
         variant="ghost"
-        size="icon-sm"
+        size="icon-xs"
         ariaLabel="Fit diagram to view"
         title="Fit to view"
         onclick={fitDiagram}
       >
-        <Maximize class="size-4" />
+        <Maximize class="size-3" />
       </Button>
       {#if onOpenStandalone}
         <Button
           variant="ghost"
-          size="icon-sm"
+          size="icon-xs"
           ariaLabel="Open diagram in tab"
           title="Open diagram in tab"
           onclick={onOpenStandalone}
         >
-          <ExternalLink class="size-4" />
+          <ExternalLink class="size-3" />
         </Button>
       {/if}
     </div>

--- a/packages/ui-kit/src/lib/core/components/mermaid-visibility.test.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-visibility.test.ts
@@ -1,0 +1,133 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  MERMAID_PRELOAD_MARGIN,
+  observeMermaidVisibility,
+} from "./mermaid-visibility";
+
+type FakeObserver = {
+  callback: IntersectionObserverCallback;
+  options: IntersectionObserverInit;
+  observed: Element[];
+  unobserved: Element[];
+  disconnectCount: number;
+};
+
+function host(): Element {
+  return {} as Element;
+}
+
+function setupObserver() {
+  const state: FakeObserver = {
+    callback: () => undefined,
+    options: {},
+    observed: [],
+    unobserved: [],
+    disconnectCount: 0,
+  };
+  const createObserver = (
+    callback: IntersectionObserverCallback,
+    options: IntersectionObserverInit,
+  ) => {
+    state.callback = callback;
+    state.options = options;
+    return {
+      observe: (target: Element) => state.observed.push(target),
+      unobserve: (target: Element) => state.unobserved.push(target),
+      disconnect: () => {
+        state.disconnectCount += 1;
+      },
+    };
+  };
+  return { state, createObserver };
+}
+
+function entry(
+  target: Element,
+  isIntersecting: boolean,
+): IntersectionObserverEntry {
+  return { target, isIntersecting } as IntersectionObserverEntry;
+}
+
+describe("Mermaid visibility observer", () => {
+  it("observes every host with the configured root and preload margin", () => {
+    const first = host();
+    const second = host();
+    const root = host();
+    const { state, createObserver } = setupObserver();
+
+    observeMermaidVisibility([first, second], {
+      root,
+      mount: () => undefined,
+      createObserver,
+    });
+
+    assert.deepEqual(state.observed, [first, second]);
+    assert.equal(state.options.root, root);
+    assert.equal(state.options.rootMargin, MERMAID_PRELOAD_MARGIN);
+    assert.equal(state.options.threshold, 0);
+  });
+
+  it("mounts intersecting hosts once and unobserves them", () => {
+    const first = host();
+    const second = host();
+    const mounted: Element[] = [];
+    const { state, createObserver } = setupObserver();
+
+    observeMermaidVisibility([first, second], {
+      root: null,
+      mount: (target) => mounted.push(target),
+      createObserver,
+    });
+
+    state.callback(
+      [entry(first, false), entry(second, true)],
+      {} as IntersectionObserver,
+    );
+    state.callback([entry(second, true)], {} as IntersectionObserver);
+
+    assert.deepEqual(mounted, [second]);
+    assert.deepEqual(state.unobserved, [second]);
+  });
+
+  it("disconnects and suppresses callbacks after cleanup", () => {
+    const target = host();
+    const mounted: Element[] = [];
+    const { state, createObserver } = setupObserver();
+    const cleanup = observeMermaidVisibility([target], {
+      root: null,
+      mount: (next) => mounted.push(next),
+      createObserver,
+    });
+
+    cleanup();
+    state.callback([entry(target, true)], {} as IntersectionObserver);
+
+    assert.equal(state.disconnectCount, 1);
+    assert.deepEqual(mounted, []);
+  });
+
+  it("mounts eagerly when IntersectionObserver is unavailable", () => {
+    const original = globalThis.IntersectionObserver;
+    const first = host();
+    const second = host();
+    const mounted: Element[] = [];
+    try {
+      Object.defineProperty(globalThis, "IntersectionObserver", {
+        configurable: true,
+        value: undefined,
+      });
+      observeMermaidVisibility([first, second], {
+        root: null,
+        mount: (target) => mounted.push(target),
+      });
+    } finally {
+      Object.defineProperty(globalThis, "IntersectionObserver", {
+        configurable: true,
+        value: original,
+      });
+    }
+
+    assert.deepEqual(mounted, [first, second]);
+  });
+});

--- a/packages/ui-kit/src/lib/core/components/mermaid-visibility.ts
+++ b/packages/ui-kit/src/lib/core/components/mermaid-visibility.ts
@@ -1,0 +1,70 @@
+export const MERMAID_PRELOAD_MARGIN = "300px 0px";
+
+type MermaidVisibilityObserver = Pick<
+  IntersectionObserver,
+  "disconnect" | "observe" | "unobserve"
+>;
+
+type MermaidVisibilityObserverFactory = (
+  callback: IntersectionObserverCallback,
+  options: IntersectionObserverInit,
+) => MermaidVisibilityObserver;
+
+type MermaidVisibilityOptions = {
+  root: Element | null;
+  mount: (host: Element) => void;
+  createObserver?: MermaidVisibilityObserverFactory;
+};
+
+export function observeMermaidVisibility(
+  hosts: Iterable<Element>,
+  options: MermaidVisibilityOptions,
+): () => void {
+  const pending = new Set(hosts);
+  let active = true;
+
+  const mountOnce = (host: Element) => {
+    if (!active || !pending.delete(host)) return;
+    options.mount(host);
+  };
+
+  const createObserver =
+    options.createObserver ??
+    (typeof IntersectionObserver === "undefined"
+      ? undefined
+      : (
+          callback: IntersectionObserverCallback,
+          init: IntersectionObserverInit,
+        ) => new IntersectionObserver(callback, init));
+
+  if (!createObserver) {
+    for (const host of [...pending]) mountOnce(host);
+    return () => {
+      active = false;
+      pending.clear();
+    };
+  }
+
+  const observer = createObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting || !pending.has(entry.target)) continue;
+        observer.unobserve(entry.target);
+        mountOnce(entry.target);
+      }
+    },
+    {
+      root: options.root,
+      rootMargin: MERMAID_PRELOAD_MARGIN,
+      threshold: 0,
+    },
+  );
+
+  for (const host of pending) observer.observe(host);
+
+  return () => {
+    active = false;
+    pending.clear();
+    observer.disconnect();
+  };
+}

--- a/packages/workbench-app/src/lib/presentation/components/mermaid/MermaidPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/mermaid/MermaidPane.svelte
@@ -35,7 +35,12 @@ let {
       <p class="m-0 max-w-xl text-sm">{error}</p>
     </div>
   {:else if source}
-    <MermaidDiagram class="h-full" {source} {ariaLabel} />
+    <MermaidDiagram
+      class="h-full"
+      {source}
+      {ariaLabel}
+      defaultWheelZoomEnabled
+    />
     {#if truncated}
       <p
         class="absolute bottom-3 left-3 m-0 rounded-md border border-border bg-background/90 px-3 py-2 text-xs text-muted-foreground shadow-sm backdrop-blur-sm"


### PR DESCRIPTION
## Summary
- lazily mount embedded Mermaid diagrams near the visible scroll region while preserving stable placeholders
- compact the diagram toolbar and add a persistent mouse-wheel zoom toggle
- allow Ctrl+wheel as temporary zoom, default embedded diagrams to parent scrolling, and retain wheel zoom by default in standalone views

## Validation
- `pnpm fix && pnpm check && pnpm test`
- manually verified embedded and standalone Mermaid wheel behavior