### PR TITLE
feat: idempotent transcript entries and task notification recovery

### DIFF
--- a/packages/workbench-server/src/domains/agents/run/message-mirror.ts
+++ b/packages/workbench-server/src/domains/agents/run/message-mirror.ts
@@ -132,6 +132,7 @@ export class MessageMirror {
     for (const entry of storageEntries) {
       if (knownEntryIds.has(entry.id)) continue;
       knownEntryIds.add(entry.id);
+      if (visibleEntryIds.has(entry.id)) continue;
       if (entry.type !== "message") continue;
       if (
         entry.message.role !== "user" &&

--- a/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
@@ -409,11 +409,9 @@ function applyEvent(
         (entry) => entry.id === event.entry.id,
       );
       if (index === -1) state.entries.push(event.entry);
-      else if (
-        JSON.stringify(state.entries[index]) !== JSON.stringify(event.entry)
-      ) {
-        throw new Error(`Conflicting conversation entry '${event.entry.id}'.`);
-      }
+      // Entry ids are the idempotency boundary for transcript materialization.
+      // Concurrent writers can derive different presentation metadata for the
+      // same durable message; the first committed representation wins.
       return;
     }
     case "model_context.entry_appended": {

--- a/packages/workbench-server/src/domains/conversations/conversation-lifecycle.service.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-lifecycle.service.ts
@@ -142,7 +142,13 @@ export class ConversationLifecycleService {
     options: AppendEntryOptions = {},
   ): Promise<ConversationEntry> {
     const conversation = this.getConversation(input.conversationId);
-    const entry: ConversationEntry = {
+    const entries = this.state.entries.get(input.conversationId) ?? [];
+    const existing = input.id
+      ? entries.find((candidate) => candidate.id === input.id)
+      : undefined;
+    if (existing) return existing;
+
+    let entry: ConversationEntry = {
       id: input.id ?? createId("entry"),
       conversationId: input.conversationId,
       agentId: input.agentId,
@@ -165,10 +171,11 @@ export class ConversationLifecycleService {
       details: input.details,
       createdAt: input.createdAt ?? new Date().toISOString(),
     };
-    const entries = this.state.entries.get(input.conversationId) ?? [];
+    entry = await this.entryRepository.append(entry);
+    const committed = entries.find((candidate) => candidate.id === entry.id);
+    if (committed) return committed;
     entries.push(entry);
     this.state.entries.set(input.conversationId, entries);
-    await this.entryRepository.append(entry);
     const lastUserMessageAt =
       entry.role === "user" &&
       (!conversation.lastUserMessageAt ||

--- a/packages/workbench-server/src/domains/conversations/entry.repository.ts
+++ b/packages/workbench-server/src/domains/conversations/entry.repository.ts
@@ -14,9 +14,10 @@ export class EntryRepository {
     return [...(await this.journal.load(conversationId)).entries];
   }
 
-  async append(entry: ConversationEntry): Promise<void> {
+  async append(entry: ConversationEntry): Promise<ConversationEntry> {
     await this.journal.commit(entry.conversationId, {
       kind: "conversation.entry_appended",
+      idempotencyKey: `conversation-entry:${entry.id}`,
       events: [
         {
           kind: "conversation.entry_appended",
@@ -25,6 +26,11 @@ export class EntryRepository {
         },
       ],
     });
+    return (
+      (await this.journal.load(entry.conversationId)).entries.find(
+        (candidate) => candidate.id === entry.id,
+      ) ?? entry
+    );
   }
 
   displayLinkedEntries(entries: ConversationEntry[]): ConversationEntry[] {

--- a/packages/workbench-server/src/domains/tasks/task-notification.service.ts
+++ b/packages/workbench-server/src/domains/tasks/task-notification.service.ts
@@ -230,6 +230,21 @@ export class TaskNotificationService {
       if (!currentEntryId) {
         await this.deps.tasks.markNotificationPending(task.id, slot, entryId);
       }
+      const existingById = this.findExistingTaskEventEntry(
+        task,
+        event,
+        entryId,
+      );
+      if (existingById) {
+        await this.deps.tasks.markNotificationDelivered(
+          task.id,
+          slot,
+          existingById.id,
+          existingById.createdAt,
+        );
+        await this.maybeContinueAwaitedTask(task, event);
+        return;
+      }
       const timestamp = new Date().toISOString();
       const { message } = await this.buildHarnessMessage(
         task,
@@ -283,7 +298,7 @@ export class TaskNotificationService {
     if (task.completion?.inject !== true) return;
     if (!task.agentId) return;
     const activeRunId = await this.activeRunId(task);
-    if (!activeRunId || this.deps.liveRuns.get(activeRunId)) return;
+    if (activeRunId) return;
     const continueAgent = this.deps.continueAgent;
     if (!continueAgent) return;
     await continueAgent(task.agentId).catch((error) =>
@@ -297,14 +312,17 @@ export class TaskNotificationService {
   }
 
   private async activeRunId(task: TaskRecord): Promise<string | undefined> {
-    if (task.origin.kind === "agent_tool" && task.origin.runId) {
-      return task.origin.runId;
-    }
+    const originRunId =
+      task.origin.kind === "agent_tool" ? task.origin.runId : undefined;
+    if (originRunId && this.deps.liveRuns.get(originRunId)) return originRunId;
     if (!task.agentId || !task.conversationId) return undefined;
     const state = await this.deps.runUnitOfWork.findActive(
       `${task.conversationId}:${task.agentId}`,
     );
-    return state?.run.runId;
+    const activeRunId = state?.run.runId;
+    return activeRunId && this.deps.liveRuns.get(activeRunId)
+      ? activeRunId
+      : undefined;
   }
 
   private shouldDeliver(task: TaskRecord, event: HarnessTaskEvent): boolean {
@@ -402,6 +420,17 @@ export class TaskNotificationService {
     message: HarnessMessage<HarnessTaskEventDetails>,
     timestamp: string,
   ): Promise<void> {
+    const event = message.details?.event ?? "completed";
+    const existing = this.findExistingTaskEventEntry(task, event, entryId);
+    if (existing) {
+      await this.deps.tasks.markNotificationDelivered(
+        task.id,
+        slotForEvent(event),
+        existing.id,
+        existing.createdAt,
+      );
+      return;
+    }
     const agent = this.deps.getAgent(task.agentId as string);
     await this.deps.harnessStorage.appendHarnessMessageWithId(
       agent,
@@ -430,7 +459,7 @@ export class TaskNotificationService {
     );
     await this.deps.tasks.markNotificationDelivered(
       task.id,
-      slotForEvent(message.details?.event ?? "completed"),
+      slotForEvent(event),
       entry.id,
       entry.createdAt,
     );
@@ -467,11 +496,13 @@ export class TaskNotificationService {
   private findExistingTaskEventEntry(
     task: TaskRecord,
     event: HarnessTaskEvent,
+    entryId?: string,
   ): ConversationEntry | undefined {
     if (!task.conversationId) return undefined;
     return this.deps
       .getConversationEntries(task.conversationId)
       .find((entry) => {
+        if (entryId && entry.id === entryId) return true;
         if (entry.kind !== "task_event") return false;
         const details = asRecord(entry.details);
         return (

--- a/packages/workbench-server/test/conversation-journal.repository.test.ts
+++ b/packages/workbench-server/test/conversation-journal.repository.test.ts
@@ -3,7 +3,10 @@ import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import type { ConversationRecord } from "@nervekit/contracts";
+import type {
+  ConversationEntry,
+  ConversationRecord,
+} from "@nervekit/contracts";
 import { ConversationJournalRepository } from "../src/domains/conversations/conversation-journal.repository.js";
 
 const conversationId = "conv_journal_test";
@@ -49,6 +52,46 @@ test("conversation journal commits are chained and idempotent", async (t) => {
   assert.equal(replayed.revision, 1);
   assert.equal(replayed.conversation?.title, "Journal test");
   assert.match(replayed.checksum, /^sha256:[a-f0-9]{64}$/);
+});
+
+test("conversation entry appends are first-write-wins by id", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-entry-idempotent-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const repository = new ConversationJournalRepository({ paths: { home } });
+  const original: ConversationEntry = {
+    id: "entry_task_event",
+    conversationId,
+    role: "system",
+    kind: "task_event",
+    text: "Task completed",
+    createdAt: now,
+  };
+  await repository.commit(conversationId, {
+    kind: "conversation.entry_appended",
+    events: [
+      { kind: "conversation.entry_appended", conversationId, entry: original },
+    ],
+  });
+  await repository.commit(conversationId, {
+    kind: "conversation.entry_appended",
+    events: [
+      {
+        kind: "conversation.entry_appended",
+        conversationId,
+        entry: {
+          ...original,
+          parentEntryId: "entry_concurrent_parent",
+          text: "Task completed with regenerated details",
+        },
+      },
+    ],
+  });
+
+  const state = await new ConversationJournalRepository({
+    paths: { home },
+  }).load(conversationId);
+  assert.equal(state.revision, 2);
+  assert.deepEqual(state.entries, [original]);
 });
 
 test("conversation journal truncates a non-terminated final append", async (t) => {

--- a/packages/workbench-server/test/helpers/registry-conversation.ts
+++ b/packages/workbench-server/test/helpers/registry-conversation.ts
@@ -60,6 +60,7 @@ export function ageConversation(
 export function appendRegistryEntry(
   state: Awaited<ReturnType<typeof createState>>,
   input: {
+    id?: string;
     conversationId: string;
     parentEntryId?: string | null;
     role: ConversationEntry["role"];

--- a/packages/workbench-server/test/message-mirror.test.ts
+++ b/packages/workbench-server/test/message-mirror.test.ts
@@ -75,11 +75,14 @@ function toolResultStorageEntry(
   };
 }
 
-function createMirror(storageEntries: unknown[]) {
+function createMirror(
+  storageEntries: unknown[],
+  existingEntries: ConversationEntry[] = [],
+) {
   const appended: AppendEntryInput[] = [];
   const mirror = new MessageMirror({
     state: {
-      getConversationEntries: () => [],
+      getConversationEntries: () => existingEntries,
       conversations: new Map(),
     } as unknown as RuntimeState,
     appendEntry: async (input) => {
@@ -133,6 +136,35 @@ describe("AssistantEntryMetaQueue", () => {
 });
 
 describe("MessageMirror assistant message correlation", () => {
+  it("does not mirror a harness entry already present in the transcript", async () => {
+    const storageEntry = toolResultStorageEntry("entry_existing", {
+      text: "Task cancelled",
+      toolName: "task_control",
+    });
+    const existing = {
+      id: "entry_existing",
+      conversationId: agent.conversationId,
+      role: "system",
+      kind: "task_event",
+      text: "Background task cancelled.",
+      createdAt: "2026-01-01T00:00:02.000Z",
+    } satisfies ConversationEntry;
+    const { mirror, storage, appended } = createMirror(
+      [storageEntry],
+      [existing],
+    );
+
+    const mirrored = await mirror.mirrorNewHarnessEntries(
+      agent,
+      storage,
+      new Set(),
+      { runId: "run_retry", turnId: "turn_retry" },
+    );
+
+    assert.deepEqual(mirrored, []);
+    assert.deepEqual(appended, []);
+  });
+
   it("assigns FIFO metas to assistant entries within one batch", async () => {
     const { mirror, storage, appended } = createMirror([
       assistantStorageEntry("entry_a1", "first answer"),

--- a/packages/workbench-server/test/registry-conversation-lifecycle.test.ts
+++ b/packages/workbench-server/test/registry-conversation-lifecycle.test.ts
@@ -81,6 +81,53 @@ describe("RuntimeRegistry conversation lifecycle", () => {
     assert.equal(persisted.lastUserMessageAt, createdAt);
   });
 
+  it("returns the first transcript entry when an id is appended again", async () => {
+    const state = await createState("nerve-registry-idempotent-entry-");
+    try {
+      const project = await state.registry.createProject({
+        dir: state.storage.paths.home,
+      });
+      const conversation = await state.registry.createConversation({
+        projectId: project.id,
+      });
+      const entryId = "entry_idempotent_task_event";
+      const original = await appendRegistryEntry(state, {
+        id: entryId,
+        conversationId: conversation.id,
+        role: "system",
+        text: "Task completed",
+        createdAt: "2026-01-01T00:01:00.000Z",
+      });
+      const repeated = await appendRegistryEntry(state, {
+        id: entryId,
+        conversationId: conversation.id,
+        parentEntryId: "entry_different_parent",
+        role: "system",
+        text: "Regenerated task completion",
+        createdAt: "2026-01-01T00:02:00.000Z",
+      });
+
+      assert.deepEqual(repeated, original);
+      assert.deepEqual(state.registry.getConversationEntries(conversation.id), [
+        original,
+      ]);
+      assert.equal(
+        state.registry.getConversation(conversation.id).activeEntryId,
+        entryId,
+      );
+      assert.equal(
+        (
+          await new ConversationJournalRepository(state.storage).load(
+            conversation.id,
+          )
+        ).entries.length,
+        1,
+      );
+    } finally {
+      state.index.close();
+    }
+  });
+
   it("tracks last user message time separately from conversation updates", async () => {
     const state = await createState("nerve-registry-last-user-message-");
     try {

--- a/packages/workbench-server/test/task-notification.service.test.ts
+++ b/packages/workbench-server/test/task-notification.service.test.ts
@@ -135,6 +135,87 @@ describe("TaskNotificationService awaited task continuation", () => {
     context.service.stop();
   });
 
+  it("recovers an existing terminal transcript entry without appending it again", async () => {
+    const existing = {
+      id: "entry_existing_notification",
+      conversationId: "conv_test",
+      agentId: "agent_test",
+      runId: "run_test",
+      role: "system",
+      kind: "task_event",
+      text: "Background task completed.",
+      details: {
+        type: "task_event",
+        taskId: "task_test",
+        event: "completed",
+      },
+      createdAt: "2026-01-02T03:04:06.000Z",
+    } satisfies ConversationEntry;
+    const context = createNotificationContext({
+      task: taskRecord(),
+      existingEntries: [existing],
+    });
+    context.service.start();
+
+    await context.events.publish("task.completed", { task: context.task });
+    await waitFor(() => context.tasks.delivered.length === 1);
+
+    assert.deepEqual(context.entries, [existing]);
+    assert.deepEqual(context.harnessMessages, []);
+    assert.deepEqual(context.tasks.pending, []);
+    assert.deepEqual(context.tasks.delivered, [
+      { slot: "terminal", entryId: existing.id },
+    ]);
+    context.service.stop();
+  });
+
+  it("adds cancellation events directly when no run is live", async () => {
+    const context = createNotificationContext({
+      task: taskRecord({ status: "cancelled", signal: "SIGTERM" }),
+    });
+    context.service.start();
+
+    await context.events.publish("task.cancelled", { task: context.task });
+    await waitFor(() => context.entries.length === 1);
+
+    const entry = context.entries[0];
+    assert.equal(entry?.kind, "task_event");
+    assert.match(entry?.text ?? "", /cancelled/i);
+    assert.deepEqual(
+      (entry?.details as { event?: string; signal?: string | null })?.event,
+      "cancelled",
+    );
+    assert.equal(
+      (entry?.details as { signal?: string | null })?.signal,
+      "SIGTERM",
+    );
+    assert.equal(context.harnessMessages.length, 1);
+    assert.equal(context.tasks.delivered[0]?.slot, "terminal");
+    context.service.stop();
+  });
+
+  it("queues into the current live run when the task origin run is dead", async () => {
+    const enqueued: AgentMessage[] = [];
+    const context = createNotificationContext({
+      task: taskRecord(),
+      activeRunId: "run_current",
+      liveRunId: "run_current",
+      liveControl: {
+        enqueueHarnessMessage: async (input) => {
+          enqueued.push(input.message);
+        },
+      },
+    });
+    context.service.start();
+
+    await context.events.publish("task.completed", { task: context.task });
+    await waitFor(() => enqueued.length === 1);
+
+    assert.equal(context.entries.length, 0);
+    assert.equal(enqueued[0]?.role, "harness");
+    context.service.stop();
+  });
+
   it("queues notifications into an active run without starting a second run", async () => {
     const enqueued: AgentMessage[] = [];
     const context = createNotificationContext({
@@ -161,6 +242,9 @@ describe("TaskNotificationService awaited task continuation", () => {
 
 function createNotificationContext(options: {
   task: TaskRecord;
+  existingEntries?: ConversationEntry[];
+  activeRunId?: string;
+  liveRunId?: string;
   liveControl?: {
     enqueueHarnessMessage(input: { message: AgentMessage }): Promise<void>;
   };
@@ -169,7 +253,7 @@ function createNotificationContext(options: {
   const events = new TestEvents();
   const task = options.task;
   const tasks = new FakeTasks(task);
-  const entries: ConversationEntry[] = [];
+  const entries: ConversationEntry[] = [...(options.existingEntries ?? [])];
   const harnessMessages: Array<{
     id: string;
     message: AgentMessage;
@@ -182,10 +266,14 @@ function createNotificationContext(options: {
     events: events as unknown as TaskNotificationServiceDeps["events"],
     liveRuns: {
       get: (runId: string) =>
-        runId === "run_test" ? options.liveControl : undefined,
+        runId === (options.liveRunId ?? "run_test")
+          ? options.liveControl
+          : undefined,
     } as unknown as TaskNotificationServiceDeps["liveRuns"],
     runUnitOfWork: {
-      findActive: async () => ({ run: { runId: "run_test" } }),
+      findActive: async () => ({
+        run: { runId: options.activeRunId ?? "run_test" },
+      }),
     } as unknown as TaskNotificationServiceDeps["runUnitOfWork"],
     appendEntry: async (input) => {
       const entry = {


### PR DESCRIPTION
## Summary

This PR introduces idempotent transcript entries and recovery logic for task notifications to prevent duplicate conversation entries on restart/retry.

## Changes

### Core Implementation

1. **MessageMirror** (`message-mirror.ts`): Skip entries already visible in the transcript to avoid mirroring harness entries that were already materialized.

2. **ConversationJournalRepository** (`conversation-journal.repository.ts`): Changed conflict handling for `conversation.entry_appended` events to **first-write-wins** by entry ID. Entry IDs are now the idempotency boundary for transcript materialization — concurrent writers can derive different presentation metadata for the same durable message; the first committed representation wins.

3. **ConversationLifecycleService** (`conversation-lifecycle.service.ts`): Made `appendEntry` idempotent — returns the existing entry when an entry with the same ID is appended again, instead of creating a duplicate.

4. **EntryRepository** (`entry.repository.ts`): Added `idempotencyKey` to journal commits and returns the committed entry.

5. **TaskNotificationService** (`task-notification.service.ts`):
   - Recovers existing terminal transcript entries instead of re-appending them
   - Fixed `activeRunId` detection to only consider runs that are actually live
   - Queues notifications into the current live run when the task's origin run is dead
   - Handles cancellation events directly when no live run exists

### Tests Added

- `conversation-journal.repository.test.ts`: Test for first-write-wins entry appends
- `message-mirror.test.ts`: Test that mirror skips harness entries already in transcript
- `registry-conversation-lifecycle.test.ts`: Test that repeated entry append returns original
- `task-notification.service.test.ts`: Tests for:
  - Recovery of existing terminal transcript entries
  - Cancellation events when no run is live
  - Queuing into current live run when origin run is dead

## Validation

Run `pnpm fix && pnpm check && pnpm test` to verify all changes pass.