### PR TITLE
Bound conversation lifecycle work as history grows

### DIFF
--- a/docs/conversation-storage-erd.md
+++ b/docs/conversation-storage-erd.md
@@ -6,6 +6,17 @@
 
 Use canonical SQLite conversation records. A conversation is a stable container; every durable lifecycle transition is a typed conversation record. Complete tool-result bytes that exceed the agent preview contract are stored as owner-scoped payload files, while SQLite remains canonical for their identity, projections, ownership, and integrity reference.
 
+## Journal persistence and performance
+
+The in-memory conversation aggregate is persisted as a checkpoint plus ordered canonical deltas:
+
+- `conversation_state` is a full checkpoint used only for cold hydration, import, and repair. Normal tool/message lifecycle commits do not rewrite it.
+- `conversation_journal_head` stores the current revision and checksum for SQLite-side compare-and-swap.
+- `conversation_journal_commit` stores one validated, revision-keyed commit. A hot transaction appends this delta, advances the head, updates only affected conversation records/context leaves, and appends its durable notification event atomically.
+- Graceful shutdown folds loaded deltas into a new checkpoint and deletes only commits covered by that checkpoint in the same transaction. If checkpointing is interrupted, the retained deltas remain the recovery source.
+
+Hot commit CPU, worker IPC, serialization, and SQLite writes must be proportional to the current commit and affected records, never to unrelated conversation history. Full-history work is permitted only during cold hydration, explicit export/repair, compaction generation, or shutdown checkpointing. Model-provider payload cost still scales with retained context until compaction; after compaction, local context projection traverses only the retained segment and post-compaction entries.
+
 This keeps the storage model small:
 
 - `CONVERSATION` stores stable metadata.

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -120,6 +120,7 @@ export {
   extractConversationState,
 } from "./runtime/conversation/context.js";
 export { Conversation } from "./runtime/conversation/conversation.js";
+export { ConversationTreeState } from "./runtime/conversation/conversation-tree-state.js";
 export {
   type ActiveToolsChangeEntry,
   type BranchSummaryEntry,

--- a/packages/harness/src/runtime/conversation/adapters/in-memory-storage.ts
+++ b/packages/harness/src/runtime/conversation/adapters/in-memory-storage.ts
@@ -61,6 +61,18 @@ export class InMemoryConversationStorage<
     return this.#tree.getPathToRoot(leafId);
   }
 
+  async getContextPath(leafId?: string | null) {
+    return this.#tree.getContextPath(
+      leafId === undefined ? this.#tree.leafId : leafId,
+    );
+  }
+
+  async buildContext(leafId?: string | null) {
+    return this.#tree.buildContext(
+      leafId === undefined ? this.#tree.leafId : leafId,
+    );
+  }
+
   async getEntries(): Promise<ConversationTreeEntry[]> {
     return this.#tree.entries();
   }

--- a/packages/harness/src/runtime/conversation/conversation-tree-state.ts
+++ b/packages/harness/src/runtime/conversation/conversation-tree-state.ts
@@ -1,4 +1,10 @@
 import { ConversationError } from "../errors.js";
+import {
+  buildContextMessages,
+  buildConversationContext,
+  type ConversationContext,
+  type ConversationState,
+} from "./context.js";
 import type { ConversationTreeEntry, LeafEntry } from "./entries.js";
 import {
   entryLinkError,
@@ -9,10 +15,45 @@ import {
 } from "./storage-utils.js";
 
 /** Backend-neutral owner of conversation-tree invariants and projections. */
+const initialState = (): ConversationState => ({
+  thinkingLevel: "off",
+  model: null,
+  activeToolNames: null,
+  compaction: null,
+});
+
+function deriveState(
+  previous: ConversationState | undefined,
+  entry: ConversationTreeEntry,
+): ConversationState {
+  const state = previous ?? initialState();
+  if (entry.type === "thinking_level_change") {
+    return { ...state, thinkingLevel: entry.thinkingLevel };
+  }
+  if (entry.type === "model_change") {
+    return {
+      ...state,
+      model: { provider: entry.provider, modelId: entry.modelId },
+    };
+  }
+  if (entry.type === "message" && entry.message.role === "assistant") {
+    return {
+      ...state,
+      model: { provider: entry.message.provider, modelId: entry.message.model },
+    };
+  }
+  if (entry.type === "active_tools_change") {
+    return { ...state, activeToolNames: [...entry.activeToolNames] };
+  }
+  if (entry.type === "compaction") return { ...state, compaction: entry };
+  return state;
+}
+
 export class ConversationTreeState {
   readonly #entries: ConversationTreeEntry[];
   readonly #byId = new Map<string, ConversationTreeEntry>();
   readonly #labelsById = new Map<string, string>();
+  readonly #stateById = new Map<string, ConversationState>();
   #leafId: string | null = null;
 
   constructor(entries: readonly ConversationTreeEntry[] = []) {
@@ -59,6 +100,10 @@ export class ConversationTreeState {
     this.#entries.push(entry);
     this.#byId.set(entry.id, entry);
     updateLabelCache(this.#labelsById, entry);
+    this.#stateById.set(
+      entry.id,
+      deriveState(this.#stateById.get(entry.parentId ?? ""), entry),
+    );
     this.#leafId = leafIdAfterEntry(entry);
   }
 
@@ -94,7 +139,7 @@ export class ConversationTreeState {
         );
       }
       visited.add(current.id);
-      path.unshift(current);
+      path.push(current);
       if (!current.parentId) break;
       const parent = this.#byId.get(current.parentId);
       if (!parent) {
@@ -105,7 +150,56 @@ export class ConversationTreeState {
       }
       current = parent;
     }
-    return path;
+    return path.reverse();
+  }
+
+  setLeafId(leafId: string | null): void {
+    if (leafId !== null && !this.#byId.has(leafId)) {
+      throw new ConversationError("not_found", `Entry ${leafId} not found`);
+    }
+    this.#leafId = leafId;
+  }
+
+  buildContext(leafId: string | null = this.leafId): ConversationContext {
+    if (leafId === null) return buildConversationContext([]);
+    const state = this.#stateById.get(leafId);
+    if (!state?.compaction) {
+      return buildConversationContext(this.getPathToRoot(leafId));
+    }
+    const path = this.getContextPath(leafId);
+    return {
+      messages: buildContextMessages(path, state),
+      thinkingLevel: state.thinkingLevel,
+      model: state.model,
+      activeToolNames: state.activeToolNames,
+    };
+  }
+
+  getContextPath(leafId: string | null = this.leafId): ConversationTreeEntry[] {
+    if (leafId === null) return [];
+    const compaction = this.#stateById.get(leafId)?.compaction;
+    if (!compaction) return this.getPathToRoot(leafId);
+    const retained: ConversationTreeEntry[] = [];
+    let cursor = compaction.parentId
+      ? this.#byId.get(compaction.parentId)
+      : undefined;
+    while (cursor) {
+      retained.push(cursor);
+      if (cursor.id === compaction.firstKeptEntryId) break;
+      cursor = cursor.parentId ? this.#byId.get(cursor.parentId) : undefined;
+    }
+    if (retained.at(-1)?.id !== compaction.firstKeptEntryId)
+      retained.length = 0;
+    retained.reverse();
+
+    const trailing: ConversationTreeEntry[] = [];
+    cursor = this.#byId.get(leafId);
+    while (cursor && cursor.id !== compaction.id) {
+      trailing.push(cursor);
+      cursor = cursor.parentId ? this.#byId.get(cursor.parentId) : undefined;
+    }
+    trailing.reverse();
+    return [...retained, compaction, ...trailing];
   }
 
   entries(): ConversationTreeEntry[] {

--- a/packages/harness/src/runtime/conversation/conversation.ts
+++ b/packages/harness/src/runtime/conversation/conversation.ts
@@ -2,7 +2,6 @@ import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { AgentMessage } from "../../agent/types/index.js";
 import { ConversationError } from "../errors.js";
 import type { ConversationContext } from "./context.js";
-import { buildConversationContext } from "./context.js";
 import type {
   ActiveToolsChangeEntry,
   BranchSummaryEntry,
@@ -55,8 +54,13 @@ export class Conversation<
     return this.storage.getPathToRoot(leafId);
   }
 
+  async getContextBranch(fromId?: string): Promise<ConversationTreeEntry[]> {
+    const leafId = fromId ?? (await this.storage.getLeafId());
+    return this.storage.getContextPath(leafId);
+  }
+
   async buildContext(): Promise<ConversationContext> {
-    return buildConversationContext(await this.getBranch());
+    return this.storage.buildContext();
   }
 
   getLabel(id: string): Promise<string | undefined> {

--- a/packages/harness/src/runtime/conversation/entries.ts
+++ b/packages/harness/src/runtime/conversation/entries.ts
@@ -1,5 +1,6 @@
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { AgentMessage } from "../../agent/types/index.js";
+import type { ConversationContext } from "./context.js";
 
 export interface ConversationTreeEntryBase {
   type: string;
@@ -115,5 +116,7 @@ export interface ConversationStorage<
   ): Promise<Array<Extract<ConversationTreeEntry, { type: TType }>>>;
   getLabel(id: string): Promise<string | undefined>;
   getPathToRoot(leafId: string | null): Promise<ConversationTreeEntry[]>;
+  getContextPath(leafId?: string | null): Promise<ConversationTreeEntry[]>;
+  buildContext(leafId?: string | null): Promise<ConversationContext>;
   getEntries(): Promise<ConversationTreeEntry[]>;
 }

--- a/packages/harness/test/runtime/conversation/conversation-tree-state.test.ts
+++ b/packages/harness/test/runtime/conversation/conversation-tree-state.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildConversationContext,
+  ConversationTreeState,
+  type ConversationTreeEntry,
+} from "../../../src/index.js";
+
+const now = "2026-08-26T00:00:00.000Z";
+
+function message(id: string, parentId: string | null): ConversationTreeEntry {
+  return {
+    type: "custom_message",
+    id,
+    parentId,
+    timestamp: now,
+    customType: "test",
+    content: id,
+    display: true,
+  };
+}
+
+describe("ConversationTreeState", () => {
+  it("builds post-compaction context from only retained branch entries", () => {
+    const tree = new ConversationTreeState();
+    tree.append({
+      type: "thinking_level_change",
+      id: "thinking",
+      parentId: null,
+      timestamp: now,
+      thinkingLevel: "high",
+    });
+    let parentId = "thinking";
+    for (let index = 0; index < 100; index += 1) {
+      const id = `old_${index}`;
+      tree.append(message(id, parentId));
+      parentId = id;
+    }
+    tree.append({
+      type: "compaction",
+      id: "compact",
+      parentId,
+      timestamp: now,
+      summary: "summary",
+      firstKeptEntryId: "old_95",
+      tokensBefore: 10_000,
+    });
+    parentId = "compact";
+    for (let index = 0; index < 3; index += 1) {
+      const id = `new_${index}`;
+      tree.append(message(id, parentId));
+      parentId = id;
+    }
+
+    const fullPath = tree.getPathToRoot(tree.leafId);
+    const contextPath = tree.getContextPath();
+    assert.equal(fullPath.length, 105);
+    assert.equal(contextPath.length, 9);
+    assert.deepEqual(tree.buildContext(), buildConversationContext(fullPath));
+    assert.equal(tree.buildContext().thinkingLevel, "high");
+  });
+
+  it("uses indexed lookup, labels, and branch traversal", () => {
+    const tree = new ConversationTreeState();
+    tree.append(message("root", null));
+    tree.append(message("child", "root"));
+    tree.append({
+      type: "label",
+      id: "label",
+      parentId: "child",
+      timestamp: now,
+      targetId: "root",
+      label: "Root",
+    });
+
+    assert.equal(tree.getEntry("child")?.parentId, "root");
+    assert.equal(tree.getLabel("root"), "Root");
+    assert.deepEqual(
+      tree.getPathToRoot("child").map((entry) => entry.id),
+      ["root", "child"],
+    );
+  });
+});

--- a/packages/workbench-server/src/app/runtime/composition.ts
+++ b/packages/workbench-server/src/app/runtime/composition.ts
@@ -142,6 +142,7 @@ export interface RuntimeServices {
   subagentTranscripts: SubagentTranscriptService;
   humanInput: HumanInputResolutionService;
   pruneConversations: PruneProjectConversationsService;
+  conversationJournal: ConversationJournalRepository;
 }
 
 export function composeRuntime(
@@ -231,7 +232,11 @@ export function composeRuntime(
     scratchNoteRepository,
     getProject,
   );
-  const conversationJournal = new ConversationJournalRepository(storage);
+  const conversationJournal = new ConversationJournalRepository(
+    storage,
+    performanceDiagnostics,
+  );
+  services.conversationJournal = conversationJournal;
   const resultPayloads = new ToolResultPayloadStore(storage.paths.home);
   events.setConversationRevisionResolver(
     (conversationId) => conversationJournal.state(conversationId)?.revision,
@@ -244,6 +249,7 @@ export function composeRuntime(
   services.harnessStorage = new ConversationHarnessStorage(
     conversationRepository,
     getConversation,
+    performanceDiagnostics,
   );
   services.conversationService = new ConversationService(
     services.harnessStorage,

--- a/packages/workbench-server/src/app/runtime/registry.ts
+++ b/packages/workbench-server/src/app/runtime/registry.ts
@@ -226,6 +226,16 @@ export class RuntimeRegistry {
     await this.services.runRuntime.coordinator.settled();
     await this.services.runRuntime.delivery.settled();
     await this.events.settled();
+    await this.services.conversationJournal
+      .checkpointLoaded()
+      .catch(async (error: unknown) => {
+        await this.logger.warn(
+          "Conversation checkpoint failed during shutdown",
+          {
+            error,
+          },
+        );
+      });
   }
 
   /** Current subscription usage snapshots (Anthropic / Codex). */

--- a/packages/workbench-server/src/app/runtime/state.ts
+++ b/packages/workbench-server/src/app/runtime/state.ts
@@ -13,6 +13,10 @@ export class RuntimeState {
   readonly conversations = new Map<string, ConversationRecord>();
   readonly agents = new Map<string, AgentRecord>();
   readonly entries = new Map<string, ConversationEntry[]>();
+  private readonly entriesById = new Map<
+    string,
+    Map<string, ConversationEntry>
+  >();
   readonly conversationRuntime = new ConversationRuntime();
   agentConversationMessages = new Map<string, Message[]>();
 
@@ -63,6 +67,30 @@ export class RuntimeState {
     return agent;
   }
 
+  getConversationEntry(
+    conversationId: string,
+    entryId: string,
+  ): ConversationEntry | undefined {
+    return this.entriesById.get(conversationId)?.get(entryId);
+  }
+
+  appendConversationEntry(entry: ConversationEntry): boolean {
+    let entriesById = this.entriesById.get(entry.conversationId);
+    if (!entriesById) {
+      entriesById = new Map();
+      this.entriesById.set(entry.conversationId, entriesById);
+    }
+    if (entriesById.has(entry.id)) return false;
+    entriesById.set(entry.id, entry);
+    let entries = this.entries.get(entry.conversationId);
+    if (!entries) {
+      entries = [];
+      this.entries.set(entry.conversationId, entries);
+    }
+    entries.push(entry);
+    return true;
+  }
+
   getConversationEntries(conversationId: string): ConversationEntry[] {
     return this.entries.get(conversationId) ?? [];
   }
@@ -84,6 +112,10 @@ export class RuntimeState {
     entries: ConversationEntry[],
   ): void {
     this.entries.set(conversationId, entries);
+    this.entriesById.set(
+      conversationId,
+      new Map(entries.map((entry) => [entry.id, entry])),
+    );
   }
 
   removeProject(projectId: string): void {
@@ -93,6 +125,7 @@ export class RuntimeState {
   removeConversation(conversationId: string): void {
     this.conversations.delete(conversationId);
     this.entries.delete(conversationId);
+    this.entriesById.delete(conversationId);
   }
 
   removeAgent(agentId: string): void {

--- a/packages/workbench-server/src/core/ports.ts
+++ b/packages/workbench-server/src/core/ports.ts
@@ -52,7 +52,13 @@ export type PerformanceMetricName =
   | "git.watcherEvicted"
   | "git.filesystemEvent"
   | "git.invalidation"
-  | "git.metadataInvalidation";
+  | "git.metadataInvalidation"
+  | "conversation.commitPrepare"
+  | "conversation.commitPersist"
+  | "conversation.commitEvents"
+  | "conversation.commitRecords"
+  | "conversation.checkpoint"
+  | "conversation.contextBuild";
 
 export interface PerformanceMetricAggregate {
   readonly count: number;

--- a/packages/workbench-server/src/domains/agents/run/auto-compaction-runner.ts
+++ b/packages/workbench-server/src/domains/agents/run/auto-compaction-runner.ts
@@ -1,6 +1,5 @@
 import type { ImageContent } from "@earendil-works/pi-ai";
 import {
-  buildConversationContext,
   computeContextUsage,
   type Conversation,
   deriveAutoCompactionPolicy,
@@ -27,8 +26,8 @@ export class AutoCompactionRunner {
   async getContextUsage(conversationId: string): Promise<ContextUsage> {
     const conversation = this.deps.state.getConversation(conversationId);
     const storage = await this.deps.harnessStorage.openStorage(conversation);
-    const branch = await storage.getPathToRoot(await storage.getLeafId());
-    const messages = buildConversationContext(branch).messages;
+    const branch = await storage.getContextPath();
+    const messages = (await storage.buildContext()).messages;
     const agent = conversation.activeAgentId
       ? this.deps.state.agents.get(conversation.activeAgentId)
       : undefined;
@@ -125,8 +124,8 @@ export class AutoCompactionRunner {
     const policy = deriveAutoCompactionPolicy(contextWindow, settings);
     if (!policy.enabled || contextWindow <= 0) return false;
 
-    const branch = await input.conversation.getBranch();
-    const messages = buildConversationContext(branch).messages;
+    const branch = await input.conversation.getContextBranch();
+    const messages = (await input.conversation.buildContext()).messages;
     const contextTokens =
       getCompactionDecisionTokens(messages, branch) + input.additionalTokens;
     if (!shouldAutoCompact(contextTokens, policy)) return false;

--- a/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
+++ b/packages/workbench-server/src/domains/agents/run/workbench-harness-execution.ts
@@ -1,7 +1,6 @@
 import {
   AgentHarness,
   type AnyModel,
-  buildConversationContext,
   Conversation,
   convertToLlm,
   isAgentToolSuspension,
@@ -707,8 +706,7 @@ export async function executeWorkbenchHarness(
         agent,
         signal: runAbortController.signal,
       });
-      const branch = await storage.getPathToRoot(await storage.getLeafId());
-      const messages = convertToLlm(buildConversationContext(branch).messages);
+      const messages = convertToLlm((await storage.buildContext()).messages);
       this.deps.conversationService.setForAgent(agent.id, messages);
       if (forcePushGeneration > handledForcePushGeneration) {
         handledForcePushGeneration = forcePushGeneration;

--- a/packages/workbench-server/src/domains/conversations/conversation-harness-storage.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-harness-storage.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "node:crypto";
+import type { PerformanceDiagnosticsPort } from "../../core/ports.js";
+import { noopPerformanceDiagnostics } from "../../infrastructure/diagnostics/performance-metrics.js";
 import type { Message } from "@earendil-works/pi-ai";
 import {
   type AgentMessage,
   Conversation,
+  ConversationTreeState,
   type ConversationMetadata,
   type ConversationStorage,
   type ConversationTreeEntry,
@@ -20,6 +23,7 @@ export class ConversationHarnessStorage {
     private readonly getConversation: (
       conversationId: string,
     ) => ConversationRecord,
+    private readonly diagnostics: PerformanceDiagnosticsPort = noopPerformanceDiagnostics,
   ) {}
 
   async openStorage(
@@ -30,6 +34,8 @@ export class ConversationHarnessStorage {
       this.conversationRepository,
       conversation.id,
       conversation.createdAt,
+      undefined,
+      this.diagnostics,
     );
   }
 
@@ -43,6 +49,7 @@ export class ConversationHarnessStorage {
       conversation.id,
       conversation.createdAt,
       agent.id,
+      this.diagnostics,
     );
   }
 
@@ -169,6 +176,7 @@ class JournalConversationStorage implements ConversationStorage<ConversationMeta
     private readonly conversationId: string,
     private readonly createdAt: string,
     private readonly ownerAgentId?: string,
+    private readonly diagnostics: PerformanceDiagnosticsPort = noopPerformanceDiagnostics,
   ) {}
 
   async getMetadata(): Promise<ConversationMetadata> {
@@ -201,19 +209,11 @@ class JournalConversationStorage implements ConversationStorage<ConversationMeta
   }
 
   async appendEntry(entry: ConversationTreeEntry): Promise<void> {
-    const state = await this.conversations.journal.load(this.conversationId);
-    const entries = this.ownerAgentId
-      ? (state.agentModelEntries.get(this.ownerAgentId) ?? [])
-      : state.modelEntries;
-    if (entries.some((candidate) => candidate.id === entry.id)) {
+    const tree = await this.tree();
+    if (tree.getEntry(entry.id)) {
       throw new Error(`Duplicate model-context entry '${entry.id}'.`);
     }
-    if (
-      entry.parentId !== null &&
-      !entries.some((candidate) => candidate.id === entry.parentId)
-    ) {
-      throw new Error(`Unknown model-context parent '${entry.parentId}'.`);
-    }
+    tree.validateAppend(entry);
     await this.conversations.journal.commit(this.conversationId, {
       kind: "model_context.entry_appended",
       events: [
@@ -228,55 +228,52 @@ class JournalConversationStorage implements ConversationStorage<ConversationMeta
   }
 
   async getEntry(id: string): Promise<ConversationTreeEntry | undefined> {
-    return (await this.entries()).find((entry) => entry.id === id);
+    return (await this.tree()).getEntry(id);
   }
 
   async findEntries<TType extends ConversationTreeEntry["type"]>(
     type: TType,
   ): Promise<Array<Extract<ConversationTreeEntry, { type: TType }>>> {
-    return (await this.entries()).filter(
-      (entry): entry is Extract<ConversationTreeEntry, { type: TType }> =>
-        entry.type === type,
-    );
+    return (await this.tree()).findEntries(type);
   }
 
   async getLabel(id: string): Promise<string | undefined> {
-    const labels = (await this.entries()).filter(
-      (entry): entry is Extract<ConversationTreeEntry, { type: "label" }> =>
-        entry.type === "label" && entry.targetId === id,
-    );
-    return labels.at(-1)?.label;
+    return (await this.tree()).getLabel(id);
   }
 
   async getPathToRoot(leafId: string | null): Promise<ConversationTreeEntry[]> {
-    if (leafId === null) return [];
-    const entries = await this.entries();
-    const byId = new Map(entries.map((entry) => [entry.id, entry]));
-    const path: ConversationTreeEntry[] = [];
-    const visited = new Set<string>();
-    let cursor: string | null = leafId;
-    while (cursor) {
-      if (visited.has(cursor))
-        throw new Error("Model-context tree has a cycle.");
-      visited.add(cursor);
-      const entry = byId.get(cursor);
-      if (!entry) throw new Error(`Unknown model-context entry '${cursor}'.`);
-      path.push(entry);
-      cursor = entry.parentId;
-    }
-    return path.reverse();
+    return (await this.tree()).getPathToRoot(leafId);
+  }
+
+  async getContextPath(leafId?: string | null) {
+    const tree = await this.tree();
+    return tree.getContextPath(leafId === undefined ? tree.leafId : leafId);
+  }
+
+  async buildContext(leafId?: string | null) {
+    const startedAt = performance.now();
+    const tree = await this.tree();
+    const context = tree.buildContext(
+      leafId === undefined ? tree.leafId : leafId,
+    );
+    this.diagnostics.duration(
+      "conversation.contextBuild",
+      performance.now() - startedAt,
+    );
+    return context;
   }
 
   async getEntries(): Promise<ConversationTreeEntry[]> {
-    return this.entries();
+    return (await this.tree()).entries();
   }
 
-  private async entries(): Promise<ConversationTreeEntry[]> {
+  private async tree() {
     const state = await this.conversations.journal.load(this.conversationId);
-    return [
-      ...(this.ownerAgentId
-        ? (state.agentModelEntries.get(this.ownerAgentId) ?? [])
-        : state.modelEntries),
-    ];
+    if (!this.ownerAgentId) return state.modelTree;
+    const existing = state.agentModelTrees.get(this.ownerAgentId);
+    if (existing) return existing;
+    const tree = new ConversationTreeState();
+    state.agentModelTrees.set(this.ownerAgentId, tree);
+    return tree;
   }
 }

--- a/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
@@ -1,12 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
+import type { PerformanceDiagnosticsPort } from "../../core/ports.js";
+import { noopPerformanceDiagnostics } from "../../infrastructure/diagnostics/performance-metrics.js";
 import { CanonicalStore } from "../../infrastructure/canonical-store/index.js";
 import { storagePaths } from "../../infrastructure/storage/paths.js";
 import {
   deserializeState,
+  prepareConversationPersistenceDelta,
   serializeState,
-  type SerializedConversationState,
+  type ConversationPersistenceDelta,
 } from "./conversation-state-materializer.js";
-import type { ConversationTreeEntry } from "@nervekit/harness";
+import {
+  ConversationTreeState,
+  type ConversationTreeEntry,
+} from "@nervekit/harness";
 import {
   CONVERSATION_JOURNAL_EPOCH,
   conversationJournalCommitSchema,
@@ -41,6 +47,14 @@ export interface ConversationJournalState {
   suspensions: Map<string, ConversationSuspensionRecord>;
   idempotencyKeys: Map<string, ConversationJournalCommit>;
   intentConversationRevisions: Map<string, number>;
+  /** Non-serialized indexes maintained with the resident projection. */
+  entryById: Map<string, ConversationEntry>;
+  modelEntryById: Map<string, ConversationTreeEntry>;
+  agentModelEntryById: Map<string, Map<string, ConversationTreeEntry>>;
+  interactionIdsByToolCall: Map<string, Set<string>>;
+  interactionByToolCallOrdinal: Map<string, ConversationInteractionRecord>;
+  modelTree: ConversationTreeState;
+  agentModelTrees: Map<string, ConversationTreeState>;
 }
 
 export interface ConversationRunProjection {
@@ -79,6 +93,7 @@ export class ConversationJournalRepository {
       paths: { home: string; sqlitePath?: string };
       canonicalStore?: CanonicalStore;
     },
+    private readonly diagnostics: PerformanceDiagnosticsPort = noopPerformanceDiagnostics,
   ) {
     this.canonical =
       storage.canonicalStore ??
@@ -102,9 +117,7 @@ export class ConversationJournalRepository {
     await this.ready;
     const states: ConversationJournalState[] = [];
     const conversationIds = new Set(
-      (await this.canonical.listDocumentKeys("conversation_state")).map(
-        (document) => document.scopeId,
-      ),
+      await this.canonical.listConversationJournalIds(),
     );
     for (const conversationId of [...conversationIds].sort()) {
       const state = options.fresh
@@ -130,11 +143,8 @@ export class ConversationJournalRepository {
     if (!toolCall.runId) return true;
     const state = this.states.get(toolCall.conversationId);
     if (!state) return false;
-    const interaction = [...state.interactions.values()].find(
-      (candidate) =>
-        candidate.runId === toolCall.runId &&
-        candidate.toolCallId === toolCall.id &&
-        candidate.interaction.ordinal === ordinal,
+    const interaction = state.interactionByToolCallOrdinal.get(
+      interactionOrdinalKey(toolCall.id, ordinal),
     );
     if (!interaction) return false;
     const suspension = state.suspensions.get(interaction.suspensionId);
@@ -183,11 +193,8 @@ export class ConversationJournalRepository {
           state.revision,
         );
       }
-      const candidate = cloneState(state);
-      for (const event of input.events) {
-        validateEventReferences(candidate, event, conversationId);
-        applyEvent(candidate, event);
-      }
+      const prepareStartedAt = performance.now();
+      const preview = validateCommitEvents(state, input.events, conversationId);
       const base = {
         epoch: CONVERSATION_JOURNAL_EPOCH,
         conversationId,
@@ -214,10 +221,27 @@ export class ConversationJournalRepository {
         ...normalizedBase,
         checksum: journalChecksum(normalizedBase),
       });
-      const next = cloneState(state);
-      applyCommit(next, parsed);
-      await this.persistState(next, parsed);
-      this.states.set(conversationId, next);
+      const delta = prepareConversationPersistenceDelta(
+        state,
+        parsed,
+        preview.runProjections,
+      );
+      this.diagnostics.duration(
+        "conversation.commitPrepare",
+        performance.now() - prepareStartedAt,
+      );
+      this.diagnostics.count("conversation.commitEvents", parsed.events.length);
+      this.diagnostics.count(
+        "conversation.commitRecords",
+        delta.records.length,
+      );
+      const persistStartedAt = performance.now();
+      await this.persistCommit(delta);
+      this.diagnostics.duration(
+        "conversation.commitPersist",
+        performance.now() - persistStartedAt,
+      );
+      applyCommit(state, parsed);
       return parsed;
     });
   }
@@ -231,31 +255,46 @@ export class ConversationJournalRepository {
 
   async loadFresh(conversationId: string): Promise<ConversationJournalState> {
     await this.ready;
-    const stored =
-      await this.canonical.readDocument<SerializedConversationState>(
-        "conversation_state",
-        conversationId,
-        "state",
-      );
-    if (stored) {
-      const restored = deserializeState(stored.data);
-      this.states.set(conversationId, restored);
-      return restored;
+    const stored = await this.canonical.readConversationJournal(conversationId);
+    const state = stored.snapshot
+      ? deserializeState(stored.snapshot)
+      : emptyState(conversationId);
+    for (const value of stored.commits) {
+      const commit = conversationJournalCommitSchema.parse(value);
+      verifyCommit(state, commit);
+      applyCommit(state, commit);
     }
-    const state = emptyState(conversationId);
+    if (
+      stored.head &&
+      (stored.head.revision !== state.revision ||
+        stored.head.checksum !== state.checksum)
+    ) {
+      throw new Error(
+        `Conversation journal '${conversationId}' does not match its head.`,
+      );
+    }
     this.states.set(conversationId, state);
     return state;
   }
 
-  private async persistState(
-    state: ConversationJournalState,
-    commit?: ConversationJournalCommit,
+  async checkpointLoaded(): Promise<void> {
+    await this.ready;
+    for (const state of this.states.values()) {
+      if (state.revision === 0) continue;
+      const startedAt = performance.now();
+      await this.canonical.checkpointConversationState(serializeState(state));
+      this.diagnostics.duration(
+        "conversation.checkpoint",
+        performance.now() - startedAt,
+      );
+    }
+  }
+
+  private async persistCommit(
+    delta: ConversationPersistenceDelta,
   ): Promise<void> {
     await this.ready;
-    await this.canonical.persistConversationState(
-      serializeState(state),
-      commit,
-    );
+    await this.canonical.persistConversationCommit(delta);
   }
   private async exclusive<T>(
     conversationId: string,
@@ -282,6 +321,164 @@ export function journalChecksum(value: unknown): string {
   return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
 }
 
+interface CommitPreview {
+  runProjections: Map<string, ConversationRunProjection>;
+}
+
+function validateCommitEvents(
+  state: ConversationJournalState,
+  events: ConversationJournalEvent[],
+  conversationId: string,
+): CommitPreview {
+  const toolCalls = new Map<string, ToolCallRecord>();
+  const interactions = new Map<string, ConversationInteractionRecord>();
+  const runProjections = new Map<string, ConversationRunProjection>();
+  const modelEntries = new Map<string, ConversationTreeEntry>();
+
+  const toolCall = (id: string) => toolCalls.get(id) ?? state.toolCalls.get(id);
+  const interaction = (id: string) =>
+    interactions.get(id) ?? state.interactions.get(id);
+  const runProjection = (id: string) =>
+    runProjections.get(id) ?? state.runProjections.get(id);
+
+  for (const event of events) {
+    validateEventIdentity(event, conversationId);
+    switch (event.kind) {
+      case "model_context.entry_appended": {
+        const entry = event.entry as unknown as ConversationTreeEntry;
+        const current = event.ownerAgentId
+          ? state.agentModelEntryById.get(event.ownerAgentId)?.get(entry.id)
+          : state.modelEntryById.get(entry.id);
+        const previous = modelEntries.get(
+          `${event.ownerAgentId ?? ""}:${entry.id}`,
+        );
+        if (
+          (current && JSON.stringify(current) !== JSON.stringify(entry)) ||
+          (previous && JSON.stringify(previous) !== JSON.stringify(entry))
+        ) {
+          throw new Error(`Conflicting model-context entry '${entry.id}'.`);
+        }
+        if (!current && !previous && entry.parentId) {
+          const parent = event.ownerAgentId
+            ? state.agentModelEntryById
+                .get(event.ownerAgentId)
+                ?.get(entry.parentId)
+            : state.modelEntryById.get(entry.parentId);
+          const pendingParent = modelEntries.get(
+            `${event.ownerAgentId ?? ""}:${entry.parentId}`,
+          );
+          if (!parent && !pendingParent) {
+            throw new Error(
+              `Unknown model-context parent '${entry.parentId}'.`,
+            );
+          }
+        }
+        modelEntries.set(`${event.ownerAgentId ?? ""}:${entry.id}`, entry);
+        break;
+      }
+      case "tool_call.upserted": {
+        const previous = toolCall(event.toolCall.id);
+        if (previous && event.toolCall.revision < previous.revision) {
+          throw new Error(
+            `Tool-call revision moved backwards for '${event.toolCall.id}'.`,
+          );
+        }
+        toolCalls.set(event.toolCall.id, event.toolCall);
+        break;
+      }
+      case "interaction.upserted": {
+        const currentToolCall = toolCall(event.interaction.toolCallId);
+        if (
+          !currentToolCall ||
+          currentToolCall.revision !== event.interaction.toolCallRevision
+        ) {
+          throw new Error("Conversation interaction tool revision is stale.");
+        }
+        interactions.set(event.interaction.id, event.interaction);
+        break;
+      }
+      case "suspension.upserted":
+        for (const member of event.suspension.members) {
+          const currentInteraction = interaction(member.interactionId);
+          if (
+            !currentInteraction ||
+            currentInteraction.suspensionId !== event.suspension.id ||
+            currentInteraction.checkpointId !== event.suspension.checkpointId ||
+            currentInteraction.toolCallId !== member.toolCallId ||
+            currentInteraction.toolCallRevision !== member.toolCallRevision
+          ) {
+            throw new Error("Conversation suspension member is inconsistent.");
+          }
+        }
+        break;
+      case "run.transition_committed": {
+        const previous = runProjection(event.transition.runId);
+        if (
+          event.transition.previousRevision !== (previous?.run.revision ?? 0)
+        ) {
+          throw new Error(
+            `Run transition chain is invalid for '${event.transition.runId}'.`,
+          );
+        }
+        runProjections.set(
+          event.transition.runId,
+          applyRunProjectionTransition(previous, event.transition),
+        );
+        break;
+      }
+      case "run.event_delivered": {
+        const previous = runProjection(event.delivery.runId);
+        if (!previous) {
+          throw new Error(
+            `Run delivery '${event.delivery.intentId}' has no run projection.`,
+          );
+        }
+        const deliveries = previous.deliveries.some(
+          (delivery) => delivery.intentId === event.delivery.intentId,
+        )
+          ? previous.deliveries
+          : [...previous.deliveries, event.delivery];
+        runProjections.set(event.delivery.runId, {
+          ...previous,
+          deliveries,
+        });
+        break;
+      }
+    }
+  }
+  return { runProjections };
+}
+
+function verifyCommit(
+  state: ConversationJournalState,
+  commit: ConversationJournalCommit,
+): void {
+  if (
+    commit.epoch !== CONVERSATION_JOURNAL_EPOCH ||
+    commit.conversationId !== state.conversationId ||
+    commit.previousRevision !== state.revision ||
+    commit.revision !== state.revision + 1 ||
+    commit.previousChecksum !== state.checksum
+  ) {
+    throw new Error(
+      `Conversation journal '${state.conversationId}' has an invalid commit chain.`,
+    );
+  }
+  const base = Object.fromEntries(
+    Object.entries(commit).filter(([key]) => key !== "checksum"),
+  );
+  if (journalChecksum(base) !== commit.checksum) {
+    throw new Error(
+      `Conversation journal '${state.conversationId}' has a checksum mismatch.`,
+    );
+  }
+  validateCommitEvents(state, commit.events, state.conversationId);
+}
+
+function interactionOrdinalKey(toolCallId: string, ordinal: number): string {
+  return `${toolCallId}:${ordinal}`;
+}
+
 function applyCommit(
   state: ConversationJournalState,
   commit: ConversationJournalCommit,
@@ -300,8 +497,7 @@ function applyCommit(
   state.checksum = commit.checksum;
 }
 
-function validateEventReferences(
-  state: ConversationJournalState,
+function validateEventIdentity(
   event: ConversationJournalEvent,
   conversationId: string,
 ): void {
@@ -324,26 +520,6 @@ function validateEventReferences(
   ) {
     throw new Error("Conversation journal record identity mismatch.");
   }
-  if (event.kind === "interaction.upserted") {
-    const toolCall = state.toolCalls.get(event.interaction.toolCallId);
-    if (!toolCall || toolCall.revision !== event.interaction.toolCallRevision) {
-      throw new Error("Conversation interaction tool revision is stale.");
-    }
-  }
-  if (event.kind === "suspension.upserted") {
-    for (const member of event.suspension.members) {
-      const interaction = state.interactions.get(member.interactionId);
-      if (
-        !interaction ||
-        interaction.suspensionId !== event.suspension.id ||
-        interaction.checkpointId !== event.suspension.checkpointId ||
-        interaction.toolCallId !== member.toolCallId ||
-        interaction.toolCallRevision !== member.toolCallRevision
-      ) {
-        throw new Error("Conversation suspension member is inconsistent.");
-      }
-    }
-  }
 }
 
 function applyEvent(
@@ -355,10 +531,10 @@ function applyEvent(
       state.conversation = event.conversation;
       return;
     case "conversation.entry_appended": {
-      const index = state.entries.findIndex(
-        (entry) => entry.id === event.entry.id,
-      );
-      if (index === -1) state.entries.push(event.entry);
+      if (!state.entryById.has(event.entry.id)) {
+        state.entries.push(event.entry);
+        state.entryById.set(event.entry.id, event.entry);
+      }
       // Entry ids are the idempotency boundary for transcript materialization.
       // Concurrent writers can derive different presentation metadata for the
       // same durable message; the first committed representation wins.
@@ -369,14 +545,29 @@ function applyEvent(
       const entries = event.ownerAgentId
         ? (state.agentModelEntries.get(event.ownerAgentId) ?? [])
         : state.modelEntries;
-      const index = entries.findIndex((item) => item.id === entry.id);
-      if (index === -1) entries.push(entry);
-      else if (JSON.stringify(entries[index]) !== JSON.stringify(entry)) {
+      const indexed = event.ownerAgentId
+        ? (state.agentModelEntryById.get(event.ownerAgentId) ?? new Map())
+        : state.modelEntryById;
+      const previous = indexed.get(entry.id);
+      if (!previous) {
+        entries.push(entry);
+        indexed.set(entry.id, entry);
+        if (event.ownerAgentId) {
+          const tree =
+            state.agentModelTrees.get(event.ownerAgentId) ??
+            new ConversationTreeState();
+          tree.append(entry);
+          state.agentModelTrees.set(event.ownerAgentId, tree);
+        } else {
+          state.modelTree.append(entry);
+        }
+      } else if (JSON.stringify(previous) !== JSON.stringify(entry)) {
         throw new Error(`Conflicting model-context entry '${entry.id}'.`);
       }
       const leafId = entry.type === "leaf" ? entry.targetId : entry.id;
       if (event.ownerAgentId) {
         state.agentModelEntries.set(event.ownerAgentId, entries);
+        state.agentModelEntryById.set(event.ownerAgentId, indexed);
         state.agentModelLeafIds.set(event.ownerAgentId, leafId);
       } else {
         state.modelLeafId = leafId;
@@ -386,8 +577,14 @@ function applyEvent(
     case "model_context.leaf_changed":
       if (event.ownerAgentId) {
         state.agentModelLeafIds.set(event.ownerAgentId, event.entryId);
+        const tree =
+          state.agentModelTrees.get(event.ownerAgentId) ??
+          new ConversationTreeState();
+        tree.setLeafId(event.entryId);
+        state.agentModelTrees.set(event.ownerAgentId, tree);
       } else {
         state.modelLeafId = event.entryId;
+        state.modelTree.setLeafId(event.entryId);
       }
       return;
     case "tool_call.upserted": {
@@ -413,9 +610,34 @@ function applyEvent(
       );
       return;
     }
-    case "interaction.upserted":
+    case "interaction.upserted": {
+      const previous = state.interactions.get(event.interaction.id);
+      if (previous) {
+        state.interactionIdsByToolCall
+          .get(previous.toolCallId)
+          ?.delete(previous.id);
+        state.interactionByToolCallOrdinal.delete(
+          interactionOrdinalKey(
+            previous.toolCallId,
+            previous.interaction.ordinal,
+          ),
+        );
+      }
       state.interactions.set(event.interaction.id, event.interaction);
+      const ids =
+        state.interactionIdsByToolCall.get(event.interaction.toolCallId) ??
+        new Set<string>();
+      ids.add(event.interaction.id);
+      state.interactionIdsByToolCall.set(event.interaction.toolCallId, ids);
+      state.interactionByToolCallOrdinal.set(
+        interactionOrdinalKey(
+          event.interaction.toolCallId,
+          event.interaction.interaction.ordinal,
+        ),
+        event.interaction,
+      );
       return;
+    }
     case "suspension.upserted":
       state.suspensions.set(event.suspension.id, event.suspension);
       return;
@@ -486,38 +708,12 @@ function emptyState(conversationId: string): ConversationJournalState {
     suspensions: new Map(),
     idempotencyKeys: new Map(),
     intentConversationRevisions: new Map(),
-  };
-}
-
-function cloneState(state: ConversationJournalState): ConversationJournalState {
-  return {
-    ...state,
-    entries: [...state.entries],
-    modelEntries: [...state.modelEntries],
-    agentModelEntries: new Map(
-      [...state.agentModelEntries].map(([agentId, entries]) => [
-        agentId,
-        [...entries],
-      ]),
-    ),
-    agentModelLeafIds: new Map(state.agentModelLeafIds),
-    toolCalls: new Map(state.toolCalls),
-    runProjections: new Map(
-      [...state.runProjections].map(([runId, projection]) => [
-        runId,
-        {
-          ...projection,
-          prompts: [...projection.prompts],
-          interactions: [...projection.interactions],
-          checkpoints: [...projection.checkpoints],
-          transitions: [...projection.transitions],
-          deliveries: [...projection.deliveries],
-        },
-      ]),
-    ),
-    interactions: new Map(state.interactions),
-    suspensions: new Map(state.suspensions),
-    idempotencyKeys: new Map(state.idempotencyKeys),
-    intentConversationRevisions: new Map(state.intentConversationRevisions),
+    entryById: new Map(),
+    modelEntryById: new Map(),
+    agentModelEntryById: new Map(),
+    interactionIdsByToolCall: new Map(),
+    interactionByToolCallOrdinal: new Map(),
+    modelTree: new ConversationTreeState(),
+    agentModelTrees: new Map(),
   };
 }

--- a/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
@@ -367,7 +367,11 @@ function validateCommitEvents(
           const pendingParent = modelEntries.get(
             `${event.ownerAgentId ?? ""}:${entry.parentId}`,
           );
-          if (!parent && !pendingParent) {
+          if (
+            !parent &&
+            !pendingParent &&
+            !(event.ownerAgentId && entry.type === "compaction")
+          ) {
             throw new Error(
               `Unknown model-context parent '${entry.parentId}'.`,
             );
@@ -541,13 +545,20 @@ function applyEvent(
       return;
     }
     case "model_context.entry_appended": {
-      const entry = event.entry as unknown as ConversationTreeEntry;
+      const incoming = event.entry as unknown as ConversationTreeEntry;
       const entries = event.ownerAgentId
         ? (state.agentModelEntries.get(event.ownerAgentId) ?? [])
         : state.modelEntries;
       const indexed = event.ownerAgentId
         ? (state.agentModelEntryById.get(event.ownerAgentId) ?? new Map())
         : state.modelEntryById;
+      const entry =
+        event.ownerAgentId &&
+        incoming.type === "compaction" &&
+        incoming.parentId !== null &&
+        !indexed.has(incoming.parentId)
+          ? { ...incoming, parentId: null }
+          : incoming;
       const previous = indexed.get(entry.id);
       if (!previous) {
         entries.push(entry);

--- a/packages/workbench-server/src/domains/conversations/conversation-lifecycle.service.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-lifecycle.service.ts
@@ -61,7 +61,7 @@ export class ConversationLifecycleService {
     };
     this.state.conversations.set(conversation.id, conversation);
     this.queryCache.upsertConversation(conversation);
-    this.state.entries.set(conversation.id, []);
+    this.state.setConversationEntries(conversation.id, []);
     await this.writeConversation(conversation);
     await this.harnessStorage.createConversation(conversation);
     await this.events.publish("conversation.created", { conversation });
@@ -83,8 +83,7 @@ export class ConversationLifecycleService {
     )) {
       await this.removeAgent(agent.id);
     }
-    this.state.conversations.delete(conversationId);
-    this.state.entries.delete(conversationId);
+    this.state.removeConversation(conversationId);
     this.queryCache.removeConversation(conversationId);
     await this.conversationRepository.remove(conversationId);
     await this.events.publish("conversation.deleted", {
@@ -152,9 +151,8 @@ export class ConversationLifecycleService {
     options: AppendEntryOptions = {},
   ): Promise<ConversationEntry> {
     const conversation = this.getConversation(input.conversationId);
-    const entries = this.state.entries.get(input.conversationId) ?? [];
     const existing = input.id
-      ? entries.find((candidate) => candidate.id === input.id)
+      ? this.state.getConversationEntry(input.conversationId, input.id)
       : undefined;
     if (existing) return existing;
 
@@ -182,10 +180,12 @@ export class ConversationLifecycleService {
       createdAt: input.createdAt ?? new Date().toISOString(),
     };
     entry = await this.entryRepository.append(entry);
-    const committed = entries.find((candidate) => candidate.id === entry.id);
+    const committed = this.state.getConversationEntry(
+      input.conversationId,
+      entry.id,
+    );
     if (committed) return committed;
-    entries.push(entry);
-    this.state.entries.set(input.conversationId, entries);
+    this.state.appendConversationEntry(entry);
     const lastUserMessageAt =
       entry.role === "user" &&
       (!conversation.lastUserMessageAt ||
@@ -235,9 +235,7 @@ export class ConversationLifecycleService {
       modelEntry,
       conversation: updatedConversation,
     });
-    const entries = this.state.entries.get(input.conversationId) ?? [];
-    entries.push(entry);
-    this.state.entries.set(input.conversationId, entries);
+    this.state.appendConversationEntry(entry);
     this.state.conversations.set(input.conversationId, updatedConversation);
     this.queryCache.upsertConversation(updatedConversation);
     return entry;
@@ -252,7 +250,7 @@ export class ConversationLifecycleService {
         );
         this.state.conversations.set(storedConversation.id, storedConversation);
         this.queryCache.upsertConversation(storedConversation);
-        this.state.entries.set(storedConversation.id, entries);
+        this.state.setConversationEntries(storedConversation.id, entries);
       }),
     );
   }

--- a/packages/workbench-server/src/domains/conversations/conversation-service.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-service.ts
@@ -1,5 +1,5 @@
 import type { Message } from "@earendil-works/pi-ai";
-import { buildConversationContext, convertToLlm } from "@nervekit/harness";
+import { convertToLlm } from "@nervekit/harness";
 import type {
   AgentRecord,
   ConversationEntry,
@@ -71,8 +71,7 @@ export class ConversationService {
   ): Promise<Message[]> {
     try {
       const storage = await this.harnessStorage.openStorage(conversation);
-      const branch = await storage.getPathToRoot(await storage.getLeafId());
-      return convertToLlm(buildConversationContext(branch).messages);
+      return convertToLlm((await storage.buildContext()).messages);
     } catch (error) {
       this.harnessStorage.warnMirror(error);
       return this.entryRepository

--- a/packages/workbench-server/src/domains/conversations/conversation-state-materializer.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-state-materializer.ts
@@ -7,7 +7,10 @@ import type {
   ConversationSuspensionRecord,
   ToolCallRecord,
 } from "@nervekit/contracts";
-import type { ConversationTreeEntry } from "@nervekit/harness";
+import {
+  ConversationTreeState,
+  type ConversationTreeEntry,
+} from "@nervekit/harness";
 import { encode } from "../../infrastructure/canonical-store/payload-codecs.js";
 import type {
   ConversationJournalState,
@@ -57,6 +60,17 @@ export function serializeState(
 export function deserializeState(
   state: SerializedConversationState,
 ): ConversationJournalState {
+  const interactions = new Map(state.interactions);
+  const modelTree = new ConversationTreeState(state.modelEntries);
+  modelTree.setLeafId(state.modelLeafId);
+  const agentModelLeafIds = new Map(state.agentModelLeafIds);
+  const agentModelTrees = new Map(
+    state.agentModelEntries.map(([agentId, entries]) => {
+      const tree = new ConversationTreeState(entries);
+      tree.setLeafId(agentModelLeafIds.get(agentId) ?? null);
+      return [agentId, tree] as const;
+    }),
+  );
   return {
     conversationId: state.conversationId,
     revision: state.revision,
@@ -66,17 +80,63 @@ export function deserializeState(
     modelEntries: state.modelEntries,
     modelLeafId: state.modelLeafId,
     agentModelEntries: new Map(state.agentModelEntries),
-    agentModelLeafIds: new Map(state.agentModelLeafIds),
+    agentModelLeafIds,
     toolCalls: new Map(state.toolCalls),
     runProjections: new Map(state.runProjections),
-    interactions: new Map(state.interactions),
+    interactions,
     suspensions: new Map(state.suspensions),
     idempotencyKeys: new Map(state.idempotencyKeys),
     intentConversationRevisions: new Map(state.intentConversationRevisions),
+    entryById: new Map(state.entries.map((entry) => [entry.id, entry])),
+    modelEntryById: new Map(
+      state.modelEntries.map((entry) => [entry.id, entry]),
+    ),
+    agentModelEntryById: new Map(
+      state.agentModelEntries.map(([agentId, entries]) => [
+        agentId,
+        new Map(entries.map((entry) => [entry.id, entry])),
+      ]),
+    ),
+    interactionIdsByToolCall: indexInteractionIds(interactions.values()),
+    interactionByToolCallOrdinal: indexInteractionOrdinals(
+      interactions.values(),
+    ),
+    modelTree,
+    agentModelTrees,
   };
 }
 
-interface MaterializedRecord {
+function interactionOrdinalKey(toolCallId: string, ordinal: number): string {
+  return `${toolCallId}:${ordinal}`;
+}
+
+function indexInteractionIds(
+  interactions: Iterable<ConversationInteractionRecord>,
+): Map<string, Set<string>> {
+  const indexed = new Map<string, Set<string>>();
+  for (const interaction of interactions) {
+    const ids = indexed.get(interaction.toolCallId) ?? new Set<string>();
+    ids.add(interaction.id);
+    indexed.set(interaction.toolCallId, ids);
+  }
+  return indexed;
+}
+
+function indexInteractionOrdinals(
+  interactions: Iterable<ConversationInteractionRecord>,
+): Map<string, ConversationInteractionRecord> {
+  return new Map(
+    [...interactions].map((interaction) => [
+      interactionOrdinalKey(
+        interaction.toolCallId,
+        interaction.interaction.ordinal,
+      ),
+      interaction,
+    ]),
+  );
+}
+
+export interface MaterializedConversationRecord {
   id: string;
   agentId?: string;
   parentId?: string;
@@ -89,6 +149,208 @@ interface MaterializedRecord {
   data: unknown;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ConversationLeafDelta {
+  agentId: string;
+  activeRecordId: string | null;
+  revision: number;
+}
+
+export interface ConversationPersistenceDelta {
+  conversationId: string;
+  previousRevision: number;
+  previousChecksum?: string;
+  commit: ConversationJournalCommit;
+  conversation?: ConversationRecord;
+  records: MaterializedConversationRecord[];
+  leaves: ConversationLeafDelta[];
+}
+
+/** Builds only the relational records named by one journal commit. */
+export function prepareConversationPersistenceDelta(
+  state: ConversationJournalState,
+  commit: ConversationJournalCommit,
+  runProjections: ReadonlyMap<string, ConversationRunProjection> = new Map(),
+): ConversationPersistenceDelta {
+  const transcriptEntries = new Map<string, ConversationEntry>();
+  const modelEntries = new Map<
+    string,
+    { ownerAgentId?: string; entry: ConversationTreeEntry }
+  >();
+  const toolCalls = new Map<string, ToolCallRecord>();
+  const affectedIds = new Set<string>();
+  const leaves = new Map<string, ConversationLeafDelta>();
+  let conversation: ConversationRecord | undefined;
+
+  for (const event of commit.events) {
+    switch (event.kind) {
+      case "conversation.upserted":
+        conversation = event.conversation;
+        break;
+      case "conversation.entry_appended":
+        if (!state.entryById.has(event.entry.id)) {
+          transcriptEntries.set(event.entry.id, event.entry);
+          affectedIds.add(event.entry.id);
+        }
+        break;
+      case "model_context.entry_appended": {
+        const entry = event.entry as unknown as ConversationTreeEntry;
+        modelEntries.set(entry.id, {
+          ownerAgentId: event.ownerAgentId,
+          entry,
+        });
+        affectedIds.add(entry.id);
+        const activeRecordId =
+          entry.type === "leaf" ? entry.targetId : entry.id;
+        const agentId = event.ownerAgentId ?? "agent_conversation";
+        leaves.set(agentId, {
+          agentId,
+          activeRecordId,
+          revision: commit.revision,
+        });
+        break;
+      }
+      case "model_context.leaf_changed": {
+        const agentId = event.ownerAgentId ?? "agent_conversation";
+        leaves.set(agentId, {
+          agentId,
+          activeRecordId: event.entryId,
+          revision: commit.revision,
+        });
+        break;
+      }
+      case "tool_call.upserted":
+        toolCalls.set(event.toolCall.id, event.toolCall);
+        affectedIds.add(event.toolCall.id);
+        break;
+      case "run.transition_committed":
+        affectedIds.add(event.transition.runId);
+        break;
+      case "run.event_delivered":
+        affectedIds.add(event.delivery.runId);
+        break;
+    }
+  }
+
+  const records: MaterializedConversationRecord[] = [];
+  for (const id of affectedIds) {
+    const toolCall = toolCalls.get(id);
+    if (toolCall) {
+      records.push(materializedToolCall(toolCall));
+      continue;
+    }
+    const projection = runProjections.get(id);
+    if (projection) {
+      records.push(materializedRun(projection));
+      continue;
+    }
+    const transcript = transcriptEntries.get(id) ?? state.entryById.get(id);
+    const model = modelEntries.get(id) ?? existingModelEntry(state, id);
+    if (transcript || model) {
+      records.push(materializedEntry(transcript, model));
+    }
+  }
+
+  return {
+    conversationId: state.conversationId,
+    previousRevision: commit.previousRevision,
+    previousChecksum: commit.previousChecksum,
+    commit,
+    conversation,
+    records,
+    leaves: [...leaves.values()],
+  };
+}
+
+function existingModelEntry(
+  state: ConversationJournalState,
+  id: string,
+): { ownerAgentId?: string; entry: ConversationTreeEntry } | undefined {
+  const global = state.modelEntryById.get(id);
+  if (global) return { entry: global };
+  for (const [ownerAgentId, entries] of state.agentModelEntryById) {
+    const entry = entries.get(id);
+    if (entry) return { ownerAgentId, entry };
+  }
+  return undefined;
+}
+
+function materializedEntry(
+  transcript: ConversationEntry | undefined,
+  model: { ownerAgentId?: string; entry: ConversationTreeEntry } | undefined,
+): MaterializedConversationRecord {
+  const modelEntry = model?.entry;
+  const summary = transcript
+    ? transcript.kind === "compaction" || transcript.kind === "branch_summary"
+    : modelEntry?.type === "compaction" ||
+      modelEntry?.type === "branch_summary";
+  const createdAt = transcript?.createdAt ?? modelEntry?.timestamp;
+  if (!createdAt) throw new Error("Conversation record has no timestamp.");
+  const transcriptData = transcript
+    ? summary
+      ? {
+          version: 1,
+          entry: transcript,
+          firstRetainedRecordId: transcript.firstKeptEntryId,
+          tokensBefore: transcript.tokensBefore,
+        }
+      : { version: 1, entry: transcript }
+    : { version: 1 };
+  return {
+    id: transcript?.id ?? modelEntry!.id,
+    agentId: model?.ownerAgentId ?? transcript?.agentId,
+    parentId: modelEntry?.parentId ?? transcript?.parentEntryId,
+    runId: transcript?.runId,
+    kind: summary ? "summary" : "message",
+    status: "completed",
+    revision: 1,
+    data: modelEntry
+      ? {
+          ...transcriptData,
+          modelContext: {
+            visibility: transcript ? "model_and_history" : "model_only",
+            entry: modelEntry,
+          },
+        }
+      : transcriptData,
+    createdAt,
+    updatedAt: modelEntry?.timestamp ?? createdAt,
+  };
+}
+
+function materializedToolCall(
+  toolCall: ToolCallRecord,
+): MaterializedConversationRecord {
+  return {
+    id: toolCall.id,
+    agentId: toolCall.agentId,
+    runId: toolCall.runId,
+    groupId: toolCall.groupId,
+    kind: "tool_call",
+    status: toolCall.phase ?? toolCall.status,
+    revision: toolCall.revision,
+    payloadVersion: 2,
+    data: { version: 2, toolCall },
+    createdAt: toolCall.createdAt,
+    updatedAt: toolCall.updatedAt,
+  };
+}
+
+function materializedRun(
+  projection: ConversationRunProjection,
+): MaterializedConversationRecord {
+  return {
+    id: projection.run.runId,
+    agentId: projection.run.agentId,
+    runId: projection.run.runId,
+    kind: "run",
+    status: projection.run.status,
+    revision: projection.run.revision,
+    data: { version: 1, run: projection.run, state: projection },
+    createdAt: projection.run.createdAt,
+    updatedAt: projection.run.updatedAt,
+  };
 }
 
 export function materializeConversationRecords(
@@ -113,7 +375,7 @@ export function materializeConversationRecords(
     .prepare(`DELETE FROM agent_context_leaves WHERE conversation_id = ?`)
     .run(state.conversationId);
 
-  const records = new Map<string, MaterializedRecord>();
+  const records = new Map<string, MaterializedConversationRecord>();
   for (const entry of state.entries) {
     const summary =
       entry.kind === "compaction" || entry.kind === "branch_summary";
@@ -202,21 +464,8 @@ export function materializeConversationRecords(
   }
 
   const known = new Set(records.keys());
-  const pending = [...records.values()];
-  const ordered: MaterializedRecord[] = [];
-  const inserted = new Set<string>();
-  while (pending.length > 0) {
-    const index = pending.findIndex(
-      (record) =>
-        !record.parentId ||
-        !known.has(record.parentId) ||
-        inserted.has(record.parentId),
-    );
-    const [record] = pending.splice(index < 0 ? 0 : index, 1);
-    if (!record) break;
-    ordered.push(record);
-    inserted.add(record.id);
-  }
+  const ordered = orderMaterializedRecords(records.values());
+  const inserted = new Set(ordered.map((record) => record.id));
 
   const affectedRecordIds = commit ? recordIdsAffectedBy(commit) : undefined;
   const insert = database.prepare(
@@ -305,6 +554,27 @@ export function materializeConversationRecords(
       Math.max(1, state.revision),
     );
   }
+}
+
+function orderMaterializedRecords(
+  records: Iterable<MaterializedConversationRecord>,
+): MaterializedConversationRecord[] {
+  const remaining = new Map([...records].map((record) => [record.id, record]));
+  const ordered: MaterializedConversationRecord[] = [];
+  while (remaining.size > 0) {
+    let advanced = false;
+    for (const [id, record] of remaining) {
+      if (record.parentId && remaining.has(record.parentId)) continue;
+      ordered.push(record);
+      remaining.delete(id);
+      advanced = true;
+    }
+    if (!advanced) {
+      ordered.push(...remaining.values());
+      break;
+    }
+  }
+  return ordered;
 }
 
 function recordIdsAffectedBy(commit: ConversationJournalCommit): Set<string> {

--- a/packages/workbench-server/src/domains/conversations/conversation-state-materializer.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-state-materializer.ts
@@ -64,8 +64,14 @@ export function deserializeState(
   const modelTree = new ConversationTreeState(state.modelEntries);
   modelTree.setLeafId(state.modelLeafId);
   const agentModelLeafIds = new Map(state.agentModelLeafIds);
+  const agentModelEntries = new Map(
+    state.agentModelEntries.map(([agentId, entries]) => [
+      agentId,
+      normalizeDetachedAgentCompactions(entries),
+    ]),
+  );
   const agentModelTrees = new Map(
-    state.agentModelEntries.map(([agentId, entries]) => {
+    [...agentModelEntries].map(([agentId, entries]) => {
       const tree = new ConversationTreeState(entries);
       tree.setLeafId(agentModelLeafIds.get(agentId) ?? null);
       return [agentId, tree] as const;
@@ -79,7 +85,7 @@ export function deserializeState(
     entries: state.entries,
     modelEntries: state.modelEntries,
     modelLeafId: state.modelLeafId,
-    agentModelEntries: new Map(state.agentModelEntries),
+    agentModelEntries,
     agentModelLeafIds,
     toolCalls: new Map(state.toolCalls),
     runProjections: new Map(state.runProjections),
@@ -92,7 +98,7 @@ export function deserializeState(
       state.modelEntries.map((entry) => [entry.id, entry]),
     ),
     agentModelEntryById: new Map(
-      state.agentModelEntries.map(([agentId, entries]) => [
+      [...agentModelEntries].map(([agentId, entries]) => [
         agentId,
         new Map(entries.map((entry) => [entry.id, entry])),
       ]),
@@ -104,6 +110,28 @@ export function deserializeState(
     modelTree,
     agentModelTrees,
   };
+}
+
+/**
+ * Legacy per-agent journals can contain standalone compaction snapshots whose
+ * parent belongs to the shared conversation journal. A compaction is a complete
+ * context boundary, so detaching that unavailable parent preserves its usable
+ * context while keeping all other tree-link failures strict.
+ */
+export function normalizeDetachedAgentCompactions(
+  entries: readonly ConversationTreeEntry[],
+): ConversationTreeEntry[] {
+  const knownIds = new Set<string>();
+  return entries.map((entry) => {
+    const normalized =
+      entry.type === "compaction" &&
+      entry.parentId !== null &&
+      !knownIds.has(entry.parentId)
+        ? { ...entry, parentId: null }
+        : entry;
+    knownIds.add(normalized.id);
+    return normalized;
+  });
 }
 
 function interactionOrdinalKey(toolCallId: string, ordinal: number): string {

--- a/packages/workbench-server/src/domains/conversations/entry.repository.ts
+++ b/packages/workbench-server/src/domains/conversations/entry.repository.ts
@@ -28,9 +28,8 @@ export class EntryRepository {
       ],
     });
     return (
-      (await this.journal.load(entry.conversationId)).entries.find(
-        (candidate) => candidate.id === entry.id,
-      ) ?? entry
+      (await this.journal.load(entry.conversationId)).entryById.get(entry.id) ??
+      entry
     );
   }
 

--- a/packages/workbench-server/src/domains/runs/run-transition.repository.ts
+++ b/packages/workbench-server/src/domains/runs/run-transition.repository.ts
@@ -143,13 +143,16 @@ export class WorkbenchRunUnitOfWork implements RunUnitOfWorkPort {
     const runState = await this.loadFresh(runId);
     if (!runState || runState.run.status !== "waiting") return false;
     const journalState = await this.journal.load(runState.run.conversationId);
-    const interaction = [...journalState.interactions.values()].find(
-      (candidate) =>
-        candidate.runId === runId &&
-        candidate.executionId === runState.run.executionId &&
-        candidate.toolCallId === toolCallId &&
-        candidate.interaction.status !== "cancelled",
-    );
+    const interaction = [
+      ...(journalState.interactionIdsByToolCall.get(toolCallId) ?? []),
+    ]
+      .map((id) => journalState.interactions.get(id))
+      .find(
+        (candidate) =>
+          candidate?.runId === runId &&
+          candidate.executionId === runState.run.executionId &&
+          candidate.interaction.status !== "cancelled",
+      );
     if (!interaction) return false;
     const suspension = journalState.suspensions.get(interaction.suspensionId);
     const toolCall = journalState.toolCalls.get(toolCallId);

--- a/packages/workbench-server/src/domains/tools/interaction-session.service.ts
+++ b/packages/workbench-server/src/domains/tools/interaction-session.service.ts
@@ -20,6 +20,11 @@ export class InteractionSessionService {
     string,
     Set<(question: UserQuestionRecord) => void>
   >();
+  private readonly questions = new Map<
+    string,
+    { toolCallId: string; ordinal: number }
+  >();
+  private questionsHydrated = false;
   constructor(private readonly deps: InteractionSessionDeps) {}
 
   async requestUserQuestion(
@@ -58,6 +63,10 @@ export class InteractionSessionService {
       ],
     });
     const question = projectQuestion(waitingToolCall, ordinal);
+    this.questions.set(question.id, {
+      toolCallId: waitingToolCall.id,
+      ordinal,
+    });
     await this.deps.publishToolCallUpdated(waitingToolCall);
     if (options.durableSuspend) throw new ToolExecutionSuspended();
     return this.userQuestionResult(
@@ -140,6 +149,7 @@ export class InteractionSessionService {
       status: "running",
     });
     const question = projectQuestion(updatedToolCall, found.ordinal);
+    this.questions.delete(questionId);
     await this.deps.publishToolCallUpdated(updatedToolCall);
     this.notify(question);
     return question;
@@ -164,15 +174,39 @@ export class InteractionSessionService {
         question: UserQuestionRecord;
       }
     | undefined {
+    if (!this.questionsHydrated) this.hydrateQuestionIndex();
+    const indexed = this.questions.get(questionId);
+    if (!indexed) return undefined;
+    const toolCall = this.deps.getToolCall(indexed.toolCallId);
+    const interaction = toolCall.interactions[indexed.ordinal];
+    if (!interaction || interaction.kind !== "user_input") {
+      this.questions.delete(questionId);
+      return undefined;
+    }
+    return {
+      toolCall,
+      ordinal: indexed.ordinal,
+      question: projectQuestion(toolCall, indexed.ordinal),
+    };
+  }
+
+  private hydrateQuestionIndex(): void {
+    this.questionsHydrated = true;
     for (const toolCall of this.deps.listToolCalls()) {
       for (const interaction of toolCall.interactions) {
-        if (interaction.kind !== "user_input") continue;
+        if (
+          interaction.kind !== "user_input" ||
+          interaction.status !== "pending"
+        ) {
+          continue;
+        }
         const question = projectQuestion(toolCall, interaction.ordinal);
-        if (question.id === questionId)
-          return { toolCall, ordinal: interaction.ordinal, question };
+        this.questions.set(question.id, {
+          toolCallId: toolCall.id,
+          ordinal: interaction.ordinal,
+        });
       }
     }
-    return undefined;
   }
 
   private wait(

--- a/packages/workbench-server/src/domains/tools/tool-call.repository.ts
+++ b/packages/workbench-server/src/domains/tools/tool-call.repository.ts
@@ -49,6 +49,7 @@ export class ToolCallRepository {
     { record: ToolCallRecord; bytes: number }
   >();
   private terminalCacheBytes = 0;
+  private readonly providerToolCallIds = new Map<string, string>();
   private readonly mutations = new Map<string, Promise<void>>();
   private hydrationStats: ToolCallHydrationStats = {
     rowCount: 0,
@@ -82,6 +83,7 @@ export class ToolCallRepository {
     onRecord?: (record: ToolCallRecord) => void,
   ): Promise<ToolCallRecord[]> {
     this.records.clear();
+    this.providerToolCallIds.clear();
     this.terminalCache.clear();
     this.terminalCacheBytes = 0;
     const ids = new Set<string>();
@@ -101,7 +103,10 @@ export class ToolCallRepository {
             record,
             toToolCallTranscriptRecord(record),
           );
-          if (!isTerminal(record.status)) this.records.set(record.id, record);
+          if (!isTerminal(record.status)) {
+            this.records.set(record.id, record);
+            this.indexProviderIds(record);
+          }
           onRecord?.(record);
         }
       }
@@ -219,14 +224,9 @@ export class ToolCallRepository {
     providerToolCallId: string | undefined,
   ): ToolCallRecord | undefined {
     if (!providerToolCallId) return undefined;
-    return [
-      ...this.records.values(),
-      ...[...this.terminalCache.values()].map((cached) => cached.record),
-    ].find(
-      (toolCall) =>
-        toolCall.providerToolCallId === providerToolCallId ||
-        toolCall.sourceToolCallId === providerToolCallId,
-    );
+    const id = this.providerToolCallIds.get(providerToolCallId);
+    if (!id) return undefined;
+    return this.records.get(id) ?? this.terminalCache.get(id)?.record;
   }
 
   async create(toolCall: ToolCallRecord): Promise<ToolCallRecord> {
@@ -283,8 +283,11 @@ export class ToolCallRepository {
         },
       ];
       const suspensions = new Set<string>();
-      for (const normalized of journalState.interactions.values()) {
-        if (normalized.toolCallId !== next.id) continue;
+      const interactionIds =
+        journalState.interactionIdsByToolCall.get(next.id) ?? new Set<string>();
+      for (const interactionId of interactionIds) {
+        const normalized = journalState.interactions.get(interactionId);
+        if (!normalized) continue;
         const interaction = next.interactions[normalized.interaction.ordinal];
         if (!interaction) continue;
         events.push({
@@ -328,17 +331,20 @@ export class ToolCallRepository {
     for (const [id, record] of [...this.records]) {
       if (!conversationIds.has(record.conversationId)) continue;
       this.records.delete(id);
+      this.unindexProviderIds(record);
       this.queryCache.deleteToolCall(id);
     }
     for (const [id, cached] of [...this.terminalCache]) {
       if (!conversationIds.has(cached.record.conversationId)) continue;
       this.terminalCache.delete(id);
       this.terminalCacheBytes -= cached.bytes;
+      this.unindexProviderIds(cached.record);
       this.queryCache.deleteToolCall(id);
     }
   }
 
   private observe(record: ToolCallRecord): void {
+    this.indexProviderIds(record);
     if (isTerminal(record.status)) {
       this.records.delete(record.id);
       this.cacheTerminal(record, Buffer.byteLength(JSON.stringify(record)));
@@ -356,7 +362,12 @@ export class ToolCallRepository {
   }
 
   private cacheTerminal(record: ToolCallRecord, bytes: number): void {
-    if (!isTerminal(record.status) || bytes > TERMINAL_CACHE_MAX_BYTES) return;
+    if (!isTerminal(record.status)) return;
+    if (bytes > TERMINAL_CACHE_MAX_BYTES) {
+      this.unindexProviderIds(record);
+      return;
+    }
+    this.indexProviderIds(record);
     const existing = this.terminalCache.get(record.id);
     if (existing) {
       this.terminalCache.delete(record.id);
@@ -372,6 +383,21 @@ export class ToolCallRepository {
       const oldest = this.terminalCache.get(oldestId);
       this.terminalCache.delete(oldestId);
       this.terminalCacheBytes -= oldest?.bytes ?? 0;
+      if (oldest) this.unindexProviderIds(oldest.record);
+    }
+  }
+
+  private indexProviderIds(record: ToolCallRecord): void {
+    for (const id of [record.providerToolCallId, record.sourceToolCallId]) {
+      if (id) this.providerToolCallIds.set(id, record.id);
+    }
+  }
+
+  private unindexProviderIds(record: ToolCallRecord): void {
+    for (const id of [record.providerToolCallId, record.sourceToolCallId]) {
+      if (id && this.providerToolCallIds.get(id) === record.id) {
+        this.providerToolCallIds.delete(id);
+      }
     }
   }
 

--- a/packages/workbench-server/src/infrastructure/canonical-store/canonical-database.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/canonical-database.ts
@@ -6,9 +6,17 @@ import type { ConversationJournalCommit } from "@nervekit/contracts";
 import {
   deserializeState,
   materializeConversationRecords,
+  type ConversationPersistenceDelta,
   type SerializedConversationState,
 } from "../../domains/conversations/conversation-state-materializer.js";
 import { permissionRuleSchema } from "@nervekit/contracts";
+import {
+  checkpointConversationStateInTransaction,
+  listConversationJournalIds,
+  persistConversationCommitInTransaction,
+  readConversationCommits,
+  readConversationJournalHead,
+} from "./conversation-journal-database.js";
 import { decode, encode } from "./payload-codecs.js";
 import {
   CANONICAL_SCHEMA_CHECKSUM,
@@ -410,6 +418,53 @@ export class CanonicalDatabase {
       .run(stream);
   }
 
+  listConversationJournalIds(): string[] {
+    return listConversationJournalIds(this.database);
+  }
+
+  readConversationJournal(conversationId: string): {
+    snapshot?: SerializedConversationState;
+    commits: unknown[];
+    head?: { revision: number; checksum?: string };
+  } {
+    this.database.exec("BEGIN");
+    try {
+      const snapshot = this.readDocument<SerializedConversationState>(
+        "conversation_state",
+        conversationId,
+        "state",
+      )?.data;
+      const commits = readConversationCommits(
+        this.database,
+        conversationId,
+        snapshot?.revision ?? 0,
+      );
+      const head = readConversationJournalHead(this.database, conversationId);
+      this.database.exec("COMMIT");
+      return {
+        ...(snapshot ? { snapshot } : {}),
+        commits,
+        ...(head ? { head } : {}),
+      };
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  persistConversationCommit(delta: ConversationPersistenceDelta): void {
+    this.transaction((database) =>
+      persistConversationCommitInTransaction(database, delta, (input) => {
+        appendDurableEventInTransaction(database, input);
+      }),
+    );
+  }
+
+  checkpointConversationState(serialized: SerializedConversationState): void {
+    this.transaction((database) =>
+      checkpointConversationStateInTransaction(database, serialized),
+    );
+  }
   persistConversationState(
     serialized: SerializedConversationState,
     commit?: ConversationJournalCommit,
@@ -485,8 +540,12 @@ export class CanonicalDatabase {
       database
         .prepare(
           `DELETE FROM domain_documents
-         WHERE (namespace = 'conversation_state' AND scope_id = ?)
-            OR (namespace = 'conversation' AND document_id = ?)`,
+           WHERE (namespace IN (
+                    'conversation_state',
+                    'conversation_journal_head',
+                    'conversation_journal_commit'
+                  ) AND scope_id = ?)
+              OR (namespace = 'conversation' AND document_id = ?)`,
         )
         .run(conversationId, conversationId);
     });

--- a/packages/workbench-server/src/infrastructure/canonical-store/canonical-store.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/canonical-store.ts
@@ -237,6 +237,35 @@ export class CanonicalStore {
       true,
     );
   }
+  persistConversationCommit(
+    delta: import("../../domains/conversations/conversation-state-materializer.js").ConversationPersistenceDelta,
+  ) {
+    return this.request<void>(
+      { kind: "persist_conversation_commit", delta },
+      true,
+    );
+  }
+  listConversationJournalIds() {
+    return this.request<string[]>(
+      { kind: "list_conversation_journal_ids" },
+      true,
+    );
+  }
+  readConversationJournal(conversationId: string) {
+    return this.request<{
+      snapshot?: import("../../domains/conversations/conversation-state-materializer.js").SerializedConversationState;
+      commits: unknown[];
+      head?: { revision: number; checksum?: string };
+    }>({ kind: "read_conversation_journal", conversationId }, true);
+  }
+  checkpointConversationState(
+    state: import("../../domains/conversations/conversation-state-materializer.js").SerializedConversationState,
+  ) {
+    return this.request<void>(
+      { kind: "checkpoint_conversation_state", state },
+      true,
+    );
+  }
   deleteConversationState(conversationId: string) {
     return this.request<void>(
       { kind: "delete_conversation_state", conversationId },

--- a/packages/workbench-server/src/infrastructure/canonical-store/conversation-journal-database.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/conversation-journal-database.ts
@@ -1,0 +1,366 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { ConversationRecord } from "@nervekit/contracts";
+import type {
+  ConversationPersistenceDelta,
+  MaterializedConversationRecord,
+  SerializedConversationState,
+} from "../../domains/conversations/conversation-state-materializer.js";
+import { decode, encode } from "./payload-codecs.js";
+
+export interface JournalHead {
+  revision: number;
+  checksum?: string;
+}
+
+interface DurableEventInput {
+  stream: string;
+  intentId: string;
+  eventType: string;
+  data: unknown;
+  occurredAt: string;
+  conversationId?: string;
+}
+
+export function journalRevisionDocumentId(revision: number): string {
+  return String(revision).padStart(20, "0");
+}
+
+export function listConversationJournalIds(database: DatabaseSync): string[] {
+  const rows = database
+    .prepare(
+      `SELECT DISTINCT scope_id FROM domain_documents
+       WHERE namespace IN (
+         'conversation_state',
+         'conversation_journal_head',
+         'conversation_journal_commit'
+       ) ORDER BY scope_id`,
+    )
+    .all() as Array<{ scope_id: string }>;
+  return rows.map((row) => row.scope_id);
+}
+
+export function readConversationCommits(
+  database: DatabaseSync,
+  conversationId: string,
+  afterRevision: number,
+): unknown[] {
+  const rows = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_journal_commit'
+         AND scope_id = ? AND document_id > ?
+       ORDER BY document_id`,
+    )
+    .all(conversationId, journalRevisionDocumentId(afterRevision)) as Array<{
+    data: Uint8Array | string;
+  }>;
+  return rows.map((row) => decode(row.data));
+}
+
+export function readConversationJournalHead(
+  database: DatabaseSync,
+  conversationId: string,
+): JournalHead | undefined {
+  const row = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_journal_head'
+         AND scope_id = ? AND document_id = 'head'`,
+    )
+    .get(conversationId) as { data: Uint8Array | string } | undefined;
+  return row ? (decode(row.data) as JournalHead) : undefined;
+}
+
+export function persistConversationCommitInTransaction(
+  database: DatabaseSync,
+  delta: ConversationPersistenceDelta,
+  appendDurableEvent: (input: DurableEventInput) => void,
+): void {
+  const existingCommit = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_journal_commit'
+         AND scope_id = ? AND document_id = ?`,
+    )
+    .get(
+      delta.conversationId,
+      journalRevisionDocumentId(delta.commit.revision),
+    ) as { data: Uint8Array | string } | undefined;
+  if (existingCommit) {
+    if (
+      JSON.stringify(decode(existingCommit.data)) !==
+      JSON.stringify(delta.commit)
+    ) {
+      throw new Error("Conflicting conversation journal revision.");
+    }
+    return;
+  }
+
+  const currentHead = readConversationJournalHead(
+    database,
+    delta.conversationId,
+  );
+  const baseHead =
+    currentHead ?? readSnapshotHead(database, delta.conversationId);
+  const actualRevision = baseHead?.revision ?? 0;
+  if (
+    actualRevision !== delta.previousRevision ||
+    baseHead?.checksum !== delta.previousChecksum
+  ) {
+    throw new Error(
+      `Conversation journal '${delta.conversationId}' revision conflict: expected ${delta.previousRevision}, current ${actualRevision}.`,
+    );
+  }
+
+  const timestamp = Date.parse(delta.commit.committedAt);
+  database
+    .prepare(
+      `INSERT INTO domain_documents (
+         namespace, scope_id, document_id, revision, payload_version, data,
+         created_at_ms, updated_at_ms
+       ) VALUES ('conversation_journal_commit', ?, ?, ?, 1, ?, ?, ?)`,
+    )
+    .run(
+      delta.conversationId,
+      journalRevisionDocumentId(delta.commit.revision),
+      delta.commit.revision,
+      encode(delta.commit),
+      timestamp,
+      timestamp,
+    );
+  upsertJournalHead(database, {
+    conversationId: delta.conversationId,
+    revision: delta.commit.revision,
+    checksum: delta.commit.checksum,
+    timestamp,
+  });
+  if (delta.conversation) {
+    upsertConversationDocument(database, delta.conversation);
+  }
+  materializeConversationDelta(database, delta);
+  appendDurableEvent({
+    stream: `internal/conv/${delta.conversationId}`,
+    conversationId: delta.conversationId,
+    intentId: delta.commit.commitId,
+    eventType: delta.commit.kind,
+    data: { version: 1, events: delta.commit.events },
+    occurredAt: delta.commit.committedAt,
+  });
+}
+
+export function checkpointConversationStateInTransaction(
+  database: DatabaseSync,
+  serialized: SerializedConversationState,
+): void {
+  const head = readConversationJournalHead(database, serialized.conversationId);
+  if (
+    head &&
+    (head.revision !== serialized.revision ||
+      head.checksum !== serialized.checksum)
+  ) {
+    throw new Error(
+      `Conversation checkpoint '${serialized.conversationId}' revision conflict: expected ${serialized.revision}, current ${head.revision}.`,
+    );
+  }
+  const timestamp = Date.now();
+  database
+    .prepare(
+      `INSERT INTO domain_documents (
+         namespace, scope_id, document_id, revision, payload_version, data,
+         created_at_ms, updated_at_ms
+       ) VALUES ('conversation_state', ?, 'state', ?, 1, ?, ?, ?)
+       ON CONFLICT(namespace, scope_id, document_id) DO UPDATE SET
+         revision = excluded.revision, data = excluded.data,
+         updated_at_ms = excluded.updated_at_ms`,
+    )
+    .run(
+      serialized.conversationId,
+      Math.max(1, serialized.revision),
+      encode(serialized),
+      timestamp,
+      timestamp,
+    );
+  database
+    .prepare(
+      `DELETE FROM domain_documents
+       WHERE namespace = 'conversation_journal_commit'
+         AND scope_id = ? AND CAST(document_id AS INTEGER) <= ?`,
+    )
+    .run(serialized.conversationId, serialized.revision);
+}
+
+function readSnapshotHead(
+  database: DatabaseSync,
+  conversationId: string,
+): JournalHead | undefined {
+  const row = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_state'
+         AND scope_id = ? AND document_id = 'state'`,
+    )
+    .get(conversationId) as { data: Uint8Array | string } | undefined;
+  if (!row) return undefined;
+  const state = decode(row.data) as SerializedConversationState;
+  return { revision: state.revision, checksum: state.checksum };
+}
+
+function upsertJournalHead(
+  database: DatabaseSync,
+  input: {
+    conversationId: string;
+    revision: number;
+    checksum: string;
+    timestamp: number;
+  },
+): void {
+  database
+    .prepare(
+      `INSERT INTO domain_documents (
+         namespace, scope_id, document_id, revision, payload_version, data,
+         created_at_ms, updated_at_ms
+       ) VALUES ('conversation_journal_head', ?, 'head', ?, 1, ?, ?, ?)
+       ON CONFLICT(namespace, scope_id, document_id) DO UPDATE SET
+         revision = excluded.revision, data = excluded.data,
+         updated_at_ms = excluded.updated_at_ms`,
+    )
+    .run(
+      input.conversationId,
+      input.revision,
+      encode({ revision: input.revision, checksum: input.checksum }),
+      input.timestamp,
+      input.timestamp,
+    );
+}
+
+function upsertConversationDocument(
+  database: DatabaseSync,
+  conversation: ConversationRecord,
+): void {
+  database
+    .prepare(
+      `INSERT INTO domain_documents (
+         namespace, scope_id, document_id, revision, payload_version,
+         data, created_at_ms, updated_at_ms
+       ) VALUES ('conversation', 'global', ?, 1, 1, ?, ?, ?)
+       ON CONFLICT(namespace, scope_id, document_id) DO UPDATE SET
+         revision = domain_documents.revision + 1,
+         data = excluded.data, updated_at_ms = excluded.updated_at_ms`,
+    )
+    .run(
+      conversation.id,
+      encode(conversation),
+      Date.parse(conversation.createdAt),
+      Date.parse(conversation.updatedAt),
+    );
+}
+
+function materializeConversationDelta(
+  database: DatabaseSync,
+  delta: ConversationPersistenceDelta,
+): void {
+  const ordered = orderAffectedRecords(delta.records);
+  const existingSequence = database.prepare(
+    `SELECT sequence FROM conversation_records
+     WHERE conversation_id = ? AND id = ?`,
+  );
+  let nextSequence = (
+    database
+      .prepare(
+        `SELECT COALESCE(MAX(sequence), 0) + 1 AS sequence
+         FROM conversation_records WHERE conversation_id = ?`,
+      )
+      .get(delta.conversationId) as { sequence: number }
+  ).sequence;
+  const recordExists = database.prepare(
+    `SELECT 1 AS present FROM conversation_records WHERE id = ?`,
+  );
+  const insert = database.prepare(
+    `INSERT INTO conversation_records (
+       id, conversation_id, agent_id, parent_id, run_id, group_id, sequence,
+       revision, kind, status, payload_version, data, created_at_ms, updated_at_ms
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       conversation_id = excluded.conversation_id,
+       agent_id = excluded.agent_id,
+       parent_id = excluded.parent_id,
+       run_id = excluded.run_id,
+       group_id = excluded.group_id,
+       sequence = excluded.sequence,
+       revision = excluded.revision,
+       kind = excluded.kind,
+       status = excluded.status,
+       payload_version = excluded.payload_version,
+       data = excluded.data,
+       created_at_ms = excluded.created_at_ms,
+       updated_at_ms = excluded.updated_at_ms`,
+  );
+  for (const record of ordered) {
+    const stored = existingSequence.get(delta.conversationId, record.id) as
+      | { sequence: number }
+      | undefined;
+    const sequence = stored?.sequence ?? nextSequence++;
+    const parentId =
+      record.parentId && recordExists.get(record.parentId)
+        ? record.parentId
+        : null;
+    insert.run(
+      record.id,
+      delta.conversationId,
+      record.agentId ?? null,
+      parentId,
+      record.runId ?? null,
+      record.groupId ?? null,
+      sequence,
+      record.revision,
+      record.kind,
+      record.status,
+      record.payloadVersion ?? 1,
+      encode(record.data),
+      Date.parse(record.createdAt),
+      Date.parse(record.updatedAt),
+    );
+  }
+
+  const insertLeaf = database.prepare(
+    `INSERT INTO agent_context_leaves (
+       conversation_id, agent_id, active_record_id, revision
+     ) VALUES (?, ?, ?, ?)
+     ON CONFLICT(conversation_id, agent_id) DO UPDATE SET
+       active_record_id = excluded.active_record_id,
+       revision = excluded.revision`,
+  );
+  for (const leaf of delta.leaves) {
+    const activeRecordId =
+      leaf.activeRecordId && recordExists.get(leaf.activeRecordId)
+        ? leaf.activeRecordId
+        : null;
+    insertLeaf.run(
+      delta.conversationId,
+      leaf.agentId,
+      activeRecordId,
+      Math.max(1, leaf.revision),
+    );
+  }
+}
+
+function orderAffectedRecords(
+  records: readonly MaterializedConversationRecord[],
+): MaterializedConversationRecord[] {
+  const remaining = new Map(records.map((record) => [record.id, record]));
+  const ordered: MaterializedConversationRecord[] = [];
+  while (remaining.size > 0) {
+    let advanced = false;
+    for (const [id, record] of remaining) {
+      if (record.parentId && remaining.has(record.parentId)) continue;
+      ordered.push(record);
+      remaining.delete(id);
+      advanced = true;
+    }
+    if (!advanced) {
+      ordered.push(...remaining.values());
+      break;
+    }
+  }
+  return ordered;
+}

--- a/packages/workbench-server/src/infrastructure/canonical-store/worker-handler.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/worker-handler.ts
@@ -55,6 +55,16 @@ export function executeCanonicalCommand(
     case "persist_conversation_state":
       database.persistConversationState(command.state, command.commit);
       return undefined;
+    case "persist_conversation_commit":
+      database.persistConversationCommit(command.delta);
+      return undefined;
+    case "list_conversation_journal_ids":
+      return database.listConversationJournalIds();
+    case "read_conversation_journal":
+      return database.readConversationJournal(command.conversationId);
+    case "checkpoint_conversation_state":
+      database.checkpointConversationState(command.state);
+      return undefined;
     case "delete_conversation_state":
       database.deleteConversationState(command.conversationId);
       return undefined;

--- a/packages/workbench-server/src/infrastructure/canonical-store/worker-protocol.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/worker-protocol.ts
@@ -1,6 +1,9 @@
 import type { PermissionRule } from "@nervekit/contracts";
 import type { ConversationJournalCommit } from "@nervekit/contracts";
-import type { SerializedConversationState } from "../../domains/conversations/conversation-state-materializer.js";
+import type {
+  ConversationPersistenceDelta,
+  SerializedConversationState,
+} from "../../domains/conversations/conversation-state-materializer.js";
 
 export type CanonicalCommand =
   | { kind: "initialize" }
@@ -63,6 +66,16 @@ export type CanonicalCommand =
       state: SerializedConversationState;
       commit?: ConversationJournalCommit;
     }
+  | {
+      kind: "persist_conversation_commit";
+      delta: ConversationPersistenceDelta;
+    }
+  | { kind: "list_conversation_journal_ids" }
+  | { kind: "read_conversation_journal"; conversationId: string }
+  | {
+      kind: "checkpoint_conversation_state";
+      state: SerializedConversationState;
+    }
   | { kind: "delete_conversation_state"; conversationId: string }
   | { kind: "integrity_check" }
   | { kind: "checkpoint" }
@@ -84,6 +97,8 @@ export type CanonicalWorkerResponse =
 export const READ_COMMANDS = new Set<CanonicalCommand["kind"]>([
   "read_document",
   "list_documents",
+  "list_conversation_journal_ids",
+  "read_conversation_journal",
   "list_permission_rules",
   "durable_event_for_intent",
   "read_durable_events",

--- a/packages/workbench-server/src/infrastructure/home-migration/migrate-legacy-v2-home.ts
+++ b/packages/workbench-server/src/infrastructure/home-migration/migrate-legacy-v2-home.ts
@@ -48,6 +48,8 @@ const IMPORTED_DOCUMENT_NAMESPACES = new Set([
   "agent",
   "conversation",
   "conversation_state",
+  "conversation_journal_head",
+  "conversation_journal_commit",
   "project",
   "scratch_notes",
   "task_definitions",
@@ -387,7 +389,12 @@ function countMigratedState(targetPath: string): HomeMigrationReport["counts"] {
       Number((database.prepare(sql).get() as { count: number }).count);
     return {
       conversations: count(
-        "SELECT COUNT(*) AS count FROM domain_documents WHERE namespace = 'conversation_state'",
+        `SELECT COUNT(DISTINCT scope_id) AS count FROM domain_documents
+         WHERE namespace IN (
+           'conversation_state',
+           'conversation_journal_head',
+           'conversation_journal_commit'
+         )`,
       ),
       conversationRecords: count(
         "SELECT COUNT(*) AS count FROM conversation_records",
@@ -465,7 +472,12 @@ function importCanonicalState(
       Number((target.prepare(sql).get() as { count: number }).count);
     return {
       conversations: count(
-        "SELECT COUNT(*) AS count FROM domain_documents WHERE namespace = 'conversation_state'",
+        `SELECT COUNT(DISTINCT scope_id) AS count FROM domain_documents
+         WHERE namespace IN (
+           'conversation_state',
+           'conversation_journal_head',
+           'conversation_journal_commit'
+         )`,
       ),
       conversationRecords: count(
         "SELECT COUNT(*) AS count FROM conversation_records",
@@ -600,8 +612,12 @@ async function validateMigratedHome(
     const row = database
       .prepare(
         `SELECT
-           (SELECT COUNT(*) FROM domain_documents
-             WHERE namespace = 'conversation_state') AS conversations,
+           (SELECT COUNT(DISTINCT scope_id) FROM domain_documents
+             WHERE namespace IN (
+               'conversation_state',
+               'conversation_journal_head',
+               'conversation_journal_commit'
+             )) AS conversations,
            (SELECT COUNT(*) FROM conversation_records) AS records,
            (SELECT COUNT(*) FROM durable_events) AS events,
            (SELECT COUNT(*) FROM conversation_records

--- a/packages/workbench-server/test/auto-compaction-runner.test.ts
+++ b/packages/workbench-server/test/auto-compaction-runner.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "node:test";
+import { buildConversationContext } from "@nervekit/harness";
 import type { AgentRecord } from "@nervekit/contracts";
 import { AutoCompactionRunner } from "../src/domains/agents/run/auto-compaction-runner.js";
 
@@ -77,6 +78,8 @@ it("uses the selected model context window for threshold compaction", async () =
       openStorage: async () => ({
         getLeafId: async () => "entry_context_usage",
         getPathToRoot: async () => branch,
+        getContextPath: async () => branch,
+        buildContext: async () => buildConversationContext(branch as never),
       }),
     },
     compactionService: {
@@ -93,6 +96,8 @@ it("uses the selected model context window for threshold compaction", async () =
 
   const activeConversation = {
     getBranch: async () => branch,
+    getContextBranch: async () => branch,
+    buildContext: async () => buildConversationContext(branch as never),
   };
   await runner.maybeCompactAtIteration({
     conversationId: selected.conversationId,
@@ -167,6 +172,8 @@ it("compacts projected prompt usage before the first provider iteration", async 
       openStorage: async () => ({
         getLeafId: async () => "entry_preflight_usage",
         getPathToRoot: async () => branch,
+        getContextPath: async () => branch,
+        buildContext: async () => buildConversationContext(branch as never),
       }),
     },
     compactionService: {
@@ -187,7 +194,11 @@ it("compacts projected prompt usage before the first provider iteration", async 
       agentId: agent.id,
       runId: "run_preflight",
       text: "x".repeat(20_000),
-      conversation: { getBranch: async () => branch } as never,
+      conversation: {
+        getBranch: async () => branch,
+        getContextBranch: async () => branch,
+        buildContext: async () => buildConversationContext(branch as never),
+      } as never,
     }),
     true,
   );

--- a/packages/workbench-server/test/conversation-journal.repository.test.ts
+++ b/packages/workbench-server/test/conversation-journal.repository.test.ts
@@ -8,6 +8,7 @@ import type {
   ConversationEntry,
   ConversationRecord,
 } from "@nervekit/contracts";
+import { PerformanceMetricsCollector } from "../src/infrastructure/diagnostics/performance-metrics.js";
 import { ConversationJournalRepository } from "../src/domains/conversations/conversation-journal.repository.js";
 
 const conversationId = "conv_journal_test";
@@ -24,6 +25,32 @@ function conversation(title: string): ConversationRecord {
     updatedAt: now,
   };
 }
+
+test("conversation journal records bounded commit diagnostics", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-metrics-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const metrics = new PerformanceMetricsCollector();
+  const repository = new ConversationJournalRepository(
+    { paths: { home } },
+    metrics,
+  );
+  await repository.commit(conversationId, {
+    kind: "conversation.created",
+    committedAt: now,
+    events: [
+      {
+        kind: "conversation.upserted",
+        conversationId,
+        conversation: conversation("Measured"),
+      },
+    ],
+  });
+  const snapshot = metrics.snapshotAndReset();
+  assert.equal(snapshot.metrics["conversation.commitEvents"]?.count, 1);
+  assert.equal(snapshot.metrics["conversation.commitRecords"]?.count, 0);
+  assert.equal(snapshot.metrics["conversation.commitPrepare"]?.count, 1);
+  assert.equal(snapshot.metrics["conversation.commitPersist"]?.count, 1);
+});
 
 test("conversation journal commits are chained and idempotent", async (t) => {
   const home = await mkdtemp(join(tmpdir(), "nerve-journal-idempotent-"));
@@ -196,6 +223,252 @@ test("hot journal commits update only affected materialized records", async (t) 
   );
 });
 
+test("hot commits append bounded deltas without rewriting the checkpoint", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-delta-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const repository = new ConversationJournalRepository({ paths: { home } });
+  const entry = (id: string): ConversationEntry => ({
+    id,
+    conversationId,
+    role: "user",
+    text: id,
+    createdAt: now,
+  });
+  for (let index = 0; index < 100; index += 1) {
+    await repository.commit(conversationId, {
+      kind: "conversation.entry_appended",
+      events: [
+        {
+          kind: "conversation.entry_appended",
+          conversationId,
+          entry: entry(`entry_history_${index}`),
+        },
+      ],
+    });
+  }
+  await repository.checkpointLoaded();
+  const database = new DatabaseSync(join(home, "data", "nerve.sqlite"));
+  t.after(() => database.close());
+  const checkpointBefore = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_state' AND scope_id = ?`,
+    )
+    .get(conversationId) as { data: Uint8Array };
+
+  await repository.commit(conversationId, {
+    kind: "conversation.entry_appended",
+    events: [
+      {
+        kind: "conversation.entry_appended",
+        conversationId,
+        entry: entry("entry_delta"),
+      },
+    ],
+  });
+
+  const checkpointAfter = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_state' AND scope_id = ?`,
+    )
+    .get(conversationId) as { data: Uint8Array };
+  assert.deepEqual(checkpointAfter.data, checkpointBefore.data);
+  const deltas = database
+    .prepare(
+      `SELECT COUNT(*) AS count FROM domain_documents
+       WHERE namespace = 'conversation_journal_commit' AND scope_id = ?`,
+    )
+    .get(conversationId) as { count: number };
+  assert.equal(deltas.count, 1);
+
+  const loaded = await new ConversationJournalRepository({
+    paths: { home },
+  }).load(conversationId);
+  assert.equal(loaded.entries.length, 101);
+  assert.equal(loaded.entries.at(-1)?.id, "entry_delta");
+});
+
+test("checkpointing atomically folds replay deltas", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-checkpoint-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const repository = new ConversationJournalRepository({ paths: { home } });
+  await repository.commit(conversationId, {
+    kind: "conversation.created",
+    committedAt: now,
+    events: [
+      {
+        kind: "conversation.upserted",
+        conversationId,
+        conversation: conversation("Checkpointed"),
+      },
+    ],
+  });
+  await repository.checkpointLoaded();
+
+  const database = new DatabaseSync(join(home, "data", "nerve.sqlite"));
+  t.after(() => database.close());
+  const deltaCount = database
+    .prepare(
+      `SELECT COUNT(*) AS count FROM domain_documents
+       WHERE namespace = 'conversation_journal_commit' AND scope_id = ?`,
+    )
+    .get(conversationId) as { count: number };
+  assert.equal(deltaCount.count, 0);
+  const loaded = await new ConversationJournalRepository({
+    paths: { home },
+  }).load(conversationId);
+  assert.equal(loaded.revision, 1);
+  assert.equal(loaded.conversation?.title, "Checkpointed");
+});
+
+test("SQLite journal head rejects a stale repository without mutating it", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-head-cas-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const first = new ConversationJournalRepository({ paths: { home } });
+  await first.commit(conversationId, {
+    kind: "conversation.created",
+    committedAt: now,
+    events: [
+      {
+        kind: "conversation.upserted",
+        conversationId,
+        conversation: conversation("Initial"),
+      },
+    ],
+  });
+  const stale = new ConversationJournalRepository({ paths: { home } });
+  const staleState = await stale.load(conversationId);
+  await first.commit(conversationId, {
+    kind: "conversation.upserted",
+    events: [
+      {
+        kind: "conversation.upserted",
+        conversationId,
+        conversation: conversation("Current"),
+      },
+    ],
+  });
+
+  await assert.rejects(
+    stale.commit(conversationId, {
+      kind: "conversation.upserted",
+      events: [
+        {
+          kind: "conversation.upserted",
+          conversationId,
+          conversation: conversation("Stale"),
+        },
+      ],
+    }),
+    /[Cc]onflict/,
+  );
+  assert.equal(staleState.revision, 1);
+  assert.equal(staleState.conversation?.title, "Initial");
+});
+
+test("hot leaf commits update only the affected context owner", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-leaf-delta-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const repository = new ConversationJournalRepository({ paths: { home } });
+  await repository.commit(conversationId, {
+    kind: "model_context.entry_appended",
+    committedAt: now,
+    events: ["agent_a", "agent_b"].map((ownerAgentId) => ({
+      kind: "model_context.entry_appended" as const,
+      conversationId,
+      ownerAgentId,
+      entry: {
+        type: "custom_message",
+        id: `entry_model_${ownerAgentId}`,
+        parentId: null,
+        timestamp: now,
+        customType: "test",
+        content: ownerAgentId,
+        display: true,
+      } as never,
+    })),
+  });
+  await repository.checkpointLoaded();
+  const database = new DatabaseSync(join(home, "data", "nerve.sqlite"));
+  t.after(() => database.close());
+  database.exec(`
+    CREATE TABLE leaf_audit (operation TEXT NOT NULL, agent_id TEXT NOT NULL) STRICT;
+    CREATE TRIGGER audit_leaf_update AFTER UPDATE ON agent_context_leaves
+    BEGIN
+      INSERT INTO leaf_audit VALUES ('update', NEW.agent_id);
+    END;
+    CREATE TRIGGER audit_leaf_delete AFTER DELETE ON agent_context_leaves
+    BEGIN
+      INSERT INTO leaf_audit VALUES ('delete', OLD.agent_id);
+    END;
+  `);
+
+  await repository.commit(conversationId, {
+    kind: "model_context.leaf_changed",
+    events: [
+      {
+        kind: "model_context.leaf_changed",
+        conversationId,
+        ownerAgentId: "agent_a",
+        entryId: "entry_model_agent_a",
+      },
+    ],
+  });
+
+  const audit = database
+    .prepare(`SELECT operation, agent_id FROM leaf_audit ORDER BY rowid`)
+    .all() as Array<{ operation: string; agent_id: string }>;
+  assert.deepEqual(
+    audit.map((row) => ({ ...row })),
+    [{ operation: "update", agent_id: "agent_a" }],
+  );
+});
+
+test("failed delta persistence leaves the resident projection unchanged", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-rollback-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const repository = new ConversationJournalRepository({ paths: { home } });
+  await repository.commit(conversationId, {
+    kind: "conversation.created",
+    committedAt: now,
+    events: [
+      {
+        kind: "conversation.upserted",
+        conversationId,
+        conversation: conversation("Before failure"),
+      },
+    ],
+  });
+  const state = await repository.load(conversationId);
+  const database = new DatabaseSync(join(home, "data", "nerve.sqlite"));
+  t.after(() => database.close());
+  database.exec(`
+    CREATE TRIGGER reject_conversation_delta
+    BEFORE INSERT ON domain_documents
+    WHEN NEW.namespace = 'conversation_journal_commit'
+    BEGIN
+      SELECT RAISE(ABORT, 'forced delta failure');
+    END;
+  `);
+
+  await assert.rejects(
+    repository.commit(conversationId, {
+      kind: "conversation.upserted",
+      events: [
+        {
+          kind: "conversation.upserted",
+          conversationId,
+          conversation: conversation("Must not apply"),
+        },
+      ],
+    }),
+    /forced delta failure/,
+  );
+  assert.equal(state.revision, 1);
+  assert.equal(state.conversation?.title, "Before failure");
+});
+
 test("conversation storage fails closed on malformed canonical state and bad references", async (t) => {
   const home = await mkdtemp(join(tmpdir(), "nerve-journal-corrupt-"));
   t.after(() => rm(home, { recursive: true, force: true }));
@@ -228,7 +501,7 @@ test("conversation storage fails closed on malformed canonical state and bad ref
   database
     .prepare(
       `UPDATE domain_documents SET data = ?
-       WHERE namespace = 'conversation_state' AND scope_id = ?`,
+       WHERE namespace = 'conversation_journal_commit' AND scope_id = ?`,
     )
     .run(Buffer.from("{bad-json"), conversationId);
   database.close();

--- a/packages/workbench-server/test/conversation-journal.repository.test.ts
+++ b/packages/workbench-server/test/conversation-journal.repository.test.ts
@@ -469,6 +469,75 @@ test("failed delta persistence leaves the resident projection unchanged", async 
   assert.equal(state.conversation?.title, "Before failure");
 });
 
+test("legacy detached agent compactions hydrate as context roots", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-journal-agent-compaction-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const repository = new ConversationJournalRepository({ paths: { home } });
+  const detachedCompaction = (id: string, parentId: string) => ({
+    type: "compaction" as const,
+    id,
+    parentId,
+    timestamp: now,
+    summary: `Summary ${id}`,
+    firstKeptEntryId: parentId,
+    tokensBefore: 100,
+  });
+
+  await repository.commit(conversationId, {
+    kind: "migration.agent_model_context",
+    events: [
+      detachedCompaction("entry_compaction_one", "entry_shared_one"),
+      detachedCompaction("entry_compaction_two", "entry_shared_two"),
+    ].map((entry) => ({
+      kind: "model_context.entry_appended" as const,
+      conversationId,
+      ownerAgentId: "agent_legacy",
+      entry: entry as never,
+    })),
+  });
+  await repository.checkpointLoaded();
+
+  const loaded = await new ConversationJournalRepository({
+    paths: { home },
+  }).load(conversationId);
+  assert.deepEqual(
+    loaded.agentModelEntries
+      .get("agent_legacy")
+      ?.map((entry) => entry.parentId),
+    [null, null],
+  );
+  assert.deepEqual(
+    loaded.agentModelTrees
+      .get("agent_legacy")
+      ?.getPathToRoot("entry_compaction_two")
+      .map((entry) => entry.id),
+    ["entry_compaction_two"],
+  );
+
+  await assert.rejects(
+    repository.commit(conversationId, {
+      kind: "model_context.entry_appended",
+      events: [
+        {
+          kind: "model_context.entry_appended",
+          conversationId,
+          ownerAgentId: "agent_legacy",
+          entry: {
+            type: "custom_message",
+            id: "entry_invalid_child",
+            parentId: "entry_missing",
+            timestamp: now,
+            customType: "test",
+            content: "invalid",
+            display: true,
+          } as never,
+        },
+      ],
+    }),
+    /Unknown model-context parent 'entry_missing'/,
+  );
+});
+
 test("conversation storage fails closed on malformed canonical state and bad references", async (t) => {
   const home = await mkdtemp(join(tmpdir(), "nerve-journal-corrupt-"));
   t.after(() => rm(home, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- replace full-state hot conversation writes with atomic checkpoint-plus-delta journal persistence and bounded relational projections
- add resident indexes for conversation trees, entries, interactions, tool calls, questions, and runtime entries
- build provider context from retained post-compaction history and run auto-compaction between agent iterations before the next provider request
- add content-free performance diagnostics, recovery/regression coverage, and storage architecture documentation

## Validation
- `pnpm fix && pnpm check && pnpm test`