### PR TITLE
Polish GitHub PR detail pane and add admin override merge

### DIFF
--- a/packages/contracts/src/domains/git/git.schema.ts
+++ b/packages/contracts/src/domains/git/git.schema.ts
@@ -429,10 +429,22 @@ export const githubPrConversationSchema = z.object({
 });
 export type GithubPrConversation = z.infer<typeof githubPrConversationSchema>;
 
+export const githubPrViewerPermissionSchema = z.enum([
+  "ADMIN",
+  "MAINTAIN",
+  "WRITE",
+  "READ",
+  "NONE",
+]);
+export type GithubPrViewerPermission = z.infer<
+  typeof githubPrViewerPermissionSchema
+>;
+
 export const githubPrOverviewSchema = z.object({
   mergeable: z.string().nullable(),
   mergeStateStatus: z.string().nullable(),
   reviewDecision: z.string().nullable(),
+  viewerPermission: githubPrViewerPermissionSchema.nullable(),
   behindBy: z.number().int().nonnegative().nullable(),
   labels: z.array(githubPrLabelSchema),
   reviewRequests: z.array(githubPrReviewerSchema),

--- a/packages/contracts/src/domains/git/git.schema.ts
+++ b/packages/contracts/src/domains/git/git.schema.ts
@@ -429,12 +429,12 @@ export const githubPrConversationSchema = z.object({
 });
 export type GithubPrConversation = z.infer<typeof githubPrConversationSchema>;
 
+/** Mirrors GitHub's RepositoryPermission enum (Repository.viewerPermission). */
 export const githubPrViewerPermissionSchema = z.enum([
   "ADMIN",
   "MAINTAIN",
   "WRITE",
   "READ",
-  "NONE",
 ]);
 export type GithubPrViewerPermission = z.infer<
   typeof githubPrViewerPermissionSchema

--- a/packages/tools/src/git/git-github-service.ts
+++ b/packages/tools/src/git/git-github-service.ts
@@ -91,6 +91,7 @@ type GithubPrDetailRaw = {
   mergeable?: string | null;
   mergeStateStatus?: string | null;
   reviewDecision?: string | null;
+  viewerPermission?: string | null;
   comments?: {
     nodes?: Array<{
       id?: string;
@@ -154,6 +155,7 @@ const CONVERSATION_FIELDS = `
 `;
 const OVERVIEW_FIELDS = `
   headRefOid baseRefOid mergeable mergeStateStatus reviewDecision
+  viewerPermission
   labels(first: 100) { nodes { name color } }
   reviewRequests(first: 100) {
     nodes {
@@ -369,6 +371,22 @@ export function allowedMergeMethods(raw: GithubRepoRaw): GithubPrMergeMethod[] {
   return methods;
 }
 
+const VIEWER_PERMISSIONS = [
+  "ADMIN",
+  "MAINTAIN",
+  "WRITE",
+  "READ",
+  "NONE",
+] as const;
+
+type GithubViewerPermission = (typeof VIEWER_PERMISSIONS)[number];
+
+function mapViewerPermission(
+  raw: string | null | undefined,
+): GithubViewerPermission | null {
+  return VIEWER_PERMISSIONS.find((permission) => permission === raw) ?? null;
+}
+
 function mapPrCore(raw: GithubPrDetailRaw): GithubPrCore {
   return {
     number: raw.number,
@@ -427,6 +445,7 @@ function mapPrOverview(
     mergeable: raw.mergeable ?? null,
     mergeStateStatus: raw.mergeStateStatus ?? null,
     reviewDecision: raw.reviewDecision ?? null,
+    viewerPermission: mapViewerPermission(raw.viewerPermission),
     behindBy,
     labels: compact(raw.labels?.nodes).flatMap((label) =>
       label.name ? [{ name: label.name, color: label.color }] : [],

--- a/packages/tools/src/git/git-github-service.ts
+++ b/packages/tools/src/git/git-github-service.ts
@@ -91,7 +91,6 @@ type GithubPrDetailRaw = {
   mergeable?: string | null;
   mergeStateStatus?: string | null;
   reviewDecision?: string | null;
-  viewerPermission?: string | null;
   comments?: {
     nodes?: Array<{
       id?: string;
@@ -133,6 +132,7 @@ type GithubPrDetailRaw = {
 type GithubRepoRaw = {
   mergeCommitAllowed?: boolean;
   squashMergeAllowed?: boolean;
+  viewerPermission?: string | null;
   rebaseMergeAllowed?: boolean;
   pullRequest?: GithubPrDetailRaw | null;
 };
@@ -155,7 +155,6 @@ const CONVERSATION_FIELDS = `
 `;
 const OVERVIEW_FIELDS = `
   headRefOid baseRefOid mergeable mergeStateStatus reviewDecision
-  viewerPermission
   labels(first: 100) { nodes { name color } }
   reviewRequests(first: 100) {
     nodes {
@@ -185,6 +184,7 @@ const CHECK_FIELDS = `
 `;
 const REPOSITORY_SETTINGS_FIELDS = `
   mergeCommitAllowed squashMergeAllowed rebaseMergeAllowed
+  viewerPermission
 `;
 
 function repositoryQuery(fields: string, includeSettings = false): string {
@@ -371,13 +371,7 @@ export function allowedMergeMethods(raw: GithubRepoRaw): GithubPrMergeMethod[] {
   return methods;
 }
 
-const VIEWER_PERMISSIONS = [
-  "ADMIN",
-  "MAINTAIN",
-  "WRITE",
-  "READ",
-  "NONE",
-] as const;
+const VIEWER_PERMISSIONS = ["ADMIN", "MAINTAIN", "WRITE", "READ"] as const;
 
 type GithubViewerPermission = (typeof VIEWER_PERMISSIONS)[number];
 
@@ -445,7 +439,7 @@ function mapPrOverview(
     mergeable: raw.mergeable ?? null,
     mergeStateStatus: raw.mergeStateStatus ?? null,
     reviewDecision: raw.reviewDecision ?? null,
-    viewerPermission: mapViewerPermission(raw.viewerPermission),
+    viewerPermission: mapViewerPermission(settings.viewerPermission),
     behindBy,
     labels: compact(raw.labels?.nodes).flatMap((label) =>
       label.name ? [{ name: label.name, color: label.color }] : [],

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrChecks.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrChecks.svelte
@@ -8,10 +8,12 @@ import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import { githubCheckRunOutcome } from "./github-pr-checks";
 import GithubPrSection from "./GithubPrSection.svelte";
-import { checksTone } from "./pr-pane-helpers";
+import { checksTone, sortCheckRuns } from "./pr-pane-helpers";
 
 type Props = { checks: GithubChecksSummary };
 let { checks }: Props = $props();
+const sortedRuns = $derived(sortCheckRuns(checks.runs));
+const hasCounts = $derived(checks.passed + checks.failed + checks.pending > 0);
 </script>
 
 <GithubPrSection title="Checks" contentClass="p-0">
@@ -30,25 +32,51 @@ let { checks }: Props = $props();
     </Badge>
   {/snippet}
 
-  <p class="px-3 py-1.5 text-muted-foreground">
-    {checks.passed} passed · {checks.failed} failed ·
-    {checks.pending} pending
-  </p>
+  <div
+    class="flex flex-wrap items-center gap-x-3 gap-y-0.5 px-3 py-1.5 text-muted-foreground"
+  >
+    {#if hasCounts}
+      {#if checks.passed > 0}
+        <span class="inline-flex items-center gap-1 text-success">
+          <Check class="size-3" aria-hidden="true" />
+          {checks.passed} passed
+        </span>
+      {/if}
+      {#if checks.failed > 0}
+        <span class="inline-flex items-center gap-1 text-destructive">
+          <X class="size-3" aria-hidden="true" />
+          {checks.failed} failed
+        </span>
+      {/if}
+      {#if checks.pending > 0}
+        <span class="inline-flex items-center gap-1 text-warning">
+          <Spinner class="size-3" />
+          {checks.pending} pending
+        </span>
+      {/if}
+    {:else}
+      <span>No checks have been reported.</span>
+    {/if}
+  </div>
 
   {#if checks.runs.length === 0}
-    <p
-      class="border-t border-border/60 px-3 py-3 text-xs text-muted-foreground"
-    >
-      No checks have been reported.
-    </p>
+    {#if hasCounts}
+      <p
+        class="border-t border-border/50 px-3 py-2 text-xs text-muted-foreground"
+      >
+        No individual check runs to show.
+      </p>
+    {/if}
   {:else}
     <ul
-      class="divide-y divide-border/60 border-t border-border/60"
+      class="divide-y divide-border/50 border-t border-border/50"
       aria-label="Check runs"
     >
-      {#each checks.runs as run (`${run.name}:${run.url ?? ""}`)}
+      {#each sortedRuns as run (`${run.name}:${run.url ?? ""}`)}
         {@const outcome = githubCheckRunOutcome(run.status)}
-        <li class="flex min-w-0 items-center gap-2 px-3 py-1.5">
+        <li
+          class="flex min-w-0 items-center gap-2 px-3 py-1.5 hover:bg-accent/40"
+        >
           <span class="min-w-0 flex-1 truncate text-foreground">{run.name}</span
           >
           {#if run.url}

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrCommits.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrCommits.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 import GitCommitHorizontal from "@lucide/svelte/icons/git-commit-horizontal";
 import type { GithubPrCommitsResponse } from "@nervekit/contracts";
+import { notifyCopyResult } from "@nervekit/ui-kit/core/notify";
 import GithubPrSection from "./GithubPrSection.svelte";
 import { formatPrDate } from "./pr-pane-helpers";
 
 type Props = { response: GithubPrCommitsResponse };
 let { response }: Props = $props();
+
+function copySha(abbrev: string) {
+  navigator.clipboard
+    .writeText(abbrev)
+    .then(() => notifyCopyResult(true, "commit SHA"))
+    .catch(() => notifyCopyResult(false, "commit SHA"));
+}
 </script>
 
 <GithubPrSection
@@ -13,11 +21,11 @@ let { response }: Props = $props();
   contentClass="p-0"
 >
   {#if response.commits.length === 0}
-    <p class="px-3 py-3 text-xs text-muted-foreground">
+    <p class="px-3 py-2 text-xs text-muted-foreground">
       No commit data available.
     </p>
   {:else}
-    <ol class="divide-y divide-border/60">
+    <ol class="divide-y divide-border/50">
       {#each response.commits as commit (commit.oid)}
         <li class="flex min-w-0 items-center gap-2 px-3 py-1.5">
           <GitCommitHorizontal
@@ -33,9 +41,15 @@ let { response }: Props = $props();
             {commit.authorName ?? "Unknown author"}{#if commit.authoredDate}
               · {formatPrDate(commit.authoredDate)}{/if}
           </span>
-          <code class="shrink-0 rounded bg-muted px-1 py-0.5 font-mono"
-            >{commit.abbrev}</code
+          <button
+            type="button"
+            class="shrink-0 rounded-sm bg-muted px-1 py-0.5 font-mono text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+            title="Copy commit SHA"
+            aria-label={`Copy commit SHA ${commit.abbrev}`}
+            onclick={() => copySha(commit.abbrev)}
           >
+            {commit.abbrev}
+          </button>
         </li>
       {/each}
     </ol>

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrConversation.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrConversation.svelte
@@ -4,15 +4,35 @@ import MessageSquare from "@lucide/svelte/icons/message-square";
 import ShieldCheck from "@lucide/svelte/icons/shield-check";
 import type { GithubPrConversation, GithubPrCore } from "@nervekit/contracts";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
 import { notifyCopyResult } from "@nervekit/ui-kit/core/notify";
 import GithubPrSection from "./GithubPrSection.svelte";
-import { formatPrDate, prTimeline, reviewTone } from "./pr-pane-helpers";
+import PrAvatar from "./PrAvatar.svelte";
+import PrCollapsibleBody from "./PrCollapsibleBody.svelte";
+import {
+  formatPrDate,
+  formatRelativePrDate,
+  prTimeline,
+  reviewSurfaceClass,
+  reviewTone,
+  shouldCollapseBody,
+} from "./pr-pane-helpers";
 
 type Props = { core: GithubPrCore; conversation: GithubPrConversation };
 let { core, conversation }: Props = $props();
 const timeline = $derived(prTimeline(conversation));
 </script>
+
+{#snippet entryBody(body: string)}
+  {#if shouldCollapseBody(body)}
+    <PrCollapsibleBody {body} />
+  {:else if body.trim()}
+    <div class="text-sm">
+      <Markdown text={body} onCopy={notifyCopyResult} />
+    </div>
+  {/if}
+{/snippet}
 
 <div class="flex flex-col gap-2">
   <GithubPrSection>
@@ -22,44 +42,60 @@ const timeline = $derived(prTimeline(conversation));
           >{core.author ?? "Unknown author"}</strong
         >
         <span class="text-muted-foreground">
-          opened this pull request {formatPrDate(core.createdAt)}</span
-        >
+          opened this pull request {formatRelativePrDate(core.createdAt)}
+        </span>
       </span>
     {/snippet}
     {#if conversation.body.trim()}
-      <div class="text-sm">
-        <Markdown text={conversation.body} onCopy={notifyCopyResult} />
-      </div>
+      {@render entryBody(conversation.body)}
     {:else}
       <p class="text-xs text-muted-foreground">No description provided.</p>
     {/if}
   </GithubPrSection>
 
   {#if timeline.length === 0}
-    <p
-      class="flex items-center gap-2 rounded-md border border-dashed border-border/60 px-3 py-3 text-xs text-muted-foreground"
-    >
+    <p class="flex items-center gap-2 px-1 py-2 text-xs text-muted-foreground">
       <MessageSquare class="size-3.5" aria-hidden="true" />
       No comments or reviews yet.
     </p>
   {:else}
     <div class="flex flex-col gap-2" aria-label="Pull request conversation">
       {#each timeline as entry (entry.kind + entry.value.id)}
-        <GithubPrSection>
+        {@const body = entry.value.body}
+        <GithubPrSection
+          class={entry.kind === "review"
+            ? reviewSurfaceClass(entry.value.state)
+            : ""}
+        >
           {#snippet header()}
-            <span
-              class="grid size-5 shrink-0 place-items-center rounded-full bg-muted text-xs font-semibold text-muted-foreground"
-            >
-              {(entry.value.author ?? "?").slice(0, 1).toUpperCase()}
-            </span>
+            <PrAvatar
+              name={entry.value.author}
+              src={entry.value.authorAvatarUrl}
+              class="size-5"
+            />
             <span class="min-w-0 flex-1 truncate">
               <strong class="font-semibold text-foreground"
                 >{entry.value.author ?? "Deleted user"}</strong
               >
               <span class="text-muted-foreground">
                 {entry.kind === "comment" ? "commented" : "reviewed"}
-                {formatPrDate(entry.at)}</span
-              >
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    {#snippet child({ props })}
+                      <button
+                        {...props}
+                        type="button"
+                        class="inline cursor-help rounded-xs hover:text-foreground"
+                      >
+                        {formatRelativePrDate(entry.at)}
+                      </button>
+                    {/snippet}
+                  </Tooltip.Trigger>
+                  <Tooltip.Content sideOffset={5}>
+                    {formatPrDate(entry.at)}
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              </span>
             </span>
             {#if entry.kind === "review"}
               <Badge tone={reviewTone(entry.value.state)} size="xs">
@@ -81,15 +117,11 @@ const timeline = $derived(prTimeline(conversation));
               </a>
             {/if}
           {/snippet}
-          {#if entry.value.body.trim()}
-            <div class="text-sm">
-              <Markdown text={entry.value.body} onCopy={notifyCopyResult} />
-            </div>
-          {:else}
+          {#if body.trim()}
+            {@render entryBody(body)}
+          {:else if entry.kind === "review"}
             <p class="text-xs text-muted-foreground">
-              {entry.kind === "review"
-                ? "Submitted a review without a comment."
-                : "No comment body."}
+              Submitted a review without a comment.
             </p>
           {/if}
         </GithubPrSection>

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrHeader.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrHeader.svelte
@@ -14,7 +14,13 @@ import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import { Skeleton } from "@nervekit/ui-kit/components/ui/skeleton";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
-import { formatPrDateCompact, stateLabel, stateTone } from "./pr-pane-helpers";
+import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
+import {
+  formatPrDateCompact,
+  formatRelativePrDate,
+  stateLabel,
+  stateTone,
+} from "./pr-pane-helpers";
 
 type Props = {
   number: number;
@@ -49,7 +55,7 @@ const StateIcon = $derived(
 );
 </script>
 
-<header class="border-b bg-background px-4 py-2.5">
+<header class="border-b bg-background px-4 py-2">
   <div class="flex items-start justify-between gap-3">
     <div class="min-w-0 flex-1">
       <div class="flex min-w-0 items-center gap-2">
@@ -76,7 +82,7 @@ const StateIcon = $derived(
 
       {#if detail}
         <div
-          class="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
+          class="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
         >
           <span>
             Opened by <span class="font-medium text-foreground"
@@ -84,7 +90,22 @@ const StateIcon = $derived(
             >
           </span>
           <span aria-hidden="true">·</span>
-          <span>{formatPrDateCompact(detail.createdAt)}</span>
+          <Tooltip.Root>
+            <Tooltip.Trigger>
+              {#snippet child({ props })}
+                <button
+                  {...props}
+                  type="button"
+                  class="inline cursor-help rounded-xs hover:text-foreground"
+                >
+                  {formatRelativePrDate(detail.createdAt)}
+                </button>
+              {/snippet}
+            </Tooltip.Trigger>
+            <Tooltip.Content sideOffset={5}
+              >{formatPrDateCompact(detail.createdAt)}</Tooltip.Content
+            >
+          </Tooltip.Root>
         </div>
       {:else}
         <div
@@ -97,19 +118,21 @@ const StateIcon = $derived(
       {/if}
 
       <div
-        class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground"
+        class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground"
       >
         {#if display}
           <span
             class="inline-flex items-center gap-1"
             aria-label={`Merges ${display.headRefName} into ${display.baseRefName}`}
           >
-            <Badge variant="outline" size="xs" class="font-mono"
-              >{display.baseRefName}</Badge
+            <span
+              class="max-w-44 truncate rounded-sm bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
+              title={display.baseRefName}>{display.baseRefName}</span
             >
             <ArrowLeft class="size-3" aria-hidden="true" />
-            <Badge variant="outline" size="xs" class="font-mono"
-              >{display.headRefName}</Badge
+            <span
+              class="max-w-44 truncate rounded-sm bg-muted px-1.5 py-0.5 font-mono text-muted-foreground"
+              title={display.headRefName}>{display.headRefName}</span
             >
           </span>
         {:else}

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrLoadingPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrLoadingPane.svelte
@@ -12,7 +12,7 @@ type Props = {
 };
 let { view, onRefresh, onOpenExternal }: Props = $props();
 const tabTriggerClass =
-  "h-full flex-none gap-1.5 rounded-sm px-2.5 text-xs font-medium data-active:bg-background data-active:shadow-xs data-active:ring-1 data-active:ring-border";
+  "h-full flex-none gap-1.5 rounded-sm px-2.5 text-xs font-medium data-active:bg-background data-active:shadow-xs";
 </script>
 
 <GithubPrHeader
@@ -24,41 +24,44 @@ const tabTriggerClass =
 />
 <Tabs.Root value="conversation" class="min-h-0 flex-1 gap-0">
   <div class="shrink-0 px-4 pt-3 pb-2">
-    <Tabs.List
-      class="h-8 gap-1 rounded-md bg-accent/35 p-1 ring-1 ring-border ring-inset"
-    >
-      <Tabs.Trigger value="conversation" class={tabTriggerClass}
-        >Conversation</Tabs.Trigger
-      >
-      <Tabs.Trigger value="commits" class={tabTriggerClass}
-        >Commits</Tabs.Trigger
-      >
-      <Tabs.Trigger value="checks" class={tabTriggerClass}>Checks</Tabs.Trigger>
-      <Tabs.Trigger value="files" class={tabTriggerClass}
-        >Files changed</Tabs.Trigger
-      >
-    </Tabs.List>
-  </div>
-  <Tabs.Content value="conversation" class="min-h-0 flex-1">
-    <ScrollArea class="h-full" viewportClass="@container px-4 pr-2 pt-1 pb-8">
-      <div
-        class="grid items-start gap-2 @3xl:grid-cols-[minmax(0,1fr)_18rem] @6xl:grid-cols-[minmax(0,1fr)_22rem]"
-      >
-        <GithubPrSectionSkeleton
-          variant="conversation"
-          label="Loading pull request conversation"
-        />
-        <aside class="flex flex-col gap-2">
+    <div class="shrink-0 px-4 pt-2 pb-1.5">
+      <Tabs.List class="h-7 gap-0.5 rounded-md bg-accent/35 p-0.5">
+        >
+        <Tabs.Trigger value="conversation" class={tabTriggerClass}
+          >Conversation</Tabs.Trigger
+        >
+        <Tabs.Trigger value="commits" class={tabTriggerClass}
+          >Commits</Tabs.Trigger
+        >
+        <Tabs.Trigger value="checks" class={tabTriggerClass}
+          >Checks</Tabs.Trigger
+        >
+        <Tabs.Trigger value="files" class={tabTriggerClass}
+          >Files changed</Tabs.Trigger
+        >
+      </Tabs.List>
+    </div>
+    <Tabs.Content value="conversation" class="min-h-0 flex-1">
+      <ScrollArea class="h-full" viewportClass="@container px-4 pr-2 pt-1 pb-8">
+        <div
+          class="grid items-start gap-2 @3xl:grid-cols-[minmax(0,1fr)_18rem] @6xl:grid-cols-[minmax(0,1fr)_22rem]"
+        >
           <GithubPrSectionSkeleton
-            variant="overview"
-            label="Loading pull request overview"
+            variant="conversation"
+            label="Loading pull request conversation"
           />
-          <GithubPrSectionSkeleton
-            variant="merge"
-            label="Loading pull request merge status"
-          />
-        </aside>
-      </div>
-    </ScrollArea>
-  </Tabs.Content>
-</Tabs.Root>
+          <aside class="flex flex-col gap-2">
+            <GithubPrSectionSkeleton
+              variant="overview"
+              label="Loading pull request overview"
+            />
+            <GithubPrSectionSkeleton
+              variant="merge"
+              label="Loading pull request merge status"
+            />
+          </aside>
+        </div>
+      </ScrollArea>
+    </Tabs.Content>
+  </div></Tabs.Root
+>

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrMergeBox.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrMergeBox.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Check from "@lucide/svelte/icons/check";
 import GitMerge from "@lucide/svelte/icons/git-merge";
+import ShieldAlert from "@lucide/svelte/icons/shield-alert";
 import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
 import type {
   GithubChecksSummary,
@@ -43,8 +44,15 @@ const showMerge = $derived(
     detail.mergeSettings.allowedMethods.length > 0,
 );
 
+/** Blocked by requirements only — admins may bypass them via override merge. */
+const showOverride = $derived(
+  !showMerge && readiness.status === "blocked" && readiness.canOverride,
+);
+
 function requestMerge() {
-  if (method && readiness.status === "ready") confirmOpen = true;
+  if (!method) return;
+  if (readiness.status === "ready") confirmOpen = true;
+  else if (showOverride) confirmOpen = true;
 }
 
 function confirmMerge() {
@@ -54,9 +62,13 @@ function confirmMerge() {
 }
 </script>
 
-<GithubPrSection contentClass="px-3 py-2.5">
+<GithubPrSection contentClass="px-3 py-2">
   <div class="flex items-start gap-2">
-    <span class="grid size-6 shrink-0 place-items-center rounded-md bg-muted">
+    <span
+      class={`grid size-6 shrink-0 place-items-center rounded-md ${
+        readiness.status === "ready" ? "bg-success/15" : "bg-warning/15"
+      }`}
+    >
       {#if readiness.status === "ready"}
         <GitMerge class="size-3.5 text-success" />
       {:else}
@@ -100,7 +112,7 @@ function confirmMerge() {
   </div>
 
   {#if showMerge && method}
-    <div class="mt-2.5">
+    <div class="mt-2">
       <SplitButton
         variant="success"
         disabled={merging || readiness.status !== "ready"}
@@ -113,16 +125,31 @@ function confirmMerge() {
           />{/if}
         {merging ? "Merging…" : mergeMethodLabel(method)}
         {#snippet menu()}
-          {#each detail.mergeSettings.allowedMethods as option (option)}
-            <DropdownMenu.Item onSelect={() => onMethodChange?.(option)}>
-              <span class="w-4"
-                >{#if option === method}<Check class="size-4" />{/if}</span
-              >
-              {mergeMethodLabel(option)}
-            </DropdownMenu.Item>
-          {/each}
+          {@render methodMenu()}
         {/snippet}
       </SplitButton>
+    </div>
+  {:else if showOverride && method}
+    <div class="mt-2">
+      <SplitButton
+        variant="outline"
+        disabled={merging}
+        triggerLabel="Choose merge method to override with"
+        menuClass="w-56"
+        onclick={requestMerge}
+      >
+        {#if merging}<Spinner class="size-3.5" />{:else}<ShieldAlert
+            class="size-3.5"
+          />{/if}
+        {merging ? "Merging…" : `Override and ${method}`}
+        {#snippet menu()}
+          {@render methodMenu()}
+        {/snippet}
+      </SplitButton>
+      <p class="mt-1 text-xs text-muted-foreground">
+        Merges without waiting for requirements. Only possible while you have
+        admin access.
+      </p>
     </div>
   {/if}
 
@@ -131,11 +158,24 @@ function confirmMerge() {
   {/if}
 </GithubPrSection>
 
+{#snippet methodMenu()}
+  {#each detail.mergeSettings.allowedMethods as option (option)}
+    <DropdownMenu.Item onSelect={() => onMethodChange?.(option)}>
+      <span class="w-4"
+        >{#if option === method}<Check class="size-4" />{/if}</span
+      >
+      {mergeMethodLabel(option)}
+    </DropdownMenu.Item>
+  {/each}
+{/snippet}
+
 <ConfirmDialog
   bind:open={confirmOpen}
   title={`Merge pull request #${detail.number}?`}
-  description={`${method ? mergeMethodLabel(method) : "Merge"} will merge ${detail.headRefName} into ${detail.baseRefName} at head ${detail.headRefOid.slice(0, 7)}.`}
-  confirmLabel="Confirm merge"
-  confirmVariant="success"
+  description={showOverride
+    ? `${method ? mergeMethodLabel(method) : "Merge"} will merge ${detail.headRefName} into ${detail.baseRefName} at head ${detail.headRefOid.slice(0, 7)}, skipping branch-protection requirements.`
+    : `${method ? mergeMethodLabel(method) : "Merge"} will merge ${detail.headRefName} into ${detail.baseRefName} at head ${detail.headRefOid.slice(0, 7)}.`}
+  confirmLabel={showOverride ? "Override and merge" : "Confirm merge"}
+  confirmVariant={showOverride ? "default" : "success"}
   onConfirm={confirmMerge}
 />

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrOverview.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrOverview.svelte
@@ -2,27 +2,28 @@
 import type { GithubPrOverview } from "@nervekit/contracts";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import GithubPrSection from "./GithubPrSection.svelte";
+import PrAvatar from "./PrAvatar.svelte";
 import { divergenceLabel, divergenceTone, reviewTone } from "./pr-pane-helpers";
 
 type Props = { overview: GithubPrOverview };
 let { overview }: Props = $props();
+
+const mergeableTone = $derived(
+  overview.mergeable === "MERGEABLE"
+    ? "good"
+    : overview.mergeable === "CONFLICTING"
+      ? "danger"
+      : ("neutral" as const),
+);
 </script>
 
-<GithubPrSection
-  title="Overview"
-  contentClass="flex flex-col gap-1.5 px-3 py-2.5"
->
+<GithubPrSection title="Overview" contentClass="flex flex-col gap-1 px-3 py-2">
   <div class="flex min-h-5 items-start gap-2">
-    <span class="w-20 shrink-0 pt-0.5 text-muted-foreground">Mergeability</span>
+    <span class="w-[4.5rem] shrink-0 pt-0.5 text-muted-foreground"
+      >Mergeability</span
+    >
     <div class="flex min-w-0 flex-wrap gap-1">
-      <Badge
-        size="xs"
-        tone={overview.mergeable === "MERGEABLE"
-          ? "good"
-          : overview.mergeable === "CONFLICTING"
-            ? "danger"
-            : "neutral"}
-      >
+      <Badge size="xs" tone={mergeableTone}>
         {overview.mergeable?.toLowerCase() ?? "calculating"}
       </Badge>
       {#if overview.reviewDecision}
@@ -34,37 +35,56 @@ let { overview }: Props = $props();
   </div>
 
   <div class="flex min-h-5 items-start gap-2">
-    <span class="w-20 shrink-0 pt-0.5 text-muted-foreground">Base branch</span>
-    <div class="flex min-w-0 flex-wrap gap-1">
-      <Badge size="xs" tone={divergenceTone(overview)}>
-        {divergenceLabel(overview)}
-      </Badge>
-    </div>
+    <span class="w-[4.5rem] shrink-0 pt-0.5 text-muted-foreground"
+      >Base branch</span
+    >
+    <Badge size="xs" tone={divergenceTone(overview)}>
+      {divergenceLabel(overview)}
+    </Badge>
   </div>
 
   <div class="flex min-h-5 items-start gap-2">
-    <span class="w-20 shrink-0 text-muted-foreground">Reviewers</span>
+    <span class="w-[4.5rem] shrink-0 text-muted-foreground">Reviewers</span>
     {#if overview.reviewRequests.length > 0}
-      <span class="min-w-0 flex-1 text-foreground">
-        {overview.reviewRequests.map((reviewer) => reviewer.login).join(", ")}
-      </span>
+      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1">
+        {#each overview.reviewRequests as reviewer (reviewer.login)}
+          <span
+            class="inline-flex max-w-full items-center gap-1 rounded-sm px-1 py-0.5 hover:bg-accent/40"
+            title={reviewer.login}
+          >
+            <PrAvatar
+              name={reviewer.login}
+              src={reviewer.avatarUrl}
+              class="size-4"
+            />
+            <span class="truncate text-foreground">{reviewer.login}</span>
+          </span>
+        {/each}
+      </div>
     {:else}
-      <span class="min-w-0 flex-1 text-muted-foreground"
-        >No pending review requests</span
-      >
+      <span class="min-w-0 flex-1 text-muted-foreground">—</span>
     {/if}
   </div>
 
   <div class="flex min-h-5 items-start gap-2">
-    <span class="w-20 shrink-0 text-muted-foreground">Labels</span>
+    <span class="w-[4.5rem] shrink-0 text-muted-foreground">Labels</span>
     {#if overview.labels.length > 0}
       <div class="flex min-w-0 flex-1 flex-wrap gap-1">
         {#each overview.labels as label (label.name)}
-          <Badge variant="outline" size="xs">{label.name}</Badge>
+          <!-- GitHub-supplied label color is content, not theme chrome -->
+          <Badge variant="outline" size="xs" title={label.name}>
+            {#if label.color}
+              <span
+                class="mr-0.5 inline-block size-2 shrink-0 rounded-full"
+                style={`background:#${label.color}`}
+              ></span>
+            {/if}
+            {label.name}
+          </Badge>
         {/each}
       </div>
     {:else}
-      <span class="min-w-0 flex-1 text-muted-foreground">No labels</span>
+      <span class="min-w-0 flex-1 text-muted-foreground">—</span>
     {/if}
   </div>
 </GithubPrSection>

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrPane.svelte
@@ -68,7 +68,7 @@ const checks = $derived(view?.checks.data?.checks);
 const files = $derived(view?.files.data);
 
 const tabTriggerClass =
-  "h-full flex-none gap-1.5 rounded-sm px-2.5 text-xs font-medium data-active:bg-background data-active:shadow-xs data-active:ring-1 data-active:ring-border";
+  "h-full flex-none gap-1.5 rounded-sm px-2.5 text-xs font-medium data-active:bg-background data-active:shadow-xs";
 
 function changeTab(value: string) {
   if (
@@ -176,10 +176,8 @@ function confirmCheckout() {
       onValueChange={changeTab}
       class="min-h-0 flex-1 gap-0"
     >
-      <div class="shrink-0 px-4 pt-3 pb-2">
-        <Tabs.List
-          class="h-8 gap-1 rounded-md bg-accent/35 p-1 ring-1 ring-border ring-inset"
-        >
+      <div class="shrink-0 px-4 pt-2 pb-1.5">
+        <Tabs.List class="h-7 gap-0.5 rounded-md bg-accent/35 p-0.5">
           <Tabs.Trigger value="conversation" class={tabTriggerClass}>
             Conversation
             {#if conversation}<span class="text-muted-foreground"

--- a/packages/workbench-app/src/lib/presentation/git/GithubPrSection.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/GithubPrSection.svelte
@@ -23,14 +23,9 @@ let {
 const hasHeader = $derived(Boolean(title) || Boolean(header));
 </script>
 
-<section
-  class={cn(
-    "min-w-0 rounded-md bg-accent/35 text-xs ring-1 ring-border ring-inset",
-    className,
-  )}
->
+<section class={cn("min-w-0 rounded-md bg-accent/35 text-xs", className)}>
   {#if hasHeader}
-    <div class="flex min-h-7 items-center gap-2 px-3 py-1.5">
+    <div class="flex min-h-7 items-center gap-2 px-3 py-1">
       {#if header}
         {@render header()}
       {:else}
@@ -47,8 +42,8 @@ const hasHeader = $derived(Boolean(title) || Boolean(header));
   {/if}
   <div
     class={cn(
-      hasHeader && "border-t border-border/60",
-      contentClass ?? "px-3 py-2.5",
+      hasHeader && "border-t border-border/50",
+      contentClass ?? "px-3 py-2",
     )}
   >
     {@render children()}

--- a/packages/workbench-app/src/lib/presentation/git/PrAvatar.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/PrAvatar.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { cn } from "@nervekit/ui-kit/core/utils";
+
+type Props = {
+  name?: string | null;
+  src?: string;
+  class?: string;
+};
+
+let { name, src, class: className }: Props = $props();
+
+let failed = $state(false);
+const initials = $derived((name ?? "?").trim().slice(0, 1).toUpperCase());
+</script>
+
+<span
+  class={cn(
+    "grid shrink-0 place-items-center overflow-hidden rounded-full bg-muted text-xs font-semibold text-muted-foreground",
+    className,
+  )}
+  title={name ?? undefined}
+>
+  {#if src && !failed}
+    <img
+      {src}
+      alt={name ?? "Avatar"}
+      loading="lazy"
+      referrerpolicy="no-referrer"
+      class="size-full object-cover"
+      onerror={() => (failed = true)}
+    />
+  {:else}
+    {initials}
+  {/if}
+</span>

--- a/packages/workbench-app/src/lib/presentation/git/PrCollapsibleBody.svelte
+++ b/packages/workbench-app/src/lib/presentation/git/PrCollapsibleBody.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import ChevronDown from "@lucide/svelte/icons/chevron-down";
+import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
+import { notifyCopyResult } from "@nervekit/ui-kit/core/notify";
+
+// Keep in sync with COLLAPSED_BODY_LINES in pr-pane-helpers.ts (the literal
+// class is required for Tailwind's static scan).
+type Props = { body: string };
+let { body }: Props = $props();
+let open = $state(false);
+</script>
+
+<div class="grid gap-1">
+  <div class="text-sm {open ? '' : 'line-clamp-14'}">
+    <Markdown text={body} onCopy={notifyCopyResult} />
+  </div>
+  <button
+    type="button"
+    onclick={() => (open = !open)}
+    class="inline-flex w-fit items-center gap-0.5 rounded-sm text-xs font-medium text-muted-foreground hover:text-foreground"
+  >
+    <ChevronDown
+      class="size-3 transition-transform {open ? 'rotate-180' : ''}"
+      aria-hidden="true"
+    />
+    {open ? "Show less" : "Show more"}
+  </button>
+</div>

--- a/packages/workbench-app/src/lib/presentation/git/pr-pane-helpers.test.ts
+++ b/packages/workbench-app/src/lib/presentation/git/pr-pane-helpers.test.ts
@@ -10,8 +10,12 @@ import {
   defaultMergeMethod,
   divergenceLabel,
   fileStatusLetter,
+  formatRelativePrDate,
   mergeReadiness,
   prTimeline,
+  reviewSurfaceClass,
+  shouldCollapseBody,
+  sortCheckRuns,
 } from "./pr-pane-helpers.js";
 
 type MergeDetail = GithubPrCore &
@@ -39,6 +43,7 @@ function detail(overrides: Partial<MergeDetail> = {}): MergeDetail {
     mergeable: "MERGEABLE",
     mergeStateStatus: "CLEAN",
     reviewDecision: "APPROVED",
+    viewerPermission: null,
     behindBy: 0,
     labels: [],
     reviewRequests: [],
@@ -82,6 +87,26 @@ describe("PR pane helpers", () => {
     );
   });
 
+  it("flags override merging for admins blocked only by requirements", () => {
+    const blocked = (
+      viewerPermission: "ADMIN" | "MAINTAIN" | "WRITE" | "READ" | null,
+    ) =>
+      mergeReadiness(detail({ viewerPermission, mergeStateStatus: "BLOCKED" }));
+    assert.equal(mergeReadiness(detail()).canOverride, false);
+    assert.equal(blocked(null).status, "blocked");
+    assert.equal(blocked(null).canOverride, false);
+    assert.equal(blocked("WRITE").canOverride, false);
+    assert.equal(blocked("MAINTAIN").canOverride, true);
+    assert.equal(blocked("ADMIN").canOverride, true);
+    // Conflicts can never be overridden.
+    assert.equal(
+      mergeReadiness(
+        detail({ viewerPermission: "ADMIN", mergeable: "CONFLICTING" }),
+      ).canOverride,
+      false,
+    );
+  });
+
   it("selects a deterministic allowed merge method", () => {
     assert.equal(defaultMergeMethod(["rebase", "squash"]), "squash");
     assert.equal(defaultMergeMethod(["merge", "squash"]), "merge");
@@ -113,6 +138,39 @@ describe("PR pane helpers", () => {
     assert.deepEqual(
       timeline.map((entry) => entry.kind),
       ["review", "comment"],
+    );
+  });
+
+  it("formats relative dates", () => {
+    const now = Date.parse("2026-08-22T12:00:00Z");
+    assert.equal(formatRelativePrDate(undefined), "");
+    assert.equal(formatRelativePrDate("2026-08-22T11:59:50Z", now), "just now");
+    assert.equal(formatRelativePrDate("2026-08-22T11:35:00Z", now), "25m ago");
+    assert.equal(formatRelativePrDate("2026-08-22T09:00:00Z", now), "3h ago");
+    assert.equal(formatRelativePrDate("2026-08-19T12:00:00Z", now), "3d ago");
+    assert.ok(formatRelativePrDate("2026-01-05T00:00:00Z", now).length > 0);
+  });
+
+  it("tints review surfaces and collapses long bodies", () => {
+    assert.equal(reviewSurfaceClass("APPROVED"), "bg-success/8");
+    assert.equal(reviewSurfaceClass("CHANGES_REQUESTED"), "bg-destructive/8");
+    assert.equal(reviewSurfaceClass("COMMENTED"), "");
+    assert.equal(shouldCollapseBody("short"), false);
+    assert.equal(shouldCollapseBody("line\n".repeat(13)), false);
+    assert.equal(shouldCollapseBody("line\n".repeat(14)), true);
+  });
+
+  it("sorts check runs failing first, then pending, then passed", () => {
+    const runs = sortCheckRuns([
+      { name: "beta", status: "COMPLETED" },
+      { name: "gamma", status: "IN_PROGRESS" },
+      { name: "alpha", status: "COMPLETED" },
+      { name: "delta", status: "QUEUED" },
+      { name: "eps", status: "FAILURE" },
+    ]);
+    assert.deepEqual(
+      runs.map((run) => run.name),
+      ["eps", "delta", "gamma", "alpha", "beta"],
     );
   });
 

--- a/packages/workbench-app/src/lib/presentation/git/pr-pane-helpers.ts
+++ b/packages/workbench-app/src/lib/presentation/git/pr-pane-helpers.ts
@@ -18,6 +18,8 @@ type TimelineEntry =
 export type MergeReadiness = {
   status: "ready" | "blocked" | "unknown";
   reasons: string[];
+  /** Admins may merge even when branch-protection requirements block the PR. */
+  canOverride: boolean;
 };
 
 export function checksTone(checks: GithubChecksSummary): BadgeTone {
@@ -68,6 +70,66 @@ export function formatPrDate(value?: string): string {
   return Number.isNaN(date.getTime()) ? "" : date.toLocaleString();
 }
 
+export function formatRelativePrDate(value?: string, now = Date.now()): string {
+  if (!value) return "";
+  const date = new Date(value);
+  const time = date.getTime();
+  if (Number.isNaN(time)) return "";
+  const seconds = Math.round((now - time) / 1000);
+  if (seconds < 45) return "just now";
+  if (seconds < 90) return "1m ago";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year:
+      date.getFullYear() === new Date(now).getFullYear()
+        ? undefined
+        : "numeric",
+  });
+}
+
+export function reviewSurfaceClass(state: string): string {
+  if (state === "APPROVED") return "bg-success/8";
+  if (state === "CHANGES_REQUESTED") return "bg-destructive/8";
+  return "";
+}
+
+const COLLAPSED_BODY_LINES = 14;
+
+export function bodyLineCount(body: string): number {
+  return body.split("\n").length;
+}
+
+export function shouldCollapseBody(body: string): boolean {
+  return bodyLineCount(body) > COLLAPSED_BODY_LINES;
+}
+
+const CHECK_RUN_SORT_ORDER = { failed: 0, pending: 1, passed: 2 } as const;
+
+export function sortCheckRuns<T extends { name: string; status: string }>(
+  runs: T[],
+): T[] {
+  return [...runs].sort((left, right) => {
+    const leftRank =
+      CHECK_RUN_SORT_ORDER[
+        githubCheckRunOutcome(left.status) as keyof typeof CHECK_RUN_SORT_ORDER
+      ] ?? 3;
+    const rightRank =
+      CHECK_RUN_SORT_ORDER[
+        githubCheckRunOutcome(right.status) as keyof typeof CHECK_RUN_SORT_ORDER
+      ] ?? 3;
+    return leftRank !== rightRank
+      ? leftRank - rightRank
+      : left.name.localeCompare(right.name);
+  });
+}
+
 export function formatPrDateCompact(value?: string): string {
   if (!value) return "";
   const date = new Date(value);
@@ -100,11 +162,24 @@ export function mergeReadiness(
   detail: GithubPrCore & GithubPrOverview & { checks: GithubChecksSummary },
 ): MergeReadiness {
   if (detail.state !== "OPEN") {
-    return { status: "blocked", reasons: ["Pull request is not open"] };
+    return {
+      status: "blocked",
+      reasons: ["Pull request is not open"],
+      canOverride: false,
+    };
   }
   if (detail.isDraft) {
-    return { status: "blocked", reasons: ["Pull request is still a draft"] };
+    return {
+      status: "blocked",
+      reasons: ["Pull request is still a draft"],
+      canOverride: false,
+    };
   }
+  const canOverride =
+    (detail.viewerPermission === "ADMIN" ||
+      detail.viewerPermission === "MAINTAIN") &&
+    detail.mergeable === "MERGEABLE" &&
+    detail.mergeSettings.allowedMethods.length > 0;
   if (
     !detail.headRefOid ||
     detail.mergeable === null ||
@@ -113,6 +188,7 @@ export function mergeReadiness(
     return {
       status: "unknown",
       reasons: ["GitHub is calculating mergeability"],
+      canOverride: false,
     };
   }
 
@@ -136,8 +212,8 @@ export function mergeReadiness(
   if (detail.mergeSettings.allowedMethods.length === 0)
     reasons.push("No merge method is enabled");
   return reasons.length > 0
-    ? { status: "blocked", reasons: [...new Set(reasons)] }
-    : { status: "ready", reasons: [] };
+    ? { status: "blocked", reasons: [...new Set(reasons)], canOverride }
+    : { status: "ready", reasons: [], canOverride };
 }
 
 export function divergenceLabel(detail: GithubPrOverview): string {


### PR DESCRIPTION
## Summary

Restyles the GitHub PR detail view to match the app design language — fewer outlines, contrast via accent/bg tokens, tighter spacing — and adds conversation features plus an admin override-merge capability.

### Design pass
- Section cards are flat `bg-accent/35` surfaces (rings removed); softer header dividers, compact padding.
- Tab strip: ring-free track, `h-7` height; active tab keeps `bg-background shadow-xs`.
- Branch refs rendered as quiet mono chips instead of outline badges.

### Conversation tab
- New `PrAvatar` component: GitHub avatars with initials fallback for timeline entries and reviewers.
- Relative timestamps ("3h ago") with tooltips showing the full timestamp.
- Status-tinted review cards: approved → success tint, changes requested → destructive tint.
- Bodies longer than 14 lines collapse to a line-clamped preview with a Show more/Show less toggle (`PrCollapsibleBody`).
- Empty conversation state is plain muted text (no dashed outline).

### Overview & merge box
- Compact definition-list rows, reviewer avatar chips, labels with their GitHub color dots.
- Merge readiness tile tinted by status; blocked-but-overridable PRs get an **"Override and merge"** action with an explicit confirmation dialog noting branch-protection requirements will be skipped.
- Override visibility is driven by new `viewerPermission` data (`ADMIN`/`MAINTAIN`, open, mergeable, allowed methods). Conflicts/drafts can never be overridden. Server merge flow unchanged; failures surface in the existing error slot.

### Checks & commits
- Tinted passed/failed/pending count chips; check runs sorted failing → pending → passed.
- Commit SHA chips are click-to-copy with toast feedback.

## Test plan
- [x] New unit tests in `pr-pane-helpers.test.ts`: override truth table, relative-date buckets, review tints/collapse threshold, check-run sorting.
- [x] `pnpm fix && pnpm check && pnpm test` passes across all packages.
- [ ] Manual smoke against a live daemon: tab strip, conversation avatars/collapse, overview rows, override affordance visibility.