### PR TITLE
feat(workbench): open pending approvals from status bar

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/StatusBar.svelte
+++ b/packages/workbench-app/src/lib/app/shell/StatusBar.svelte
@@ -5,6 +5,7 @@ import Diff from "@lucide/svelte/icons/diff";
 import GitBranch from "@lucide/svelte/icons/git-branch";
 import Terminal from "@lucide/svelte/icons/terminal";
 import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
 import { ShellStatusBar, type DockToggle } from "$lib/presentation/shell";
 import type { TaskRecord, ProjectRecord, StatusResponse } from "$lib/api";
 import type { SubscriptionUsageEntry } from "$lib/features/usage";
@@ -31,6 +32,7 @@ type Props = {
   connection?: string;
   live?: boolean;
   pendingApprovals?: number;
+  onOpenPendingApproval?: () => void;
   tasks?: TaskRecord[];
   gitStatus?: GitStatus;
   subscriptionUsages?: SubscriptionUsageEntry[];
@@ -47,6 +49,7 @@ let {
   connection = "connecting",
   live = false,
   pendingApprovals = 0,
+  onOpenPendingApproval,
   tasks = [],
   gitStatus,
   subscriptionUsages = [],
@@ -165,10 +168,17 @@ function gitStatusTitle(status: GitStatus): string {
         {/if}
 
         {#if pendingApprovals > 0}
-          <span class="footer-item warn" title="Pending approvals">
+          <Button
+            variant="ghost"
+            size="xs"
+            class="footer-item warn text-xs"
+            ariaLabel={`Open ${pendingApprovals === 1 ? "pending approval" : "pending approvals"}`}
+            title={`${pendingApprovals} ${pendingApprovals === 1 ? "pending approval" : "pending approvals"} · Open conversation`}
+            onclick={() => onOpenPendingApproval?.()}
+          >
             <TriangleAlert size={12} strokeWidth={2.1} aria-hidden="true" />
             <span>{pendingApprovals}</span>
-          </span>
+          </Button>
         {/if}
 
         <SubscriptionUsageChip usages={subscriptionUsages} />

--- a/packages/workbench-app/src/lib/app/shell/WorkbenchStatusBarHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/WorkbenchStatusBarHost.svelte
@@ -13,7 +13,10 @@ import {
   shellSheets,
   togglePanelDock,
 } from "$lib/app/shell/shell-layout.svelte";
-import { conversationSelectors } from "$lib/features/conversations";
+import {
+  conversationSelectors,
+  openConversation,
+} from "$lib/features/conversations";
 import { gitSelectors } from "$lib/features/git";
 import { taskSelectors } from "$lib/features/tasks";
 import { settingsSelectors } from "$lib/features/settings";
@@ -27,6 +30,9 @@ const live = $derived(conversationSelectors.live);
 const pendingApprovalCount = $derived(
   conversationSelectors.pendingApprovalCount,
 );
+const pendingApprovalConversationId = $derived(
+  conversationSelectors.approvals[0]?.conversationId,
+);
 const tasks = $derived(taskSelectors.scopedTasks);
 const gitStatus = $derived(gitSelectors.gitStatus);
 const subscriptionUsages = $derived(usageSelectors.subscriptionUsages);
@@ -38,6 +44,11 @@ const currentZoomLevel = $derived(
 
 const isCompact = $derived(responsive.isCompact);
 const isPhone = $derived(responsive.isPhone);
+
+function openPendingApproval(): void {
+  const conversationId = pendingApprovalConversationId;
+  if (conversationId) void openConversation(conversationId);
+}
 
 // In compact mode the dock toggles drive the overlay sheets instead of the
 // desktop collapse model; mirror the sheet state so the pressed affordance
@@ -63,6 +74,7 @@ const dockToggles = $derived<DockToggle[]>(
   {connection}
   {live}
   pendingApprovals={pendingApprovalCount}
+  onOpenPendingApproval={openPendingApproval}
   {tasks}
   {gitStatus}
   {subscriptionUsages}

--- a/packages/workbench-app/src/lib/features/conversations/index.ts
+++ b/packages/workbench-app/src/lib/features/conversations/index.ts
@@ -34,5 +34,6 @@ export {
   navigateToEntry,
 } from "./state/run-control";
 export { restoreConversationTabs } from "./state/conversation-flow.svelte";
+export { openConversation } from "./state/tabs";
 export { refreshConversationView } from "./state/selection";
 export { registerConversationEventHandlers } from "./state/conversation-events";


### PR DESCRIPTION
## Summary
- Make the pending-approvals status-bar indicator actionable.
- Open the first conversation with a pending approval when clicked.

## Validation
- `pnpm fix`
- `pnpm check`
- `pnpm test`