### PR TITLE
Fix plan mode presentation flow

### DIFF
--- a/packages/tools/src/catalog/orchestration/plan-mode.tools.ts
+++ b/packages/tools/src/catalog/orchestration/plan-mode.tools.ts
@@ -15,12 +15,6 @@ const planModePresentParameters = Type.Object(
     file_path: Type.String({
       description: "Path to the markdown plan file inside Nerve plan storage",
     }),
-    title: Type.Optional(
-      Type.String({ description: "Optional display title" }),
-    ),
-    summary: Type.Optional(
-      Type.String({ description: "Short summary for the review UI" }),
-    ),
   },
   { additionalProperties: false },
 );

--- a/packages/tools/src/runtime/orchestration/args.ts
+++ b/packages/tools/src/runtime/orchestration/args.ts
@@ -41,8 +41,6 @@ export function parseQuestion(args: Record<string, unknown>) {
 export function parsePlanRequest(args: Record<string, unknown>) {
   return {
     filePath: requiredString(args.file_path, "file_path"),
-    title: optionalString(args.title),
-    summary: optionalString(args.summary),
   };
 }
 

--- a/packages/tools/test/catalog-manifest.test.ts
+++ b/packages/tools/test/catalog-manifest.test.ts
@@ -35,6 +35,19 @@ describe("model-facing tool schema compatibility", () => {
     }
   });
 
+  it("keeps plan_mode_present limited to the plan file path", () => {
+    const schema = requireToolDefinition("plan_mode_present").parameters;
+    assert.equal(Check(schema, { file_path: "/tmp/plan.md" }), true);
+    assert.equal(
+      Check(schema, { file_path: "/tmp/plan.md", summary: "override" }),
+      false,
+    );
+    assert.equal(
+      Check(schema, { file_path: "/tmp/plan.md", title: "override" }),
+      false,
+    );
+  });
+
   it("does not expose top-level schema composition for action tools", () => {
     for (const definition of allToolDefinitions) {
       if (!flattenedActionTools.has(definition.name)) continue;

--- a/packages/tools/test/runtime-contract.test.ts
+++ b/packages/tools/test/runtime-contract.test.ts
@@ -185,6 +185,7 @@ describe("shared tool runtime contract", () => {
       },
       present: async (value, request) => {
         assert.equal(value, identity);
+        assert.deepEqual(request, { filePath: "plans/reuse.md" });
         calls.push(`plan.present:${request.filePath}`);
         return { content: "review" };
       },

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
@@ -17,6 +17,7 @@ import {
   type ToolView,
 } from "../../views/tool-result-view";
 import PlanImplementationModelDialog from "./PlanImplementationModelDialog.svelte";
+import { planReviewContent, planReviewPreview } from "./plan-mode-preview";
 import ToolFooter from "./ToolFooter.svelte";
 
 type PlanAcceptTarget = "same" | "compact" | "new-chat";
@@ -88,11 +89,6 @@ function resultPayload(toolCall: ToolCallDisplayRecord): unknown {
   return payloads.resultPreview ?? payloads.result;
 }
 
-function firstLines(text: string, count: number): string {
-  const lines = text.split("\n");
-  return lines.length > count ? lines.slice(0, count).join("\n") : text;
-}
-
 const rawResult = $derived(resultPayload(toolCall));
 const resultReview = $derived(reviewFromResult(rawResult));
 const displayedReview = $derived(
@@ -100,7 +96,7 @@ const displayedReview = $derived(
     ? {
         ...resultReview,
         ...planReview,
-        content: resultReview?.content ?? planReview.content,
+        content: planReviewContent(resultReview?.content, planReview.content),
       }
     : resultReview,
 );
@@ -117,13 +113,8 @@ const acceptedInNewChat = $derived(reviewStatus === "accepted_in_new_chat");
 const rejected = $derived(
   reviewStatus === "changes_requested" || reviewStatus === "discarded",
 );
-const collapsedContent = $derived(
-  resultReview?.content ?? displayedReview?.content ?? "",
-);
 const preview = $derived(
-  expanded
-    ? (displayedReview?.content ?? "")
-    : firstLines(collapsedContent, COLLAPSED_LINES),
+  planReviewPreview(displayedReview?.content ?? "", expanded, COLLAPSED_LINES),
 );
 const showPlanCard = $derived(
   toolCall.toolName === "plan_mode_present" && Boolean(displayedReview),

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { planReviewContent, planReviewPreview } from "./plan-mode-preview";
+
+describe("plan mode preview", () => {
+  it("prefers the hydrated full plan over the bounded transcript result", () => {
+    const bounded = "line 1\nline 2";
+    const full = "line 1\nline 2\nline 3\nline 4";
+    assert.equal(planReviewContent(bounded, full), full);
+    assert.equal(planReviewContent(bounded, undefined), bounded);
+  });
+
+  it("uses leading lines when collapsed and all content when expanded", () => {
+    const content = "line 1\nline 2\nline 3\nline 4";
+    assert.equal(planReviewPreview(content, false, 2), "line 1\nline 2");
+    assert.equal(planReviewPreview(content, true, 2), content);
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.ts
@@ -1,0 +1,18 @@
+export function planReviewContent(
+  resultContent: string | undefined,
+  hydratedContent: string | undefined,
+): string {
+  return hydratedContent ?? resultContent ?? "";
+}
+
+export function planReviewPreview(
+  content: string,
+  expanded: boolean,
+  collapsedLines: number,
+): string {
+  if (expanded) return content;
+  const lines = content.split("\n");
+  return lines.length > collapsedLines
+    ? lines.slice(0, collapsedLines).join("\n")
+    : content;
+}

--- a/packages/workbench-app/src/lib/presentation/tools/lifecycle/orchestration-specs.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/lifecycle/orchestration-specs.ts
@@ -292,12 +292,6 @@ export const orchestrationToolLifecycleSpecs = {
           ? { text: path.split(/[\\/]/).pop() || path, openPath: path }
           : textArg("Plan review"),
         secondary: path ? [{ text: path, mono: true, openPath: path }] : [],
-        body: source.string("summary")
-          ? {
-              kind: "text-summary",
-              text: boundedText(source.string("summary"))!,
-            }
-          : undefined,
       });
     },
   }),

--- a/packages/workbench-server/src/domains/plans/plan-service.ts
+++ b/packages/workbench-server/src/domains/plans/plan-service.ts
@@ -5,6 +5,7 @@ import {
   createId,
   type Mode,
   type PlanReviewRecord,
+  PLAN_REVIEW_SUMMARY_PREVIEW_CHARACTERS,
   type PlanReviewStatus,
   toPlanReviewPreview,
   type ToolCallRecord,
@@ -27,6 +28,7 @@ export type PlanReviewResult = {
 };
 
 const UNRESOLVED_PLAN_MARKER = /\[!(QUESTION|DECISION)\]/i;
+const PLAN_FILE_PREVIEW_LINES = 6;
 
 export const planReviewPreview = toPlanReviewPreview;
 
@@ -155,8 +157,8 @@ export class PlanService {
     }
 
     const slug = planSlugFromPath(planPath);
-    const title = optionalStringArg(args.title) ?? basename(planPath);
-    const summary = optionalStringArg(args.summary);
+    const title = basename(planPath);
+    const summary = planFilePreview(content);
     const existingPending = this.listPlanReviews("pending").find(
       (review) => review.agentId === agent.id && review.planPath === planPath,
     );
@@ -382,6 +384,15 @@ export class PlanService {
     }
     return `Plan review status: ${review.status}.`;
   }
+}
+
+function planFilePreview(content: string): string {
+  return content
+    .split(/\r?\n/)
+    .slice(0, PLAN_FILE_PREVIEW_LINES)
+    .join("\n")
+    .trim()
+    .slice(0, PLAN_REVIEW_SUMMARY_PREVIEW_CHARACTERS);
 }
 
 function optionalStringArg(value: unknown): string | undefined {

--- a/packages/workbench-server/src/domains/tools/orchestration-tool-dispatcher.ts
+++ b/packages/workbench-server/src/domains/tools/orchestration-tool-dispatcher.ts
@@ -199,11 +199,7 @@ export class OrchestrationToolDispatcher {
           result(
             this.requestPlanReview(
               toolCall,
-              {
-                file_path: request.filePath,
-                title: request.title,
-                summary: request.summary,
-              },
+              { file_path: request.filePath },
               options,
             ),
           ),

--- a/packages/workbench-server/src/domains/tools/permission/evaluate-workbench-tool-permission.ts
+++ b/packages/workbench-server/src/domains/tools/permission/evaluate-workbench-tool-permission.ts
@@ -54,6 +54,7 @@ export function evaluateWorkbenchToolPermission(
   const request = toolRequestContext(agent, args);
   let normalizedArgs = request.normalizedArgs;
   let denial: string | undefined;
+  let allowWithoutApproval = false;
 
   if (agent.mode === "planning") {
     const guardrails = planningModeGuardrails({
@@ -65,6 +66,7 @@ export function evaluateWorkbenchToolPermission(
     });
     normalizedArgs = guardrails.normalizedArgs;
     denial = guardrails.denial;
+    allowWithoutApproval = guardrails.allowWithoutApproval ?? false;
   } else if (
     toolName === "plan_mode_present" ||
     toolName === "plan_mode_force_exit"
@@ -99,21 +101,33 @@ export function evaluateWorkbenchToolPermission(
     constraints: denial ? [{ decision: "deny", reason: denial }] : undefined,
     evaluatedAt,
   });
+  const autoAllowPlanWrite =
+    agent.mode === "planning" &&
+    allowWithoutApproval &&
+    evaluated.decision === "approval" &&
+    supervision.decision === "prompt";
   const planningDecision =
     agent.mode === "planning"
-      ? evaluated.decision === "approval"
-        ? "prompt"
-        : evaluated.decision
+      ? autoAllowPlanWrite
+        ? "allow"
+        : evaluated.decision === "approval"
+          ? "prompt"
+          : evaluated.decision
       : supervision.decision;
   const durableSupervision =
-    planningDecision === supervision.decision
+    supervision.decision === "deny" || planningDecision === supervision.decision
       ? supervision
       : {
           ...supervision,
           decision: planningDecision,
           effectiveRisk: evaluated.risk,
-          reason: evaluated.reason,
+          reason: autoAllowPlanWrite
+            ? "Planning mode allows plan files to be saved without separate approval."
+            : evaluated.reason,
           normalizedArgs: evaluated.normalizedArgs,
+          ...(autoAllowPlanWrite
+            ? { matchedRuleIds: [], suggestedRules: [] }
+            : {}),
         };
   return {
     decision:
@@ -124,7 +138,9 @@ export function evaluateWorkbenchToolPermission(
     reason: durableSupervision.reason,
     normalizedArgs: durableSupervision.normalizedArgs,
     cwd: request.cwd,
-    suggestedExceptions: evaluated.suggestedExceptions,
+    suggestedExceptions: autoAllowPlanWrite
+      ? []
+      : evaluated.suggestedExceptions,
     supervision: durableSupervision,
   };
 }

--- a/packages/workbench-server/src/domains/tools/permission/planning-mode-guardrails.ts
+++ b/packages/workbench-server/src/domains/tools/permission/planning-mode-guardrails.ts
@@ -17,7 +17,11 @@ export function planningModeGuardrails(input: {
   normalizedArgs: Record<string, unknown>;
   cwd: string;
   dataDir: string;
-}): { normalizedArgs: Record<string, unknown>; denial?: string } {
+}): {
+  normalizedArgs: Record<string, unknown>;
+  denial?: string;
+  allowWithoutApproval?: boolean;
+} {
   const allowedInteractionTools = new Set<ToolName>([
     "ask_user",
     "todos_set",
@@ -55,10 +59,12 @@ export function planningModeGuardrails(input: {
       const targetPath = resolvePlanPath(input.cwd, input.args.path);
       const planDir = planDirForStorageHome(input.dataDir);
       const temporaryDir = tmpdir();
-      const allowed = [planDir, temporaryDir].some((directory) =>
-        isPathInsideDirectory(directory, targetPath),
+      const insidePlanDir = isPathInsideDirectory(planDir, targetPath);
+      const insideTemporaryDir = isPathInsideDirectory(
+        temporaryDir,
+        targetPath,
       );
-      if (!allowed) {
+      if (!insidePlanDir && !insideTemporaryDir) {
         return {
           normalizedArgs: input.normalizedArgs,
           denial: `Planning mode allows ${input.toolName} only inside the plan directory (${planDir}) or system temporary directory (${temporaryDir}). Attempted: ${targetPath}`,
@@ -66,6 +72,7 @@ export function planningModeGuardrails(input: {
       }
       return {
         normalizedArgs: { ...input.normalizedArgs, path: targetPath },
+        allowWithoutApproval: insidePlanDir,
       };
     } catch (error) {
       return {

--- a/packages/workbench-server/test/plan-service.test.ts
+++ b/packages/workbench-server/test/plan-service.test.ts
@@ -6,6 +6,7 @@ import { after, describe, it } from "node:test";
 import {
   type AgentRecord,
   PLAN_REVIEW_PREVIEW_CHARACTERS,
+  PLAN_REVIEW_SUMMARY_PREVIEW_CHARACTERS,
   type ToolCallRecord,
 } from "@nervekit/contracts";
 import {
@@ -71,6 +72,8 @@ describe("PlanService", () => {
     }
     assert.ok(review);
     assert.equal(review.slug, "accepted-plan");
+    assert.equal(review.title, "accepted-plan.md");
+    assert.equal(review.summary, "# Accepted");
     assert.equal(review.planPath, planPath);
     assert.equal(review.content, "# Accepted\n");
 
@@ -123,6 +126,11 @@ describe("PlanService", () => {
     }
     assert.ok(review);
     assert.equal(review.content, content);
+    assert.equal(review.summary?.startsWith("# Long plan"), true);
+    assert.equal(
+      review.summary?.length,
+      PLAN_REVIEW_SUMMARY_PREVIEW_CHARACTERS,
+    );
     assert.equal(
       planReviewPreview(review).content?.length,
       PLAN_REVIEW_PREVIEW_CHARACTERS,

--- a/packages/workbench-server/test/policy.test.ts
+++ b/packages/workbench-server/test/policy.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentRecord,
   PermissionException,
   PermissionLevel,
+  PermissionRule,
 } from "@nervekit/contracts";
 import { evaluateWorkbenchToolPermission } from "../src/domains/tools/permission/index.js";
 
@@ -122,7 +123,7 @@ describe("Workbench tool permission", () => {
       { path: planPath, content: "# Plan" },
       context,
     );
-    assert.equal(insidePlanDir.decision, "approval");
+    assert.equal(insidePlanDir.decision, "allow");
     assert.equal(insidePlanDir.normalizedArgs.path, resolve(planPath));
 
     const temporaryPath = join(tmpdir(), "nerve-plan-mode", "notes.md");
@@ -140,6 +141,15 @@ describe("Workbench tool permission", () => {
       insideTemporaryDir.normalizedArgs.path,
       resolve(temporaryPath),
     );
+    assert.equal(
+      evaluateWorkbenchToolPermission(
+        agent("supervised", "planning"),
+        "write",
+        { path: temporaryPath, content: "notes" },
+        context,
+      ).decision,
+      "approval",
+    );
 
     const outsidePath = resolve(
       tmpdir(),
@@ -155,6 +165,29 @@ describe("Workbench tool permission", () => {
     );
     assert.equal(outside.decision, "deny");
     assert.match(outside.reason, /system temporary directory/);
+  });
+
+  it("keeps explicit plan-write denials stronger than planning auto-allow", () => {
+    const planPath = join(context.dataDir, "plans", "blocked.md");
+    const rule: PermissionRule = {
+      id: "rule_block_plan_write",
+      scope: "project",
+      projectId: "proj_test",
+      effect: "deny",
+      toolName: "write",
+      matcherKind: "whole_tool",
+      pattern: "*",
+      enabled: true,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    };
+    const result = evaluateWorkbenchToolPermission(
+      agent("supervised", "planning"),
+      "write",
+      { path: planPath, content: "# Blocked" },
+      { ...context, rules: [rule] },
+    );
+    assert.equal(result.decision, "deny");
   });
 
   it("cannot override planning denials with an exception", () => {


### PR DESCRIPTION
## Summary
- simplify `plan_mode_present` to accept only the plan file path
- derive review metadata from the plan file and fix full-content rendering
- allow canonical plan-directory writes during planning while preserving explicit denials
- add focused schema, service, permission, and UI preview tests

## Validation
- `pnpm fix && pnpm check && pnpm test`