### PR TITLE
Fix dangling tool drafts after failed responses

### DIFF
--- a/packages/workbench-server/src/domains/agents/run/live-tool-draft-reconciliation.ts
+++ b/packages/workbench-server/src/domains/agents/run/live-tool-draft-reconciliation.ts
@@ -38,9 +38,22 @@ export class LiveToolDraftReconciler {
     message: AssistantMessage,
     drafts: LiveToolDraftState[],
   ): Promise<void> {
+    const ordered = [...drafts].sort((a, b) => a.contentIndex - b.contentIndex);
+    const terminalDiscardReason =
+      message.stopReason === "error"
+        ? "invalid"
+        : message.stopReason === "aborted"
+          ? "abandoned"
+          : undefined;
+    if (terminalDiscardReason) {
+      for (const draft of ordered) {
+        await this.discard(draft, terminalDiscardReason);
+      }
+      return;
+    }
+
     const finalToolCalls = assistantToolCallSnapshots(message);
     const consumedFinalIndexes = new Set<number>();
-    const ordered = [...drafts].sort((a, b) => a.contentIndex - b.contentIndex);
     for (const draft of ordered) {
       if (draft.ended) continue;
       const matchIndex = finalToolCalls.findIndex(

--- a/packages/workbench-server/test/live-tool-draft-reconciliation.test.ts
+++ b/packages/workbench-server/test/live-tool-draft-reconciliation.test.ts
@@ -16,7 +16,13 @@ const usage = {
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
-function assistant(content: AssistantMessage["content"]): AssistantMessage {
+function assistant(
+  content: AssistantMessage["content"],
+  outcome: Pick<AssistantMessage, "stopReason" | "errorMessage"> = {
+    stopReason: "stop",
+    errorMessage: undefined,
+  },
+): AssistantMessage {
   return {
     role: "assistant",
     content,
@@ -24,7 +30,7 @@ function assistant(content: AssistantMessage["content"]): AssistantMessage {
     provider: "anthropic",
     model: "test-model",
     usage,
-    stopReason: "stop",
+    ...outcome,
     timestamp: Date.now(),
   } as AssistantMessage;
 }
@@ -115,6 +121,78 @@ describe("LiveToolDraftReconciler", () => {
       assert.equal(block.done, true);
       assert.deepEqual(block.args, { command: "pwd" });
     }
+  });
+
+  it("discards every draft when the final message failed", async () => {
+    const fx = setup();
+    const unfinished = fx.startDraft(0, "call_partial", "write");
+    const ended = fx.startDraft(1, "call_ended", "edit");
+    ended.ended = true;
+
+    await fx.reconciler.reconcile(
+      assistant(
+        [
+          {
+            type: "toolCall",
+            id: "call_partial",
+            name: "write",
+            arguments: { path: "plan.md", content: "partial" },
+          },
+          {
+            type: "toolCall",
+            id: "call_ended",
+            name: "edit",
+            arguments: { path: "plan.md", replacements: [] },
+          },
+        ],
+        { stopReason: "error", errorMessage: "terminated" },
+      ),
+      [ended, unfinished],
+    );
+
+    assert.deepEqual(
+      fx.published.map(({ type, data }) => ({
+        type,
+        reason: (data as { reason?: string }).reason,
+        contentIndex: (data as { contentIndex?: number }).contentIndex,
+      })),
+      [
+        {
+          type: "conversation.live.tool_draft.discarded",
+          reason: "invalid",
+          contentIndex: 0,
+        },
+        {
+          type: "conversation.live.tool_draft.discarded",
+          reason: "invalid",
+          contentIndex: 1,
+        },
+      ],
+    );
+    assert.deepEqual(fx.blocks(), []);
+  });
+
+  it("abandons drafts when the final message was aborted", async () => {
+    const fx = setup();
+    const draft = fx.startDraft(0, "call_aborted", "write");
+
+    await fx.reconciler.reconcile(
+      assistant([], {
+        stopReason: "aborted",
+        errorMessage: "Request cancelled",
+      }),
+      [draft],
+    );
+
+    assert.equal(
+      fx.published.at(0)?.type,
+      "conversation.live.tool_draft.discarded",
+    );
+    assert.equal(
+      (fx.published.at(0)?.data as { reason?: string }).reason,
+      "abandoned",
+    );
+    assert.deepEqual(fx.blocks(), []);
   });
 
   it("projects oversized final arguments before publishing a done event", async () => {


### PR DESCRIPTION
## Summary
- discard transient tool drafts when an assistant response fails or is aborted
- prevent failed tool drafts from remaining stuck in the transcript
- add regression coverage for failed, aborted, and already-ended drafts

## Validation
- pnpm fix
- pnpm check
- pnpm test