### PR TITLE
Fix durable plan review body previews

### DIFF
--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -1095,32 +1095,44 @@ export class ToolService {
     const next = await this.toolCallRepository.replace(
       toolCallId,
       expectedRevision,
-      (record) => ({
-        ...record,
-        ...patch,
-        ...(patch.status ? { phase: phaseForStatus(patch.status) } : {}),
-        ...(patch.status === "running" && record.status !== "running"
-          ? { attempt: record.attempt + 1 }
-          : {}),
-        ...(terminal ? { settledAt: updatedAt } : {}),
-        ...(terminal && record.execution
-          ? {
-              execution: {
-                ...record.execution,
-                status:
-                  patch.status === "completed"
-                    ? ("completed" as const)
-                    : patch.status === "cancelled"
-                      ? ("cancelled" as const)
-                      : patch.status === "failed" || patch.status === "denied"
-                        ? ("failed" as const)
-                        : ("interrupted" as const),
-                endedAt: updatedAt,
-              },
-            }
-          : {}),
-        updatedAt,
-      }),
+      (record) => {
+        const candidate: ToolCallRecord = {
+          ...record,
+          ...patch,
+          ...(patch.status ? { phase: phaseForStatus(patch.status) } : {}),
+          ...(patch.status === "running" && record.status !== "running"
+            ? { attempt: record.attempt + 1 }
+            : {}),
+          ...(terminal ? { settledAt: updatedAt } : {}),
+          ...(terminal && record.execution
+            ? {
+                execution: {
+                  ...record.execution,
+                  status:
+                    patch.status === "completed"
+                      ? ("completed" as const)
+                      : patch.status === "cancelled"
+                        ? ("cancelled" as const)
+                        : patch.status === "failed" || patch.status === "denied"
+                          ? ("failed" as const)
+                          : ("interrupted" as const),
+                  endedAt: updatedAt,
+                },
+              }
+            : {}),
+          updatedAt,
+        };
+        if (
+          Object.hasOwn(patch, "result") &&
+          !Object.hasOwn(patch, "resultPreview")
+        ) {
+          candidate.resultPreview = toToolCallTranscriptRecord({
+            ...candidate,
+            resultPreview: undefined,
+          }).resultPreview;
+        }
+        return candidate;
+      },
     );
     if (isTerminalToolCall(next)) this.notifyWaiters(next);
     return next;

--- a/packages/workbench-server/test/tool-call-transcript-preview.test.ts
+++ b/packages/workbench-server/test/tool-call-transcript-preview.test.ts
@@ -82,6 +82,55 @@ describe("explain_image transcript preview", () => {
     });
   });
 
+  it("keeps a bounded plan body in the durable transcript preview", () => {
+    const content = Array.from(
+      { length: 10 },
+      (_, index) => `Plan step ${index + 1}`,
+    ).join("\n");
+    const toolCall = {
+      ...explainImageToolCall("unused"),
+      toolName: "plan_mode_present" as const,
+      status: "waiting" as const,
+      result: {
+        review: {
+          id: "plan_review_01H0000000000000000000",
+          planPath: "/tmp/project/.nerve/plans/example.md",
+          content,
+          status: "pending",
+        },
+        outcome: "pending",
+      },
+    } satisfies ToolCallRecord;
+
+    const preview = toToolCallTranscriptRecord(toolCall);
+    const result = preview.resultPreview as {
+      review?: { content?: string };
+    };
+
+    assert.equal(
+      result.review?.content,
+      "Plan step 1\nPlan step 2\nPlan step 3\nPlan step 4\nPlan step 5\nPlan step 6",
+    );
+    assert.deepEqual(preview.previewOverflow, {
+      hidden: 4,
+      noun: "lines",
+      direction: "head",
+    });
+    assert.doesNotThrow(() =>
+      validatePublicEvent(
+        "toolCall.updated",
+        {
+          conversationId: toolCall.conversationId,
+          conversationRevision: 1,
+          agentId: toolCall.agentId,
+          projectId: toolCall.projectId,
+          toolCall: preview,
+        },
+        "workbench_server",
+      ),
+    );
+  });
+
   it("omits unbounded durable supervision arguments from public events", () => {
     const toolCall = {
       ...explainImageToolCall("Interrupted."),


### PR DESCRIPTION
## Summary
- Persist refreshed bounded tool result previews when durable tool results change.
- Preserve plan content in `plan_mode_present` previews after reload.
- Add regression coverage for bounded plan body projection and public event validity.

## Validation
- `pnpm fix && pnpm check && pnpm test`