### PR TITLE
fix(tools): allow unsupported bash in autonomous mode

### DIFF
--- a/packages/tools/src/policy/evaluate-tool-supervision.ts
+++ b/packages/tools/src/policy/evaluate-tool-supervision.ts
@@ -213,15 +213,15 @@ function validationFailure(
   if (input.mode === "planning" && input.constraints?.length) {
     return input.constraints[0]?.reason;
   }
+  if (input.toolName === "bash" && commandSupported === false) {
+    return undefined; // Follows the permission level; it can never match a durable allow.
+  }
   const descriptor = requireToolDefinition(input.toolName);
   if (
     (descriptor.permission?.targets?.length ?? 0) > 0 &&
     targets.length === 0
   ) {
     return "Tool targets are missing or malformed.";
-  }
-  if (input.toolName === "bash" && commandSupported === false) {
-    return undefined; // May still be approved once; it can never match a durable allow.
   }
   return undefined;
 }

--- a/packages/tools/test/supervision.test.ts
+++ b/packages/tools/test/supervision.test.ts
@@ -95,6 +95,53 @@ test("external paths retain normal supervised read and write behavior", () => {
   );
 });
 
+test("unsupported bash syntax follows the configured permission level", () => {
+  const common = {
+    toolName: "bash" as const,
+    args: { command: 'gh pr create --body "$(cat file)"' },
+    mode: "coding" as const,
+    projectId: "proj_test",
+    projectDir: "/workspace",
+    cwd: "/workspace",
+    rules: [],
+    evaluatedAt: timestamp,
+  };
+
+  const supervised = evaluateToolSupervision({
+    ...common,
+    permissionLevel: "supervised",
+  });
+  assert.equal(supervised.decision, "prompt");
+  assert.equal(supervised.effectiveRisk, "command");
+  assert.deepEqual(supervised.normalizedTargets, []);
+  assert.deepEqual(supervised.suggestedRules, []);
+
+  const autonomous = evaluateToolSupervision({
+    ...common,
+    permissionLevel: "autonomous",
+  });
+  assert.equal(autonomous.decision, "allow");
+  assert.equal(autonomous.effectiveRisk, "command");
+  assert.deepEqual(autonomous.normalizedTargets, []);
+});
+
+test("malformed non-bash targets remain denied", () => {
+  const decision = evaluateToolSupervision({
+    toolName: "web_fetch",
+    args: { url: "not a url" },
+    mode: "coding",
+    permissionLevel: "autonomous",
+    projectId: "proj_test",
+    projectDir: "/workspace",
+    cwd: "/workspace",
+    rules: [],
+    evaluatedAt: timestamp,
+  });
+
+  assert.equal(decision.decision, "deny");
+  assert.equal(decision.reason, "Tool targets are missing or malformed.");
+});
+
 test("supervision applies covering deny rules before allows", () => {
   const decision = evaluate([
     rule({ id: "rule_allow", pattern: "https://evil.example/*" }),


### PR DESCRIPTION
## Summary

- Let parser-unsupported Bash commands follow the configured permission level instead of being rejected as malformed.
- Preserve conservative command risk and prevent durable permission suggestions for unparsed commands.
- Add regression coverage for autonomous, supervised, and malformed non-Bash behavior.

## Validation

- `pnpm fix && pnpm check && pnpm test`