### PR TITLE
fix(workbench): stop active-item outline clipping during resize and zoom

### DIFF
--- a/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
+++ b/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import { tick, type Snippet } from "svelte";
 import { cn } from "@nervekit/ui-kit/core/utils";
-import { relativeItemRectangle } from "./item-collection.js";
+import {
+  relativeItemRectangle,
+  type RelativeItemRectangle,
+} from "./item-collection.js";
 
 let {
   activeKey,
@@ -19,8 +22,56 @@ let y = $state(0);
 let width = $state(0);
 let height = $state(0);
 let visible = $state(false);
+
+/** Outline glides between items; everything else snaps to avoid clip lag. */
+const MOVE_DURATION_MS = 200;
 let measureFrame: number | undefined;
 let showFrame: number | undefined;
+let overlay = $state<HTMLDivElement>();
+/** Key the drawn outline currently reflects, to detect item switches. */
+let drawnKey: string | undefined;
+
+/** Re-measures from resize/scroll/layout must snap; only item moves glide. */
+function applyGeometry(geometry: RelativeItemRectangle, moving: boolean): void {
+  if (
+    moving &&
+    overlay &&
+    visible &&
+    (geometry.x !== x ||
+      geometry.y !== y ||
+      geometry.width !== width ||
+      geometry.height !== height)
+  ) {
+    // Read the current interpolated frame first so rapid retargets stay smooth.
+    const computed = getComputedStyle(overlay);
+    const from = {
+      transform: computed.transform,
+      width: computed.width,
+      height: computed.height,
+    };
+    for (const animation of overlay.getAnimations()) animation.cancel();
+    overlay.animate([from, toKeyframe(geometry)], {
+      duration: MOVE_DURATION_MS,
+      easing: "ease-out",
+    });
+  }
+  x = geometry.x;
+  y = geometry.y;
+  width = geometry.width;
+  height = geometry.height;
+}
+
+function toKeyframe(geometry: RelativeItemRectangle): {
+  transform: string;
+  width: string;
+  height: string;
+} {
+  return {
+    transform: `translate3d(${geometry.x}px, ${geometry.y}px, 0)`,
+    width: `${geometry.width}px`,
+    height: `${geometry.height}px`,
+  };
+}
 
 function candidates(): HTMLElement[] {
   if (!collection) return [];
@@ -51,11 +102,11 @@ function measure(): void {
   const geometry = relativeItemRectangle(
     collection.getBoundingClientRect(),
     target.getBoundingClientRect(),
+    window.devicePixelRatio || 1,
   );
-  x = geometry.x;
-  y = geometry.y;
-  width = geometry.width;
-  height = geometry.height;
+  const moving = drawnKey !== undefined && activeKey !== drawnKey;
+  drawnKey = activeKey;
+  applyGeometry(geometry, moving);
 
   if (!visible) {
     if (showFrame !== undefined) cancelAnimationFrame(showFrame);
@@ -121,8 +172,9 @@ $effect(() => {
 >
   {@render children()}
   <div
+    bind:this={overlay}
     aria-hidden="true"
-    class="pointer-events-none absolute top-0 left-0 z-20 rounded-md border border-primary/60 opacity-0 transition-[transform,width,height,opacity] duration-200 ease-out will-change-transform"
+    class="pointer-events-none absolute top-0 left-0 z-20 rounded-md border border-primary/60 opacity-0 transition-[opacity] duration-200 ease-out will-change-transform"
     class:opacity-100={visible}
     style:transform={`translate3d(${x}px, ${y}px, 0)`}
     style:width={`${width}px`}

--- a/packages/workbench-app/src/lib/presentation/items/item-collection.test.ts
+++ b/packages/workbench-app/src/lib/presentation/items/item-collection.test.ts
@@ -21,3 +21,24 @@ test("relativeItemRectangle retains targets above or left of a scrolled viewport
     { x: -12, y: -40, width: 200, height: 28 },
   );
 });
+
+test("relativeItemRectangle snaps fractional edges to whole pixels", () => {
+  assert.deepEqual(
+    relativeItemRectangle(
+      { left: 10.4, top: 20.6, width: 400, height: 300 },
+      { left: 74.7, top: 72.2, width: 180.3, height: 36.4 },
+    ),
+    { x: 64, y: 52, width: 181, height: 36 },
+  );
+});
+
+test("relativeItemRectangle snaps to device pixels at fractional scale factors", () => {
+  assert.deepEqual(
+    relativeItemRectangle(
+      { left: 10.4, top: 20.6, width: 400, height: 300 },
+      { left: 74.7, top: 72.2, width: 180.3, height: 36.4 },
+      2,
+    ),
+    { x: 64.5, y: 51.5, width: 180, height: 36.5 },
+  );
+});

--- a/packages/workbench-app/src/lib/presentation/items/item-collection.ts
+++ b/packages/workbench-app/src/lib/presentation/items/item-collection.ts
@@ -12,15 +12,23 @@ export type RelativeItemRectangle = {
   height: number;
 };
 
-/** Returns target geometry in the collection's local coordinate space. */
+/**
+ * Returns target geometry in the collection's local coordinate space, snapped to
+ * whole `scale` (device-pixel) steps so the 1px outline never straddles a pixel
+ * boundary and fades out at fractional zoom levels or panel sizes.
+ */
 export function relativeItemRectangle(
   collection: ItemRectangle,
   target: ItemRectangle,
+  scale = 1,
 ): RelativeItemRectangle {
+  const snap = (value: number): number => Math.round(value * scale) / scale;
+  const x = snap(target.left - collection.left);
+  const y = snap(target.top - collection.top);
   return {
-    x: target.left - collection.left,
-    y: target.top - collection.top,
-    width: target.width,
-    height: target.height,
+    x,
+    y,
+    width: snap(target.left + target.width - collection.left) - x,
+    height: snap(target.top + target.height - collection.top) - y,
   };
 }


### PR DESCRIPTION
## Summary

The moving outline that marks the active conversation row / project button sometimes rendered with one vertical side cut off, triggered by side-panel resizing and by various zoom levels.

**Root cause** (confirmed by pixel analysis of the affected screenshot + Chromium repros): the outline is an absolutely-positioned overlay in `ItemCollection.svelte` sized from live `getBoundingClientRect()` values.

1. Its 200ms geometry transition ran on *every* re-measure, so during resize the overlay trailed the real item rectangle and overhung the clipping containers (`overflow-y-auto` viewport, `overflow-hidden` titlebar nav) — the trailing side was clipped off (screenshot signature: crisp top/left/bottom borders, missing right border, corner arcs truncated at the clip edge).
2. Raw fractional rects made the 1px 60%-alpha border straddle device-pixel boundaries (~30% alpha per pixel), so sides looked faint or missing, with the affected side varying by zoom/panel width.

**Fix**

- Pixel-snap outline edges to whole device pixels in `relativeItemRectangle()` (new `scale` param, driven by `devicePixelRatio`, re-read per measure so zoom changes are tracked).
- Snap geometry instantly on resize/scroll/layout re-measures; glide (200ms ease-out) only when the active item changes — via the Web Animations API with mid-flight retargeting instead of CSS transitions (changing the `transition` property and transform in the same style recalc would never animate).
- Tests cover edge snapping at `scale=1` and `scale=2`.

## Test plan

- [x] `pnpm fix && pnpm check && pnpm test` passes
- [x] New `relativeItemRectangle` snapping tests (whole-pixel and device-pixel scales)
- [ ] Manual: drag the panel splitter continuously — outline hugs the active row with no side cut off; switching conversations/projects still animates the outline; zoom changes stay crisp on all four sides
