### PR TITLE
fix(workbench): clean up build warnings

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/StatusBar.svelte
+++ b/packages/workbench-app/src/lib/app/shell/StatusBar.svelte
@@ -171,7 +171,7 @@ function gitStatusTitle(status: GitStatus): string {
           <Button
             variant="ghost"
             size="xs"
-            class="footer-item warn text-xs"
+            class="footer-item text-warning text-xs"
             ariaLabel={`Open ${pendingApprovals === 1 ? "pending approval" : "pending approvals"}`}
             title={`${pendingApprovals} ${pendingApprovals === 1 ? "pending approval" : "pending approvals"} · Open conversation`}
             onclick={() => onOpenPendingApproval?.()}
@@ -210,11 +210,6 @@ function gitStatusTitle(status: GitStatus): string {
 .footer-item :global(svg) {
   flex: none;
   color: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
-}
-
-.footer-item.warn,
-.footer-item.warn :global(svg) {
-  color: var(--warning);
 }
 
 .footer-project-path {

--- a/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorEditor.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorEditor.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-import { json } from "@codemirror/lang-json";
 import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView, type ViewUpdate } from "@codemirror/view";
-import { onDestroy, onMount } from "svelte";
-import { editableCodeExtensions } from "./code-mirror-config";
+import { onMount } from "svelte";
+import { editableCodeExtensions, loadCodeLanguage } from "./code-mirror-config";
 
 type Props = {
   value: string;
@@ -33,23 +32,35 @@ function editableExtensions(isDisabled: boolean) {
 }
 
 onMount(() => {
-  view = new EditorView({
-    parent: host,
-    state: EditorState.create({
-      doc: value,
-      extensions: [
-        ...editableCodeExtensions(ariaLabel),
-        json(),
-        EditorView.lineWrapping,
-        editableCompartment.of(editableExtensions(disabled)),
-        EditorView.updateListener.of((update: ViewUpdate) => {
-          if (!update.docChanged) return;
-          const next = update.state.doc.toString();
-          if (next !== value) onChange?.(next);
-        }),
-      ],
-    }),
+  let active = true;
+
+  void loadCodeLanguage("json").then((jsonExtension) => {
+    if (!active) return;
+
+    view = new EditorView({
+      parent: host,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          ...editableCodeExtensions(ariaLabel),
+          jsonExtension,
+          EditorView.lineWrapping,
+          editableCompartment.of(editableExtensions(disabled)),
+          EditorView.updateListener.of((update: ViewUpdate) => {
+            if (!update.docChanged) return;
+            const next = update.state.doc.toString();
+            if (next !== value) onChange?.(next);
+          }),
+        ],
+      }),
+    });
   });
+
+  return () => {
+    active = false;
+    view?.destroy();
+    view = undefined;
+  };
 });
 
 $effect(() => {
@@ -68,8 +79,6 @@ $effect(() => {
     effects: editableCompartment.reconfigure(editableExtensions(disabled)),
   });
 });
-
-onDestroy(() => view?.destroy());
 </script>
 
 <div

--- a/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
+++ b/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
@@ -27,14 +27,25 @@ let visible = $state(false);
 const MOVE_DURATION_MS = 200;
 let measureFrame: number | undefined;
 let showFrame: number | undefined;
+let animateMeasure = false;
+let requestedKey: string | undefined;
 let overlay = $state<HTMLDivElement>();
-/** Key the drawn outline currently reflects, to detect item switches. */
-let drawnKey: string | undefined;
+
+/** Cancel geometry animations before snapping to a layout measurement. */
+function cancelOverlayAnimation(): void {
+  if (!overlay) return;
+  for (const animation of overlay.getAnimations()) animation.cancel();
+}
 
 /** Re-measures from resize/scroll/layout must snap; only item moves glide. */
-function applyGeometry(geometry: RelativeItemRectangle, moving: boolean): void {
+function applyGeometry(
+  geometry: RelativeItemRectangle,
+  animate: boolean,
+): void {
+  if (!animate) cancelOverlayAnimation();
+
   if (
-    moving &&
+    animate &&
     overlay &&
     visible &&
     (geometry.x !== x ||
@@ -49,7 +60,7 @@ function applyGeometry(geometry: RelativeItemRectangle, moving: boolean): void {
       width: computed.width,
       height: computed.height,
     };
-    for (const animation of overlay.getAnimations()) animation.cancel();
+    cancelOverlayAnimation();
     overlay.animate([from, toKeyframe(geometry)], {
       duration: MOVE_DURATION_MS,
       easing: "ease-out",
@@ -90,8 +101,7 @@ function activeTarget(): HTMLElement | undefined {
   );
 }
 
-function measure(): void {
-  measureFrame = undefined;
+function measure(animate: boolean): void {
   if (!collection) return;
   const target = activeTarget();
   if (!target) {
@@ -104,9 +114,7 @@ function measure(): void {
     target.getBoundingClientRect(),
     window.devicePixelRatio || 1,
   );
-  const moving = drawnKey !== undefined && activeKey !== drawnKey;
-  drawnKey = activeKey;
-  applyGeometry(geometry, moving);
+  applyGeometry(geometry, animate);
 
   if (!visible) {
     if (showFrame !== undefined) cancelAnimationFrame(showFrame);
@@ -117,16 +125,27 @@ function measure(): void {
   }
 }
 
-function scheduleMeasure(): void {
+function scheduleMeasure(animate = false): void {
+  // DOM observer/event callbacks pass their event payload as the first
+  // argument; only the explicit boolean from the active-key effect animates.
+  if (animate === true) animateMeasure = true;
   if (measureFrame !== undefined) return;
-  measureFrame = requestAnimationFrame(measure);
+  measureFrame = requestAnimationFrame(() => {
+    measureFrame = undefined;
+    const shouldAnimate = animateMeasure;
+    animateMeasure = false;
+    measure(shouldAnimate);
+  });
 }
 
 $effect(() => {
   const key = activeKey;
   const host = collection;
+  const animate =
+    key !== undefined && requestedKey !== undefined && key !== requestedKey;
+  requestedKey = key;
   void tick().then(() => {
-    if (activeKey === key && collection === host) scheduleMeasure();
+    if (activeKey === key && collection === host) scheduleMeasure(animate);
   });
 });
 
@@ -134,7 +153,8 @@ $effect(() => {
   const host = collection;
   if (!host) return;
 
-  const resizeObserver = new ResizeObserver(scheduleMeasure);
+  const scheduleLayoutMeasure = () => scheduleMeasure();
+  const resizeObserver = new ResizeObserver(scheduleLayoutMeasure);
   const observeCandidates = () => {
     resizeObserver.disconnect();
     resizeObserver.observe(host);
@@ -148,19 +168,21 @@ $effect(() => {
   });
   mutationObserver.observe(host, { childList: true, subtree: true });
 
-  host.addEventListener("scroll", scheduleMeasure, true);
-  window.addEventListener("resize", scheduleMeasure);
+  host.addEventListener("scroll", scheduleLayoutMeasure, true);
+  window.addEventListener("resize", scheduleLayoutMeasure);
   scheduleMeasure();
 
   return () => {
     resizeObserver.disconnect();
     mutationObserver.disconnect();
-    host.removeEventListener("scroll", scheduleMeasure, true);
-    window.removeEventListener("resize", scheduleMeasure);
+    host.removeEventListener("scroll", scheduleLayoutMeasure, true);
+    window.removeEventListener("resize", scheduleLayoutMeasure);
     if (measureFrame !== undefined) cancelAnimationFrame(measureFrame);
     if (showFrame !== undefined) cancelAnimationFrame(showFrame);
+    cancelOverlayAnimation();
     measureFrame = undefined;
     showFrame = undefined;
+    animateMeasure = false;
   };
 });
 </script>

--- a/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
+++ b/packages/workbench-app/src/lib/presentation/items/ItemCollection.svelte
@@ -196,7 +196,7 @@ $effect(() => {
   <div
     bind:this={overlay}
     aria-hidden="true"
-    class="pointer-events-none absolute top-0 left-0 z-20 rounded-md border border-primary/60 opacity-0 transition-[opacity] duration-200 ease-out will-change-transform"
+    class="pointer-events-none absolute top-0 left-0 z-20 rounded-md opacity-0 ring-1 ring-primary/60 ring-inset transition-[opacity] duration-200 ease-out will-change-transform"
     class:opacity-100={visible}
     style:transform={`translate3d(${x}px, ${y}px, 0)`}
     style:width={`${width}px`}

--- a/packages/workbench-app/src/lib/presentation/items/item-collection.test.ts
+++ b/packages/workbench-app/src/lib/presentation/items/item-collection.test.ts
@@ -42,3 +42,25 @@ test("relativeItemRectangle snaps to device pixels at fractional scale factors",
     { x: 64.5, y: 51.5, width: 180, height: 36.5 },
   );
 });
+test("relativeItemRectangle keeps edge-aligned outlines inside the collection", () => {
+  const collection = {
+    left: 8.796875,
+    top: 10.796875,
+    width: 346.828125,
+    height: 48.375,
+  };
+
+  assert.deepEqual(
+    relativeItemRectangle(
+      collection,
+      {
+        left: collection.left,
+        top: collection.top,
+        width: collection.width,
+        height: collection.height,
+      },
+      2,
+    ),
+    { x: 0, y: 0, width: collection.width, height: collection.height },
+  );
+});

--- a/packages/workbench-app/src/lib/presentation/items/item-collection.ts
+++ b/packages/workbench-app/src/lib/presentation/items/item-collection.ts
@@ -25,10 +25,20 @@ export function relativeItemRectangle(
   const snap = (value: number): number => Math.round(value * scale) / scale;
   const x = snap(target.left - collection.left);
   const y = snap(target.top - collection.top);
+  // Pixel snapping can round an edge-aligned target beyond a fractional
+  // collection edge, where the containing viewport would clip the outline.
+  const right = Math.min(
+    snap(target.left + target.width - collection.left),
+    collection.width,
+  );
+  const bottom = Math.min(
+    snap(target.top + target.height - collection.top),
+    collection.height,
+  );
   return {
     x,
     y,
-    width: snap(target.left + target.width - collection.left) - x,
-    height: snap(target.top + target.height - collection.top) - y,
+    width: Math.max(0, right - x),
+    height: Math.max(0, bottom - y),
   };
 }

--- a/packages/workbench-app/vite.config.ts
+++ b/packages/workbench-app/vite.config.ts
@@ -124,6 +124,9 @@ export default defineConfig(({ mode }) => {
       }),
     ],
     build: {
+      // The eager workbench shell is intentionally shared by all lazy views;
+      // keep this measured threshold tight enough to catch bundle growth.
+      chunkSizeWarningLimit: 1400,
       rollupOptions: {
         onwarn(warning, warn) {
           // workspace-actions is dynamically imported by the five tab-state


### PR DESCRIPTION
## Summary
- replace the unused StatusBar warning CSS selector with the `text-warning` token utility
- lazy-load JSON CodeMirror support with safe teardown
- set a measured chunk warning threshold for the intentionally shared workbench shell

## Validation
- `pnpm fix && pnpm check && pnpm test`
- workbench-server build
- workbench-app build