### PR TITLE
Persist conversation workspace tabs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 Root `docs/` contains maintainer and development workflow material that is not part of the public product documentation:
 
+- `conversation-storage-erd.md` records the non-normative SQLite conversation-storage ERD brainstorm.
 - `performance-profiling.md` documents automatic source-desktop performance diagnostics and the local summary tool.
 - `release.md` is the maintainer release procedure.
 

--- a/docs/conversation-storage-erd.md
+++ b/docs/conversation-storage-erd.md
@@ -1,0 +1,458 @@
+# Conversation storage ERD (brainstorm)
+
+> **Status:** Non-normative design exploration. This describes a possible replacement for the current conversation journals; it is not an implementation plan or product contract.
+
+## Direction
+
+Use one canonical SQLite database for all projects, conversations, agents, entries, runs, and tool calls. Current state is directly queryable. A bounded outbox supports reliable event delivery, but the outbox is not the canonical state and is not an indefinitely retained event-sourcing journal.
+
+The design aims to:
+
+- store each piece of authoritative data once;
+- use one conversation/model-context entry tree rather than separate display and model copies;
+- store all tool arguments and results through one transactional payload abstraction, regardless of size;
+- represent approvals, user questions, and plan review with one interaction model;
+- preserve branching, sub-agent isolation, retries, recovery checkpoints, and reliable event delivery;
+- keep frequently queried fields relational while allowing JSON at genuinely extensible boundaries.
+
+## Entity relationship diagram
+
+```mermaid
+erDiagram
+    PROJECT ||--o{ CONVERSATION : contains
+    CONVERSATION ||--o{ AGENT : owns
+    AGENT o|--o{ AGENT : parent_of
+
+    CONVERSATION ||--o{ ENTRY : contains
+    AGENT ||--o{ ENTRY : owns_context
+    ENTRY o|--o{ ENTRY : parent_of
+    ENTRY ||--o{ ENTRY_BLOCK : contains
+
+    CONVERSATION ||--o{ RUN : contains
+    AGENT ||--o{ RUN : executes
+    RUN ||--o{ RUN_ATTEMPT : attempts
+    RUN_ATTEMPT ||--o{ CHECKPOINT : creates
+
+    CONVERSATION ||--o{ RUN_PROMPT : queues
+    AGENT ||--o{ RUN_PROMPT : receives
+    RUN o|--o{ RUN_PROMPT : assigned_to
+
+    RUN ||--o{ TOOL_CALL : invokes
+    TOOL_CALL ||--|{ TOOL_PAYLOAD : has
+    TOOL_CALL ||--o{ TOOL_INTERACTION : requests
+    TOOL_CALL o|--o{ ENTRY_BLOCK : referenced_by
+    CHECKPOINT o|--o{ TOOL_INTERACTION : resumes_from
+
+    CONVERSATION ||--o{ OUTBOX_EVENT : publishes
+    RUN o|--o{ OUTBOX_EVENT : produces
+
+    PROJECT {
+        text id PK
+        text name
+        text directory
+        integer created_at_ms
+        integer updated_at_ms
+    }
+
+    CONVERSATION {
+        text id PK
+        text project_id FK
+        text active_agent_id FK
+        text title
+        text default_mode
+        text default_permission_level
+        integer pinned
+        integer completed_at_ms
+        integer last_user_message_at_ms
+        integer created_at_ms
+        integer updated_at_ms
+    }
+
+    AGENT {
+        text id PK
+        text conversation_id FK
+        text parent_agent_id FK
+        text root_agent_id FK
+        text active_entry_id FK
+        text mode
+        text permission_level
+        text status
+        text model_provider
+        text model_id
+        text thinking_level
+        json configuration_json
+        integer created_at_ms
+        integer updated_at_ms
+    }
+
+    ENTRY {
+        text id PK
+        text conversation_id FK
+        text agent_id FK
+        text parent_entry_id FK
+        text run_id FK
+        text role
+        text kind
+        integer visible_in_transcript
+        integer include_in_model_context
+        integer input_tokens
+        integer output_tokens
+        integer cache_read_tokens
+        integer cache_write_tokens
+        integer cost_microusd
+        json metadata_json
+        integer created_at_ms
+    }
+
+    ENTRY_BLOCK {
+        integer id PK
+        text entry_id FK
+        integer ordinal
+        text kind
+        text tool_call_id FK
+        text text_content
+        text mime_type
+        blob data
+    }
+
+    RUN {
+        text id PK
+        text conversation_id FK
+        text agent_id FK
+        integer revision
+        text status
+        text recoverability
+        text active_attempt_id FK
+        text failure_code
+        text failure_message
+        integer failure_retryable
+        integer failure_continuable
+        integer created_at_ms
+        integer updated_at_ms
+        integer terminal_at_ms
+    }
+
+    RUN_ATTEMPT {
+        text id PK
+        text run_id FK
+        integer ordinal
+        text status
+        text provider_boundary
+        text failure_code
+        text failure_message
+        integer started_at_ms
+        integer completed_at_ms
+    }
+
+    RUN_PROMPT {
+        text id PK
+        text conversation_id FK
+        text agent_id FK
+        text run_id FK
+        integer ordinal
+        text behavior
+        text status
+        json content_json
+        integer delivery_attempts
+        integer created_at_ms
+        integer updated_at_ms
+    }
+
+    CHECKPOINT {
+        text id PK
+        text run_attempt_id FK
+        text parent_checkpoint_id FK
+        text boundary
+        text active_entry_id FK
+        integer schema_version
+        blob recovery_state
+        text checksum
+        integer created_at_ms
+    }
+
+    TOOL_CALL {
+        text id PK
+        text run_id FK
+        text agent_id FK
+        text tool_name
+        text tool_group
+        text execution_kind
+        text status
+        text risk
+        integer revision
+        integer attempt
+        text cwd
+        json args_preview_json
+        json result_preview_json
+        text error_code
+        text error_message
+        integer error_retryable
+        integer hidden
+        integer created_at_ms
+        integer updated_at_ms
+        integer settled_at_ms
+    }
+
+    TOOL_PAYLOAD {
+        text tool_call_id PK,FK
+        text kind PK
+        text encoding
+        blob data
+        text digest
+        integer byte_length
+    }
+
+    TOOL_INTERACTION {
+        text id PK
+        text tool_call_id FK
+        text checkpoint_id FK
+        text batch_id
+        integer ordinal
+        text kind
+        text status
+        json request_json
+        json resolution_json
+        text resolution_request_id
+        integer requested_at_ms
+        integer updated_at_ms
+        integer resolved_at_ms
+        integer cancelled_at_ms
+    }
+
+    OUTBOX_EVENT {
+        integer sequence PK
+        text conversation_id FK
+        text run_id FK
+        text event_type
+        json payload_json
+        integer occurred_at_ms
+        integer delivery_attempts
+        integer delivered_at_ms
+        text last_error
+    }
+```
+
+## Entity responsibilities
+
+### Conversation entries
+
+`ENTRY` is the canonical conversation and model-context tree. `parent_entry_id` provides branching, while `agent_id` gives each parent or sub-agent an isolated context. The agent's `active_entry_id` identifies its current leaf.
+
+`visible_in_transcript` and `include_in_model_context` are independent because visibility and model inclusion are orthogonal. This supports ordinary messages, UI-only notices, model-only context, and private sub-agent context without copying content.
+
+`ENTRY_BLOCK` preserves ordered structured content. Text, thinking, images, tool invocations, and tool results are blocks of the same entry. Tool blocks reference canonical `TOOL_CALL` rows rather than embedding another tool record.
+
+### Runs and recovery
+
+`RUN` contains the latest durable run state. `RUN_ATTEMPT` records each execution or retry without repeatedly serializing a cumulative run snapshot.
+
+`CHECKPOINT` contains a versioned, checksummed recovery payload at a defined provider boundary. Recovery checkpoints should have a bounded retention policy; they are not permanent audit history.
+
+`RUN_PROMPT` owns queued, steered, and follow-up prompts. A prompt may exist before assignment to a run, so `run_id` is nullable.
+
+### Tool calls and interactions
+
+`TOOL_CALL` contains lifecycle and queryable metadata. `tool_name` is an open string so adding a tool does not require a database migration. Group, execution kind, and risk are recorded as the values effective when the call was created.
+
+`TOOL_PAYLOAD` is the uniform storage path for every tool argument and result. `(tool_call_id, kind)` is the composite primary key. Arguments exist from creation; results are added when available. Small and large payloads have identical transactional behavior, with no filesystem threshold or artifact marker.
+
+`TOOL_INTERACTION` is the sole canonical model for approval, user input, and plan review. Kind-specific request and resolution objects are discriminated JSON contracts. `batch_id` groups interactions when the UI resolves several together; no separate suspension copy is required. A run is suspended when it has pending interactions and resumes from the referenced checkpoint.
+
+### Outbox
+
+`OUTBOX_EVENT` provides atomic event publication: state changes and their outward-facing events are inserted in the same transaction. Delivered rows can be pruned after the required reconnect/replay window. Domain state never has to be reconstructed from this table.
+
+## Enum catalogue
+
+SQLite has no native enum type. Closed enums are stored as readable `TEXT` with `CHECK` constraints. Integer ordinals are avoided because they are difficult to inspect and evolve.
+
+### Conversation and agent
+
+```text
+Mode
+  planning | coding
+
+PermissionLevel
+  autonomous | supervised | read_only
+
+AgentStatus
+  idle | running | awaiting_user | aborted | error
+```
+
+Conversation completion is represented by nullable `completed_at_ms`, and pinning is an independent boolean. A conversation status enum would duplicate those fields.
+
+### Entries
+
+```text
+EntryRole
+  user | assistant | system | tool
+
+EntryKind
+  message | compaction | branch_summary | explore_report
+
+EntryBlockKind
+  text | thinking | image | tool_call | tool_result
+```
+
+Run status and task activity are projected from their canonical tables rather than copied into entries.
+
+### Runs and recovery
+
+```text
+RunStatus
+  starting
+  running
+  retrying
+  waiting
+  suspended
+  cancellation_requested
+  cancellation_failed
+  interrupted
+  completed
+  failed
+  cancelled
+
+RunRecoverability
+  not_needed | checkpoint | retryable | manual | none
+
+RunAttemptStatus
+  starting | streaming | waiting | completed | failed | cancelled | superseded
+
+CheckpointBoundary
+  before_provider_request
+  after_provider_response
+  after_tool_result
+  suspension
+
+PromptBehavior
+  steer | follow-up
+
+PromptStatus
+  queued | accepted | delivered | cancelled | failed
+```
+
+### Tool calls
+
+```text
+ToolCallStatus
+  committed | waiting | running | completed | denied | failed | cancelled
+
+ToolExecutionKind
+  local | host
+
+ToolRisk
+  read
+  workspace_write
+  command
+  network
+  secret
+  destructive
+  agent_spawn
+  deployment
+  interaction
+
+ToolGroup
+  fileInspection
+  fileEditing
+  shell
+  python
+  web
+  vision
+  jira
+  confluence
+  input
+  todos
+  taskManagement
+  explore
+  planMode
+
+ToolPayloadKind
+  args | result
+
+ToolPayloadEncoding
+  json_utf8 | json_zstd
+```
+
+`tool_name`, model provider, model ID, and event type are intentionally open strings rather than enums.
+
+### Tool interactions
+
+```text
+ToolInteractionKind
+  approval | user_input | plan_review
+
+ToolInteractionStatus
+  pending | resolved | cancelled
+
+ApprovalAction
+  allow | deny
+
+ApprovalScope
+  single_call
+  same_tool_same_args
+  run
+  always
+  always_project
+  always_user
+
+UserInputAction
+  answer | dismiss
+
+PlanReviewAction
+  accept
+  accept_in_new_chat
+  request_changes
+  reject
+  discard
+```
+
+Kind-specific actions and fields are validated by the shared discriminated request/resolution contracts.
+
+## SQLite type conventions
+
+| Domain value               | SQLite representation                                                                   |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| IDs                        | `TEXT`, retaining the existing prefixed IDs such as `conv_`, `run_`, and `tool_`        |
+| Closed enums               | `TEXT NOT NULL` with `CHECK` constraints                                                |
+| Extensible discriminators  | Unconstrained `TEXT` validated at the contract boundary                                 |
+| Booleans                   | `INTEGER` constrained to `0` or `1`                                                     |
+| Timestamps                 | Unix epoch milliseconds in `INTEGER` columns; API contracts may expose ISO 8601 strings |
+| Token counts and revisions | Non-negative `INTEGER`                                                                  |
+| Cost                       | Integer micro-USD to avoid floating-point accumulation errors                           |
+| Flexible metadata          | JSON text with `json_valid(...)` constraints where supported                            |
+| Potentially large payloads | `BLOB`, with an explicit encoding and byte length                                       |
+| Digests                    | Lowercase SHA-256 text or fixed-width bytes, chosen consistently                        |
+
+The shared contracts remain the semantic source of truth. Database constraints protect durable invariants and reject corrupt writes close to storage.
+
+## Key constraints
+
+- Foreign keys are enabled and conversation-owned rows cascade on conversation deletion.
+- Entry parents must belong to the same conversation and agent context.
+- `(entry_id, ordinal)` is unique for entry blocks.
+- `(run_id, ordinal)` is unique for run attempts and assigned prompts.
+- `(tool_call_id, kind)` is unique for tool payloads.
+- `(tool_call_id, ordinal)` is unique for tool interactions.
+- Terminal runs, attempts, and tool calls require their corresponding terminal timestamp.
+- A waiting tool call has exactly one pending interaction; batch membership does not change per-call ownership.
+- Tool results and interactions reference the same canonical tool call revision where stale-resolution protection is required.
+- Outbox `sequence` is globally monotonic; `delivered_at_ms IS NULL` identifies pending delivery.
+
+## Initial index shape
+
+Indexes should follow actual query paths rather than index every field. The likely baseline is:
+
+```text
+conversations(project_id, updated_at_ms DESC)
+entries(conversation_id, agent_id, created_at_ms)
+entries(parent_entry_id)
+entry_blocks(entry_id, ordinal)
+runs(conversation_id, status, updated_at_ms DESC)
+run_attempts(run_id, ordinal)
+run_prompts(agent_id, status, created_at_ms)
+tool_calls(run_id, status, updated_at_ms DESC)
+tool_interactions(status, requested_at_ms) WHERE status = 'pending'
+outbox_events(sequence) WHERE delivered_at_ms IS NULL
+```
+
+Whether `conversation_id` should also be copied onto `TOOL_CALL` for a direct covering index is a measurement-driven denormalization decision. It is not required for correctness.

--- a/packages/workbench-app/src/lib/app/composition/conversations/WorkbenchConversationHost.svelte
+++ b/packages/workbench-app/src/lib/app/composition/conversations/WorkbenchConversationHost.svelte
@@ -18,6 +18,8 @@ import { setConversationUiCapabilities } from "$lib/presentation/context.svelte"
 import WorkbenchComposerAdapter from "./WorkbenchComposerAdapter.svelte";
 import { workbenchConversationUiCapabilities } from "./conversation-capabilities.svelte";
 import ConversationWelcome from "$lib/features/conversations/components/ConversationWelcome.svelte";
+import { openInlineMermaidPane } from "$lib/features/filesystem";
+import type { MermaidMarkdownBlock } from "@nervekit/ui-kit/core/components/mermaid-blocks";
 
 setConversationUiCapabilities(workbenchConversationUiCapabilities());
 import { transcriptMenu } from "$lib/features/conversations/components/conversation-menus";
@@ -200,6 +202,21 @@ function quoteInComposer(text: string) {
   onComposerChange?.(`${prefix}${quoted}\n\n`);
 }
 
+function openAssistantMermaid(
+  block: MermaidMarkdownBlock,
+  messageKey: string,
+): void {
+  if (!activeProject) return;
+  const conversationKey =
+    activeConversation?.id ?? activePendingConversation?.id ?? "pending";
+  void openInlineMermaidPane({
+    projectId: activeProject.id,
+    sourceKey: `${conversationKey}:${messageKey}`,
+    name: "Assistant diagram",
+    block,
+  });
+}
+
 function menuForTranscript(
   target: TranscriptMenuTarget,
   selectedText?: string,
@@ -262,6 +279,7 @@ function menuForTranscript(
   }}
   actions={{
     onOpenFile,
+    onOpenMermaid: openAssistantMermaid,
     onAnswerUserQuestion,
     onDismissUserQuestion,
     onGrantApproval,

--- a/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.test.ts
+++ b/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.test.ts
@@ -45,6 +45,7 @@ test("labels embedded Mermaid tabs with their source and block location", () => 
   const model: Extract<CenterTabModel, { kind: "mermaid" }> = {
     kind: "mermaid",
     id: "diagram_a",
+    origin: "file",
     path: "/repo/docs/architecture.md",
     relativePath: "docs/architecture.md",
     name: "architecture.md",
@@ -59,6 +60,24 @@ test("labels embedded Mermaid tabs with their source and block location", () => 
     "/repo/docs/architecture.md · Mermaid diagram at line 42",
   );
   assert.equal(statusLabel(model), "Loading diagram");
+});
+
+test("labels Mermaid tabs opened from assistant messages", () => {
+  const model: Extract<CenterTabModel, { kind: "mermaid" }> = {
+    kind: "mermaid",
+    id: "diagram_assistant",
+    origin: "inline",
+    name: "Assistant diagram",
+    locator: { ordinal: 1, startLine: 12, fingerprint: "def" },
+    active: true,
+    sending: false,
+  };
+
+  assert.equal(tabLabel(model), "Assistant diagram 2");
+  assert.equal(
+    tabTitle(model),
+    "Assistant diagram 2 · Mermaid diagram from assistant message",
+  );
 });
 
 test("labels the Discover singleton tab", () => {

--- a/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.ts
+++ b/packages/workbench-app/src/lib/app/shell/editor-tab-helpers.ts
@@ -29,12 +29,15 @@ export function tabLabel(tab: CenterTabModel): string {
       "File"
     );
   if (tab.kind === "mermaid") {
+    const diagramNumber = tab.locator ? tab.locator.ordinal + 1 : undefined;
+    if (tab.origin === "inline")
+      return `${tab.name ?? "Assistant diagram"}${diagramNumber ? ` ${diagramNumber}` : ""}`;
     const name =
       tab.name ??
       tab.relativePath?.split("/").pop() ??
       tab.path?.split("/").pop() ??
       "Markdown";
-    return `${name} · diagram ${tab.locator ? tab.locator.ordinal + 1 : ""}`.trim();
+    return `${name} · diagram ${diagramNumber ?? ""}`.trim();
   }
   if (tab.kind === "pr") return `#${tab.number}`;
   if (tab.kind === "diff") {
@@ -54,8 +57,11 @@ export function tabTitle(tab: CenterTabModel, homeDir?: string): string {
     return `${taskLabel(tab)} · ${tab.task.status} · ${shortenPath(tab.task.cwd, homeDir)} · ${tab.task.id}`;
   }
   if (tab.kind === "file") return tab.file?.path ?? tab.path ?? tab.id;
-  if (tab.kind === "mermaid")
+  if (tab.kind === "mermaid") {
+    if (tab.origin === "inline")
+      return `${tabLabel(tab)} · Mermaid diagram from assistant message`;
     return `${tab.path ?? tab.id} · Mermaid diagram${tab.locator ? ` at line ${tab.locator.startLine}` : ""}`;
+  }
   if (tab.kind === "diff")
     return `${tab.path ?? tab.id} · ${tab.area === "staged" ? "staged" : "unstaged"} changes${tab.repo && tab.repo !== "." ? ` · ${tab.repo}` : ""}`;
   if (tab.kind === "pr")

--- a/packages/workbench-app/src/lib/application/workspace/center-tab-models.ts
+++ b/packages/workbench-app/src/lib/application/workspace/center-tab-models.ts
@@ -66,6 +66,7 @@ export type FileTabModel = {
 export type MermaidTabModel = {
   kind: "mermaid";
   id: string;
+  origin: "file" | "inline";
   path?: string;
   relativePath?: string;
   name?: string;

--- a/packages/workbench-app/src/lib/application/workspace/workspace-selectors.svelte.ts
+++ b/packages/workbench-app/src/lib/application/workspace/workspace-selectors.svelte.ts
@@ -341,8 +341,9 @@ export const workspaceSelectors = {
         {
           kind: "mermaid" as const,
           id: tab.id,
-          path: view.path,
-          relativePath: view.relativePath,
+          origin: view.origin,
+          path: view.origin === "file" ? view.path : undefined,
+          relativePath: view.origin === "file" ? view.relativePath : undefined,
           name: view.name,
           locator: view.locator,
           active: activeTabMatches("mermaid", tab.id),

--- a/packages/workbench-app/src/lib/application/workspace/workspace-tab-sessions.ts
+++ b/packages/workbench-app/src/lib/application/workspace/workspace-tab-sessions.ts
@@ -209,6 +209,9 @@ type StoredTab = CenterTabIdentity & {
   renamedFrom?: string;
   area?: GitDiffArea;
   locator?: MermaidBlockLocator;
+  source?: string;
+  sourceKey?: string;
+  name?: string;
 };
 
 type StoredSession = {
@@ -275,19 +278,37 @@ function parseSession(value: unknown): ProjectTabSession | undefined {
         loading: false,
       };
     } else if (stored.kind === "mermaid") {
-      if (
-        !stored.projectId ||
-        !stored.path ||
-        !isMermaidBlockLocator(stored.locator)
-      )
+      if (!stored.projectId || !isMermaidBlockLocator(stored.locator)) continue;
+      if (stored.path) {
+        fileState.mermaidViews[mermaidViewKey(stored.id)] = {
+          origin: "file",
+          id: stored.id,
+          projectId: stored.projectId,
+          path: stored.path,
+          locator: stored.locator,
+          loading: false,
+        };
+      } else if (
+        typeof stored.source === "string" &&
+        stored.source.trim() &&
+        typeof stored.sourceKey === "string" &&
+        stored.sourceKey &&
+        typeof stored.name === "string" &&
+        stored.name
+      ) {
+        fileState.mermaidViews[mermaidViewKey(stored.id)] = {
+          origin: "inline",
+          id: stored.id,
+          projectId: stored.projectId,
+          sourceKey: stored.sourceKey,
+          name: stored.name,
+          locator: stored.locator,
+          source: stored.source,
+          loading: false,
+        };
+      } else {
         continue;
-      fileState.mermaidViews[mermaidViewKey(stored.id)] = {
-        id: stored.id,
-        projectId: stored.projectId,
-        path: stored.path,
-        locator: stored.locator,
-        loading: false,
-      };
+      }
     } else if (stored.kind === "pr") {
       if (
         !stored.projectId ||
@@ -474,7 +495,8 @@ export function persistWorkspaceTabSessions(): void {
           }
           if (tab.kind === "mermaid") {
             const view = fileState.mermaidViews[mermaidViewKey(tab.id)];
-            return view
+            if (!view) return [];
+            return view.origin === "file"
               ? [
                   {
                     ...tab,
@@ -483,7 +505,16 @@ export function persistWorkspaceTabSessions(): void {
                     locator: view.locator,
                   },
                 ]
-              : [];
+              : [
+                  {
+                    ...tab,
+                    projectId: view.projectId,
+                    locator: view.locator,
+                    source: view.source,
+                    sourceKey: view.sourceKey,
+                    name: view.name,
+                  },
+                ];
           }
           if (tab.kind === "pr") {
             const view = gitState.prViews[prViewKey(tab.id)];

--- a/packages/workbench-app/src/lib/features/filesystem/components/MermaidCenterHost.svelte
+++ b/packages/workbench-app/src/lib/features/filesystem/components/MermaidCenterHost.svelte
@@ -3,13 +3,17 @@ import { MermaidPane } from "$lib/presentation/components/mermaid";
 import { fileSelectors } from "$lib/features/filesystem/state/file-selectors.svelte";
 
 const view = $derived(fileSelectors.activeCenterMermaidView);
-const filePath = $derived(view?.relativePath ?? view?.path ?? "Markdown file");
+const sourceLabel = $derived(
+  view?.origin === "file"
+    ? (view.relativePath ?? view.path)
+    : (view?.name ?? "assistant message"),
+);
 </script>
 
 <MermaidPane
   source={view?.source}
   loading={view?.loading}
   error={view?.error}
-  truncated={view?.truncated}
-  ariaLabel={`Mermaid diagram from ${filePath}`}
+  truncated={view?.origin === "file" ? view.truncated : false}
+  ariaLabel={`Mermaid diagram from ${sourceLabel}`}
 />

--- a/packages/workbench-app/src/lib/features/filesystem/index.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/index.ts
@@ -12,6 +12,7 @@ export {
   toggleFileLineWrap,
 } from "./state/file-tabs.svelte";
 export {
+  openInlineMermaidPane,
   openMarkdownMermaidPane,
   refreshMermaidPane,
 } from "./state/mermaid-tabs.svelte";

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-state.svelte.ts
@@ -14,18 +14,29 @@ export type FileViewState = {
   error?: string;
 };
 
-export type MarkdownMermaidViewState = {
+type MermaidViewStateBase = {
   id: string;
   projectId: string;
-  path: string;
-  relativePath?: string;
-  name?: string;
   locator: MermaidBlockLocator;
   source?: string;
   loading: boolean;
-  truncated?: boolean;
   error?: string;
 };
+
+export type MarkdownMermaidViewState =
+  | (MermaidViewStateBase & {
+      origin: "file";
+      path: string;
+      relativePath?: string;
+      name?: string;
+      truncated?: boolean;
+    })
+  | (MermaidViewStateBase & {
+      origin: "inline";
+      sourceKey: string;
+      name: string;
+      source: string;
+    });
 
 export const fileState = $state({
   fileViews: {} as Record<string, FileViewState>,

--- a/packages/workbench-app/src/lib/features/filesystem/state/file-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/file-tabs.svelte.ts
@@ -116,8 +116,10 @@ export function closeFileTabsAtPath(input: {
   );
   const matchingMermaidIds = new SvelteSet(
     Object.values(fileState.mermaidViews)
-      .filter((view) =>
-        pathMatches(view.projectId, view.relativePath ?? view.path),
+      .filter(
+        (view) =>
+          view.origin === "file" &&
+          pathMatches(view.projectId, view.relativePath ?? view.path),
       )
       .map((view) => view.id),
   );

--- a/packages/workbench-app/src/lib/features/filesystem/state/mermaid-tabs.svelte.ts
+++ b/packages/workbench-app/src/lib/features/filesystem/state/mermaid-tabs.svelte.ts
@@ -17,7 +17,7 @@ import {
 } from "@nervekit/ui-kit/core/components/mermaid-blocks";
 import { fileState } from "./file-state.svelte";
 
-function encodeMermaidTabId(
+function encodeFileMermaidTabId(
   projectId: string,
   path: string,
   block: MermaidMarkdownBlock,
@@ -25,13 +25,22 @@ function encodeMermaidTabId(
   return `${projectId}:${encodeURIComponent(path)}:mermaid:${block.locator.startLine}:${block.locator.fingerprint}`;
 }
 
-function existingViewId(
+export function encodeInlineMermaidTabId(
+  projectId: string,
+  sourceKey: string,
+  block: MermaidMarkdownBlock,
+): string {
+  return `${projectId}:inline-mermaid:${encodeURIComponent(sourceKey)}:${block.locator.ordinal}:${block.locator.fingerprint}`;
+}
+
+function existingFileViewId(
   projectId: string,
   path: string,
   block: MermaidMarkdownBlock,
 ): string | undefined {
   const candidates = Object.values(fileState.mermaidViews).filter(
     (view) =>
+      view.origin === "file" &&
       view.projectId === projectId &&
       view.path === path &&
       view.locator.fingerprint === block.locator.fingerprint,
@@ -39,11 +48,12 @@ function existingViewId(
   return candidates.reduce<string | undefined>((closestId, candidate) => {
     if (!closestId) return candidate.id;
     const closest = fileState.mermaidViews[mermaidViewKey(closestId)];
+    const closestLine =
+      closest?.origin === "file"
+        ? closest.locator.startLine
+        : Number.POSITIVE_INFINITY;
     return Math.abs(candidate.locator.startLine - block.locator.startLine) <
-      Math.abs(
-        (closest?.locator.startLine ?? Number.POSITIVE_INFINITY) -
-          block.locator.startLine,
-      )
+      Math.abs(closestLine - block.locator.startLine)
       ? candidate.id
       : closestId;
   }, undefined);
@@ -51,7 +61,7 @@ function existingViewId(
 
 async function loadMermaidView(id: string) {
   const view = fileState.mermaidViews[mermaidViewKey(id)];
-  if (!view) return;
+  if (!view || view.origin === "inline") return;
   view.loading = true;
   view.error = undefined;
   try {
@@ -89,6 +99,18 @@ async function loadMermaidView(id: string) {
   }
 }
 
+async function selectProject(projectId: string): Promise<void> {
+  if (projectId === workspaceState.selectedProjectId) return;
+  const { selectProject } =
+    await import("$lib/application/workspace/workspace-actions.svelte");
+  await selectProject(projectId);
+}
+
+function activateMermaidTab(id: string): void {
+  addCenterTab({ kind: "mermaid", id });
+  setActiveCenterTab({ kind: "mermaid", id });
+}
+
 export async function openMarkdownMermaidPane(input: {
   projectId: string;
   path: string;
@@ -96,16 +118,14 @@ export async function openMarkdownMermaidPane(input: {
   name?: string;
   block: MermaidMarkdownBlock;
 }) {
-  if (input.projectId !== workspaceState.selectedProjectId) {
-    const { selectProject } =
-      await import("$lib/application/workspace/workspace-actions.svelte");
-    await selectProject(input.projectId);
-  }
-  const existing = existingViewId(input.projectId, input.path, input.block);
+  await selectProject(input.projectId);
+  const existing = existingFileViewId(input.projectId, input.path, input.block);
   const id =
-    existing ?? encodeMermaidTabId(input.projectId, input.path, input.block);
+    existing ??
+    encodeFileMermaidTabId(input.projectId, input.path, input.block);
   const key = mermaidViewKey(id);
   fileState.mermaidViews[key] ??= {
+    origin: "file",
     id,
     projectId: input.projectId,
     path: input.path,
@@ -116,18 +136,49 @@ export async function openMarkdownMermaidPane(input: {
     loading: false,
   };
   const view = fileState.mermaidViews[key];
+  if (view.origin !== "file") return;
   view.source = input.block.source;
   view.locator = input.block.locator;
   view.error = undefined;
-  addCenterTab({ kind: "mermaid", id });
-  setActiveCenterTab({ kind: "mermaid", id });
+  activateMermaidTab(id);
+}
+
+export async function openInlineMermaidPane(input: {
+  projectId: string;
+  sourceKey: string;
+  name?: string;
+  block: MermaidMarkdownBlock;
+}) {
+  await selectProject(input.projectId);
+  const id = encodeInlineMermaidTabId(
+    input.projectId,
+    input.sourceKey,
+    input.block,
+  );
+  const key = mermaidViewKey(id);
+  fileState.mermaidViews[key] ??= {
+    origin: "inline",
+    id,
+    projectId: input.projectId,
+    sourceKey: input.sourceKey,
+    name: input.name ?? "Assistant diagram",
+    locator: input.block.locator,
+    source: input.block.source,
+    loading: false,
+  };
+  const view = fileState.mermaidViews[key];
+  if (view.origin !== "inline") return;
+  view.source = input.block.source;
+  view.locator = input.block.locator;
+  view.name = input.name ?? "Assistant diagram";
+  view.error = undefined;
+  activateMermaidTab(id);
 }
 
 export async function selectCenterMermaidTab(id: string) {
   const view = fileState.mermaidViews[mermaidViewKey(id)];
   if (!view) return;
-  addCenterTab({ kind: "mermaid", id });
-  setActiveCenterTab({ kind: "mermaid", id });
+  activateMermaidTab(id);
   if (!view.source && !view.loading) await loadMermaidView(id);
 }
 

--- a/packages/workbench-app/src/lib/presentation/components/conversation/ConversationPane.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/ConversationPane.svelte
@@ -111,6 +111,7 @@ const scroll = createConversationScrollController({
           planReviewThinkingLevel={model.planReviewThinkingLevel}
           {lastTimelineKey}
           onOpenFile={actions.onOpenFile}
+          onOpenMermaid={actions.onOpenMermaid}
           onAnswerUserQuestion={actions.onAnswerUserQuestion}
           onDismissUserQuestion={actions.onDismissUserQuestion}
           onGrantApproval={actions.onGrantApproval}

--- a/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
+++ b/packages/workbench-app/src/lib/presentation/components/conversation/types.ts
@@ -25,6 +25,7 @@ import type {
   TranscriptItem,
 } from "../../state/transcript-types.js";
 import type { ContextMenuItem } from "@nervekit/ui-kit/components/ui/context-menu-list";
+import type { MermaidMarkdownBlock } from "@nervekit/ui-kit/core/components/mermaid-blocks";
 
 export type ConversationComposerCapabilities = {
   voice?: boolean;
@@ -125,6 +126,7 @@ export type ConversationPaneActions = {
   onPasteImage?: (file: File) => Promise<string>;
   onDropFiles?: (files: readonly File[]) => Promise<readonly string[]>;
   onOpenFile?: (path: string, line?: number) => void;
+  onOpenMermaid?: (block: MermaidMarkdownBlock, sourceKey: string) => void;
   onAnswerUserQuestion?: (id: string, answer: string) => void | Promise<void>;
   onDismissUserQuestion?: (id: string) => void | Promise<void>;
   onGrantApproval?: (

--- a/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptList.svelte
@@ -16,6 +16,7 @@ import {
   type VirtualScrollerController,
 } from "@nervekit/ui-kit/components/ui/virtual-list";
 import type { TimelineItem } from "../../state/timeline";
+import type { MermaidMarkdownBlock } from "@nervekit/ui-kit/core/components/mermaid-blocks";
 import ConversationSignal from "../conversation/ConversationSignal.svelte";
 import QueuedPromptRow from "./QueuedPromptRow.svelte";
 import TranscriptRow from "./TranscriptRow.svelte";
@@ -61,6 +62,7 @@ type Props = {
   planReviewThinkingLevel?: AgentRecord["thinkingLevel"];
   lastTimelineKey?: string;
   onOpenFile?: (path: string, line?: number) => void;
+  onOpenMermaid?: (block: MermaidMarkdownBlock, sourceKey: string) => void;
   onAnswerUserQuestion?: (questionId: string, answer: string) => void;
   onDismissUserQuestion?: (questionId: string) => void;
   onGrantApproval?: (
@@ -117,6 +119,7 @@ let {
   planReviewThinkingLevel = "off",
   lastTimelineKey,
   onOpenFile,
+  onOpenMermaid,
   onAnswerUserQuestion,
   onDismissUserQuestion,
   onGrantApproval,
@@ -354,6 +357,7 @@ $effect(() => {
             {planReviewModelKey}
             {planReviewThinkingLevel}
             {onOpenFile}
+            {onOpenMermaid}
             {onAnswerUserQuestion}
             {onDismissUserQuestion}
             {onGrantApproval}

--- a/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/transcript/TranscriptRow.svelte
@@ -12,6 +12,7 @@ import type { ConversationMenuBuilders } from "../conversation/types.js";
 import ToolCallCard from "../../tools/components/ToolCallCard.svelte";
 import ToolResultErrorCard from "../../tools/components/tool-call/ToolResultErrorCard.svelte";
 import Markdown from "@nervekit/ui-kit/core/components/Markdown.svelte";
+import type { MermaidMarkdownBlock } from "@nervekit/ui-kit/core/components/mermaid-blocks";
 import { notifyCopyResult } from "@nervekit/ui-kit/core/notify";
 import CompactionCard from "./CompactionCard.svelte";
 import UserMessageContent from "./UserMessageContent.svelte";
@@ -37,6 +38,7 @@ type Props = {
   planReviewThinkingLevel?: AgentRecord["thinkingLevel"];
   lastTimelineKey?: string;
   onOpenFile?: (path: string, line?: number) => void;
+  onOpenMermaid?: (block: MermaidMarkdownBlock, sourceKey: string) => void;
   onAnswerUserQuestion?: (questionId: string, answer: string) => void;
   onDismissUserQuestion?: (questionId: string) => void;
   onGrantApproval?: (
@@ -72,6 +74,7 @@ let {
   planReviewThinkingLevel = "off",
   lastTimelineKey,
   onOpenFile,
+  onOpenMermaid,
   onAnswerUserQuestion,
   onDismissUserQuestion,
   onGrantApproval,
@@ -104,6 +107,13 @@ const messageState = $derived.by<"running" | "complete" | "static">(() => {
   }
   return "static";
 });
+
+// Markdown uses callback identity to retain its lazy Mermaid enhancement. Keep
+// this handler stable so unrelated transcript updates do not remount diagrams.
+function openMessageMermaid(block: MermaidMarkdownBlock): void {
+  if (node.kind !== "message" || node.item.role !== "assistant") return;
+  onOpenMermaid?.(block, node.item.liveMessageId ?? node.item.id ?? node.key);
+}
 
 let entering = $state(false);
 let activeEntrance = $state<TranscriptEntranceMotion>();
@@ -272,6 +282,9 @@ $effect(() => {
                   streaming={Boolean(node.item.live && !node.item.done)}
                   linkBasePath={activeProject?.dir}
                   {onOpenFile}
+                  onOpenMermaid={node.item.role === "assistant" && onOpenMermaid
+                    ? openMessageMermaid
+                    : undefined}
                   onCopy={notifyCopyResult}
                 />
               {/if}

--- a/packages/workbench-server/src/domains/runs/workbench-run.service.ts
+++ b/packages/workbench-server/src/domains/runs/workbench-run.service.ts
@@ -350,12 +350,7 @@ export class WorkbenchRunService {
       this.state.getConversationEntries(conversation.id),
       conversation.activeEntryId,
     );
-    if (
-      currentEntryIds.length !== checkpoint.entryIds.length ||
-      currentEntryIds.some(
-        (entryId, index) => entryId !== checkpoint.entryIds[index],
-      )
-    ) {
+    if (!activeBranchEndsWithCheckpoint(currentEntryIds, checkpoint.entryIds)) {
       throw new ApplicationError(
         409,
         "RUN_CHECKPOINT_STALE",
@@ -511,6 +506,19 @@ export class WorkbenchRunService {
   private scopeId(agent: AgentRecord): string {
     return `${agent.conversationId}:${agent.id}`;
   }
+}
+
+// Checkpoints contain this run's transcript, while the active branch also
+// contains entries from earlier runs. The run transcript must remain its tail.
+export function activeBranchEndsWithCheckpoint(
+  activeBranchEntryIds: readonly string[],
+  checkpointEntryIds: readonly string[],
+): boolean {
+  if (checkpointEntryIds.length > activeBranchEntryIds.length) return false;
+  const offset = activeBranchEntryIds.length - checkpointEntryIds.length;
+  return checkpointEntryIds.every(
+    (entryId, index) => activeBranchEntryIds[offset + index] === entryId,
+  );
 }
 
 function activeBranchEntryIds(

--- a/packages/workbench-server/test/workbench-run-context.test.ts
+++ b/packages/workbench-server/test/workbench-run-context.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { activeBranchEndsWithCheckpoint } from "../src/domains/runs/workbench-run.service.js";
+
+test("approval checkpoint matches the run-local suffix of an existing conversation", () => {
+  assert.equal(
+    activeBranchEndsWithCheckpoint(
+      ["entry_old_user", "entry_old_assistant", "entry_user", "entry_tool"],
+      ["entry_user", "entry_tool"],
+    ),
+    true,
+  );
+});
+
+test("approval checkpoint rejects a branch changed after suspension", () => {
+  assert.equal(
+    activeBranchEndsWithCheckpoint(
+      [
+        "entry_old_user",
+        "entry_old_assistant",
+        "entry_user",
+        "entry_tool",
+        "entry_new",
+      ],
+      ["entry_user", "entry_tool"],
+    ),
+    false,
+  );
+  assert.equal(
+    activeBranchEndsWithCheckpoint(
+      ["entry_old_user", "entry_fork_user", "entry_fork_tool"],
+      ["entry_user", "entry_tool"],
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- persist and restore conversation, file, and Mermaid workspace tab sessions
- add conversation storage ERD documentation and run-context coverage
- improve transcript and center-tab integration

## Validation
- `pnpm fix`
- `pnpm check`
- `pnpm test`