### PR TITLE
fix: show plan preview body text

### DIFF
--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
@@ -96,7 +96,11 @@ const displayedReview = $derived(
     ? {
         ...resultReview,
         ...planReview,
-        content: planReviewContent(resultReview?.content, planReview.content),
+        content: planReviewContent(
+          resultReview?.content,
+          planReview.content,
+          planReview.summary ?? resultReview?.summary,
+        ),
       }
     : resultReview,
 );
@@ -113,8 +117,15 @@ const acceptedInNewChat = $derived(reviewStatus === "accepted_in_new_chat");
 const rejected = $derived(
   reviewStatus === "changes_requested" || reviewStatus === "discarded",
 );
+const previewContent = $derived(
+  planReviewContent(
+    displayedReview?.content,
+    undefined,
+    displayedReview?.summary,
+  ),
+);
 const preview = $derived(
-  planReviewPreview(displayedReview?.content ?? "", expanded, COLLAPSED_LINES),
+  planReviewPreview(previewContent, expanded, COLLAPSED_LINES),
 );
 const showPlanCard = $derived(
   toolCall.toolName === "plan_mode_present" && Boolean(displayedReview),

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.test.ts
@@ -3,11 +3,15 @@ import { describe, it } from "node:test";
 import { planReviewContent, planReviewPreview } from "./plan-mode-preview";
 
 describe("plan mode preview", () => {
-  it("prefers the hydrated full plan over the bounded transcript result", () => {
-    const bounded = "line 1\nline 2";
+  it("uses the best available plan content", () => {
+    const summary = "line 1\nline 2";
+    const bounded = "line 1\nline 2\nline 3";
     const full = "line 1\nline 2\nline 3\nline 4";
-    assert.equal(planReviewContent(bounded, full), full);
-    assert.equal(planReviewContent(bounded, undefined), bounded);
+
+    assert.equal(planReviewContent(bounded, full, summary), full);
+    assert.equal(planReviewContent(bounded, undefined, summary), bounded);
+    assert.equal(planReviewContent(undefined, undefined, summary), summary);
+    assert.equal(planReviewContent(undefined, undefined), "");
   });
 
   it("uses leading lines when collapsed and all content when expanded", () => {

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/plan-mode-preview.ts
@@ -1,8 +1,9 @@
 export function planReviewContent(
   resultContent: string | undefined,
   hydratedContent: string | undefined,
+  summaryContent?: string,
 ): string {
-  return hydratedContent ?? resultContent ?? "";
+  return hydratedContent ?? resultContent ?? summaryContent ?? "";
 }
 
 export function planReviewPreview(


### PR DESCRIPTION
## Summary
- show the persisted six-line plan summary in plan_mode_present cards when full content is unavailable
- preserve hydrated and transcript content precedence
- add preview fallback coverage

## Validation
- pnpm fix && pnpm check && pnpm test