### PR TITLE
typography: improve 100% zoom readability with compact scale

### DIFF
--- a/packages/desktop-shell/src/window/loading-pages.ts
+++ b/packages/desktop-shell/src/window/loading-pages.ts
@@ -177,13 +177,11 @@ function shellStyles(): string {
       --radius-lg: 0.625rem;
       --font-sans: "Outfit", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       --font-mono: "Iosevka", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-      --text-xs: 0.75rem;
-      --text-sm: 0.875rem;
+      --text-xs: 0.8125rem;
+      --text-sm: 0.9375rem;
       --text-xl: 1.25rem;
       font-family: var(--font-sans);
       text-rendering: optimizeLegibility;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
       font-kerning: normal;
     }
     @media (prefers-color-scheme: dark) {

--- a/packages/ui-kit/src/styles/base.css
+++ b/packages/ui-kit/src/styles/base.css
@@ -12,8 +12,6 @@
     @apply font-sans;
     font-size: calc(var(--text-base) * var(--nerve-zoom-scale, 1));
     text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
     font-kerning: normal;
   }
 

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -294,6 +294,12 @@
 }
 
 @theme inline {
+  /* Nerve's compact readable scale keeps everyday use comfortable at 100% zoom. */
+  --text-xs: 0.8125rem;
+  --text-xs--line-height: 1.125rem;
+  --text-sm: 0.9375rem;
+  --text-sm--line-height: 1.375rem;
+
   --font-sans:
     "Outfit", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;


### PR DESCRIPTION
## Summary

Raises the compact typography scale so everyday 100% zoom is comfortable without globally enlarging layout.

## Changes

- **`packages/ui-kit/src/styles/theme.css`**: Added Nerve-owned `--text-xs` (13px/18px) and `--text-sm` (15px/22px) tokens to `@theme inline`. These override Tailwind's defaults (12px/16px and 14px/20px) and match the readable sizes users see at 110% zoom.

- **`packages/desktop-shell/src/window/loading-pages.ts`**: Synchronized the standalone pre-daemon shell's mirrored typography tokens.

- **`packages/ui-kit/src/styles/base.css` & `packages/desktop-shell/src/window/loading-pages.ts`**: Temporarily removed `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` to test Linux/Wayland Chromium rendering (these have minimal effect on Linux and may soften text on macOS).

## Rationale

Users reported 100% zoom feels too small (using 110% for comfort). Increasing only the two smallest sizes preserves layout density, pane geometry, icons, and larger typography at true 100% while making logs, tool output, transcripts, and secondary UI text more legible.

## Testing

- `pnpm fix && pnpm check && pnpm test` — all pass
- Visual validation at 100% (light/dark, desktop/compact): no clipping or problematic wrapping
- Computed sizes confirmed: `text-xs` = 13px, `text-sm` = 15px at `--nerve-zoom-scale: 1.0000`