### PR TITLE
Guard task launches with configured ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,25 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -15,6 +30,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -86,10 +127,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
 
 [[package]]
 name = "clru"
@@ -218,7 +279,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -246,6 +307,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encoding_rs"
@@ -471,7 +538,7 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -498,7 +565,7 @@ dependencies = [
  "gix-quote",
  "gix-trace",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
  "unicode-bom",
 ]
 
@@ -562,7 +629,7 @@ dependencies = [
  "gix-sec",
  "gix-utils",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
  "unicode-bom",
 ]
 
@@ -576,7 +643,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -612,7 +679,7 @@ dependencies = [
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -632,7 +699,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -647,7 +714,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -696,7 +763,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -709,7 +776,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -734,7 +801,7 @@ dependencies = [
  "gix-features",
  "sha1-checked",
  "sha2",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -796,7 +863,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -807,7 +874,7 @@ checksum = "d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -826,7 +893,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -848,7 +915,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -868,7 +935,7 @@ dependencies = [
  "gix-zlib",
  "memmap2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -880,7 +947,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -892,7 +959,7 @@ dependencies = [
  "bstr",
  "gix-trace",
  "gix-validate",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -907,7 +974,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -926,7 +993,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "nonempty",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -957,7 +1024,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -973,7 +1040,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1008,7 +1075,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1033,7 +1100,7 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "nonempty",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1057,7 +1124,7 @@ dependencies = [
  "gix-worktree",
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror",
+ "thiserror 2.0.20",
  "windows-sys",
 ]
 
@@ -1073,7 +1140,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1111,7 +1178,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1128,7 +1195,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1141,7 +1208,7 @@ dependencies = [
  "gix-path",
  "gix-utils",
  "percent-encoding",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1208,9 +1275,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e8813f5579b3075ff9c90f7c59cd2b62b4ebb639361f0911648b22d7446cc7c"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
  "zlib-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hash32"
@@ -1266,6 +1339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1335,6 +1417,16 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -1378,6 +1470,12 @@ checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1445,7 +1543,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -1457,8 +1555,76 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "netstat2",
  "tokio",
  "windows-sys",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-sock-diag"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a495cb1de50560a7cd12fdcf023db70eec00e340df81be31cedbbfd4aadd6b76"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+ "smallvec",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "netstat2"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496f264d3ead4870d6b366deb9d20597592d64aac2a907f3e7d07c2325ba4663"
+dependencies = [
+ "bindgen",
+ "bitflags 2.13.1",
+ "byteorder",
+ "netlink-packet-core",
+ "netlink-packet-sock-diag",
+ "netlink-packet-utils",
+ "netlink-sys",
+ "num-derive",
+ "num-traits",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1468,10 +1634,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -1503,6 +1699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1729,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1572,10 +1784,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
@@ -1691,6 +1926,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1971,17 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -1765,11 +2017,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/packages/contracts/src/domains/task-definitions/task-definition.schema.ts
+++ b/packages/contracts/src/domains/task-definitions/task-definition.schema.ts
@@ -5,6 +5,8 @@ export type TaskDefinitionRunPolicy = z.infer<
   typeof taskDefinitionRunPolicySchema
 >;
 
+export const taskDefinitionPortSchema = z.number().int().min(1).max(65_535);
+
 export const taskDefinitionScopeSchema = z.object({
   kind: z.literal("project"),
   projectId: z.string().startsWith("proj_"),
@@ -17,6 +19,7 @@ export const taskDefinitionSchema = z.object({
   label: z.string().min(1).optional(),
   command: z.string().min(1),
   cwd: z.string().min(1).optional(),
+  port: taskDefinitionPortSchema.optional(),
   runPolicy: taskDefinitionRunPolicySchema.default("single"),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
@@ -27,6 +30,7 @@ export const createTaskDefinitionRequestSchema = z.object({
   label: z.string().min(1).optional(),
   command: z.string().min(1),
   cwd: z.string().min(1).optional(),
+  port: taskDefinitionPortSchema.optional(),
   runPolicy: taskDefinitionRunPolicySchema.default("single"),
   sourceTaskId: z.string().startsWith("task_").optional(),
 });
@@ -38,6 +42,7 @@ export const updateTaskDefinitionRequestSchema = z.object({
   label: z.string().min(1).optional(),
   command: z.string().min(1),
   cwd: z.string().min(1).optional(),
+  port: taskDefinitionPortSchema.optional(),
   runPolicy: taskDefinitionRunPolicySchema,
 });
 export type UpdateTaskDefinitionRequest = z.infer<

--- a/packages/contracts/src/domains/tasks/task.operations.schema.ts
+++ b/packages/contracts/src/domains/tasks/task.operations.schema.ts
@@ -2,6 +2,7 @@ import {
   startTaskRequestSchema,
   taskLogQueryResponseSchema,
   taskLogQuerySchema,
+  taskPortConflictListenerSchema,
   taskRecordSchema,
 } from "./index.js";
 import { z } from "zod";
@@ -15,7 +16,28 @@ const taskRestartParamsSchema = taskIdParamsSchema.extend({
 });
 const taskDefinitionLaunchParamsSchema = z.object({
   definitionId: z.string().startsWith("taskdef_"),
+  terminateListeners: z.array(taskPortConflictListenerSchema).min(1).optional(),
 });
+
+export const taskDefinitionLaunchResultSchema = z.discriminatedUnion(
+  "disposition",
+  [
+    z.object({
+      disposition: z.enum(["started", "focused_existing"]),
+      task: taskRecordSchema,
+    }),
+    z.object({
+      disposition: z.literal("port_conflict"),
+      conflict: z.object({
+        port: z.number().int().positive().max(65_535),
+        listeners: z.array(taskPortConflictListenerSchema).min(1),
+      }),
+    }),
+  ],
+);
+export type TaskDefinitionLaunchResult = z.infer<
+  typeof taskDefinitionLaunchResultSchema
+>;
 const taskLogsParamsSchema = taskIdParamsSchema.merge(taskLogQuerySchema);
 const taskCancelParamsSchema = taskIdParamsSchema.extend({
   signal: z.enum(["SIGTERM", "SIGINT", "SIGKILL"]).optional(),
@@ -45,10 +67,7 @@ export const tasksOperationDefinitions = [
   defineOperation(
     "task.launchDefinition",
     taskDefinitionLaunchParamsSchema,
-    z.object({
-      task: taskRecordSchema,
-      disposition: z.enum(["started", "focused_existing"]),
-    }),
+    taskDefinitionLaunchResultSchema,
     "mutation",
     "recommended",
     ["workbench_server"] as const,

--- a/packages/contracts/src/domains/tasks/task.schema.ts
+++ b/packages/contracts/src/domains/tasks/task.schema.ts
@@ -37,6 +37,18 @@ export const taskReadinessSchema = z.object({
 });
 export type TaskReadiness = z.infer<typeof taskReadinessSchema>;
 
+export const taskPortConflictListenerSchema = z.object({
+  protocol: z.enum(["tcp", "tcp6"]),
+  address: z.string().min(1),
+  port: z.number().int().positive().max(65_535),
+  pid: z.number().int().positive(),
+  identity: z.string().min(1),
+  processName: z.string().min(1).optional(),
+});
+export type TaskPortConflictListener = z.infer<
+  typeof taskPortConflictListenerSchema
+>;
+
 export const taskListeningPortSchema = z.object({
   protocol: z.enum(["tcp", "tcp6"]),
   address: z.string().min(1),

--- a/packages/contracts/test/task-definition.schema.test.ts
+++ b/packages/contracts/test/task-definition.schema.test.ts
@@ -20,6 +20,23 @@ test("task definitions default to a single active run", () => {
   assert.equal(definition.runPolicy, "single");
 });
 
+test("task definitions accept an optional guarded TCP port", () => {
+  assert.equal(
+    createTaskDefinitionRequestSchema.parse({ command: "pnpm dev", port: 3000 })
+      .port,
+    3000,
+  );
+  assert.throws(() =>
+    createTaskDefinitionRequestSchema.parse({ command: "pnpm dev", port: 0 }),
+  );
+  assert.throws(() =>
+    createTaskDefinitionRequestSchema.parse({
+      command: "pnpm dev",
+      port: 65_536,
+    }),
+  );
+});
+
 test("task definitions support explicit concurrent runs", () => {
   assert.equal(
     createTaskDefinitionRequestSchema.parse({

--- a/packages/native/native/Cargo.toml
+++ b/packages/native/native/Cargo.toml
@@ -33,6 +33,9 @@ tokio = { version = "1.53.0", features = [
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.180"
 
+[target.'cfg(any(target_os = "macos", windows))'.dependencies]
+netstat2 = "0.11.2"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [
   "Win32_Foundation",

--- a/packages/native/native/src/api/process/mod.rs
+++ b/packages/native/native/src/api/process/mod.rs
@@ -6,6 +6,7 @@ use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 
 use crate::platform::process as sys_process;
+use crate::platform::process::TcpListenerInfo;
 use crate::process::{
     self, Containment, EnforcementEntry, InspectionResult, ManagedProcess, ManagedProcessEvents,
     ManagedTarget, OutputDrain, OutputStats, RequestedOutputPolicy, RequestedPolicy,
@@ -74,6 +75,57 @@ impl From<ManagedTarget> for NativeManagedTarget {
             containment: value.containment.as_str().to_string(),
             identity: value.identity,
         }
+    }
+}
+
+#[napi(object)]
+#[derive(Clone, Debug)]
+pub struct NativeTcpListener {
+    pub protocol: String,
+    pub address: String,
+    pub port: u32,
+    pub pid: u32,
+    pub process_group_id: Option<u32>,
+    pub identity: String,
+    pub process_name: Option<String>,
+}
+
+impl From<TcpListenerInfo> for NativeTcpListener {
+    fn from(value: TcpListenerInfo) -> Self {
+        Self {
+            protocol: value.protocol.to_string(),
+            address: value.address,
+            port: u32::from(value.port),
+            pid: value.pid,
+            process_group_id: value.process_group_id,
+            identity: value.identity,
+            process_name: value.process_name,
+        }
+    }
+}
+
+impl TryFrom<NativeTcpListener> for TcpListenerInfo {
+    type Error = napi::Error;
+
+    fn try_from(value: NativeTcpListener) -> Result<Self> {
+        let protocol = match value.protocol.as_str() {
+            "tcp" => "tcp",
+            "tcp6" => "tcp6",
+            _ => return Err(napi::Error::from_reason("Unsupported TCP protocol")),
+        };
+        let port = u16::try_from(value.port)
+            .ok()
+            .filter(|port| *port > 0)
+            .ok_or_else(|| napi::Error::from_reason("Invalid TCP listener port"))?;
+        Ok(Self {
+            protocol,
+            address: value.address,
+            port,
+            pid: value.pid,
+            process_group_id: value.process_group_id,
+            identity: value.identity,
+            process_name: value.process_name,
+        })
     }
 }
 
@@ -261,6 +313,33 @@ impl NativeManagedProcess {
 pub fn configure_managed_process_runtime(options: NativeRuntimeOptions) -> Result<()> {
     let maximum = positive_usize("maxActiveProcesses", options.max_active_processes)?;
     process::configure_registry(maximum).map_err(napi::Error::from_reason)
+}
+
+#[napi]
+pub fn inspect_tcp_listeners(port: Option<u32>) -> Result<Vec<NativeTcpListener>> {
+    let port = port
+        .map(|value| {
+            u16::try_from(value)
+                .ok()
+                .filter(|port| *port > 0)
+                .ok_or_else(|| napi::Error::from_reason("Invalid TCP listener port"))
+        })
+        .transpose()?;
+    sys_process::inspect_tcp_listeners(port)
+        .map(|listeners| listeners.into_iter().map(Into::into).collect())
+        .map_err(napi::Error::from_reason)
+}
+
+#[napi]
+pub fn terminate_tcp_listener(
+    listener: NativeTcpListener,
+    signal: Option<String>,
+) -> Result<NativeTerminationResult> {
+    Ok(sys_process::terminate_tcp_listener(
+        &listener.try_into()?,
+        signal.as_deref().unwrap_or("SIGTERM"),
+    )
+    .into())
 }
 
 #[napi]

--- a/packages/native/native/src/platform/process/linux/mod.rs
+++ b/packages/native/native/src/platform/process/linux/mod.rs
@@ -2,8 +2,12 @@ mod cgroup;
 
 pub(crate) use cgroup::{CgroupGuard, prepare as prepare_cgroup};
 
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::ErrorKind;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use super::TcpListenerInfo;
 
 use crate::process::{InspectionResult, ManagedTarget, TerminationMethod, TerminationResult};
 
@@ -71,6 +75,126 @@ pub(crate) fn terminate(target: &ManagedTarget, signal: &str) -> TerminationResu
         }
     }
     super::signal_target(target, signal)
+}
+
+pub(crate) fn inspect_tcp_listeners(port: Option<u16>) -> Result<Vec<TcpListenerInfo>, String> {
+    let mut sockets = HashMap::new();
+    read_socket_table("tcp", port, &mut sockets)?;
+    read_socket_table("tcp6", port, &mut sockets)?;
+    if sockets.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut listeners = Vec::new();
+    let entries = fs::read_dir("/proc").map_err(|error| error.to_string())?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid) = name.to_str().and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        let ReadIdentity::Found(process) = read_identity(pid) else {
+            continue;
+        };
+        let Ok(fds) = fs::read_dir(format!("/proc/{pid}/fd")) else {
+            continue;
+        };
+        let mut owned = HashSet::new();
+        for fd in fds.flatten() {
+            let Ok(target) = fs::read_link(fd.path()) else {
+                continue;
+            };
+            let target = target.to_string_lossy();
+            let Some(inode) = target
+                .strip_prefix("socket:[")
+                .and_then(|value| value.strip_suffix(']'))
+            else {
+                continue;
+            };
+            if !owned.insert(inode.to_string()) {
+                continue;
+            }
+            let Some(socket) = sockets.get(inode) else {
+                continue;
+            };
+            listeners.push(TcpListenerInfo {
+                protocol: socket.protocol,
+                address: socket.address.clone(),
+                port: socket.port,
+                pid,
+                process_group_id: Some(process.process_group_id),
+                identity: format!("linux:{}", process.start_time_ticks),
+                process_name: fs::read_to_string(format!("/proc/{pid}/comm"))
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty()),
+            });
+        }
+    }
+    listeners.sort_by_key(|listener| (listener.port, listener.pid));
+    Ok(listeners)
+}
+
+struct SocketRow {
+    protocol: &'static str,
+    address: String,
+    port: u16,
+}
+
+fn read_socket_table(
+    protocol: &'static str,
+    port_filter: Option<u16>,
+    sockets: &mut HashMap<String, SocketRow>,
+) -> Result<(), String> {
+    let content = match fs::read_to_string(format!("/proc/net/{protocol}")) {
+        Ok(content) => content,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.to_string()),
+    };
+    for line in content.lines().skip(1) {
+        let columns: Vec<&str> = line.split_whitespace().collect();
+        if columns.len() < 10 || columns[3] != "0A" {
+            continue;
+        }
+        let Some((address, port)) = parse_local_address(protocol, columns[1]) else {
+            continue;
+        };
+        if port_filter.is_some_and(|expected| expected != port) {
+            continue;
+        }
+        if columns[9] != "0" {
+            sockets.insert(
+                columns[9].to_string(),
+                SocketRow {
+                    protocol,
+                    address,
+                    port,
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn parse_local_address(protocol: &str, value: &str) -> Option<(String, u16)> {
+    let (address, port) = value.split_once(':')?;
+    let port = u16::from_str_radix(port, 16).ok()?;
+    if port == 0 {
+        return None;
+    }
+    if protocol == "tcp" {
+        let raw = u32::from_str_radix(address, 16).ok()?;
+        return Some((Ipv4Addr::from(raw.swap_bytes()).to_string(), port));
+    }
+    if address.len() != 32 {
+        return None;
+    }
+    let mut octets = [0_u8; 16];
+    for (word_index, chunk) in address.as_bytes().chunks_exact(8).enumerate() {
+        let chunk = std::str::from_utf8(chunk).ok()?;
+        let word = u32::from_str_radix(chunk, 16).ok()?.swap_bytes();
+        octets[word_index * 4..word_index * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    Some((Ipv6Addr::from(octets).to_string(), port))
 }
 
 fn read_identity(pid: u32) -> ReadIdentity {

--- a/packages/native/native/src/platform/process/macos/mod.rs
+++ b/packages/native/native/src/platform/process/macos/mod.rs
@@ -1,6 +1,10 @@
 use std::ffi::{c_int, c_void};
 use std::mem::size_of;
 
+use netstat2::{AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo, TcpState, get_sockets_info};
+
+use super::TcpListenerInfo;
+
 use crate::process::{InspectionResult, ManagedTarget, TerminationMethod, TerminationResult};
 
 const PROC_PIDTBSDINFO: c_int = 3;
@@ -100,6 +104,53 @@ pub(crate) fn terminate(target: &ManagedTarget, signal: &str) -> TerminationResu
         }
     }
     super::signal_target(target, signal)
+}
+
+pub(crate) fn inspect_tcp_listeners(port: Option<u16>) -> Result<Vec<TcpListenerInfo>, String> {
+    let sockets = get_sockets_info(
+        AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6,
+        ProtocolFlags::TCP,
+    )
+    .map_err(|error| error.to_string())?;
+    let mut listeners = Vec::new();
+    for socket in sockets {
+        let ProtocolSocketInfo::Tcp(tcp) = socket.protocol_socket_info else {
+            continue;
+        };
+        if tcp.state != TcpState::Listen || port.is_some_and(|expected| expected != tcp.local_port)
+        {
+            continue;
+        }
+        for pid in socket.associated_pids {
+            let ReadIdentity::Found(info) = read_identity(pid) else {
+                continue;
+            };
+            listeners.push(TcpListenerInfo {
+                protocol: if tcp.local_addr.is_ipv6() {
+                    "tcp6"
+                } else {
+                    "tcp"
+                },
+                address: tcp.local_addr.to_string(),
+                port: tcp.local_port,
+                pid,
+                process_group_id: Some(info.pbi_pgid),
+                identity: identity_value(&info),
+                process_name: c_string(&info.pbi_name),
+            });
+        }
+    }
+    Ok(listeners)
+}
+
+fn c_string(value: &[u8]) -> Option<String> {
+    let end = value
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(value.len());
+    String::from_utf8(value[..end].to_vec())
+        .ok()
+        .filter(|value| !value.is_empty())
 }
 
 fn identity_value(value: &ProcBsdInfo) -> String {

--- a/packages/native/native/src/platform/process/mod.rs
+++ b/packages/native/native/src/platform/process/mod.rs
@@ -14,12 +14,21 @@ use std::os::unix::process::CommandExt;
 
 #[cfg(unix)]
 use crate::process::EnforcementMode;
-#[cfg(unix)]
-use crate::process::TerminationMethod;
 use crate::process::{
     Containment, EnforcementEntry, ExitReason, InspectionResult, ManagedTarget, ResourcePolicy,
-    TerminationResult,
+    TerminationMethod, TerminationResult,
 };
+
+#[derive(Clone, Debug)]
+pub(crate) struct TcpListenerInfo {
+    pub(crate) protocol: &'static str,
+    pub(crate) address: String,
+    pub(crate) port: u16,
+    pub(crate) pid: u32,
+    pub(crate) process_group_id: Option<u32>,
+    pub(crate) identity: String,
+    pub(crate) process_name: Option<String>,
+}
 
 pub(crate) struct SpawnedChild {
     pub(crate) child: Child,
@@ -83,6 +92,8 @@ pub(crate) fn capabilities() -> Vec<String> {
         "bounded-output-queue".to_string(),
         "async-process-io".to_string(),
         "managed-resource-policy".to_string(),
+        "tcp-listener-inspection".to_string(),
+        "tcp-listener-termination".to_string(),
     ];
     #[cfg(unix)]
     {
@@ -257,14 +268,55 @@ pub(crate) fn terminate(target: &ManagedTarget, signal: &str) -> TerminationResu
     platform_terminate(target, signal)
 }
 
+pub(crate) fn inspect_tcp_listeners(port: Option<u16>) -> Result<Vec<TcpListenerInfo>, String> {
+    platform_inspect_tcp_listeners(port)
+}
+
+pub(crate) fn terminate_tcp_listener(
+    listener: &TcpListenerInfo,
+    signal: &str,
+) -> TerminationResult {
+    let current = match platform_inspect_tcp_listeners(Some(listener.port)) {
+        Ok(current) => current,
+        Err(error) => {
+            return TerminationResult::not_attempted(TerminationMethod::None, Some(error));
+        }
+    };
+    if !current.iter().any(|candidate| {
+        candidate.pid == listener.pid
+            && candidate.identity == listener.identity
+            && candidate.port == listener.port
+    }) {
+        return TerminationResult::not_attempted(
+            TerminationMethod::None,
+            Some("TCP listener identity no longer matches".to_string()),
+        );
+    }
+    platform_terminate(
+        &ManagedTarget {
+            pid: listener.pid,
+            process_group_id: None,
+            containment: Containment::ProcessGroup,
+            identity: listener.identity.clone(),
+        },
+        signal,
+    )
+}
+
+#[cfg(target_os = "linux")]
+use linux::inspect_tcp_listeners as platform_inspect_tcp_listeners;
 #[cfg(target_os = "linux")]
 use linux::{
     identity as platform_identity, inspect as platform_inspect, terminate as platform_terminate,
 };
 #[cfg(target_os = "macos")]
+use macos::inspect_tcp_listeners as platform_inspect_tcp_listeners;
+#[cfg(target_os = "macos")]
 use macos::{
     identity as platform_identity, inspect as platform_inspect, terminate as platform_terminate,
 };
+#[cfg(windows)]
+use windows::inspect_tcp_listeners as platform_inspect_tcp_listeners;
 #[cfg(windows)]
 use windows::{
     identity as platform_identity, inspect as platform_inspect, terminate as platform_terminate,

--- a/packages/native/native/src/platform/process/windows/mod.rs
+++ b/packages/native/native/src/platform/process/windows/mod.rs
@@ -1,6 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::os::windows::process::CommandExt;
 
+use netstat2::{AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo, TcpState, get_sockets_info};
+
+use super::TcpListenerInfo;
+
 use tokio::process::{Child, Command};
 
 use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, HANDLE, INVALID_HANDLE_VALUE};
@@ -204,6 +208,45 @@ pub(crate) fn inspect(target: &ManagedTarget) -> InspectionResult {
         }
         OpenedProcess::Found(_, _, true) => InspectionResult::alive(),
     }
+}
+
+pub(crate) fn inspect_tcp_listeners(port: Option<u16>) -> Result<Vec<TcpListenerInfo>, String> {
+    let sockets = get_sockets_info(
+        AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6,
+        ProtocolFlags::TCP,
+    )
+    .map_err(|error| error.to_string())?;
+    let mut listeners = Vec::new();
+    for socket in sockets {
+        let ProtocolSocketInfo::Tcp(tcp) = socket.protocol_socket_info else {
+            continue;
+        };
+        if tcp.state != TcpState::Listen || port.is_some_and(|expected| expected != tcp.local_port)
+        {
+            continue;
+        }
+        for pid in socket.associated_pids {
+            let OpenedProcess::Found(_, identity, true) =
+                open_process_with_identity(pid, PROCESS_QUERY_LIMITED_INFORMATION)
+            else {
+                continue;
+            };
+            listeners.push(TcpListenerInfo {
+                protocol: if tcp.local_addr.is_ipv6() {
+                    "tcp6"
+                } else {
+                    "tcp"
+                },
+                address: tcp.local_addr.to_string(),
+                port: tcp.local_port,
+                pid,
+                process_group_id: None,
+                identity,
+                process_name: None,
+            });
+        }
+    }
+    Ok(listeners)
 }
 
 pub(crate) fn terminate(target: &ManagedTarget, _signal: &str) -> TerminationResult {

--- a/packages/native/src/process/managed-process.ts
+++ b/packages/native/src/process/managed-process.ts
@@ -14,12 +14,28 @@ import type {
   ManagedProcessRuntimeOptions,
   ManagedTarget,
   TerminationResult,
+  TcpListenerProcess,
 } from "./types.js";
 
 export function configureManagedProcessRuntime(
   options: ManagedProcessRuntimeOptions,
 ): void {
   binding.configureManagedProcessRuntime(options);
+}
+
+export function inspectTcpListeners(port?: number): TcpListenerProcess[] {
+  return binding.inspectTcpListeners(port);
+}
+
+export async function terminateTcpListener(
+  listener: TcpListenerProcess,
+  signal: NodeJS.Signals = "SIGTERM",
+): Promise<TerminationResult> {
+  try {
+    return binding.terminateTcpListener(listener, signal);
+  } catch (error) {
+    return failedTermination(error);
+  }
 }
 
 export function inspectManagedTarget(target: ManagedTarget): InspectionResult {

--- a/packages/native/src/process/native-contract.ts
+++ b/packages/native/src/process/native-contract.ts
@@ -6,6 +6,7 @@ import type {
   ManagedTarget,
   NativeContainment,
   TerminationResult,
+  TcpListenerProcess,
 } from "./types.js";
 
 export interface NativeOutputEvent {
@@ -33,6 +34,11 @@ export interface NativeProcessHandle {
 }
 
 export interface ProcessNativeBinding {
+  inspectTcpListeners(port?: number): TcpListenerProcess[];
+  terminateTcpListener(
+    listener: TcpListenerProcess,
+    signal?: string,
+  ): TerminationResult;
   inspectManagedTarget(target: ManagedTarget): InspectionResult;
   terminateManagedTarget(
     target: ManagedTarget,

--- a/packages/native/src/process/types.ts
+++ b/packages/native/src/process/types.ts
@@ -8,6 +8,16 @@ export type TerminationMethod =
   | "direct-child"
   | "none";
 
+export interface TcpListenerProcess {
+  protocol: "tcp" | "tcp6";
+  address: string;
+  port: number;
+  pid: number;
+  processGroupId?: number;
+  identity: string;
+  processName?: string;
+}
+
 export interface ManagedTarget {
   pid: number;
   processGroupId?: number;

--- a/packages/native/test/managed-process.test.ts
+++ b/packages/native/test/managed-process.test.ts
@@ -8,9 +8,11 @@ import { pathToFileURL } from "node:url";
 import {
   configureManagedProcessRuntime,
   inspectManagedTarget,
+  inspectTcpListeners,
   nativeRuntimeCapabilities,
   spawnManagedProcess,
   terminateManagedTarget,
+  terminateTcpListener,
 } from "../src/index.js";
 
 const node = process.execPath;
@@ -277,6 +279,40 @@ describe("native managed process facade", () => {
     const terminated = await terminateManagedTarget(managed.target, "SIGKILL");
     assert.equal(terminated.terminated, true);
     await managed.closed;
+  });
+
+  it("discovers and identity-checks TCP listener termination", async () => {
+    const managed = spawnManagedProcess(node, [
+      "-e",
+      "const n=require('node:net');const s=n.createServer();s.listen(0,'127.0.0.1',()=>console.log(s.address().port));setInterval(()=>{},1000)",
+    ]);
+    const port = await new Promise<number>((resolve, reject) => {
+      managed.stdout.once("data", (chunk: Buffer) =>
+        resolve(Number(String(chunk).trim())),
+      );
+      managed.stderr.once("data", (chunk: Buffer) =>
+        reject(new Error(String(chunk))),
+      );
+    });
+    const listener = inspectTcpListeners(port).find(
+      (candidate) => candidate.pid === managed.pid,
+    );
+    assert.ok(listener);
+    const stale = await terminateTcpListener(
+      { ...listener, identity: `${listener.identity}-stale` },
+      "SIGKILL",
+    );
+    assert.equal(stale.terminated, false);
+    assert.match(stale.error ?? "", /identity/i);
+    const terminated = await terminateTcpListener(listener, "SIGKILL");
+    assert.equal(terminated.terminated, true);
+    await managed.exited;
+    assert.equal(
+      inspectTcpListeners(port).some(
+        (candidate) => candidate.pid === managed.pid,
+      ),
+      false,
+    );
   });
 
   it("observes exit before inherited pipes close", async () => {

--- a/packages/workbench-app/src/lib/features/tasks/api/tasks.api.ts
+++ b/packages/workbench-app/src/lib/features/tasks/api/tasks.api.ts
@@ -3,6 +3,7 @@ import type {
   StartTaskRequest,
   TaskLogQuery,
   TaskLogQueryResponse,
+  TaskPortConflictListener,
   TaskRecord,
 } from "@nervekit/contracts";
 import { apiGet, apiPathSegment } from "@nervekit/ui-kit/core/api/client";
@@ -27,9 +28,14 @@ export async function startTask(body: StartTaskRequest): Promise<TaskRecord> {
 
 export async function launchTaskDefinition(
   definitionId: string,
-): Promise<{ task: TaskRecord; disposition: "started" | "focused_existing" }> {
-  return (await protocolRequest("task.launchDefinition", { definitionId }))
-    .result;
+  terminateListeners?: TaskPortConflictListener[],
+) {
+  return (
+    await protocolRequest("task.launchDefinition", {
+      definitionId,
+      terminateListeners,
+    })
+  ).result;
 }
 
 export async function cancelTask(

--- a/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/tasks/state/workbench-task-panel-adapter.svelte.ts
@@ -73,6 +73,7 @@ export function createWorkbenchTaskPanelAdapter(
 ): { readonly model: TaskPanelModel; readonly actions: TaskPanelActions } {
   let loadingDefinitions = $state(false);
   let runningDefinitionId = $state<string | undefined>(undefined);
+  let portConflict = $state<TaskPanelModel["portConflict"]>(undefined);
   const definitionRevalidation = createTaskDefinitionRevalidationGate();
   const definitions = $derived(
     cachedTaskDefinitions(activeProject()?.id) ?? [],
@@ -105,6 +106,7 @@ export function createWorkbenchTaskPanelAdapter(
         defaultCwd: project?.dir ?? "",
         definitionsLoading: loadingDefinitions,
         runningDefinitionId,
+        portConflict,
         capabilities: {
           start:
             project && hostActions.runCommand ? enabledCapability : noRunner,
@@ -134,6 +136,37 @@ export function createWorkbenchTaskPanelAdapter(
     return definitions.find((item) => item.id === definition.id);
   }
 
+  async function launchDefinition(
+    definition: TaskPanelDefinition,
+    terminateListeners?: import("@nervekit/contracts").TaskPortConflictListener[],
+  ): Promise<void> {
+    const project = activeProject();
+    if (!project) return;
+    runningDefinitionId = definition.id;
+    try {
+      const result = await launchTaskDefinition(
+        definition.id,
+        terminateListeners,
+      );
+      if (result.disposition === "port_conflict") {
+        portConflict = { definition, ...result.conflict };
+        return;
+      }
+      portConflict = undefined;
+      await loadWorkspaceState();
+      notify.success(
+        result.disposition === "focused_existing"
+          ? "Task is already running"
+          : "Task started",
+        { description: definition.label ?? definition.command },
+      );
+    } catch (error) {
+      showCriticalError("Could not run task", errorMessage(error));
+    } finally {
+      runningDefinitionId = undefined;
+    }
+  }
+
   const host: TaskPanelActions = {
     selectTask: async (taskId) => {
       taskState.selectedTaskId = taskId;
@@ -155,24 +188,14 @@ export function createWorkbenchTaskPanelAdapter(
         name: request.name,
       });
     },
-    runDefinition: async (definition) => {
-      const project = activeProject();
-      if (!project) return;
-      runningDefinitionId = definition.id;
-      try {
-        const result = await launchTaskDefinition(definition.id);
-        await loadWorkspaceState();
-        notify.success(
-          result.disposition === "focused_existing"
-            ? "Task is already running"
-            : "Task started",
-          { description: definition.label ?? definition.command },
-        );
-      } catch (error) {
-        showCriticalError("Could not run task", errorMessage(error));
-      } finally {
-        runningDefinitionId = undefined;
-      }
+    runDefinition: (definition) => launchDefinition(definition),
+    confirmPortConflict: () => {
+      const pending = portConflict;
+      if (!pending) return;
+      return launchDefinition(pending.definition, [...pending.listeners]);
+    },
+    dismissPortConflict: () => {
+      portConflict = undefined;
     },
     cancelTask: (id, request) => hostActions.cancelTask?.(id, request),
     forceKillTask: (id) =>

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionDialog.svelte
@@ -14,7 +14,7 @@ import type { TaskPanelDefinition } from "./task-panel-types";
 type Props = {
   open?: boolean;
   definition?: TaskPanelDefinition;
-  initial?: { label?: string; command: string; cwd?: string };
+  initial?: { label?: string; command: string; cwd?: string; port?: number };
   projectCwd?: string;
   saving?: boolean;
   title?: string;
@@ -42,6 +42,7 @@ let {
 let label = $state("");
 let commandText = $state("");
 let cwd = $state("");
+let port = $state<number | undefined>(undefined);
 let runPolicy = $state<"single" | "concurrent">("single");
 
 const dialogTitle = $derived(
@@ -56,7 +57,10 @@ const dialogDescription = $derived(
 const dialogSubmitLabel = $derived(
   submitLabel ?? (definition ? "Save task" : "Create task"),
 );
-const canSave = $derived(!saving && commandText.trim().length > 0);
+const portValid = $derived(
+  port === undefined || (Number.isInteger(port) && port >= 1 && port <= 65_535),
+);
+const canSave = $derived(!saving && commandText.trim().length > 0 && portValid);
 
 $effect(() => {
   if (!open) return;
@@ -64,6 +68,7 @@ $effect(() => {
   label = source?.label ?? "";
   commandText = source?.command ?? "";
   cwd = source?.cwd ?? "";
+  port = source?.port;
   runPolicy = definition?.runPolicy ?? "single";
 });
 
@@ -75,6 +80,7 @@ function submit() {
     command: commandText.trim(),
     ...(nextLabel.length > 0 ? { label: nextLabel } : {}),
     ...(nextCwd.length > 0 ? { cwd: nextCwd } : {}),
+    ...(port === undefined ? {} : { port }),
     runPolicy,
   });
 }
@@ -110,6 +116,23 @@ function submit() {
       />
       <p class="text-xs text-muted-foreground">
         This is the shell command run by the play button.
+      </p>
+    </div>
+
+    <div class="grid gap-1.5">
+      <Label for="task-definition-port">Port</Label>
+      <Input
+        id="task-definition-port"
+        bind:value={port}
+        type="number"
+        min="1"
+        max="65535"
+        placeholder="3000"
+        disabled={saving}
+        aria-invalid={!portValid}
+      />
+      <p class="text-xs text-muted-foreground">
+        Optional TCP port to check before this task starts.
       </p>
     </div>
 

--- a/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TaskDefinitionRow.svelte
@@ -56,6 +56,7 @@ const status = $derived(latest?.status ?? "saved");
 const label = $derived(taskDefinitionLabel(entry));
 const command = $derived(entry.definition.command);
 const cwd = $derived(entry.definition.cwd);
+const port = $derived(entry.definition.port);
 const concurrent = $derived(entry.definition.runPolicy === "concurrent");
 const canStart = $derived(concurrent || entry.activeRuns.length === 0);
 const activeRun = $derived(entry.activeRuns[0]);
@@ -70,7 +71,9 @@ const recoveryHint = $derived(
     : undefined,
 );
 const tooltip = $derived(
-  [command, cwd, recoveryHint].filter(Boolean).join("\n"),
+  [command, cwd, port ? `TCP port ${port}` : undefined, recoveryHint]
+    .filter(Boolean)
+    .join("\n"),
 );
 const runLabel = $derived(
   concurrent && activeRun ? "Start another run" : "Run task",

--- a/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tasks/TasksPanelView.svelte
@@ -78,6 +78,19 @@ let runsDialogOpen = $state(false);
 // The wide bottom dock can host the run output next to the list.
 const SPLIT_MIN_WIDTH = 720;
 const splitLayout = $derived(panelWidth >= SPLIT_MIN_WIDTH);
+const portConflictDescription = $derived.by(() => {
+  const conflict = model.portConflict;
+  if (!conflict) return "";
+  const processes = [
+    ...new Map(
+      conflict.listeners.map((listener) => [
+        `${listener.pid}|${listener.identity}`,
+        `${listener.processName ?? "Process"} (PID ${listener.pid})`,
+      ]),
+    ).values(),
+  ];
+  return `${processes.join(", ")} is listening on TCP port ${conflict.port}. Terminate ${processes.length === 1 ? "it" : "them"} and run this task?`;
+});
 const prunableRuns = $derived(
   projected.runs.filter((entry) => entry.isRemovable).length,
 );
@@ -371,6 +384,18 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
     void createDefinition({ ...input, sourceTaskId: saveSourceTask.id })}
   onOpenChange={(open) => {
     if (!open) saveSourceTask = undefined;
+  }}
+/>
+<ConfirmDialog
+  open={Boolean(model.portConflict)}
+  destructive
+  title="Port already in use"
+  description={portConflictDescription}
+  confirmLabel="Terminate and run"
+  onConfirm={() => void panelActions.confirmPortConflict()}
+  onCancel={() => void panelActions.dismissPortConflict()}
+  onOpenChange={(open) => {
+    if (!open) void panelActions.dismissPortConflict();
   }}
 />
 <ConfirmDialog

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-controller.ts
@@ -71,6 +71,7 @@ export function normalizeTaskDefinition(
     label: definition.label,
     command: definition.command,
     cwd: definition.cwd,
+    port: definition.port,
     createdAt: definition.createdAt,
     updatedAt: definition.updatedAt,
     runPolicy: definition.runPolicy,
@@ -270,6 +271,10 @@ export function createTaskPanelActions(
     runDefinition: (definition) => {
       if (enabled("start")) return host.runDefinition(definition);
     },
+    confirmPortConflict: () => {
+      if (enabled("start")) return host.confirmPortConflict();
+    },
+    dismissPortConflict: () => host.dismissPortConflict(),
     cancelTask: (taskId, request) => {
       if (enabled("cancel")) return host.cancelTask(taskId, request);
     },

--- a/packages/workbench-app/src/lib/presentation/tasks/task-panel-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tasks/task-panel-types.ts
@@ -4,6 +4,7 @@ import type {
   StartTaskRequest,
   TaskLogQuery,
   TaskLogQueryResponse,
+  TaskPortConflictListener,
   TaskRecord,
   UpdateTaskDefinitionRequest,
 } from "@nervekit/contracts";
@@ -14,6 +15,7 @@ export interface TaskPanelDefinition {
   readonly label?: string;
   readonly command: string;
   readonly cwd?: string;
+  readonly port?: number;
   readonly createdAt: string;
   readonly updatedAt: string;
   readonly runPolicy: "single" | "concurrent";
@@ -77,6 +79,11 @@ export interface TaskPanelModel {
   readonly defaultCwd: string;
   readonly definitionsLoading: boolean;
   readonly runningDefinitionId?: string;
+  readonly portConflict?: {
+    readonly definition: TaskPanelDefinition;
+    readonly port: number;
+    readonly listeners: readonly TaskPortConflictListener[];
+  };
   readonly capabilities: TaskPanelCapabilities;
 }
 
@@ -87,6 +94,8 @@ export interface TaskPanelActions {
   readonly runDefinition: (
     definition: TaskPanelDefinition,
   ) => void | Promise<void>;
+  readonly confirmPortConflict: () => void | Promise<void>;
+  readonly dismissPortConflict: () => void | Promise<void>;
   readonly cancelTask: (
     taskId: string,
     request?: CancelTaskRequest,

--- a/packages/workbench-server/src/domains/task-definitions/task-definition.service.ts
+++ b/packages/workbench-server/src/domains/task-definitions/task-definition.service.ts
@@ -43,6 +43,7 @@ export class TaskDefinitionService {
       label: request.label,
       command: request.command,
       cwd: request.cwd,
+      port: request.port,
       runPolicy: request.runPolicy,
       createdAt: now,
       updatedAt: now,
@@ -69,6 +70,7 @@ export class TaskDefinitionService {
       label: request.label,
       command: request.command,
       cwd: request.cwd,
+      port: request.port,
       runPolicy: request.runPolicy,
       updatedAt: new Date().toISOString(),
     };

--- a/packages/workbench-server/src/domains/tasks/task-definition-launch.ts
+++ b/packages/workbench-server/src/domains/tasks/task-definition-launch.ts
@@ -1,0 +1,31 @@
+import type { TaskPortConflictListener, TaskRecord } from "@nervekit/contracts";
+
+export type TaskDefinitionLaunchOutcome =
+  | {
+      readonly disposition: "started" | "focused_existing";
+      readonly task: TaskRecord;
+    }
+  | {
+      readonly disposition: "port_conflict";
+      readonly conflict: {
+        readonly port: number;
+        readonly listeners: TaskPortConflictListener[];
+      };
+    };
+
+export async function inspectDefinitionPort(
+  guard: TaskDefinitionPortGuard | undefined,
+  port: number | undefined,
+  approvedListeners?: readonly TaskPortConflictListener[],
+): Promise<TaskPortConflictListener[]> {
+  if (port === undefined) return [];
+  if (!guard) throw new Error("Task port inspection is unavailable");
+  return guard.prepare(port, approvedListeners);
+}
+
+export interface TaskDefinitionPortGuard {
+  prepare(
+    port: number,
+    approvedListeners?: readonly TaskPortConflictListener[],
+  ): Promise<TaskPortConflictListener[]>;
+}

--- a/packages/workbench-server/src/domains/tasks/task-port-inspector.ts
+++ b/packages/workbench-server/src/domains/tasks/task-port-inspector.ts
@@ -1,51 +1,45 @@
-import { spawn } from "node:child_process";
-import { readdir, readFile, readlink } from "node:fs/promises";
-import { join } from "node:path";
-import type { TaskListeningPort, TaskRuntime } from "@nervekit/contracts";
+import type {
+  TaskListeningPort,
+  TaskPortConflictListener,
+  TaskRuntime,
+} from "@nervekit/contracts";
+import {
+  inspectTcpListeners,
+  terminateTcpListener,
+  type TcpListenerProcess,
+  type TerminationResult,
+} from "@nervekit/native";
 
 export interface TaskPortInspector {
   inspectRuntime(runtime: TaskRuntime): Promise<TaskListeningPort[]>;
   inspectListeners(ports: TaskListeningPort[]): Promise<TaskListeningPort[]>;
+  inspectPort(port: number): Promise<TaskPortConflictListener[]>;
+  terminateListener(
+    listener: TaskPortConflictListener,
+    signal: "SIGTERM" | "SIGKILL",
+  ): Promise<TerminationResult>;
 }
 
 export const defaultTaskPortInspector: TaskPortInspector = {
   inspectRuntime: inspectRuntimeListeningPorts,
   inspectListeners: inspectPortListeners,
+  inspectPort: inspectConfiguredPort,
+  terminateListener: terminateConfiguredPortListener,
 };
-
-const LISTEN_STATE = "0A";
-const PROC_ROOT = "/proc";
-
-interface ProcSocket {
-  protocol: "tcp" | "tcp6";
-  address: string;
-  port: number;
-  inode: string;
-}
-
-interface ProcIdentity {
-  pid: number;
-  processGroupId?: number;
-  processStartTimeTicks?: number;
-}
 
 export async function inspectRuntimeListeningPorts(
   runtime: TaskRuntime,
   now = new Date(),
 ): Promise<TaskListeningPort[]> {
   if (runtime.platform !== process.platform || !runtime.childPid) return [];
-  if (process.platform === "darwin") return inspectDarwinPorts(runtime, now);
-  if (process.platform === "win32") return inspectWindowsPorts(runtime, now);
-  if (process.platform !== "linux") return [];
-
-  const ports = await inspectAllListeningPorts(now);
   return dedupeListeningPorts(
-    ports.filter((port) => {
-      if (runtime.processGroupId) {
-        return port.processGroupId === runtime.processGroupId;
-      }
-      return port.pid === runtime.childPid;
-    }),
+    inspectTcpListeners()
+      .filter((listener) =>
+        runtime.processGroupId
+          ? listener.processGroupId === runtime.processGroupId
+          : listener.pid === runtime.childPid,
+      )
+      .map((listener) => taskListeningPort(listener, now)),
   );
 }
 
@@ -53,16 +47,42 @@ export async function inspectPortListeners(
   ports: TaskListeningPort[],
   now = new Date(),
 ): Promise<TaskListeningPort[]> {
-  if (process.platform !== "linux" || ports.length === 0) return [];
+  if (ports.length === 0) return [];
   const expected = new Set(
     ports.map((port) => endpointKey(port.protocol, port.address, port.port)),
   );
-  const current = await inspectAllListeningPorts(now);
+  const listeners = await inspectPorts([
+    ...new Set(ports.map(({ port }) => port)),
+  ]);
   return dedupeListeningPorts(
-    current.filter((port) =>
-      expected.has(endpointKey(port.protocol, port.address, port.port)),
-    ),
+    listeners
+      .filter((listener) =>
+        expected.has(
+          endpointKey(listener.protocol, listener.address, listener.port),
+        ),
+      )
+      .map((listener) => taskListeningPort(listener, now)),
   );
+}
+
+export async function inspectConfiguredPort(
+  port: number,
+): Promise<TaskPortConflictListener[]> {
+  return inspectTcpListeners(port).map((listener) => ({
+    protocol: listener.protocol,
+    address: listener.address,
+    port: listener.port,
+    pid: listener.pid,
+    identity: listener.identity,
+    processName: listener.processName,
+  }));
+}
+
+export async function terminateConfiguredPortListener(
+  listener: TaskPortConflictListener,
+  signal: "SIGTERM" | "SIGKILL",
+): Promise<TerminationResult> {
+  return terminateTcpListener(listener, signal);
 }
 
 export function isSameProcessIdentity(
@@ -118,335 +138,33 @@ export function formatListeningPort(port: TaskListeningPort): string {
   return `${host}:${port.port}/${port.protocol}`;
 }
 
-async function inspectAllListeningPorts(
-  now = new Date(),
-): Promise<TaskListeningPort[]> {
-  const sockets = await readListeningSockets();
-  if (sockets.size === 0) return [];
-
-  const detectedAt = now.toISOString();
-  const ports: TaskListeningPort[] = [];
-  for (const identity of await readProcSocketOwners(sockets)) {
-    for (const socket of identity.sockets) {
-      ports.push({
-        protocol: socket.protocol,
-        address: socket.address,
-        port: socket.port,
-        pid: identity.pid,
-        processGroupId: identity.processGroupId,
-        processStartTimeTicks: identity.processStartTimeTicks,
-        detectedAt,
-      });
-    }
-  }
-  return dedupeListeningPorts(ports);
-}
-
-async function readListeningSockets(): Promise<Map<string, ProcSocket>> {
-  const sockets = new Map<string, ProcSocket>();
-  await Promise.all([
-    readProcNetTcp("tcp").then((rows) => {
-      for (const row of rows) sockets.set(row.inode, row);
-    }),
-    readProcNetTcp("tcp6").then((rows) => {
-      for (const row of rows) sockets.set(row.inode, row);
-    }),
-  ]);
-  return sockets;
-}
-
-async function readProcNetTcp(protocol: "tcp" | "tcp6"): Promise<ProcSocket[]> {
-  let content: string;
-  try {
-    content = await readFile(join(PROC_ROOT, "net", protocol), "utf8");
-  } catch {
-    return [];
-  }
-
-  const rows: ProcSocket[] = [];
-  for (const line of content.split("\n").slice(1)) {
-    const columns = line.trim().split(/\s+/);
-    if (columns.length < 10) continue;
-    const localAddress = columns[1];
-    const state = columns[3];
-    const inode = columns[9];
-    if (!localAddress || state !== LISTEN_STATE || !inode || inode === "0") {
-      continue;
-    }
-    const parsed = parseProcNetLocalAddress(protocol, localAddress);
-    if (!parsed) continue;
-    rows.push({ protocol, inode, ...parsed });
-  }
-  return rows;
-}
-
-async function readProcSocketOwners(
-  sockets: Map<string, ProcSocket>,
-): Promise<Array<ProcIdentity & { sockets: ProcSocket[] }>> {
-  let entries: string[];
-  try {
-    entries = await readdir(PROC_ROOT);
-  } catch {
-    return [];
-  }
-
-  const owners: Array<ProcIdentity & { sockets: ProcSocket[] }> = [];
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (!/^\d+$/.test(entry)) return;
-      const pid = Number(entry);
-      const identity = await readProcIdentity(pid);
-      if (!identity) return;
-      const owned = await readProcessSockets(pid, sockets);
-      if (owned.length === 0) return;
-      owners.push({ ...identity, sockets: owned });
-    }),
+async function inspectPorts(ports: number[]): Promise<TcpListenerProcess[]> {
+  const listeners = await Promise.all(
+    ports.map(async (port) => inspectTcpListeners(port)),
   );
-  return owners;
+  return listeners.flat();
 }
 
-async function readProcessSockets(
-  pid: number,
-  sockets: Map<string, ProcSocket>,
-): Promise<ProcSocket[]> {
-  const fdDir = join(PROC_ROOT, String(pid), "fd");
-  let fds: string[];
-  try {
-    fds = await readdir(fdDir);
-  } catch {
-    return [];
-  }
-
-  const owned = new Map<string, ProcSocket>();
-  await Promise.all(
-    fds.map(async (fd) => {
-      let target: string;
-      try {
-        target = await readlink(join(fdDir, fd));
-      } catch {
-        return;
-      }
-      const inode = socketInode(target);
-      if (!inode) return;
-      const socket = sockets.get(inode);
-      if (socket) owned.set(inode, socket);
-    }),
-  );
-  return [...owned.values()];
-}
-
-async function readProcIdentity(
-  pid: number,
-): Promise<ProcIdentity | undefined> {
-  let stat: string;
-  try {
-    stat = await readFile(join(PROC_ROOT, String(pid), "stat"), "utf8");
-  } catch {
-    return undefined;
-  }
-  const closeParen = stat.lastIndexOf(")");
-  if (closeParen < 0) return { pid };
-  const fields = stat
-    .slice(closeParen + 2)
-    .trim()
-    .split(/\s+/);
-  const processGroupId = positiveNumber(fields[2]);
-  const processStartTimeTicks = nonNegativeNumber(fields[19]);
-  return { pid, processGroupId, processStartTimeTicks };
-}
-
-function parseProcNetLocalAddress(
-  protocol: "tcp" | "tcp6",
-  value: string,
-): { address: string; port: number } | undefined {
-  const [addressHex, portHex] = value.split(":");
-  if (!addressHex || !portHex) return undefined;
-  const port = Number.parseInt(portHex, 16);
-  if (!Number.isInteger(port) || port <= 0 || port > 65_535) return undefined;
-  const address =
-    protocol === "tcp"
-      ? parseIpv4ProcAddress(addressHex)
-      : parseIpv6ProcAddress(addressHex);
-  return address ? { address, port } : undefined;
-}
-
-function parseIpv4ProcAddress(hex: string): string | undefined {
-  if (!/^[0-9A-Fa-f]{8}$/.test(hex)) return undefined;
-  const bytes = hex
-    .match(/../g)
-    ?.reverse()
-    .map((byte) => Number.parseInt(byte, 16));
-  if (!bytes || bytes.some((byte) => !Number.isInteger(byte))) return undefined;
-  return bytes.join(".");
-}
-
-function parseIpv6ProcAddress(hex: string): string | undefined {
-  if (!/^[0-9A-Fa-f]{32}$/.test(hex)) return undefined;
-  const bytes: number[] = [];
-  for (let i = 0; i < hex.length; i += 8) {
-    const word = hex.slice(i, i + 8);
-    const wordBytes = word.match(/../g)?.reverse() ?? [];
-    for (const byte of wordBytes) bytes.push(Number.parseInt(byte, 16));
-  }
-  if (bytes.length !== 16 || bytes.some((byte) => !Number.isInteger(byte))) {
-    return undefined;
-  }
-  const groups: string[] = [];
-  for (let i = 0; i < bytes.length; i += 2) {
-    groups.push((((bytes[i] ?? 0) << 8) | (bytes[i + 1] ?? 0)).toString(16));
-  }
-  return compressIpv6(groups);
-}
-
-function compressIpv6(groups: string[]): string {
-  let bestStart = -1;
-  let bestLength = 0;
-  for (let i = 0; i < groups.length;) {
-    if (groups[i] !== "0") {
-      i += 1;
-      continue;
-    }
-    let end = i;
-    while (end < groups.length && groups[end] === "0") end += 1;
-    const length = end - i;
-    if (length > bestLength && length > 1) {
-      bestStart = i;
-      bestLength = length;
-    }
-    i = end;
-  }
-  if (bestStart < 0) return groups.join(":");
-  const before = groups.slice(0, bestStart).join(":");
-  const after = groups.slice(bestStart + bestLength).join(":");
-  if (!before && !after) return "::";
-  if (!before) return `::${after}`;
-  if (!after) return `${before}::`;
-  return `${before}::${after}`;
-}
-
-function socketInode(target: string): string | undefined {
-  const match = /^socket:\[(\d+)\]$/.exec(target);
-  return match?.[1];
-}
-
-function positiveNumber(value: string | undefined): number | undefined {
-  if (!value) return undefined;
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function nonNegativeNumber(value: string | undefined): number | undefined {
-  if (!value) return undefined;
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
-}
-
-async function inspectDarwinPorts(
-  runtime: TaskRuntime,
+function taskListeningPort(
+  listener: TcpListenerProcess,
   now: Date,
-): Promise<TaskListeningPort[]> {
-  const result = await runCommand(
-    "lsof",
-    [
-      "-nP",
-      "-a",
-      "-p",
-      String(runtime.childPid),
-      "-iTCP",
-      "-sTCP:LISTEN",
-      "-F",
-      "n",
-    ],
-    2_000,
-  ).catch(() => undefined);
-  if (!result || result.code !== 0) return [];
-  return dedupeListeningPorts(
-    result.stdout
-      .split("\n")
-      .filter((line) => line.startsWith("n"))
-      .flatMap((line): TaskListeningPort[] => {
-        const match = /(?:\[([^\]]+)\]|([^:]+)):(\d+)$/.exec(line.slice(1));
-        if (!match) return [];
-        return [
-          {
-            protocol: "tcp",
-            address: match[1] ?? match[2] ?? "*",
-            port: Number(match[3]),
-            pid: runtime.childPid,
-            processGroupId: runtime.processGroupId,
-            detectedAt: now.toISOString(),
-          },
-        ];
-      }),
-  );
-}
-
-async function inspectWindowsPorts(
-  runtime: TaskRuntime,
-  now: Date,
-): Promise<TaskListeningPort[]> {
-  const script = `Get-NetTCPConnection -State Listen -OwningProcess ${runtime.childPid} -ErrorAction SilentlyContinue | Select-Object LocalAddress,LocalPort,OwningProcess | ConvertTo-Json -Compress`;
-  const result = await runCommand(
-    "powershell.exe",
-    ["-NoProfile", "-NonInteractive", "-Command", script],
-    3_000,
-  ).catch(() => undefined);
-  if (!result || result.code !== 0 || !result.stdout.trim()) return [];
-  try {
-    const parsed = JSON.parse(result.stdout) as
-      | WindowsListener
-      | WindowsListener[];
-    const rows = Array.isArray(parsed) ? parsed : [parsed];
-    return dedupeListeningPorts(
-      rows.map((row) => ({
-        protocol: row.LocalAddress.includes(":") ? "tcp6" : "tcp",
-        address: row.LocalAddress,
-        port: row.LocalPort,
-        pid: row.OwningProcess,
-        detectedAt: now.toISOString(),
-      })),
-    );
-  } catch {
-    return [];
-  }
-}
-
-interface WindowsListener {
-  LocalAddress: string;
-  LocalPort: number;
-  OwningProcess: number;
-}
-
-async function runCommand(
-  command: string,
-  args: string[],
-  timeoutMs: number,
-): Promise<{ code: number | null; stdout: string }> {
-  return await new Promise((resolve, reject) => {
-    let child;
-    try {
-      child = spawn(command, args, {
-        stdio: ["ignore", "pipe", "ignore"],
-        windowsHide: true,
-      });
-    } catch (error) {
-      reject(error);
-      return;
-    }
-    let stdout = "";
-    child.stdout?.on("data", (chunk: Buffer) => {
-      stdout = `${stdout}${String(chunk)}`.slice(-256 * 1024);
-    });
-    const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
-    child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.once("close", (code) => {
-      clearTimeout(timer);
-      resolve({ code, stdout });
-    });
-  });
+): TaskListeningPort {
+  const processStartTimeTicks = listener.identity.startsWith("linux:")
+    ? Number(listener.identity.slice("linux:".length))
+    : undefined;
+  return {
+    protocol: listener.protocol,
+    address: listener.address,
+    port: listener.port,
+    pid: listener.pid,
+    processGroupId: listener.processGroupId,
+    processStartTimeTicks:
+      Number.isSafeInteger(processStartTimeTicks) &&
+      (processStartTimeTicks ?? -1) >= 0
+        ? processStartTimeTicks
+        : undefined,
+    detectedAt: now.toISOString(),
+  };
 }
 
 function endpointKey(

--- a/packages/workbench-server/src/domains/tasks/task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-service.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type {
   StartTaskRequest,
+  TaskPortConflictListener,
   TaskLogQuery,
   TaskLogQueryResponse,
   TaskOutputRetention,
@@ -13,6 +14,11 @@ import type {
   DomainEventPublisherPort,
   IdPort,
 } from "../../core/ports.js";
+import {
+  inspectDefinitionPort,
+  type TaskDefinitionLaunchOutcome,
+  type TaskDefinitionPortGuard,
+} from "./task-definition-launch.js";
 import { TaskProcessSupervisor } from "./task-process-supervisor.js";
 import { isTerminalTaskStatus } from "./task-status.js";
 
@@ -148,6 +154,7 @@ export interface TaskServicePorts {
   readonly capabilities?: TaskOptionalCapabilitiesPort;
   readonly timers?: TaskTimerPort;
   readonly diagnostics?: DiagnosticPort;
+  readonly definitionPortGuard?: TaskDefinitionPortGuard;
   readonly stopTimeoutMs?: number;
 }
 
@@ -165,7 +172,10 @@ export type TaskStartInput = StartTaskRequest & {
 };
 
 export class TaskService {
-  private readonly definitionLaunches = new Map<string, Promise<TaskRecord>>();
+  private readonly definitionLaunches = new Map<
+    string,
+    Promise<TaskDefinitionLaunchOutcome>
+  >();
   private readonly stopReasons = new Map<string, "cancelled" | "timed_out">();
   private readonly startCallbacks = new Map<
     string,
@@ -330,12 +340,12 @@ export class TaskService {
     request: TaskStartInput & {
       definitionId: string;
       definitionRunPolicy: "single" | "concurrent";
+      definitionPort?: number;
+      terminateListeners?: readonly TaskPortConflictListener[];
     },
-  ): Promise<{
-    task: TaskRecord;
-    disposition: "started" | "focused_existing";
-  }> {
-    if (request.definitionRunPolicy === "concurrent") {
+  ): Promise<TaskDefinitionLaunchOutcome> {
+    const guarded = request.definitionPort !== undefined;
+    if (request.definitionRunPolicy === "concurrent" && !guarded) {
       return { task: await this.start(request), disposition: "started" };
     }
     const active = (await this.list()).find(
@@ -347,12 +357,28 @@ export class TaskService {
     );
     if (active) return { task: active, disposition: "focused_existing" };
     const pending = this.definitionLaunches.get(request.definitionId);
-    if (pending)
-      return { task: await pending, disposition: "focused_existing" };
-    const launch = this.start(request);
+    if (pending) {
+      const outcome = await pending;
+      return outcome.disposition === "started"
+        ? { task: outcome.task, disposition: "focused_existing" }
+        : outcome;
+    }
+    const launch = (async (): Promise<TaskDefinitionLaunchOutcome> => {
+      const listeners = await inspectDefinitionPort(
+        this.ports.definitionPortGuard,
+        request.definitionPort,
+        request.terminateListeners,
+      );
+      return listeners.length > 0 && request.definitionPort !== undefined
+        ? {
+            disposition: "port_conflict",
+            conflict: { port: request.definitionPort, listeners },
+          }
+        : { task: await this.start(request), disposition: "started" };
+    })();
     this.definitionLaunches.set(request.definitionId, launch);
     try {
-      return { task: await launch, disposition: "started" };
+      return await launch;
     } finally {
       if (this.definitionLaunches.get(request.definitionId) === launch)
         this.definitionLaunches.delete(request.definitionId);

--- a/packages/workbench-server/src/domains/tasks/task-supervisor.ts
+++ b/packages/workbench-server/src/domains/tasks/task-supervisor.ts
@@ -67,6 +67,13 @@ export interface TaskSupervisor {
   inspectPortListeners(
     ports: TaskListeningPort[],
   ): Promise<TaskListeningPort[]>;
+  inspectConfiguredPort(
+    port: number,
+  ): Promise<import("@nervekit/contracts").TaskPortConflictListener[]>;
+  terminateConfiguredPortListener(
+    listener: import("@nervekit/contracts").TaskPortConflictListener,
+    signal: "SIGTERM" | "SIGKILL",
+  ): Promise<TerminateTaskResult>;
 }
 
 export function managedTaskShellCommand(
@@ -137,6 +144,9 @@ export function createTaskSupervisor(
       return portInspector.inspectRuntime(runtime);
     },
     inspectPortListeners: (ports) => portInspector.inspectListeners(ports),
+    inspectConfiguredPort: (port) => portInspector.inspectPort(port),
+    terminateConfiguredPortListener: (listener, signal) =>
+      portInspector.terminateListener(listener, signal),
   };
 }
 

--- a/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
+++ b/packages/workbench-server/src/domains/tasks/workbench-task-adapters.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { StringDecoder } from "node:string_decoder";
+import type { TaskDefinitionPortGuard } from "./task-definition-launch.js";
 import type {
   TaskProcessExit,
   TaskServicePorts,
@@ -11,7 +12,11 @@ import type {
   DomainEventPublisherPort,
   PerformanceDiagnosticsPort,
 } from "../../core/ports.js";
-import type { StartTaskRequest, TaskRecord } from "@nervekit/contracts";
+import type {
+  StartTaskRequest,
+  TaskPortConflictListener,
+  TaskRecord,
+} from "@nervekit/contracts";
 import type { ApplicationLogger } from "../../infrastructure/diagnostics/index.js";
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { IndexStore } from "../../infrastructure/index-store/index.js";
@@ -30,6 +35,60 @@ import {
   type TaskSupervisor,
 } from "./task-supervisor.js";
 import { TaskRepository } from "./task.repository.js";
+
+function createDefinitionPortGuard(
+  supervisor: TaskSupervisor,
+): TaskDefinitionPortGuard {
+  const inspect = (port: number) => supervisor.inspectConfiguredPort(port);
+  const key = (listener: TaskPortConflictListener) =>
+    `${listener.pid}|${listener.identity}`;
+  const waitForChange = async (port: number) => {
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const current = await inspect(port);
+      if (current.length === 0) return current;
+    }
+    return inspect(port);
+  };
+
+  return {
+    async prepare(port, approvedListeners) {
+      let current = await inspect(port);
+      if (current.length === 0 || !approvedListeners) return current;
+      const approved = new Set(approvedListeners.map(key));
+      if (current.some((listener) => !approved.has(key(listener)))) {
+        return current;
+      }
+      const unique = [
+        ...new Map(
+          current.map((listener) => [key(listener), listener]),
+        ).values(),
+      ];
+      for (const listener of unique) {
+        const result = await supervisor.terminateConfiguredPortListener(
+          listener,
+          "SIGTERM",
+        );
+        if (result.error) throw new Error(result.error);
+      }
+      current = await waitForChange(port);
+      if (current.length === 0) return current;
+      if (current.some((listener) => !approved.has(key(listener)))) {
+        return current;
+      }
+      for (const listener of [
+        ...new Map(current.map((item) => [key(item), item])).values(),
+      ]) {
+        const result = await supervisor.terminateConfiguredPortListener(
+          listener,
+          "SIGKILL",
+        );
+        if (result.error) throw new Error(result.error);
+      }
+      return waitForChange(port);
+    },
+  };
+}
 
 class WorkbenchReadinessCoordinator {
   private readonly output = new Map<string, string>();
@@ -205,6 +264,7 @@ export function createWorkbenchTaskResources(
       },
     },
     events: eventPublisher,
+    definitionPortGuard: createDefinitionPortGuard(supervisor),
     diagnostics: logger
       ? {
           debug: (message, data) => {

--- a/packages/workbench-server/src/protocol/method-handlers/project-task-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/project-task-method-handlers.ts
@@ -74,7 +74,10 @@ export const projectTaskMethodHandlers = defineWorkbenchMethodHandlers({
     task: await state.registry.startTask(params),
   }),
   "task.launchDefinition": (state, params) =>
-    state.registry.launchTaskDefinition(params.definitionId),
+    state.registry.launchTaskDefinition(
+      params.definitionId,
+      params.terminateListeners,
+    ),
   "task.get": (state, params) => ({
     task: state.registry.getTask(params.taskId),
   }),

--- a/packages/workbench-server/src/runtime/runtime-registry.ts
+++ b/packages/workbench-server/src/runtime/runtime-registry.ts
@@ -791,7 +791,10 @@ export class RuntimeRegistry {
     return this.tasks.startTask(request);
   }
 
-  async launchTaskDefinition(definitionId: string) {
+  async launchTaskDefinition(
+    definitionId: string,
+    terminateListeners?: import("@nervekit/contracts").TaskPortConflictListener[],
+  ) {
     for (const project of this.listProjects()) {
       const definition = (
         await this.services.taskDefinitions.list(project.id)
@@ -800,6 +803,8 @@ export class RuntimeRegistry {
       return this.tasks.launchDefinition({
         definitionId: definition.id,
         definitionRunPolicy: definition.runPolicy,
+        definitionPort: definition.port,
+        terminateListeners,
         projectId: project.id,
         cwd: definition.cwd ?? project.dir,
         command: definition.command,

--- a/packages/workbench-server/test/task-port-inspector.test.ts
+++ b/packages/workbench-server/test/task-port-inspector.test.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:net";
 import { describe, it } from "node:test";
 import type { TaskRuntime } from "@nervekit/contracts";
 import {
+  inspectConfiguredPort,
   inspectRuntimeListeningPorts,
   isSameProcessIdentity,
 } from "../src/domains/tasks/task-port-inspector.js";
@@ -40,6 +41,26 @@ describe("task port inspector", () => {
             port.pid === process.pid,
         ),
       );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("reports configured-port conflicts with a stable process identity", async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    try {
+      const address = server.address();
+      assert.ok(address && typeof address === "object");
+      const listeners = await inspectConfiguredPort(address.port);
+      const listener = listeners.find((item) => item.pid === process.pid);
+      assert.ok(listener);
+      assert.equal(listener.port, address.port);
+      assert.ok(listener.identity.length > 0);
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/packages/workbench-server/test/task-port-inspector.test.ts
+++ b/packages/workbench-server/test/task-port-inspector.test.ts
@@ -19,7 +19,7 @@ function runtime(): TaskRuntime {
 }
 
 describe("task port inspector", () => {
-  it("detects current-process TCP listeners on supported POSIX hosts", async () => {
+  it("detects current-process TCP listeners on supported hosts", async () => {
     const server = createServer();
     await new Promise<void>((resolve) =>
       server.listen(0, "127.0.0.1", resolve),
@@ -28,7 +28,11 @@ describe("task port inspector", () => {
       const address = server.address();
       assert.ok(address && typeof address === "object");
       const ports = await inspectRuntimeListeningPorts(runtime());
-      if (process.platform !== "linux" && process.platform !== "darwin") {
+      if (
+        !(["linux", "darwin", "win32"] as NodeJS.Platform[]).includes(
+          process.platform,
+        )
+      ) {
         assert.deepEqual(ports, []);
         return;
       }

--- a/packages/workbench-server/test/task-service.contract.test.ts
+++ b/packages/workbench-server/test/task-service.contract.test.ts
@@ -75,6 +75,7 @@ function servicePortsForRecords(
     diagnostics?: TaskServicePorts["diagnostics"];
     timers?: TaskServicePorts["timers"];
     clock?: TaskServicePorts["clock"];
+    definitionPortGuard?: TaskServicePorts["definitionPortGuard"];
   } = {},
 ): TaskServicePorts {
   return {
@@ -110,8 +111,53 @@ function servicePortsForRecords(
     ids: { next: () => "task_contract" },
     diagnostics: options.diagnostics,
     timers: options.timers,
+    definitionPortGuard: options.definitionPortGuard,
   };
 }
+
+test("definition launch returns a port conflict and starts only after confirmed release", async () => {
+  const records = new Map<string, TaskRecord>();
+  const events: DomainEventIntent[] = [];
+  const listener = {
+    protocol: "tcp" as const,
+    address: "127.0.0.1",
+    port: 3000,
+    pid: 99,
+    identity: "linux:123",
+    processName: "node",
+  };
+  const approvals: unknown[] = [];
+  const ports = servicePortsForRecords(records, events, {
+    definitionPortGuard: {
+      prepare: async (_port, approved) => {
+        approvals.push(approved);
+        return approved ? [] : [listener];
+      },
+    },
+  });
+  const service = new TaskService(ports);
+  const request = {
+    definitionId: "taskdef_web",
+    definitionRunPolicy: "single" as const,
+    definitionPort: 3000,
+    cwd: "/workspace",
+    command: "pnpm dev",
+  };
+
+  assert.deepEqual(await service.launchDefinition(request), {
+    disposition: "port_conflict",
+    conflict: { port: 3000, listeners: [listener] },
+  });
+  assert.equal(records.size, 0);
+
+  const launched = await service.launchDefinition({
+    ...request,
+    terminateListeners: [listener],
+  });
+  assert.equal(launched.disposition, "started");
+  assert.equal(records.size, 1);
+  assert.deepEqual(approvals, [undefined, [listener]]);
+});
 
 test("runtime timeout includes process startup and identity delay", async () => {
   const records = new Map<string, TaskRecord>();


### PR DESCRIPTION
## Summary
- add an optional TCP port to saved task definitions
- detect listeners and terminate confirmed processes through the native Rust library with process-identity checks
- prompt before resolving port conflicts and launching tasks
- add contract, native, server, and UI coverage

## Validation
- `pnpm fix && pnpm check && pnpm test`

## Notes
- removed the task-row port chip; the port remains available in definition details
- Linux native behavior was exercised locally; macOS and Windows implementations are platform-conditional
