### PR TITLE
fix: allow markdown tables to size to content

### DIFF
--- a/packages/ui-kit/src/lib/core/components/Markdown.svelte
+++ b/packages/ui-kit/src/lib/core/components/Markdown.svelte
@@ -640,7 +640,7 @@ $effect(() => () => streamingScheduler.destroy());
   width: 100%;
   min-width: 0;
   max-width: 100%;
-  table-layout: fixed;
+  table-layout: auto;
   border-collapse: separate;
   border-spacing: 0;
   font-size: var(--text-xs);


### PR DESCRIPTION
## Summary
- Allow Markdown tables to size columns to their content instead of forcing fixed widths.

## Testing
- Not run (not requested).