### PR TITLE
Fix committed tool-call recovery

### DIFF
--- a/packages/contracts/src/domains/events/lifecycles.ts
+++ b/packages/contracts/src/domains/events/lifecycles.ts
@@ -19,7 +19,7 @@ export class LifecycleTransitionError extends Error {
 }
 
 export const toolCallTransitions = {
-  committed: ["waiting", "running", "denied", "cancelled"],
+  committed: ["waiting", "running", "denied", "failed", "cancelled"],
   waiting: ["committed", "running", "denied", "failed", "cancelled"],
   running: ["waiting", "completed", "failed", "cancelled"],
   completed: [],

--- a/packages/contracts/test/protocol.schema.test.ts
+++ b/packages/contracts/test/protocol.schema.test.ts
@@ -603,6 +603,11 @@ describe("Protocol v1 shared schemas", () => {
       true,
     );
     assert.equal(
+      canTransition(toolCallTransitions, "committed", "failed"),
+      true,
+      "startup recovery must be able to fail a committed tool call",
+    );
+    assert.equal(
       canTransition(toolCallTransitions, "completed", "running"),
       false,
     );

--- a/packages/workbench-server/src/domains/tools/tool-call-transcript-preview.ts
+++ b/packages/workbench-server/src/domains/tools/tool-call-transcript-preview.ts
@@ -530,6 +530,11 @@ export function toToolCallTranscriptRecord(
   toolCall: ToolCallRecord,
 ): ToolCallTranscriptRecord {
   const { args, result, ...base } = toolCall;
+  // Durable supervision retains the complete normalized execution arguments for
+  // policy revalidation. Transcript events already carry a bounded argsPreview,
+  // so publishing supervision would duplicate unbounded (and potentially
+  // sensitive) arguments across the public event boundary.
+  delete base.supervision;
   const argsRecord = record(args);
   const resultRecord = record(result);
   let argsPreview: unknown = args;

--- a/packages/workbench-server/test/tool-call-transcript-preview.test.ts
+++ b/packages/workbench-server/test/tool-call-transcript-preview.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { ToolCallRecord } from "@nervekit/contracts";
+import { type ToolCallRecord, validatePublicEvent } from "@nervekit/contracts";
 import { toToolCallTranscriptRecord } from "../src/domains/tools/tool-call-transcript-preview.js";
 
 function explainImageToolCall(explanation: string): ToolCallRecord {
@@ -55,5 +55,43 @@ describe("explain_image transcript preview", () => {
       direction: "head",
     });
     assert.equal(JSON.stringify(preview).includes("thinking"), false);
+  });
+
+  it("omits unbounded durable supervision arguments from public events", () => {
+    const toolCall = {
+      ...explainImageToolCall("Interrupted."),
+      supervision: {
+        status: "approved" as const,
+        source: "automatic" as const,
+        decision: {
+          version: 1 as const,
+          decision: "allow" as const,
+          effectiveRisk: "read" as const,
+          reason: "Allowed by policy.",
+          normalizedArgs: { content: "x".repeat(20_000) },
+          normalizedTargets: [{ kind: "whole_tool" as const }],
+          matchedRuleIds: [],
+          policySnapshotHash: `sha256:${"a".repeat(64)}`,
+          suggestedRules: [],
+        },
+      },
+    } satisfies ToolCallRecord;
+
+    const preview = toToolCallTranscriptRecord(toolCall);
+
+    assert.equal(preview.supervision, undefined);
+    assert.doesNotThrow(() =>
+      validatePublicEvent(
+        "toolCall.updated",
+        {
+          conversationId: toolCall.conversationId,
+          conversationRevision: 1,
+          agentId: toolCall.agentId,
+          projectId: toolCall.projectId,
+          toolCall: preview,
+        },
+        "workbench_server",
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- allow committed tool calls to transition to failed during startup recovery
- omit durable supervision arguments from public transcript events
- add regression coverage for both protocol recovery and event validation

## Validation
- pnpm fix
- pnpm check
- pnpm test