### PR TITLE
feat(providers): add JSON editor for model definitions with advanced pi config support

### DIFF
--- a/packages/contracts/src/domains/providers/providers.schema.ts
+++ b/packages/contracts/src/domains/providers/providers.schema.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { modelInputSchema, thinkingLevelSchema } from "../models/index.js";
+import {
+  modelInputSchema,
+  type ThinkingLevel,
+  thinkingLevelSchema,
+  thinkingLevels,
+} from "../models/index.js";
 
 /**
  * pi-ai `KnownApi` values. Custom providers pick one of these API
@@ -20,11 +25,20 @@ export const piApiSchema = z.enum([
 ]);
 export type PiApi = z.infer<typeof piApiSchema>;
 
-export const modelCostSchema = z.object({
+const modelCostRatesSchema = z.object({
   input: z.number().nonnegative().default(0),
   output: z.number().nonnegative().default(0),
   cacheRead: z.number().nonnegative().default(0),
   cacheWrite: z.number().nonnegative().default(0),
+});
+
+export const modelCostTierSchema = modelCostRatesSchema.extend({
+  inputTokensAbove: z.number().int().nonnegative(),
+});
+export type ModelCostTier = z.infer<typeof modelCostTierSchema>;
+
+export const modelCostSchema = modelCostRatesSchema.extend({
+  tiers: z.array(modelCostTierSchema).optional(),
 });
 export type ModelCost = z.infer<typeof modelCostSchema>;
 
@@ -77,8 +91,52 @@ export const modelDefinitionSchema = z.object({
   }),
   contextWindow: z.number().int().nonnegative().default(0),
   maxTokens: z.number().int().nonnegative().default(0),
+  samplingParams: z.record(z.string(), z.unknown()).optional(),
 });
 export type ModelDefinition = z.infer<typeof modelDefinitionSchema>;
+
+/**
+ * One model object from a pi `models` array. Provider connection and credential
+ * fields intentionally remain outside this schema because Nerve manages them
+ * separately.
+ */
+export const piModelConfigSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1).optional(),
+    api: piApiSchema.optional(),
+    reasoning: z.boolean().default(false),
+    thinkingLevelMap: z
+      .partialRecord(thinkingLevelSchema, z.string().nullable())
+      .optional(),
+    input: z.array(modelInputSchema).min(1).default(["text"]),
+    cost: modelCostSchema.default({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    }),
+    contextWindow: z.number().int().nonnegative().default(128_000),
+    maxTokens: z.number().int().nonnegative().default(16_384),
+    samplingParams: z.record(z.string(), z.unknown()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    compat: providerCompatSchema.optional(),
+  })
+  .strict();
+export type PiModelConfig = z.infer<typeof piModelConfigSchema>;
+
+/** Mirrors pi-ai's `getSupportedThinkingLevels()` behavior. */
+export function supportedThinkingLevelsForPiModel(
+  model: Pick<PiModelConfig, "reasoning" | "thinkingLevelMap">,
+): ThinkingLevel[] {
+  if (!model.reasoning) return ["off"];
+  return thinkingLevels.filter((level) => {
+    const mapped = model.thinkingLevelMap?.[level];
+    if (mapped === null) return false;
+    if (level === "xhigh" || level === "max") return mapped !== undefined;
+    return true;
+  });
+}
 
 export const providerCatalogSchema = z.object({
   version: z.literal(1).default(1),

--- a/packages/contracts/test/providers.schema.test.ts
+++ b/packages/contracts/test/providers.schema.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  piModelConfigSchema,
+  supportedThinkingLevelsForPiModel,
+} from "../src/domains/providers/providers.schema.js";
+
+const oxAlpha = {
+  id: "ox-alpha-free",
+  name: "Ox Alpha Free (Unlimited)",
+  reasoning: true,
+  input: ["text", "image"],
+  thinkingLevelMap: {
+    off: null,
+    minimal: null,
+    low: "low",
+    medium: null,
+    high: "high",
+    xhigh: null,
+    max: "max",
+  },
+  contextWindow: 1_000_000,
+  maxTokens: 131_072,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  compat: {
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: "max_tokens",
+  },
+} as const;
+
+describe("pi model configuration", () => {
+  it("accepts a model object copied from pi.dev", () => {
+    const parsed = piModelConfigSchema.parse(oxAlpha);
+
+    assert.equal(parsed.id, "ox-alpha-free");
+    assert.deepEqual(supportedThinkingLevelsForPiModel(parsed), [
+      "low",
+      "high",
+      "max",
+    ]);
+  });
+
+  it("applies pi defaults to a minimal model", () => {
+    const parsed = piModelConfigSchema.parse({ id: "local-model" });
+
+    assert.equal(parsed.name, undefined);
+    assert.equal(parsed.reasoning, false);
+    assert.deepEqual(parsed.input, ["text"]);
+    assert.equal(parsed.contextWindow, 128_000);
+    assert.equal(parsed.maxTokens, 16_384);
+    assert.deepEqual(parsed.cost, {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+    assert.deepEqual(supportedThinkingLevelsForPiModel(parsed), ["off"]);
+  });
+
+  it("preserves sampling parameters and tiered costs", () => {
+    const parsed = piModelConfigSchema.parse({
+      id: "tiered-model",
+      samplingParams: { temperature: 0.4, top_k: 20 },
+      cost: {
+        input: 1,
+        output: 2,
+        cacheRead: 0.1,
+        cacheWrite: 0.2,
+        tiers: [
+          {
+            inputTokensAbove: 272_000,
+            input: 2,
+            output: 3,
+            cacheRead: 0.2,
+            cacheWrite: 0.4,
+          },
+        ],
+      },
+    });
+
+    assert.deepEqual(parsed.samplingParams, {
+      temperature: 0.4,
+      top_k: 20,
+    });
+    assert.equal(parsed.cost.tiers?.[0]?.inputTokensAbove, 272_000);
+  });
+
+  it("rejects unknown fields and a full providers envelope", () => {
+    assert.equal(
+      piModelConfigSchema.safeParse({ id: "model", unexpected: true }).success,
+      false,
+    );
+    assert.equal(
+      piModelConfigSchema.safeParse({ providers: { example: {} } }).success,
+      false,
+    );
+  });
+
+  it("rejects invalid values", () => {
+    assert.equal(
+      piModelConfigSchema.safeParse({ id: "model", input: ["audio"] }).success,
+      false,
+    );
+    assert.equal(
+      piModelConfigSchema.safeParse({ id: "model", maxTokens: -1 }).success,
+      false,
+    );
+  });
+});

--- a/packages/harness/src/models/resolution.ts
+++ b/packages/harness/src/models/resolution.ts
@@ -56,6 +56,7 @@ function toPiModel(model: AgentCustomModel): Model<string> | undefined {
       },
     contextWindow: model.contextWindow ?? template?.contextWindow ?? 0,
     maxTokens: model.maxTokens ?? template?.maxTokens ?? 0,
+    samplingParams: model.samplingParams ?? template?.samplingParams,
     headers: { ...(template?.headers ?? {}), ...(model.headers ?? {}) },
     compat: (model.compat ?? template?.compat) as never,
   } as Model<string>;

--- a/packages/harness/src/models/types.ts
+++ b/packages/harness/src/models/types.ts
@@ -36,9 +36,17 @@ export interface AgentCustomModel {
     output: number;
     cacheRead: number;
     cacheWrite: number;
+    tiers?: Array<{
+      inputTokensAbove: number;
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+    }>;
   };
   contextWindow?: number;
   maxTokens?: number;
+  samplingParams?: Record<string, unknown>;
   headers?: Record<string, string>;
   compat?: Record<string, unknown>;
 }

--- a/packages/harness/test/models/resolution.test.ts
+++ b/packages/harness/test/models/resolution.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { listAvailableModels } from "../../src/models/resolution.js";
+import {
+  listAvailableModels,
+  resolveAgentModel,
+} from "../../src/models/resolution.js";
 
 describe("model resolution", () => {
   it("lists complete provider catalogs without silently truncating them", () => {
@@ -17,5 +20,43 @@ describe("model resolution", () => {
       new Set(openRouterModels.map((model) => model.modelId)).size,
       openRouterModels.length,
     );
+  });
+
+  it("preserves advanced pi model configuration", () => {
+    const model = resolveAgentModel(
+      { provider: "test-pi-json", modelId: "tiered" },
+      [
+        {
+          provider: "test-pi-json",
+          modelId: "tiered",
+          name: "Tiered",
+          api: "openai-completions",
+          baseUrl: "https://example.test/v1",
+          reasoning: false,
+          cost: {
+            input: 1,
+            output: 2,
+            cacheRead: 0.1,
+            cacheWrite: 0.2,
+            tiers: [
+              {
+                inputTokensAbove: 272_000,
+                input: 2,
+                output: 3,
+                cacheRead: 0.2,
+                cacheWrite: 0.4,
+              },
+            ],
+          },
+          samplingParams: { temperature: 0.4, top_k: 20 },
+        },
+      ],
+    );
+
+    assert.deepEqual(model.samplingParams, {
+      temperature: 0.4,
+      top_k: 20,
+    });
+    assert.equal(model.cost.tiers?.[0]?.inputTokensAbove, 272_000);
   });
 });

--- a/packages/website/src/content/docs/models/custom-providers.md
+++ b/packages/website/src/content/docs/models/custom-providers.md
@@ -21,15 +21,28 @@ The UI supports the transports Nerve deliberately registers with pi-ai. “OpenA
 
 ## Model definition
 
-A model belongs to a configured provider and can declare:
+Choose **Add model**, select an already configured or authenticated provider, and paste one pi-compatible model object into the JSON editor. Copy the object inside the provider's `models` array—not the outer `providers` configuration—from [pi.dev/models](https://pi.dev/models), or edit the template Nerve provides.
 
-- model ID and display name;
-- context and maximum-output limits;
-- reasoning capability and supported thinking levels/mappings;
-- text/image input modalities;
-- input/output/cache cost metadata.
+```json
+{
+  "id": "my-model",
+  "name": "My Model",
+  "reasoning": false,
+  "input": ["text"],
+  "contextWindow": 128000,
+  "maxTokens": 16384,
+  "cost": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0
+  }
+}
+```
 
-The runtime inherits connection fields from its custom provider or a built-in provider template. Test a new definition with read-only permission before granting mutation.
+Nerve accepts pi model metadata such as `thinkingLevelMap`, `compat`, model headers, sampling parameters, and tiered costs. Invalid JSON, unknown fields, and full provider configurations are rejected instead of being silently discarded.
+
+Provider URLs, API types, headers shared by every model, and API keys remain in provider settings. The runtime inherits those connection fields from the selected custom provider or built-in provider template. Test a new definition with read-only permission before granting mutation.
 
 ## Removal
 

--- a/packages/workbench-app/src/lib/features/settings/components/pages/providers/ModelDefinitionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/providers/ModelDefinitionDialog.svelte
@@ -104,8 +104,13 @@ async function submit() {
       <div class="flex flex-wrap items-end justify-between gap-2">
         <Label>Model JSON</Label>
         <p class="text-xs text-muted-foreground">
-          Paste one object from a provider's
-          <code class="font-mono">models</code> array.
+          Find model JSON on
+          <a
+            class="text-info underline underline-offset-2"
+            href="https://pi.dev/models"
+            target="_blank"
+            rel="noreferrer">pi.dev/models</a
+          >.
         </p>
       </div>
       <div
@@ -131,8 +136,9 @@ async function submit() {
         </p>
       {:else}
         <p class="text-xs text-muted-foreground">
-          Use the model object only. Provider URLs and API keys stay in provider
-          settings.
+          Paste one object from a provider's
+          <code class="font-mono">models</code> array. Provider URLs and API keys
+          stay in provider settings.
         </p>
       {/if}
     </div>

--- a/packages/workbench-app/src/lib/features/settings/components/pages/providers/ModelDefinitionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/providers/ModelDefinitionDialog.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
 import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
-import type { ModelDefinition, ThinkingLevel } from "$lib/api";
-import { thinkingLevels } from "@nervekit/contracts";
+import type { ModelDefinition } from "$lib/api";
 import { upsertModelDefinition } from "$lib/api";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
-import { Input } from "@nervekit/ui-kit/components/ui/input";
 import { Label } from "@nervekit/ui-kit/components/ui/label";
 import SelectField, {
   type SelectItem,
 } from "@nervekit/ui-kit/components/ui/select-field";
-import { SettingsToggleRow } from "$lib/presentation/components/settings";
-import { Textarea } from "@nervekit/ui-kit/components/ui/textarea";
-import * as ToggleGroup from "@nervekit/ui-kit/components/ui/toggle-group";
-import { providerCatalogState } from "$lib/features/settings/state/provider-catalog-state.svelte";
+import { CodeMirrorEditor } from "$lib/presentation/components/code";
 import { refreshProviderCatalog } from "$lib/features/settings/state/provider-catalog-actions.svelte";
+import {
+  DEFAULT_MODEL_JSON,
+  modelDefinitionToJson,
+  parseModelDefinitionJson,
+} from "./model-definition-json";
 
 type Props = {
   open?: boolean;
@@ -25,19 +25,10 @@ type Props = {
 let { open = $bindable(false), model, providerItems = [] }: Props = $props();
 
 const editing = $derived(Boolean(model));
-const THINKING_LEVELS: ThinkingLevel[] = [...thinkingLevels];
-
 let provider = $state("");
-let modelId = $state("");
-let name = $state("");
-let reasoning = $state(false);
-let thinking = $state<ThinkingLevel[]>(["off"]);
-let imageInput = $state(false);
-let contextWindow = $state(0);
-let maxTokens = $state(0);
-let headersText = $state("");
+let jsonText = $state(DEFAULT_MODEL_JSON);
 let busy = $state(false);
-let error = $state<string | undefined>(undefined);
+let submitError = $state<string | undefined>(undefined);
 
 const selectProviderItems = $derived<SelectItem[]>(
   editing &&
@@ -49,83 +40,31 @@ const selectProviderItems = $derived<SelectItem[]>(
       ]
     : providerItems,
 );
-const isCustomProvider = $derived(
-  providerCatalogState.customProviders.some((custom) => custom.id === provider),
-);
 const providerAvailable = $derived(
   providerItems.some((item) => item.value === provider),
 );
+const parseResult = $derived(
+  parseModelDefinitionJson(jsonText, provider, model?.modelId),
+);
+const canSubmit = $derived(parseResult.success && providerAvailable && !busy);
 
 $effect(() => {
   if (!open) return;
   provider = model?.provider ?? "";
-  modelId = model?.modelId ?? "";
-  name = model?.name ?? "";
-  reasoning = model?.reasoning ?? false;
-  thinking = model?.supportedThinkingLevels ?? ["off"];
-  imageInput = model?.input?.includes("image") ?? false;
-  contextWindow = model?.contextWindow ?? 0;
-  maxTokens = model?.maxTokens ?? 0;
-  headersText = headersToText(model?.headers);
-  error = undefined;
+  jsonText = model ? modelDefinitionToJson(model) : DEFAULT_MODEL_JSON;
+  submitError = undefined;
 });
 
-function headersToText(headers?: Record<string, string>): string {
-  if (!headers) return "";
-  return Object.entries(headers)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join("\n");
-}
-
-function parseHeaders(text: string): Record<string, string> {
-  const headers: Record<string, string> = {};
-  for (const line of text.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const index = trimmed.indexOf(":");
-    if (index === -1) continue;
-    const key = trimmed.slice(0, index).trim();
-    if (key) headers[key] = trimmed.slice(index + 1).trim();
-  }
-  return headers;
-}
-
-function setThinking(values: string[]): void {
-  const next = THINKING_LEVELS.filter((level) => values.includes(level));
-  thinking = next.length > 0 ? next : ["off"];
-}
-
-const canSubmit = $derived(
-  provider.trim().length > 0 &&
-    providerAvailable &&
-    modelId.trim().length > 0 &&
-    name.trim().length > 0 &&
-    !busy,
-);
-
 async function submit() {
-  if (!canSubmit) return;
+  if (!canSubmit || !parseResult.success) return;
   busy = true;
-  error = undefined;
+  submitError = undefined;
   try {
-    const headers = parseHeaders(headersText);
-    const next: ModelDefinition = {
-      provider,
-      modelId: modelId.trim(),
-      name: name.trim(),
-      reasoning,
-      supportedThinkingLevels: thinking.length > 0 ? thinking : ["off"],
-      input: imageInput ? ["text", "image"] : ["text"],
-      contextWindow: Math.max(0, Math.trunc(contextWindow)),
-      maxTokens: Math.max(0, Math.trunc(maxTokens)),
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      ...(Object.keys(headers).length > 0 ? { headers } : {}),
-    };
-    await upsertModelDefinition(next);
+    await upsertModelDefinition(parseResult.model);
     await refreshProviderCatalog();
     open = false;
-  } catch (err) {
-    error = err instanceof Error ? err.message : String(err);
+  } catch (error) {
+    submitError = error instanceof Error ? error.message : String(error);
   } finally {
     busy = false;
   }
@@ -135,10 +74,10 @@ async function submit() {
 <Dialog
   bind:open
   title={editing ? `Edit ${model?.name}` : "Add model"}
-  description="Register a model under a configured or authenticated provider."
-  size="md"
+  description="Select a configured provider and define one pi-compatible model."
+  size="wide"
 >
-  <div class="grid gap-3">
+  <div class="grid min-h-0 gap-3">
     <div class="grid gap-1.5">
       <Label>Provider</Label>
       <SelectField
@@ -147,118 +86,64 @@ async function submit() {
         onValueChange={(value) => (provider = value)}
         placeholder="Select a provider"
         ariaLabel="Provider"
-        disabled={editing}
+        disabled={busy || editing}
       />
     </div>
 
-    <div class="grid gap-3 sm:grid-cols-2">
-      <div class="grid gap-1.5">
-        <Label for="model-id">Model id</Label>
-        <Input
-          size="xs"
-          id="model-id"
-          bind:value={modelId}
-          placeholder="llama-3.1-8b"
-          disabled={busy || editing}
-        />
-      </div>
-      <div class="grid gap-1.5">
-        <Label for="model-name">Display name</Label>
-        <Input
-          size="xs"
-          id="model-name"
-          bind:value={name}
-          placeholder="Llama 3.1 8B"
-          disabled={busy}
-        />
-      </div>
-    </div>
-
     {#if provider.length > 0 && !providerAvailable}
-      <p class="flex items-center gap-1.5 text-xs text-destructive">
-        <TriangleAlert size={14} strokeWidth={2} />
+      <p
+        class="flex items-center gap-1.5 text-xs text-destructive"
+        role="alert"
+      >
+        <TriangleAlert class="size-3.5" aria-hidden="true" />
         This provider is not configured or authenticated.
       </p>
     {/if}
 
-    <div class="grid gap-3 sm:grid-cols-2">
-      <div class="grid gap-1.5">
-        <Label for="model-context">Context window (tokens)</Label>
-        <Input
-          size="xs"
-          id="model-context"
-          type="number"
-          min="0"
-          bind:value={contextWindow}
-          disabled={busy}
-        />
-      </div>
-      <div class="grid gap-1.5">
-        <Label for="model-max-tokens">Max output tokens</Label>
-        <Input
-          size="xs"
-          id="model-max-tokens"
-          type="number"
-          min="0"
-          bind:value={maxTokens}
-          disabled={busy}
-        />
-      </div>
-    </div>
-
-    <SettingsToggleRow
-      checked={reasoning}
-      label="Reasoning model"
-      description="Enable thinking/reasoning controls for this model."
-      onCheckedChange={(value) => (reasoning = value)}
-    />
-
-    <div class="grid gap-1.5">
-      <Label>Supported thinking levels</Label>
-      <ToggleGroup.Root
-        type="multiple"
-        variant="outline"
-        size="sm"
-        value={thinking}
-        onValueChange={setThinking}
-        aria-label="Supported thinking levels"
-      >
-        {#each THINKING_LEVELS as level (level)}
-          <ToggleGroup.Item value={level} aria-label={level} class="text-xs">
-            {level}
-          </ToggleGroup.Item>
-        {/each}
-      </ToggleGroup.Root>
-    </div>
-
-    <SettingsToggleRow
-      checked={imageInput}
-      label="Image input"
-      description="The model accepts image content in addition to text."
-      onCheckedChange={(value) => (imageInput = value)}
-    />
-
-    {#if isCustomProvider}
-      <div class="grid gap-1.5">
-        <Label for="model-headers">Header overrides (optional)</Label>
-        <Textarea
-          id="model-headers"
-          bind:value={headersText}
-          rows={2}
-          placeholder="X-Header: value"
-          disabled={busy}
-        />
+    <div class="grid min-h-0 gap-1.5">
+      <div class="flex flex-wrap items-end justify-between gap-2">
+        <Label>Model JSON</Label>
         <p class="text-xs text-muted-foreground">
-          Merged on top of the provider headers. One
-          <code class="font-mono">Name: value</code> per line.
+          Paste one object from a provider's
+          <code class="font-mono">models</code> array.
         </p>
       </div>
-    {/if}
+      <div
+        class="h-96 min-h-64 overflow-hidden rounded-md border bg-background"
+      >
+        <CodeMirrorEditor
+          value={jsonText}
+          onChange={(value) => {
+            jsonText = value;
+            submitError = undefined;
+          }}
+          disabled={busy}
+          ariaLabel="Model definition JSON"
+        />
+      </div>
+      {#if provider && !parseResult.success}
+        <p
+          class="flex items-start gap-1.5 text-xs text-destructive"
+          role="alert"
+        >
+          <TriangleAlert class="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          {parseResult.error}
+        </p>
+      {:else}
+        <p class="text-xs text-muted-foreground">
+          Use the model object only. Provider URLs and API keys stay in provider
+          settings.
+        </p>
+      {/if}
+    </div>
 
-    {#if error}
-      <p class="flex items-center gap-1.5 text-xs text-destructive">
-        <TriangleAlert size={14} strokeWidth={2} />
-        {error}
+    {#if submitError}
+      <p
+        class="flex items-center gap-1.5 text-xs text-destructive"
+        role="alert"
+      >
+        <TriangleAlert class="size-3.5" aria-hidden="true" />
+        {submitError}
       </p>
     {/if}
   </div>

--- a/packages/workbench-app/src/lib/features/settings/components/pages/providers/model-definition-json.test.ts
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/providers/model-definition-json.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_MODEL_JSON,
+  modelDefinitionToJson,
+  parseModelDefinitionJson,
+} from "./model-definition-json.js";
+
+const oxAlphaJson = JSON.stringify({
+  id: "ox-alpha-free",
+  name: "Ox Alpha Free (Unlimited)",
+  reasoning: true,
+  input: ["text", "image"],
+  thinkingLevelMap: {
+    off: null,
+    minimal: null,
+    low: "low",
+    medium: null,
+    high: "high",
+    xhigh: null,
+    max: "max",
+  },
+  contextWindow: 1_000_000,
+  maxTokens: 131_072,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  compat: {
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    maxTokensField: "max_tokens",
+  },
+});
+
+describe("model definition JSON", () => {
+  it("converts a pi.dev model object to a Nerve definition", () => {
+    const result = parseModelDefinitionJson(oxAlphaJson, "opencode-go");
+    assert.equal(result.success, true);
+    if (!result.success) return;
+
+    assert.equal(result.model.provider, "opencode-go");
+    assert.equal(result.model.modelId, "ox-alpha-free");
+    assert.deepEqual(result.model.supportedThinkingLevels, [
+      "low",
+      "high",
+      "max",
+    ]);
+    assert.deepEqual(result.model.compat, {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      maxTokensField: "max_tokens",
+    });
+  });
+
+  it("uses pi defaults and the id as the display name", () => {
+    const result = parseModelDefinitionJson('{"id":"minimal"}', "ollama");
+    assert.equal(result.success, true);
+    if (!result.success) return;
+
+    assert.equal(result.model.name, "minimal");
+    assert.equal(result.model.contextWindow, 128_000);
+    assert.equal(result.model.maxTokens, 16_384);
+    assert.deepEqual(result.model.input, ["text"]);
+  });
+
+  it("round trips supported model metadata", () => {
+    const initial = parseModelDefinitionJson(oxAlphaJson, "opencode-go");
+    assert.equal(initial.success, true);
+    if (!initial.success) return;
+
+    const roundTrip = parseModelDefinitionJson(
+      modelDefinitionToJson(initial.model),
+      "opencode-go",
+      "ox-alpha-free",
+    );
+    assert.deepEqual(roundTrip, initial);
+  });
+
+  it("returns actionable validation errors", () => {
+    const malformed = parseModelDefinitionJson("{", "ollama");
+    assert.equal(malformed.success, false);
+
+    const envelope = parseModelDefinitionJson(
+      '{"providers":{"ollama":{}}}',
+      "ollama",
+    );
+    assert.equal(envelope.success, false);
+    if (!envelope.success) assert.match(envelope.error, /one model object/i);
+
+    const unknown = parseModelDefinitionJson(
+      '{"id":"model","apiKey":"secret"}',
+      "ollama",
+    );
+    assert.equal(unknown.success, false);
+  });
+
+  it("prevents changing identity while editing", () => {
+    const result = parseModelDefinitionJson(
+      '{"id":"different"}',
+      "ollama",
+      "original",
+    );
+    assert.equal(result.success, false);
+    if (!result.success) assert.match(result.error, /cannot be changed/i);
+  });
+
+  it("ships a valid default template", () => {
+    assert.equal(
+      parseModelDefinitionJson(DEFAULT_MODEL_JSON, "ollama").success,
+      true,
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/features/settings/components/pages/providers/model-definition-json.ts
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/providers/model-definition-json.ts
@@ -1,0 +1,132 @@
+import {
+  piModelConfigSchema,
+  supportedThinkingLevelsForPiModel,
+  type PiModelConfig,
+} from "@nervekit/contracts";
+import type { ModelDefinition } from "$lib/api";
+
+export const DEFAULT_MODEL_JSON = JSON.stringify(
+  {
+    id: "model-id",
+    name: "Model name",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+  },
+  null,
+  2,
+);
+
+export type ModelJsonParseResult =
+  | { success: true; model: ModelDefinition }
+  | { success: false; error: string };
+
+function issueMessage(issue: {
+  path?: PropertyKey[];
+  message: string;
+}): string {
+  const path = issue.path?.map(String).join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+export function modelDefinitionFromPiConfig(
+  provider: string,
+  config: PiModelConfig,
+): ModelDefinition {
+  return {
+    provider,
+    modelId: config.id,
+    name: config.name ?? config.id,
+    ...(config.api ? { api: config.api } : {}),
+    reasoning: config.reasoning,
+    supportedThinkingLevels: supportedThinkingLevelsForPiModel(config),
+    ...(config.thinkingLevelMap
+      ? { thinkingLevelMap: config.thinkingLevelMap }
+      : {}),
+    input: config.input,
+    cost: config.cost,
+    contextWindow: config.contextWindow,
+    maxTokens: config.maxTokens,
+    ...(config.samplingParams ? { samplingParams: config.samplingParams } : {}),
+    ...(config.headers ? { headers: config.headers } : {}),
+    ...(config.compat ? { compat: config.compat } : {}),
+  };
+}
+
+export function parseModelDefinitionJson(
+  text: string,
+  provider: string,
+  existingModelId?: string,
+): ModelJsonParseResult {
+  if (!provider) return { success: false, error: "Select a provider." };
+
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof SyntaxError ? error.message : "Invalid JSON.",
+    };
+  }
+
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    "providers" in value
+  ) {
+    return {
+      success: false,
+      error:
+        "Paste one model object from the provider's models array, not the full providers configuration.",
+    };
+  }
+
+  const parsed = piModelConfigSchema.safeParse(value);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: issueMessage(
+        parsed.error.issues[0] ?? { message: "Invalid model." },
+      ),
+    };
+  }
+  if (existingModelId && parsed.data.id !== existingModelId) {
+    return {
+      success: false,
+      error: `Model id cannot be changed while editing (${existingModelId}).`,
+    };
+  }
+  return {
+    success: true,
+    model: modelDefinitionFromPiConfig(provider, parsed.data),
+  };
+}
+
+export function modelDefinitionToJson(model: ModelDefinition): string {
+  const config = {
+    id: model.modelId,
+    name: model.name,
+    ...(model.api ? { api: model.api } : {}),
+    reasoning: model.reasoning,
+    input: model.input,
+    ...(model.thinkingLevelMap
+      ? { thinkingLevelMap: model.thinkingLevelMap }
+      : {}),
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxTokens,
+    cost: model.cost,
+    ...(model.samplingParams ? { samplingParams: model.samplingParams } : {}),
+    ...(model.headers ? { headers: model.headers } : {}),
+    ...(model.compat ? { compat: model.compat } : {}),
+  };
+  return JSON.stringify(config, null, 2);
+}

--- a/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorEditor.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorEditor.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+import { json } from "@codemirror/lang-json";
+import { Compartment, EditorState } from "@codemirror/state";
+import { EditorView, type ViewUpdate } from "@codemirror/view";
+import { onDestroy, onMount } from "svelte";
+import { editableCodeExtensions } from "./code-mirror-config";
+
+type Props = {
+  value: string;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  class?: string;
+};
+
+let {
+  value,
+  onChange,
+  disabled = false,
+  ariaLabel = "Code editor",
+  class: className = "",
+}: Props = $props();
+
+let host: HTMLElement;
+let view: EditorView | undefined;
+const editableCompartment = new Compartment();
+
+function editableExtensions(isDisabled: boolean) {
+  return [
+    EditorState.readOnly.of(isDisabled),
+    EditorView.editable.of(!isDisabled),
+  ];
+}
+
+onMount(() => {
+  view = new EditorView({
+    parent: host,
+    state: EditorState.create({
+      doc: value,
+      extensions: [
+        ...editableCodeExtensions(ariaLabel),
+        json(),
+        EditorView.lineWrapping,
+        editableCompartment.of(editableExtensions(disabled)),
+        EditorView.updateListener.of((update: ViewUpdate) => {
+          if (!update.docChanged) return;
+          const next = update.state.doc.toString();
+          if (next !== value) onChange?.(next);
+        }),
+      ],
+    }),
+  });
+});
+
+$effect(() => {
+  if (!view) return;
+  const current = view.state.doc.toString();
+  if (current !== value) {
+    view.dispatch({
+      changes: { from: 0, to: current.length, insert: value },
+    });
+  }
+});
+
+$effect(() => {
+  if (!view) return;
+  view.dispatch({
+    effects: editableCompartment.reconfigure(editableExtensions(disabled)),
+  });
+});
+
+onDestroy(() => view?.destroy());
+</script>
+
+<div
+  bind:this={host}
+  class={`h-full min-h-0 min-w-0 overflow-hidden bg-background ${className}`}
+></div>

--- a/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.ts
@@ -1,14 +1,22 @@
 import {
+  bracketMatching,
   HighlightStyle,
   StreamLanguage,
   syntaxHighlighting,
 } from "@codemirror/language";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from "@codemirror/commands";
 import type { Extension } from "@codemirror/state";
 import { EditorState } from "@codemirror/state";
 import {
   drawSelection,
   EditorView,
   highlightSpecialChars,
+  keymap,
   lineNumbers,
 } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
@@ -335,6 +343,20 @@ function codeMinimapExtension(): Extension {
     displayText: "blocks",
     showOverlay: "always",
   });
+}
+
+export function editableCodeExtensions(ariaLabel: string): Extension[] {
+  return [
+    history(),
+    lineNumbers(),
+    highlightSpecialChars(),
+    drawSelection(),
+    bracketMatching(),
+    syntaxHighlighting(codeHighlightStyle),
+    keymap.of([indentWithTab, ...defaultKeymap, ...historyKeymap]),
+    EditorView.contentAttributes.of({ "aria-label": ariaLabel }),
+    codeMirrorTheme,
+  ];
 }
 
 export function readOnlyCodeExtensions(input: {

--- a/packages/workbench-app/src/lib/presentation/components/code/index.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/index.ts
@@ -1,7 +1,9 @@
+export { default as CodeMirrorEditor } from "./CodeMirrorEditor.svelte";
 export { default as CodeMirrorViewer } from "./CodeMirrorViewer.svelte";
 export {
   codeLanguageId,
   codeMirrorTheme,
+  editableCodeExtensions,
   loadCodeLanguage,
   localLineNumber,
   readOnlyCodeExtensions,

--- a/packages/workbench-server/src/domains/providers/provider-catalog.store.ts
+++ b/packages/workbench-server/src/domains/providers/provider-catalog.store.ts
@@ -135,6 +135,7 @@ export class ProviderCatalogStore {
         cost: model.cost,
         contextWindow: model.contextWindow,
         maxTokens: model.maxTokens,
+        samplingParams: model.samplingParams,
         headers: { ...(provider?.headers ?? {}), ...(model.headers ?? {}) },
         compat: model.compat ?? provider?.compat,
       });


### PR DESCRIPTION
## Summary

This PR introduces a JSON-based model definition editor that supports the full pi-ai model configuration surface, replacing the previous form-based approach.

## Changes

### Contracts (`packages/contracts`)
- Added `piModelConfigSchema` with support for:
  - `samplingParams` (arbitrary model parameters like temperature, top_k)
  - Tiered cost configuration (`cost.tiers` with `inputTokensAbove`)
  - Model-level `headers` and `compat` objects
  - `thinkingLevelMap` for reasoning model thinking level mappings
  - `api` field for pi API type override
- Added `supportedThinkingLevelsForPiModel()` helper mirroring pi-ai's `getSupportedThinkingLevels()`
- Added test coverage in `providers.schema.test.ts`

### Model Definition JSON Utilities (`packages/workbench-app/src/lib/features/settings/components/pages/providers/`)
- `model-definition-json.ts`: Parse/serialize utilities with validation
  - Rejects full provider envelopes (detects `providers` key)
  - Validates against `piModelConfigSchema` (rejects unknown fields like `apiKey`)
  - Prevents model ID changes while editing existing definitions
  - Round-trip safe for supported metadata
- `model-definition-json.test.ts`: Unit tests for parsing, validation, round-trips

### UI (`packages/workbench-app`)
- **New** `CodeMirrorEditor.svelte`: Full-featured JSON editor with:
  - History/undo, line numbers, bracket matching, syntax highlighting
  - Standard keymaps (tab indent, default keys, history keys)
  - ARIA label support
- Refactored `ModelDefinitionDialog.svelte`:
  - Single JSON editor replaces 12+ individual form fields
  - Real-time validation with inline error display
  - Template pre-filled from pi.dev model object structure
  - Read-only provider selection when editing

### Harness & Server (`packages/harness`, `packages/workbench-server`)
- Propagate `samplingParams` through model resolution and provider catalog
- Added test for advanced pi config preservation in `resolution.test.ts`

### Documentation (`packages/website`)
- Updated `custom-providers.md` with JSON workflow example and guidance

## Testing
- Run `pnpm fix && pnpm check && pnpm test` to validate