### PR TITLE
feat: add Bash tool configuration dialog

### DIFF
--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/BashToolDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/BashToolDialog.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+import type { Settings } from "$lib/api";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import Dialog from "@nervekit/ui-kit/components/ui/dialog-shell";
+import { Input } from "@nervekit/ui-kit/components/ui/input";
+import { Label } from "@nervekit/ui-kit/components/ui/label";
+import { Switch } from "@nervekit/ui-kit/components/ui/switch";
+import type { SettingsChange } from "../settings-change";
+
+type Props = {
+  open?: boolean;
+  settingsDraft: Settings;
+  onSettingsChange?: SettingsChange;
+};
+
+let {
+  open = $bindable(false),
+  settingsDraft,
+  onSettingsChange,
+}: Props = $props();
+
+let enabledDraft = $state(true);
+let secondsDraft = $state("120");
+let lastOpen = false;
+
+$effect(() => {
+  if (open && !lastOpen) {
+    const autoPromotion = settingsDraft.tools.bash.autoPromotion;
+    enabledDraft = autoPromotion.enabled;
+    secondsDraft = String(autoPromotion.afterMs / 1000);
+  }
+  lastOpen = open;
+});
+
+const validSeconds = $derived(
+  Number.isInteger(Number(secondsDraft)) &&
+    Number(secondsDraft) >= 1 &&
+    Number(secondsDraft) <= 86_400,
+);
+
+function save(): void {
+  if (!validSeconds) return;
+  const afterMs = Number(secondsDraft) * 1000;
+  settingsDraft.tools.bash.autoPromotion.enabled = enabledDraft;
+  settingsDraft.tools.bash.autoPromotion.afterMs = afterMs;
+  onSettingsChange?.(
+    {
+      tools: {
+        bash: {
+          autoPromotion: { enabled: enabledDraft, afterMs },
+        },
+      },
+    },
+    { immediate: true },
+  );
+  open = false;
+}
+</script>
+
+<Dialog
+  bind:open
+  size="sm"
+  title="Configure Shell"
+  description="Choose whether long-running Bash calls should continue in the background."
+>
+  <div class="grid gap-4">
+    <div class="flex items-center justify-between gap-4">
+      <div class="grid gap-1">
+        <Label for="tools-bash-auto-promotion-enabled"
+          >Automatic backgrounding</Label
+        >
+        <p class="text-xs text-muted-foreground">
+          Promote Bash calls that are still running after the configured delay.
+        </p>
+      </div>
+      <Switch
+        id="tools-bash-auto-promotion-enabled"
+        size="settings"
+        checked={enabledDraft}
+        aria-label="Enable automatic backgrounding"
+        onCheckedChange={(checked) => (enabledDraft = checked)}
+      />
+    </div>
+
+    <div class="grid gap-1.5">
+      <Label for="tools-bash-auto-promotion-seconds">Background after</Label>
+      <div class="flex items-center gap-2">
+        <Input
+          size="xs"
+          id="tools-bash-auto-promotion-seconds"
+          type="number"
+          min={1}
+          max={86_400}
+          step={1}
+          bind:value={secondsDraft}
+          disabled={!enabledDraft}
+          aria-label="Background after seconds"
+        />
+        <span class="text-xs text-muted-foreground">seconds</span>
+      </div>
+      {#if !validSeconds}
+        <p class="text-xs text-destructive">
+          Enter a whole number from 1 to 86,400.
+        </p>
+      {/if}
+    </div>
+  </div>
+
+  {#snippet footer()}
+    <Button size="sm" variant="ghost" onclick={() => (open = false)}
+      >Cancel</Button
+    >
+    <Button size="sm" onclick={save} disabled={!validSeconds}>Save</Button>
+  {/snippet}
+</Dialog>

--- a/packages/workbench-app/src/lib/features/settings/components/pages/tools/ToolCatalogSection.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/tools/ToolCatalogSection.svelte
@@ -11,12 +11,10 @@ import type {
 import { Switch } from "@nervekit/ui-kit/components/ui/switch";
 import * as Tooltip from "@nervekit/ui-kit/components/ui/tooltip";
 import {
-  SettingsFieldRow,
   SettingsGroup,
   SettingsInlineMessage,
   SettingsList,
   SettingsSummaryRow,
-  SettingsToggleRow,
 } from "$lib/presentation/components/settings";
 import {
   modelDisplayName,
@@ -27,6 +25,7 @@ import {
 } from "$lib/presentation/utils/model";
 import SingleModelSelectionDialog from "../../shared/SingleModelSelectionDialog.svelte";
 import type { SettingsChange } from "../settings-change";
+import BashToolDialog from "./BashToolDialog.svelte";
 import PythonRuntimeDialog from "./PythonRuntimeDialog.svelte";
 import ToolConfigureButton from "./ToolConfigureButton.svelte";
 import ToolGroupItem from "./ToolGroupItem.svelte";
@@ -59,6 +58,7 @@ let {
   category = "core",
 }: Props = $props();
 
+let bashDialogOpen = $state(false);
 let pythonDialogOpen = $state(false);
 let visionModelDialogOpen = $state(false);
 let webDialogOpen = $state(false);
@@ -150,25 +150,6 @@ function setTavilyProfile(profileId?: string): void {
     setToolsEnabled(["web_search", "web_fetch"], false);
   }
 }
-
-function setBashAutoPromotionEnabled(enabled: boolean): void {
-  settingsDraft.tools.bash.autoPromotion.enabled = enabled;
-  onSettingsChange?.(
-    { tools: { bash: { autoPromotion: { enabled } } } },
-    { immediate: true },
-  );
-}
-
-function updateBashAutoPromotionSeconds(value: string): void {
-  const seconds = Number(value);
-  if (!Number.isInteger(seconds) || seconds < 1 || seconds > 86_400) return;
-  const afterMs = seconds * 1000;
-  settingsDraft.tools.bash.autoPromotion.afterMs = afterMs;
-  onSettingsChange?.(
-    { tools: { bash: { autoPromotion: { afterMs } } } },
-    { debounceMs: 650 },
-  );
-}
 </script>
 
 <SettingsGroup>
@@ -184,7 +165,12 @@ function updateBashAutoPromotionSeconds(value: string): void {
         tools={group.tools}
       >
         {#snippet actions()}
-          {#if group.id === "web"}
+          {#if group.id === "shell"}
+            <ToolConfigureButton
+              label="Configure Shell"
+              onclick={() => (bashDialogOpen = true)}
+            />
+          {:else if group.id === "web"}
             <ToolConfigureButton
               label="Configure Web access"
               onclick={() => (webDialogOpen = true)}
@@ -232,27 +218,17 @@ function updateBashAutoPromotionSeconds(value: string): void {
         {/snippet}
         {#snippet extra()}
           {#if group.id === "shell"}
-            <div class="grid gap-2 pt-1">
-              <SettingsToggleRow
-                label="Automatic backgrounding"
-                description="Promote Bash calls that are still running after the configured delay."
-                checked={bashAutoPromotion.enabled}
-                onCheckedChange={setBashAutoPromotionEnabled}
-              />
-              <SettingsFieldRow
-                id="tools-bash-auto-promotion-seconds"
-                label="Background after"
-                type="number"
-                min={1}
-                max={86_400}
-                step={1}
-                suffix="seconds"
-                disabled={!bashAutoPromotion.enabled}
-                class="max-w-xs"
-                value={String(bashAutoPromotion.afterMs / 1000)}
-                onValueChange={updateBashAutoPromotionSeconds}
-              />
-            </div>
+            <SettingsSummaryRow
+              class="mt-1"
+              title="Automatic backgrounding"
+              status={bashAutoPromotion.enabled ? "ok" : "muted"}
+            >
+              {#snippet meta()}
+                {bashAutoPromotion.enabled
+                  ? `After ${bashAutoPromotion.afterMs / 1000} seconds`
+                  : "Disabled"}
+              {/snippet}
+            </SettingsSummaryRow>
           {:else if group.id === "web"}
             <SettingsSummaryRow
               class="mt-1"
@@ -320,6 +296,8 @@ function updateBashAutoPromotionSeconds(value: string): void {
     {/each}
   </SettingsList>
 </SettingsGroup>
+
+<BashToolDialog bind:open={bashDialogOpen} {settingsDraft} {onSettingsChange} />
 
 <ToolProfileDialog
   bind:open={webDialogOpen}


### PR DESCRIPTION
## Summary
- add a Configure button for the Shell/Bash tool
- move automatic backgrounding settings into a dialog
- show the current backgrounding configuration in the Shell row

## Validation
- pnpm fix && pnpm check && pnpm test