### PR TITLE
feat(storage): v1 home usage taxonomy and cleanup overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ assets/brand/*
 !assets/brand/nerve-mark-small.svg
 !assets/brand/nerve-app-icon.svg
 dogfood-output/
+.idea/

--- a/packages/contracts/src/domains/storage/storage.schema.ts
+++ b/packages/contracts/src/domains/storage/storage.schema.ts
@@ -9,20 +9,22 @@ export const daemonStartupProgressSchema = z.object({
 export type DaemonStartupProgress = z.infer<typeof daemonStartupProgressSchema>;
 
 export const storageCategoryKeySchema = z.enum([
-  "conversations",
+  "database",
   "payloads",
-  "logs",
-  "sqliteIndex",
-  "exploreReports",
-  "crashes",
+  "reports",
+  "images",
   "plans",
-  "agents",
   "tasks",
-  "workflowState",
-  "projects",
+  "agentResources",
+  "runtimeState",
+  "logs",
+  "crashReports",
+  "queryCache",
   "cache",
-  "tmp",
-  "protected",
+  "temporaryFiles",
+  "migrations",
+  "backups",
+  "configurationIdentity",
   "other",
 ]);
 export type StorageCategoryKey = z.infer<typeof storageCategoryKeySchema>;
@@ -70,12 +72,12 @@ export type LargestConversationUsage = z.infer<
 >;
 
 export const storageUsageResponseSchema = z.object({
-  dataDir: z.string(),
+  homeDir: z.string(),
   generatedAt: z.string().datetime(),
   totalBytes: z.number().int().nonnegative(),
   categories: z.array(storageCategoryUsageSchema),
   cleanupTargets: z.array(storageCleanupTargetUsageSchema),
-  sqlite: z.object({
+  database: z.object({
     dbBytes: z.number().int().nonnegative(),
     walBytes: z.number().int().nonnegative(),
     shmBytes: z.number().int().nonnegative(),

--- a/packages/contracts/test/storage.schema.test.ts
+++ b/packages/contracts/test/storage.schema.test.ts
@@ -2,10 +2,74 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   operationDefinition,
+  storageCleanupOperationSchema,
   storageCleanupRequestSchema,
+  storageUsageResponseSchema,
 } from "../src/index.js";
 
 describe("storage cleanup contracts", () => {
+  it("validates the v1 home usage taxonomy", () => {
+    const parsed = storageUsageResponseSchema.parse({
+      homeDir: "/tmp/nerve-home",
+      generatedAt: "2026-08-26T00:00:00.000Z",
+      totalBytes: 12,
+      categories: [
+        {
+          key: "database",
+          label: "Canonical database",
+          description: "Authoritative records.",
+          bytes: 12,
+          fileCount: 1,
+          cleanable: false,
+          protected: true,
+        },
+      ],
+      cleanupTargets: [],
+      database: { dbBytes: 12, walBytes: 0, shmBytes: 0 },
+      conversations: { total: 0, largest: [] },
+    });
+    assert.equal(parsed.categories[0]?.key, "database");
+    assert.equal(
+      storageUsageResponseSchema.safeParse({
+        ...parsed,
+        homeDir: undefined,
+        dataDir: parsed.homeDir,
+      }).success,
+      false,
+    );
+  });
+
+  it("deliberately rejects completed legacy operations with old usage snapshots", () => {
+    const now = "2026-08-26T00:00:00.000Z";
+    const legacy = {
+      id: "storageop_LEGACY",
+      request: { clearCache: true },
+      status: "succeeded",
+      createdAt: now,
+      updatedAt: now,
+      completedAt: now,
+      message: "Complete.",
+      completedTargets: 1,
+      totalTargets: 1,
+      cancellable: false,
+      cancellationRequested: false,
+      freedBytes: 0,
+      results: [],
+      usage: {
+        dataDir: "/tmp/nerve-home",
+        generatedAt: now,
+        totalBytes: 0,
+        categories: [],
+        cleanupTargets: [],
+        sqlite: { dbBytes: 0, walBytes: 0, shmBytes: 0 },
+        conversations: { total: 0, largest: [] },
+      },
+    };
+    assert.equal(
+      storageCleanupOperationSchema.safeParse(legacy).success,
+      false,
+    );
+  });
   it("requires at least one valid cleanup target", () => {
     assert.equal(storageCleanupRequestSchema.safeParse({}).success, false);
     assert.equal(

--- a/packages/website/src/content/docs/guides/settings.md
+++ b/packages/website/src/content/docs/guides/settings.md
@@ -32,7 +32,7 @@ Model availability depends on authentication and provider metadata. Changes to d
 
 ## Storage
 
-**Storage** shows local usage and provides cancellable cleanup. Depending on the selected targets, cleanup can remove old conversations and logs, Explore reports, crash and Node reports, cache and temporary data, and rebuild the search index. Cleanup is asynchronous and reports progress; it does not replace a backup or change authoritative project files unexpectedly.
+**Storage** shows an ownership and retention breakdown of readable files under `NERVE_HOME` and provides cancellable cleanup. It distinguishes the authoritative database at `data/nerve.sqlite`, the rebuildable query cache at `cache/query-cache.sqlite`, and other disposable cache data. Depending on the selected targets, cleanup can remove old conversations and logs, Explore reports, crash and Node reports, non-query cache and temporary data, or rebuild the query cache from canonical records. Cleanup is asynchronous and reports progress; it never treats the canonical database, migrations, or backups as cleanup targets.
 
 ## System
 

--- a/packages/website/src/content/docs/operations/storage-migration.md
+++ b/packages/website/src/content/docs/operations/storage-migration.md
@@ -11,7 +11,7 @@ Electron's active Chromium profile remains outside `NERVE_HOME`. A whole-home ba
 
 ## Inspect and clean up
 
-Settings can estimate usage and run asynchronous cleanup for old conversations and diagnostics, event compaction, reports, cache/temp data, and rebuildable indexes. Cleanup skips symlinks and observes cancellation between targets.
+Settings reports readable files across the complete Nerve home, including canonical data, payloads, runtime state, diagnostics, migrations, and backups. It can run asynchronous cleanup for old conversations and diagnostics, event compaction, reports, non-query cache/temp data, and the rebuildable query cache. Rebuilding the query cache replaces files under `cache/query-cache.sqlite`; it never modifies the authoritative `data/nerve.sqlite`. Migrations and backups are visible in usage but are not cleanup targets. Cleanup skips symlinks and observes cancellation between targets.
 
 Conversation pruning skips running or awaiting agents and conversations with active tasks before removing associated inactive records and managed files.
 

--- a/packages/website/src/content/docs/reference/data-formats.md
+++ b/packages/website/src/content/docs/reference/data-formats.md
@@ -7,20 +7,26 @@ sidebar:
 
 All Nerve-home paths move with `NERVE_HOME`; default is `~/.nerve`.
 
-| Data                                       | Default location / format                                 |
-| ------------------------------------------ | --------------------------------------------------------- |
-| State marker                               | `<NERVE_HOME>`; `nerve-workbench-state` v2                |
-| Projects/conversations/settings/auth/tasks | Canonical domain storage under `<NERVE_HOME>`             |
-| Conversation records                       | Versioned SQLite payloads with parent lineage             |
-| Protocol event streams                     | Dense per-stream JSONL with bounded retention             |
-| Search/index cache                         | Rebuildable SQLite/cache                                  |
-| Desktop/daemon logs                        | `<NERVE_HOME>/logs`, JSONL                                |
-| Crash/Node reports                         | `<NERVE_HOME>/crashes`; age-retained diagnostics          |
-| TLS CA/leaf material                       | `<NERVE_HOME>/tls` when mobile HTTPS is enabled           |
-| Daemon metadata                            | `<NERVE_HOME>/daemon.json`                                |
-| Explore reports                            | Nerve-owned report storage under the active home          |
-| Python/large tool artifacts                | Nerve artifact paths returned by the tool                 |
-| Pasted clipboard images                    | OS temp directory under `nerve/`; not durable attachments |
+| Data                          | Default location / format                                    |
+| ----------------------------- | ------------------------------------------------------------ |
+| Nerve-home marker             | `<NERVE_HOME>/manifest.json`; `nerve-home` v1                |
+| Canonical domain records      | `<NERVE_HOME>/data/nerve.sqlite` plus SQLite WAL/SHM         |
+| Conversation/tool payloads    | `<NERVE_HOME>/data/payloads`                                 |
+| Durable images and plans      | `<NERVE_HOME>/data/images` and `<NERVE_HOME>/data/plans`     |
+| Explore reports               | `<NERVE_HOME>/data/reports`                                  |
+| RPC and maintenance state     | `<NERVE_HOME>/data/idempotency` and `data/maintenance`       |
+| Rebuildable query cache       | `<NERVE_HOME>/cache/query-cache.sqlite` plus SQLite sidecars |
+| Other disposable caches       | Other content under `<NERVE_HOME>/cache`                     |
+| Task records and logs         | `<NERVE_HOME>/tasks`                                         |
+| Agent resources               | `<NERVE_HOME>/agent`                                         |
+| Desktop/daemon/event logs     | `<NERVE_HOME>/logs`, JSONL                                   |
+| Crash/Node reports            | `<NERVE_HOME>/crashes`; age-retained diagnostics             |
+| Configuration and credentials | `<NERVE_HOME>/config` and encrypted `<NERVE_HOME>/secrets`   |
+| TLS CA/leaf material          | `<NERVE_HOME>/tls` when mobile HTTPS is enabled              |
+| Daemon discovery metadata     | `<NERVE_HOME>/daemon.json`                                   |
+| Migration history and backups | `<NERVE_HOME>/migrations` and `<NERVE_HOME>/backups`         |
+| Python/large tool artifacts   | Nerve artifact paths returned by the tool                    |
+| Pasted clipboard images       | OS temp directory under `nerve/`; not durable attachments    |
 
 ## Conversation exports
 

--- a/packages/workbench-app/src/lib/features/settings/components/pages/storage/StorageCleanupDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/storage/StorageCleanupDialog.svelte
@@ -210,7 +210,7 @@ function start(): void {
           id="cleanup-cache"
           bind:checked={selection.cache}
           title="Cache"
-          description={`Disposable cached data · ${targetFootprint("cache")}`}
+          description={`Disposable non-query cached data · ${targetFootprint("cache")}`}
         />
         <StorageCleanupChoice
           id="cleanup-tmp"
@@ -224,25 +224,19 @@ function start(): void {
     <Collapsible.Root bind:open={openGroups.index}>
       {@render groupHeader(
         "index",
-        "Search index",
-        "Rebuild the query cache instead of vacuuming the large database in place.",
+        "Query cache",
+        "Rebuild the disposable read model without changing canonical data.",
       )}
       <Collapsible.Content class="mt-0.5 rounded-md border border-border/60">
         <StorageCleanupChoice
           id="cleanup-index"
           bind:checked={selection.searchIndex}
-          title="Rebuild search index"
-          description={`Recreate from current records and retained event logs · ${targetFootprint("searchIndex")}`}
+          title="Rebuild query cache"
+          description={`Recreate from canonical records · ${targetFootprint("searchIndex")}`}
         />
       </Collapsible.Content>
     </Collapsible.Root>
 
-    {#if selection.searchIndex}
-      <SettingsInlineMessage
-        tone="warning"
-        text="Older searchable event history that exists only in the index will be dropped. Conversation files are not removed by this option."
-      />
-    {/if}
     {#if selection.conversations}
       <SettingsInlineMessage
         tone="error"

--- a/packages/workbench-app/src/lib/features/settings/components/pages/storage/StorageSettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/components/pages/storage/StorageSettingsPage.svelte
@@ -72,9 +72,9 @@ const progressValue = $derived(operation ? cleanupProgress(operation) : 0);
 const completedWithIssues = $derived(
   operation?.results.some((result) => result.outcome === "failed") ?? false,
 );
-const indexBytes = $derived(
+const databaseBytes = $derived(
   usage
-    ? usage.sqlite.dbBytes + usage.sqlite.walBytes + usage.sqlite.shmBytes
+    ? usage.database.dbBytes + usage.database.walBytes + usage.database.shmBytes
     : 0,
 );
 
@@ -108,7 +108,7 @@ onMount(() => {
         <span class="text-2xl font-semibold">{formatBytes(totalBytes)}</span>
         <span
           class="truncate font-mono text-xs text-muted-foreground"
-          title={usage.dataDir}>{usage.dataDir}</span
+          title={usage.homeDir}>{usage.homeDir}</span
         >
         <span class="text-xs text-muted-foreground">
           Calculated {new Date(usage.generatedAt).toLocaleString()}
@@ -275,17 +275,18 @@ onMount(() => {
               <span class="font-mono">{category.bytes.toLocaleString()}</span>
               bytes
             </p>
-            {#if category.key === "sqliteIndex"}
+            {#if category.key === "database"}
               <p>
-                Search index total <span class="font-mono"
-                  >{formatBytes(indexBytes)}</span
-                > across the database, write-ahead log, and shared memory files. It
-                can be rebuilt into a fresh compact index.
+                Canonical database total <span class="font-mono"
+                  >{formatBytes(databaseBytes)}</span
+                > across the database, write-ahead log, and shared memory files. This
+                authoritative state is never removed by cleanup.
               </p>
             {/if}
-            {#if category.key === "conversations"}
+            {#if category.key === "payloads"}
               <p>
-                {usage.conversations.total.toLocaleString()} conversations stored.
+                Retained payload footprints for
+                {usage.conversations.total.toLocaleString()} conversations.
               </p>
               {#if usage.conversations.largest.length > 0}
                 <ul class="grid gap-1">

--- a/packages/workbench-app/src/lib/features/settings/state/storage-cleanup.test.ts
+++ b/packages/workbench-app/src/lib/features/settings/state/storage-cleanup.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  allCleanupSelection,
   buildCleanupRequest,
   EMPTY_CLEANUP_SELECTION,
   recommendedCleanupSelection,
@@ -31,6 +32,24 @@ describe("storage cleanup selection", () => {
         },
       ]),
       { bytes: 4_096, upTo: false },
+    );
+  });
+
+  it("adds non-overlapping cache and query-cache estimates", () => {
+    const selection = allCleanupSelection(EMPTY_CLEANUP_SELECTION);
+    assert.equal(recommendedCleanupSelection().searchIndex, false);
+    assert.equal(selection.searchIndex, true);
+    assert.deepEqual(
+      selectedFootprint(selection, [
+        { target: "cache", bytes: 200, itemCount: 2, estimate: "exact" },
+        {
+          target: "searchIndex",
+          bytes: 500,
+          itemCount: 3,
+          estimate: "upTo",
+        },
+      ]),
+      { bytes: 700, upTo: true },
     );
   });
 

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
@@ -117,11 +117,21 @@ const acceptedInNewChat = $derived(reviewStatus === "accepted_in_new_chat");
 const rejected = $derived(
   reviewStatus === "changes_requested" || reviewStatus === "discarded",
 );
+let retainedReviewContent = $state("");
+
+$effect(() => {
+  const content = planReviewContent(
+    displayedReview?.content,
+    planReview?.content,
+  );
+  if (content.trim()) retainedReviewContent = content;
+});
+
 const previewContent = $derived(
   planReviewContent(
     displayedReview?.content,
-    undefined,
-    displayedReview?.summary,
+    planReview?.content,
+    retainedReviewContent || displayedReview?.summary,
   ),
 );
 const preview = $derived(

--- a/packages/workbench-server/src/app/workbench-state.ts
+++ b/packages/workbench-server/src/app/workbench-state.ts
@@ -84,9 +84,7 @@ export function createWorkbenchState(
   } = {},
 ): WorkbenchState {
   // Rebuildable read model; data/nerve.sqlite remains authoritative.
-  const queryCache = new RuntimeQueryCache(
-    join(storage.paths.home, "cache", "query-cache.sqlite"),
-  );
+  const queryCache = new RuntimeQueryCache(storage.paths.queryCachePath);
   queryCache.initialize();
   const performanceDiagnostics = options.performanceDiagnosticsEnabled
     ? new PerformanceMetricsCollector(
@@ -204,7 +202,7 @@ export function createWorkbenchState(
   const storageCleanup = new StorageCleanupService({
     paths: storage.paths,
     repository: new StorageCleanupRepository(
-      join(storage.paths.dataPath, "maintenance", "storage-cleanup.json"),
+      storage.paths.storageCleanupOperationPath,
     ),
     usage: storageUsage,
     events,

--- a/packages/workbench-server/src/domains/storage/storage-cleanup.service.ts
+++ b/packages/workbench-server/src/domains/storage/storage-cleanup.service.ts
@@ -11,7 +11,13 @@ import type { ApplicationLogger } from "../../infrastructure/diagnostics/index.j
 import type { StreamLogRegistry } from "../../infrastructure/events/index.js";
 import type { StoragePaths } from "../../infrastructure/storage/index.js";
 import type { StorageCleanupRepository } from "./storage-cleanup.repository.js";
-import { dirSize, fileSize } from "./storage-files.js";
+import {
+  dirSize,
+  fileSize,
+  pathsSize,
+  queryCacheFileNames,
+  queryCacheFilePaths,
+} from "./storage-files.js";
 import type { StorageUsageService } from "./storage-usage.service.js";
 
 export interface StorageCleanupRegistryPort {
@@ -312,7 +318,7 @@ export class StorageCleanupService {
         target: "rotatedEventLog",
         message: "Removing the rotated event log…",
         run: () =>
-          this.removeFile(join(this.deps.paths.home, "logs", "events.jsonl.1")),
+          this.removeFile(join(this.deps.paths.logsPath, "events.jsonl.1")),
       });
     }
     if (request.clearExploreReports)
@@ -325,19 +331,24 @@ export class StorageCleanupService {
       plans.push({
         target: "crashReports",
         message: "Clearing crash reports…",
-        run: () => this.clearDirContents(join(this.deps.paths.home, "crashes")),
+        run: () => this.clearDirContents(this.deps.paths.crashesPath),
       });
     if (request.clearCache)
       plans.push({
         target: "cache",
         message: "Clearing cached data…",
-        run: () => this.clearDirContents(join(this.deps.paths.home, "cache")),
+        run: () =>
+          this.clearDirContents(
+            this.deps.paths.cachePath,
+            queryCacheFileNames(this.deps.paths.queryCachePath),
+            true,
+          ),
       });
     if (request.clearTmp)
       plans.push({
         target: "tmp",
         message: "Clearing temporary files…",
-        run: () => this.clearDirContents(join(this.deps.paths.home, "tmp")),
+        run: () => this.clearDirContents(this.deps.paths.tmpPath),
       });
     if (request.rebuildSearchIndex) {
       plans.push({
@@ -351,7 +362,7 @@ export class StorageCleanupService {
             freedBytes: Math.max(0, before - after),
             removedItems: 0,
             skipped: 0,
-            note: "Rebuilt from current records and retained event logs.",
+            note: "Rebuilt from canonical records.",
           };
         },
       });
@@ -362,7 +373,7 @@ export class StorageCleanupService {
   private async pruneDatedLogs(
     olderThanDays: number,
   ): Promise<Omit<StorageCleanupResult, "target" | "outcome">> {
-    const logsDir = join(this.deps.paths.home, "logs");
+    const logsDir = this.deps.paths.logsPath;
     const cutoff = new Date(Date.now() - olderThanDays * 86_400_000)
       .toISOString()
       .slice(0, 10);
@@ -375,7 +386,7 @@ export class StorageCleanupService {
       const match = datedLog.exec(file);
       if (!match || (match[2] as string) >= cutoff) continue;
       const path = join(logsDir, file);
-      const bytes = await fileSize(path);
+      const bytes = (await fileSize(path)) ?? 0;
       try {
         await unlink(path);
         freedBytes += bytes;
@@ -391,13 +402,16 @@ export class StorageCleanupService {
     path: string,
   ): Promise<Omit<StorageCleanupResult, "target" | "outcome">> {
     const bytes = await fileSize(path);
-    if (bytes === 0) return { freedBytes: 0, removedItems: 0, skipped: 0 };
+    if (bytes === undefined)
+      return { freedBytes: 0, removedItems: 0, skipped: 0 };
     await unlink(path);
     return { freedBytes: bytes, removedItems: 1, skipped: 0 };
   }
 
   private async clearDirContents(
     path: string,
+    excludedNames: ReadonlySet<string> = new Set(),
+    preserveRoot = false,
   ): Promise<Omit<StorageCleanupResult, "target" | "outcome">> {
     const entries = await readdir(path, { withFileTypes: true }).catch(
       () => [],
@@ -406,6 +420,7 @@ export class StorageCleanupService {
     let removedItems = 0;
     let skipped = 0;
     for (const entry of entries) {
+      if (excludedNames.has(entry.name)) continue;
       if (entry.isSymbolicLink()) {
         skipped += 1;
         continue;
@@ -413,7 +428,7 @@ export class StorageCleanupService {
       const child = join(path, entry.name);
       const bytes = entry.isDirectory()
         ? (await dirSize(child)).bytes
-        : await fileSize(child);
+        : ((await fileSize(child)) ?? 0);
       try {
         await rm(child, { recursive: true, force: true });
         freedBytes += bytes;
@@ -422,6 +437,7 @@ export class StorageCleanupService {
         skipped += 1;
       }
     }
+    if (preserveRoot) return { freedBytes, removedItems, skipped };
     await rmdir(path).catch((error: unknown) => {
       const code =
         error && typeof error === "object" && "code" in error
@@ -435,10 +451,8 @@ export class StorageCleanupService {
 
   private async indexFootprint(): Promise<number> {
     return (
-      (await fileSize(this.deps.paths.sqlitePath)) +
-      (await fileSize(`${this.deps.paths.sqlitePath}-wal`)) +
-      (await fileSize(`${this.deps.paths.sqlitePath}-shm`))
-    );
+      await pathsSize(queryCacheFilePaths(this.deps.paths.queryCachePath))
+    ).bytes;
   }
 
   private async update(

--- a/packages/workbench-server/src/domains/storage/storage-files.ts
+++ b/packages/workbench-server/src/domains/storage/storage-files.ts
@@ -1,32 +1,68 @@
-import { readdir, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { lstat, readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
 
 export interface SizeTally {
   bytes: number;
   files: number;
 }
 
-export async function dirSize(path: string): Promise<SizeTally> {
+export const SQLITE_SIDECAR_SUFFIXES = ["", "-wal", "-shm"] as const;
+
+export function sqliteFilePaths(path: string): string[] {
+  return SQLITE_SIDECAR_SUFFIXES.map((suffix) => `${path}${suffix}`);
+}
+
+export function queryCacheFilePaths(path: string): string[] {
+  return [
+    ...sqliteFilePaths(path),
+    ...sqliteFilePaths(`${path}.cleanup-backup`),
+  ];
+}
+
+export function queryCacheFileNames(path: string): Set<string> {
+  return new Set(
+    queryCacheFilePaths(path).map((candidate) => basename(candidate)),
+  );
+}
+
+export async function pathsSize(paths: Iterable<string>): Promise<SizeTally> {
+  let bytes = 0;
+  let files = 0;
+  for (const path of paths) {
+    const size = await fileSize(path);
+    if (size === undefined) continue;
+    bytes += size;
+    files += 1;
+  }
+  return { bytes, files };
+}
+
+export async function dirSize(
+  path: string,
+  excludedNames: ReadonlySet<string> = new Set(),
+): Promise<SizeTally> {
   let bytes = 0;
   let files = 0;
   const entries = await readdir(path, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
-    if (entry.isSymbolicLink()) continue;
+    if (excludedNames.has(entry.name) || entry.isSymbolicLink()) continue;
     const child = join(path, entry.name);
     if (entry.isDirectory()) {
       const nested = await dirSize(child);
       bytes += nested.bytes;
       files += nested.files;
     } else if (entry.isFile()) {
-      bytes += await fileSize(child);
+      const size = await fileSize(child);
+      if (size === undefined) continue;
+      bytes += size;
       files += 1;
     }
   }
   return { bytes, files };
 }
 
-export async function fileSize(path: string): Promise<number> {
-  return stat(path)
-    .then((value) => (value.isFile() ? value.size : 0))
-    .catch(() => 0);
+export async function fileSize(path: string): Promise<number | undefined> {
+  return lstat(path)
+    .then((value) => (value.isFile() ? value.size : undefined))
+    .catch(() => undefined);
 }

--- a/packages/workbench-server/src/domains/storage/storage-usage.service.ts
+++ b/packages/workbench-server/src/domains/storage/storage-usage.service.ts
@@ -1,5 +1,5 @@
 import { readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type {
   LargestConversationUsage,
   StorageCategoryKey,
@@ -8,7 +8,15 @@ import type {
   StorageUsageResponse,
 } from "@nervekit/contracts";
 import type { StoragePaths } from "../../infrastructure/storage/index.js";
-import { dirSize, fileSize, type SizeTally } from "./storage-files.js";
+import {
+  dirSize,
+  fileSize,
+  pathsSize,
+  queryCacheFileNames,
+  queryCacheFilePaths,
+  sqliteFilePaths,
+  type SizeTally,
+} from "./storage-files.js";
 
 export interface StorageUsageRegistryPort {
   listConversations(): Array<{ id: string; title: string | null }>;
@@ -27,43 +35,28 @@ interface CategoryMeta {
 }
 
 const CATEGORY_META: Record<StorageCategoryKey, CategoryMeta> = {
-  conversations: {
-    label: "Conversations",
-    description: "Legacy conversation files pending migration.",
-    cleanable: true,
-    protected: false,
+  database: {
+    label: "Canonical database",
+    description: "Authoritative Nerve records. Never removed by cleanup.",
+    cleanable: false,
+    protected: true,
   },
   payloads: {
     label: "Payloads",
-    description:
-      "Complete tool results retained when agent output is truncated.",
+    description: "Retained tool results and other conversation payloads.",
     cleanable: true,
     protected: false,
   },
-  logs: {
-    label: "Logs & events",
-    description:
-      "Application logs, the global event log, and tool-call history.",
-    cleanable: true,
-    protected: false,
-  },
-  sqliteIndex: {
-    label: "Search index (SQLite)",
-    description:
-      "Rebuildable query cache for recent durable events and records.",
-    cleanable: true,
-    protected: false,
-  },
-  exploreReports: {
-    label: "Explore reports",
+  reports: {
+    label: "Reports",
     description: "Saved output from codebase explore sub-agents.",
     cleanable: true,
     protected: false,
   },
-  crashes: {
-    label: "Crash reports",
-    description: "Nerve crash reports and Node diagnostic reports.",
-    cleanable: true,
+  images: {
+    label: "Images",
+    description: "Durable images managed by Nerve.",
+    cleanable: false,
     protected: false,
   },
   plans: {
@@ -72,72 +65,100 @@ const CATEGORY_META: Record<StorageCategoryKey, CategoryMeta> = {
     cleanable: false,
     protected: false,
   },
-  agents: {
-    label: "Agents",
-    description: "Per-agent runtime state.",
-    cleanable: false,
-    protected: false,
-  },
   tasks: {
     label: "Tasks",
-    description: "Background task state and logs.",
+    description: "Background task records, process metadata, and logs.",
     cleanable: false,
     protected: false,
   },
-  workflowState: {
-    label: "Workflow state",
-    description: "Approvals, user questions, and maintenance state.",
+  agentResources: {
+    label: "Agent resources",
+    description: "Nerve-managed resources used by agents.",
     cleanable: false,
     protected: false,
   },
-  projects: {
-    label: "Projects",
-    description: "Project metadata.",
+  runtimeState: {
+    label: "Runtime state",
+    description: "Idempotency and maintenance operation state.",
     cleanable: false,
+    protected: false,
+  },
+  logs: {
+    label: "Logs & events",
+    description: "Application, desktop, event, and tool-call logs.",
+    cleanable: true,
+    protected: false,
+  },
+  crashReports: {
+    label: "Crash reports",
+    description: "Nerve crash reports and Node diagnostic reports.",
+    cleanable: true,
+    protected: false,
+  },
+  queryCache: {
+    label: "Query cache",
+    description:
+      "A rebuildable SQLite read model sourced from canonical records.",
+    cleanable: true,
     protected: false,
   },
   cache: {
     label: "Cache",
-    description: "Disposable cached data.",
+    description: "Disposable cached data other than the query cache.",
     cleanable: true,
     protected: false,
   },
-  tmp: {
+  temporaryFiles: {
     label: "Temporary files",
     description: "Scratch files that can be safely removed.",
     cleanable: true,
     protected: false,
   },
-  protected: {
-    label: "Credentials & config",
-    description: "Auth tokens, keys, TLS, and configuration. Never deleted.",
+  migrations: {
+    label: "Migrations",
+    description: "Migration ledger and reports retained for storage integrity.",
+    cleanable: false,
+    protected: false,
+  },
+  backups: {
+    label: "Backups",
+    description: "Retained Nerve-home backups that require manual removal.",
+    cleanable: false,
+    protected: false,
+  },
+  configurationIdentity: {
+    label: "Configuration & identity",
+    description:
+      "Configuration, credentials, TLS identity, and daemon metadata.",
     cleanable: false,
     protected: true,
   },
   other: {
     label: "Other",
-    description: "Uncategorized data under the Nerve home directory.",
+    description: "Unrecognized readable files under the Nerve home.",
     cleanable: false,
     protected: false,
   },
 };
 
 const CATEGORY_ORDER: StorageCategoryKey[] = [
+  "database",
   "payloads",
-  "conversations",
-  "logs",
-  "sqliteIndex",
-  "exploreReports",
-  "crashes",
-  "cache",
-  "tmp",
+  "reports",
+  "images",
   "plans",
-  "agents",
   "tasks",
-  "workflowState",
-  "projects",
+  "agentResources",
+  "runtimeState",
+  "logs",
+  "crashReports",
+  "queryCache",
+  "cache",
+  "temporaryFiles",
+  "migrations",
+  "backups",
+  "configurationIdentity",
   "other",
-  "protected",
 ];
 const USAGE_CACHE_TTL_MS = 15_000;
 const LARGEST_CONVERSATION_LIMIT = 5;
@@ -161,9 +182,8 @@ export class StorageUsageService {
       return this.#cache.value;
     }
 
-    const home = this.deps.paths.home;
+    const { paths } = this.deps;
     const totals = new Map<StorageCategoryKey, SizeTally>();
-    const conversationSizes: Array<{ id: string; bytes: number }> = [];
     const add = (key: StorageCategoryKey, tally: SizeTally) => {
       const current = totals.get(key) ?? { bytes: 0, files: 0 };
       totals.set(key, {
@@ -172,67 +192,95 @@ export class StorageUsageService {
       });
     };
 
-    add("payloads", await dirSize(this.deps.paths.payloadsPath));
-    add("exploreReports", await dirSize(this.deps.paths.reportsPath));
-    add("plans", await dirSize(this.deps.paths.plansPath));
-    add("tasks", await dirSize(this.deps.paths.tasksPath));
-    add("logs", await dirSize(this.deps.paths.logsPath));
-    add("crashes", await dirSize(this.deps.paths.crashesPath));
-    add("cache", await dirSize(this.deps.paths.cachePath));
-    add("tmp", await dirSize(this.deps.paths.tmpPath));
-    add("agents", await dirSize(this.deps.paths.agentPath));
-    add("other", await dirSize(this.deps.paths.imagesPath));
-    add("other", await dirSize(this.deps.paths.migrationsPath));
-    add("other", await dirSize(this.deps.paths.backupsPath));
-    add("protected", await dirSize(this.deps.paths.configPath));
-    add("protected", await dirSize(this.deps.paths.secretsPath));
-    add("protected", await dirSize(this.deps.paths.tlsPath));
-    add("protected", {
-      bytes:
-        (await fileSize(this.deps.paths.manifestPath)) +
-        (await fileSize(this.deps.paths.daemonPath)),
-      files: 2,
-    });
-    add("sqliteIndex", {
-      bytes:
-        (await fileSize(this.deps.paths.sqlitePath)) +
-        (await fileSize(`${this.deps.paths.sqlitePath}-wal`)) +
-        (await fileSize(`${this.deps.paths.sqlitePath}-shm`)),
-      files: 3,
-    });
-    const conversationRoot = join(
-      this.deps.paths.payloadsPath,
-      "conversations",
+    const databaseTally = await pathsSize(sqliteFilePaths(paths.sqlitePath));
+    const queryCacheTally = await pathsSize(
+      queryCacheFilePaths(paths.queryCachePath),
     );
+    const queryCacheNames = queryCacheFileNames(paths.queryCachePath);
+    const conversationRoot = join(paths.payloadsPath, "conversations");
+    const conversationPayloadTally = await dirSize(conversationRoot);
+
+    add("database", databaseTally);
+    add("payloads", await dirSize(paths.payloadsPath));
+    add("reports", await dirSize(paths.reportsPath));
+    add("images", await dirSize(paths.imagesPath));
+    add("plans", await dirSize(paths.plansPath));
+    add("tasks", await dirSize(paths.tasksPath));
+    add("agentResources", await dirSize(paths.agentPath));
+    add("runtimeState", await dirSize(paths.idempotencyPath));
+    add("runtimeState", await dirSize(paths.maintenancePath));
+    add("logs", await dirSize(paths.logsPath));
+    add("crashReports", await dirSize(paths.crashesPath));
+    add("queryCache", queryCacheTally);
+    add("cache", await dirSize(paths.cachePath, queryCacheNames));
+    add("temporaryFiles", await dirSize(paths.tmpPath));
+    add("migrations", await dirSize(paths.migrationsPath));
+    add("backups", await dirSize(paths.backupsPath));
+    add("configurationIdentity", await dirSize(paths.configPath));
+    add("configurationIdentity", await dirSize(paths.secretsPath));
+    add("configurationIdentity", await dirSize(paths.tlsPath));
+    add(
+      "configurationIdentity",
+      await pathsSize([paths.manifestPath, paths.daemonPath]),
+    );
+
+    const knownDataNames = new Set([
+      ...sqliteFilePaths(paths.sqlitePath).map((path) => basename(path)),
+      basename(paths.payloadsPath),
+      basename(paths.reportsPath),
+      basename(paths.imagesPath),
+      basename(paths.plansPath),
+      basename(paths.idempotencyPath),
+      basename(paths.maintenancePath),
+    ]);
+    add("other", await dirSize(paths.dataPath, knownDataNames));
+
+    const knownRootNames = new Set([
+      basename(paths.dataPath),
+      basename(paths.configPath),
+      basename(paths.secretsPath),
+      basename(paths.tlsPath),
+      basename(paths.tmpPath),
+      basename(paths.cachePath),
+      basename(paths.logsPath),
+      basename(paths.crashesPath),
+      basename(paths.migrationsPath),
+      basename(paths.backupsPath),
+      basename(paths.tasksPath),
+      basename(paths.agentPath),
+      basename(paths.manifestPath),
+      basename(paths.daemonPath),
+    ]);
+    add("other", await dirSize(paths.home, knownRootNames));
+
+    const categories: StorageCategoryUsage[] = CATEGORY_ORDER.flatMap((key) => {
+      const tally = totals.get(key);
+      if (!tally || tally.bytes === 0) return [];
+      return [
+        {
+          key,
+          ...CATEGORY_META[key],
+          fileCount: tally.files,
+          bytes: tally.bytes,
+        },
+      ];
+    });
+    const totalBytes = categories.reduce(
+      (sum, category) => sum + category.bytes,
+      0,
+    );
+
+    const conversationSizes: Array<{ id: string; bytes: number }> = [];
     const children = await readdir(conversationRoot, {
       withFileTypes: true,
     }).catch(() => []);
     for (const child of children) {
       if (!child.isDirectory() || child.isSymbolicLink()) continue;
-      const tally = await dirSize(join(conversationRoot, child.name));
-      conversationSizes.push({ id: child.name, bytes: tally.bytes });
-    }
-
-    const categories: StorageCategoryUsage[] = [];
-    let totalBytes = 0;
-    for (const key of CATEGORY_ORDER) {
-      const tally = totals.get(key);
-      if (!tally || tally.bytes === 0) continue;
-      const meta = CATEGORY_META[key];
-      categories.push({
-        key,
-        ...meta,
-        fileCount: tally.files,
-        bytes: tally.bytes,
+      conversationSizes.push({
+        id: child.name,
+        bytes: (await dirSize(join(conversationRoot, child.name))).bytes,
       });
-      totalBytes += tally.bytes;
     }
-
-    const sqlite = {
-      dbBytes: await fileSize(this.deps.paths.sqlitePath),
-      walBytes: await fileSize(`${this.deps.paths.sqlitePath}-wal`),
-      shmBytes: await fileSize(`${this.deps.paths.sqlitePath}-shm`),
-    };
     const titleById = new Map(
       this.deps
         .getRegistry()
@@ -248,14 +296,23 @@ export class StorageUsageService {
         bytes: item.bytes,
       }));
 
-    const cleanupTargets = await this.cleanupTargetUsage(totals, sqlite);
+    const database = {
+      dbBytes: (await fileSize(paths.sqlitePath)) ?? 0,
+      walBytes: (await fileSize(`${paths.sqlitePath}-wal`)) ?? 0,
+      shmBytes: (await fileSize(`${paths.sqlitePath}-shm`)) ?? 0,
+    };
+    const cleanupTargets = await this.cleanupTargetUsage(
+      totals,
+      queryCacheTally,
+      conversationPayloadTally,
+    );
     const value: StorageUsageResponse = {
-      dataDir: home,
+      homeDir: paths.home,
       generatedAt: new Date().toISOString(),
       totalBytes,
       categories,
       cleanupTargets,
-      sqlite,
+      database,
       conversations: { total: conversationSizes.length, largest },
     };
     this.#cache = { at: Date.now(), value };
@@ -264,27 +321,28 @@ export class StorageUsageService {
 
   private async cleanupTargetUsage(
     totals: Map<StorageCategoryKey, SizeTally>,
-    sqlite: StorageUsageResponse["sqlite"],
+    queryCache: SizeTally,
+    conversationPayloads: SizeTally,
   ): Promise<StorageCleanupTargetUsage[]> {
-    const home = this.deps.paths.home;
-    const logsDir = join(home, "logs");
-    const logEntries = await readdir(logsDir, { withFileTypes: true }).catch(
-      () => [],
-    );
+    const logEntries = await readdir(this.deps.paths.logsPath, {
+      withFileTypes: true,
+    }).catch(() => []);
     let datedBytes = 0;
     let datedItems = 0;
     for (const entry of logEntries) {
       if (!entry.isFile() || !DATED_LOG.test(entry.name)) continue;
-      datedBytes += await fileSize(join(logsDir, entry.name));
+      datedBytes +=
+        (await fileSize(join(this.deps.paths.logsPath, entry.name))) ?? 0;
       datedItems += 1;
     }
     const category = (key: StorageCategoryKey): SizeTally =>
       totals.get(key) ?? { bytes: 0, files: 0 };
-    const rotatedBytes = await fileSize(join(logsDir, "events.jsonl.1"));
+    const rotatedBytes =
+      (await fileSize(join(this.deps.paths.logsPath, "events.jsonl.1"))) ?? 0;
     return [
       {
         target: "conversations",
-        bytes: category("payloads").bytes,
+        bytes: conversationPayloads.bytes,
         itemCount: this.deps.getRegistry().listConversations().length,
         estimate: "upTo",
       },
@@ -302,14 +360,14 @@ export class StorageUsageService {
       },
       {
         target: "exploreReports",
-        bytes: category("exploreReports").bytes,
-        itemCount: category("exploreReports").files,
+        bytes: category("reports").bytes,
+        itemCount: category("reports").files,
         estimate: "exact",
       },
       {
         target: "crashReports",
-        bytes: category("crashes").bytes,
-        itemCount: category("crashes").files,
+        bytes: category("crashReports").bytes,
+        itemCount: category("crashReports").files,
         estimate: "exact",
       },
       {
@@ -320,16 +378,14 @@ export class StorageUsageService {
       },
       {
         target: "tmp",
-        bytes: category("tmp").bytes,
-        itemCount: category("tmp").files,
+        bytes: category("temporaryFiles").bytes,
+        itemCount: category("temporaryFiles").files,
         estimate: "exact",
       },
       {
         target: "searchIndex",
-        bytes: sqlite.dbBytes + sqlite.walBytes + sqlite.shmBytes,
-        itemCount: [sqlite.dbBytes, sqlite.walBytes, sqlite.shmBytes].filter(
-          (bytes) => bytes > 0,
-        ).length,
+        bytes: queryCache.bytes,
+        itemCount: queryCache.files,
         estimate: "upTo",
       },
     ];

--- a/packages/workbench-server/src/infrastructure/storage/initialize.ts
+++ b/packages/workbench-server/src/infrastructure/storage/initialize.ts
@@ -28,6 +28,8 @@ const HOME_DIRECTORIES: Array<[keyof StoragePaths, number]> = [
   ["configPath", 0o755],
   ["secretsPath", 0o700],
   ["dataPath", 0o700],
+  ["idempotencyPath", 0o700],
+  ["maintenancePath", 0o700],
   ["payloadsPath", 0o700],
   ["reportsPath", 0o700],
   ["imagesPath", 0o700],

--- a/packages/workbench-server/src/infrastructure/storage/paths.ts
+++ b/packages/workbench-server/src/infrastructure/storage/paths.ts
@@ -20,6 +20,9 @@ export interface StoragePaths {
   localTokenPath: string;
   dataPath: string;
   sqlitePath: string;
+  idempotencyPath: string;
+  maintenancePath: string;
+  storageCleanupOperationPath: string;
   payloadsPath: string;
   reportsPath: string;
   imagesPath: string;
@@ -30,6 +33,7 @@ export interface StoragePaths {
   tlsPath: string;
   tmpPath: string;
   cachePath: string;
+  queryCachePath: string;
   logsPath: string;
   crashesPath: string;
   migrationsPath: string;
@@ -48,7 +52,9 @@ export function storagePaths(home = resolveDataDir()): StoragePaths {
   const secretsPath = join(home, "secrets");
   const dataPath = join(home, "data");
   const agentPath = join(home, "agent");
+  const maintenancePath = join(dataPath, "maintenance");
   const migrationsPath = join(home, "migrations");
+  const cachePath = join(home, "cache");
   return {
     home,
     userHome: homedir(),
@@ -67,6 +73,9 @@ export function storagePaths(home = resolveDataDir()): StoragePaths {
     localTokenPath: join(secretsPath, "daemon-token"),
     dataPath,
     sqlitePath: join(dataPath, "nerve.sqlite"),
+    idempotencyPath: join(dataPath, "idempotency"),
+    maintenancePath,
+    storageCleanupOperationPath: join(maintenancePath, "storage-cleanup.json"),
     payloadsPath: join(dataPath, "payloads"),
     reportsPath: join(dataPath, "reports"),
     imagesPath: join(dataPath, "images"),
@@ -76,7 +85,8 @@ export function storagePaths(home = resolveDataDir()): StoragePaths {
     suggestionsPath: join(agentPath, "suggestions"),
     tlsPath: join(home, "tls"),
     tmpPath: join(home, "tmp"),
-    cachePath: join(home, "cache"),
+    cachePath,
+    queryCachePath: join(cachePath, "query-cache.sqlite"),
     logsPath: join(home, "logs"),
     crashesPath: join(home, "crashes"),
     migrationsPath,

--- a/packages/workbench-server/src/protocol/http-dispatcher.ts
+++ b/packages/workbench-server/src/protocol/http-dispatcher.ts
@@ -178,7 +178,7 @@ function workbenchIdempotencyStore(
   const existing = workbenchIdempotencyStores.get(state);
   if (existing) return existing;
   const store = new FileIdempotencyStore(
-    join(state.storage.paths.dataPath, "idempotency", "http-v1.json"),
+    join(state.storage.paths.idempotencyPath, "http-v1.json"),
   );
   workbenchIdempotencyStores.set(state, store);
   return store;

--- a/packages/workbench-server/test/storage-cleanup.service.test.ts
+++ b/packages/workbench-server/test/storage-cleanup.service.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
@@ -30,8 +37,11 @@ async function seedHome(): Promise<string> {
   await write("logs/application-2020-01-01.jsonl", 300);
   await write("crashes/report.json", 500);
   await write("cache/value.json", 250);
+  await write("cache/query-cache.sqlite", 600);
+  await write("cache/query-cache.sqlite.cleanup-backup", 80);
+  await write("data/nerve.sqlite", 900);
   await write("tmp/scratch.txt", 60);
-  await write("auth/local-token", 40);
+  await write("secrets/daemon-token", 40);
   return home;
 }
 
@@ -42,6 +52,7 @@ function makeService(
       prunedConversationIds: string[];
       skippedCount: number;
     }>;
+    rebuild?: () => Promise<void>;
   } = {},
 ) {
   const paths = storagePaths(home);
@@ -50,7 +61,7 @@ function makeService(
     pruneConversationsAcrossProjects:
       overrides.prune ??
       (async () => ({ prunedConversationIds: [], skippedCount: 0 })),
-    async rebuildSearchIndex() {},
+    rebuildSearchIndex: overrides.rebuild ?? (async () => {}),
     tools: {
       async compactToolCallLog() {
         await writeFile(join(home, "logs", "tool-calls.jsonl"), "x".repeat(20));
@@ -105,7 +116,8 @@ describe("StorageCleanupService", () => {
     await service.hydrate();
     const before = await usage.computeUsage(true);
     assert.equal(
-      before.categories.find((category) => category.key === "crashes")?.bytes,
+      before.categories.find((category) => category.key === "crashReports")
+        ?.bytes,
       500,
     );
     assert.equal(
@@ -129,10 +141,60 @@ describe("StorageCleanupService", () => {
     assert.equal(result.results.length, 5);
     assert.ok(result.freedBytes >= 300 + 1_200 + 500 + 250 + 60);
     await assert.rejects(readdir(join(home, "crashes")), /ENOENT/);
-    await assert.rejects(readdir(join(home, "cache")), /ENOENT/);
+    assert.deepEqual(await readdir(join(home, "cache")), [
+      "query-cache.sqlite",
+      "query-cache.sqlite.cleanup-backup",
+    ]);
     await assert.rejects(readdir(join(home, "tmp")), /ENOENT/);
-    assert.deepEqual(await readdir(join(home, "auth")), ["local-token"]);
+    assert.deepEqual(await readdir(join(home, "secrets")), ["daemon-token"]);
     assert.equal((await repository.read())?.id, result.id);
+  });
+
+  it("keeps generic cache and query-cache rebuild disjoint", async () => {
+    const home = await seedHome();
+    const canonicalBefore = await readFile(join(home, "data", "nerve.sqlite"));
+    const { service, usage } = makeService(home, {
+      rebuild: async () => {
+        await writeFile(
+          join(home, "cache", "query-cache.sqlite"),
+          "x".repeat(100),
+        );
+        await rm(join(home, "cache", "query-cache.sqlite.cleanup-backup"), {
+          force: true,
+        });
+      },
+    });
+    await service.hydrate();
+
+    const before = await usage.computeUsage(true);
+    assert.equal(
+      before.cleanupTargets.find((target) => target.target === "cache")?.bytes,
+      250,
+    );
+    assert.equal(
+      before.cleanupTargets.find((target) => target.target === "searchIndex")
+        ?.bytes,
+      680,
+    );
+
+    await service.start({ clearCache: true, rebuildSearchIndex: true });
+    const result = await waitForTerminal(service);
+    assert.equal(result.status, "succeeded", result.error);
+    assert.equal(
+      result.results.find((item) => item.target === "cache")?.freedBytes,
+      250,
+    );
+    assert.equal(
+      result.results.find((item) => item.target === "searchIndex")?.freedBytes,
+      580,
+    );
+    assert.deepEqual(
+      await readFile(join(home, "data", "nerve.sqlite")),
+      canonicalBefore,
+    );
+    assert.deepEqual(await readdir(join(home, "cache")), [
+      "query-cache.sqlite",
+    ]);
   });
 
   it("cancels at a target boundary and leaves later targets untouched", async () => {
@@ -164,7 +226,11 @@ describe("StorageCleanupService", () => {
       result.results.find((item) => item.target === "cache")?.outcome,
       "cancelled",
     );
-    assert.deepEqual(await readdir(join(home, "cache")), ["value.json"]);
+    assert.deepEqual(await readdir(join(home, "cache")), [
+      "query-cache.sqlite",
+      "query-cache.sqlite.cleanup-backup",
+      "value.json",
+    ]);
   });
 
   it("marks an active persisted operation interrupted during hydrate", async () => {

--- a/packages/workbench-server/test/storage-usage.service.test.ts
+++ b/packages/workbench-server/test/storage-usage.service.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { StorageUsageService } from "../src/domains/storage/storage-usage.service.js";
+import { storagePaths } from "../src/infrastructure/storage/index.js";
+
+const roots: string[] = [];
+after(async () =>
+  Promise.all(roots.map((root) => rm(root, { recursive: true, force: true }))),
+);
+
+async function fixtureHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "nerve-usage-"));
+  roots.push(home);
+  const write = async (relative: string, bytes: number) => {
+    const path = join(home, relative);
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, "x".repeat(bytes));
+  };
+
+  await write("data/nerve.sqlite", 10);
+  await write("data/nerve.sqlite-wal", 2);
+  await write("data/payloads/conversations/conv_a/result.json", 11);
+  await write("data/payloads/conversations/conv_b/result.json", 7);
+  await write("data/payloads/shared.bin", 3);
+  await write("data/reports/report.md", 4);
+  await write("data/images/image.png", 5);
+  await write("data/plans/plan.md", 6);
+  await write("tasks/task_1/log.txt", 8);
+  await write("agent/suggestions/items.json", 9);
+  await write("data/idempotency/http-v1.json", 10);
+  await write("data/maintenance/storage-cleanup.json", 11);
+  await write("logs/application-2020-01-01.jsonl", 12);
+  await write("logs/events.jsonl.1", 13);
+  await write("crashes/report.json", 14);
+  await write("cache/query-cache.sqlite", 15);
+  await write("cache/query-cache.sqlite-wal", 16);
+  await write("cache/query-cache.sqlite.cleanup-backup", 17);
+  await write("cache/models.json", 18);
+  await write("tmp/scratch", 19);
+  await write("migrations/ledger.json", 20);
+  await write("backups/legacy/file", 21);
+  await write("config/daemon.json", 22);
+  await write("secrets/master.key", 23);
+  await write("tls/ca.pem", 24);
+  await write("manifest.json", 25);
+  await write("daemon.json", 26);
+  await write("unknown-root.bin", 27);
+  await write("data/unknown-data.bin", 28);
+
+  const external = join(home, "..", `${home.split("/").at(-1)}-external`);
+  await writeFile(external, "x".repeat(100));
+  roots.push(external);
+  await symlink(external, join(home, "unknown-link"));
+  await symlink(external, join(home, "cache", "cache-link"));
+  return home;
+}
+
+function categoryBytes(
+  usage: Awaited<ReturnType<StorageUsageService["computeUsage"]>>,
+  key: string,
+): number | undefined {
+  return usage.categories.find((category) => category.key === key)?.bytes;
+}
+
+function targetBytes(
+  usage: Awaited<ReturnType<StorageUsageService["computeUsage"]>>,
+  target: string,
+): number | undefined {
+  return usage.cleanupTargets.find((item) => item.target === target)?.bytes;
+}
+
+describe("StorageUsageService", () => {
+  it("classifies readable v1 home files exactly once", async () => {
+    const home = await fixtureHome();
+    const service = new StorageUsageService({
+      paths: storagePaths(home),
+      getRegistry: () => ({
+        listConversations: () => [
+          { id: "conv_a", title: "Alpha" },
+          { id: "conv_b", title: "Beta" },
+        ],
+      }),
+    });
+
+    const usage = await service.computeUsage(true);
+    assert.equal(usage.homeDir, home);
+    assert.equal(usage.totalBytes, 426);
+    assert.equal(
+      usage.categories.reduce((sum, category) => sum + category.bytes, 0),
+      usage.totalBytes,
+    );
+    assert.equal(categoryBytes(usage, "database"), 12);
+    assert.equal(
+      usage.categories.find((category) => category.key === "database")
+        ?.fileCount,
+      2,
+    );
+    assert.equal(categoryBytes(usage, "payloads"), 21);
+    assert.equal(categoryBytes(usage, "runtimeState"), 21);
+    assert.equal(categoryBytes(usage, "queryCache"), 48);
+    assert.equal(categoryBytes(usage, "cache"), 18);
+    assert.equal(categoryBytes(usage, "other"), 55);
+    assert.deepEqual(usage.database, {
+      dbBytes: 10,
+      walBytes: 2,
+      shmBytes: 0,
+    });
+    assert.deepEqual(usage.conversations, {
+      total: 2,
+      largest: [
+        { conversationId: "conv_a", title: "Alpha", bytes: 11 },
+        { conversationId: "conv_b", title: "Beta", bytes: 7 },
+      ],
+    });
+
+    assert.equal(targetBytes(usage, "cache"), 18);
+    assert.equal(targetBytes(usage, "searchIndex"), 48);
+    assert.equal(targetBytes(usage, "conversations"), 18);
+    assert.equal(targetBytes(usage, "datedLogs"), 12);
+    assert.equal(targetBytes(usage, "rotatedEventLog"), 13);
+    assert.equal(targetBytes(usage, "exploreReports"), 4);
+    assert.equal(targetBytes(usage, "crashReports"), 14);
+    assert.equal(targetBytes(usage, "tmp"), 19);
+  });
+
+  it("returns a stable empty response for an empty home", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-usage-empty-"));
+    roots.push(home);
+    const usage = await new StorageUsageService({
+      paths: storagePaths(home),
+      getRegistry: () => ({ listConversations: () => [] }),
+    }).computeUsage(true);
+
+    assert.equal(usage.totalBytes, 0);
+    assert.deepEqual(usage.categories, []);
+    assert.deepEqual(usage.database, {
+      dbBytes: 0,
+      walBytes: 0,
+      shmBytes: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive v1 storage taxonomy for Nerve's home directory, replacing the legacy category system with a clearer ownership and retention model.

## Changes

### Contracts (`packages/contracts`)
- New `StorageCategoryKey` enum with 16 categories: `database`, `payloads`, `reports`, `images`, `plans`, `tasks`, `agentResources`, `runtimeState`, `logs`, `crashReports`, `queryCache`, `cache`, `temporaryFiles`, `migrations`, `backups`, `configurationIdentity`, `other`
- Renamed `storageUsageResponse.dataDir` → `homeDir` and `sqlite` → `database`
- Added contract tests validating v1 taxonomy and rejecting legacy operation snapshots

### Server (`packages/workbench-server`)
- **storage-usage.service.ts**: Complete rewrite of categorization logic
  - Distinguishes authoritative database (`data/nerve.sqlite`) from rebuildable query cache (`cache/query-cache.sqlite`)
  - New `pathsSize`, `sqliteFilePaths`, `queryCacheFilePaths`, `queryCacheFileNames` utilities in `storage-files.ts`
  - Clean separation: `database` (protected, never cleaned), `queryCache` (cleanable), `cache` (other disposables)
  - Adds `migrations`, `backups`, `configurationIdentity` as visible but non-cleanable categories
- **storage-cleanup.service.ts**: Updated to use new taxonomy; excludes canonical DB, migrations, backups from cleanup targets
- **storage-cleanup.service.test.ts**: Updated for new taxonomy
- **storage-usage.service.test.ts**: New comprehensive test suite
- **paths.ts**, **initialize.ts**, **http-dispatcher.ts**: Supporting changes

### UI (`packages/workbench-app`)
- **StorageSettingsPage.svelte**: Updated for new category display and cleanup targets
- **StorageCleanupDialog.svelte**: Updated cleanup target labels and descriptions
- **storage-cleanup.test.ts**: Updated tests

### Documentation (`packages/website`)
- **guides/settings.md**: Clarifies database vs query cache distinction, cleanup behavior
- **operations/storage-migration.md**: Updated to reflect complete home reporting and new cleanup targets
- **reference/data-formats.md**: Full rewrite of Nerve-home data table with v1 paths

### Misc
- `.gitignore`: Added `.idea/`

## Testing

- All contract tests pass
- New `storage-usage.service.test.ts` covers categorization, cleanup targets, and edge cases
- Updated `storage-cleanup.service.test.ts` validates new taxonomy

## Breaking Changes

- **API**: `storageUsageResponse.dataDir` → `homeDir`, `sqlite` → `database`
- **Categories**: All category keys changed; consumers must migrate to v1 taxonomy
- **Cleanup**: Canonical database, migrations, and backups are no longer cleanup targets