### PR TITLE
feat(tools): agent preview snapshots and complete tool result handling

### DIFF
--- a/packages/contracts/src/domains/tools/records.schema.ts
+++ b/packages/contracts/src/domains/tools/records.schema.ts
@@ -8,6 +8,7 @@ import {
 } from "../permissions/permissions.schema.js";
 import { recordedToolNameSchema, toolNameSchema } from "./tool-name.schema.js";
 import {
+  agentPreviewSnapshotSchema,
   agentProjectionSnapshotSchema,
   validatedToolArtifactSchema,
 } from "./tool-agent-projection.schema.js";
@@ -319,6 +320,7 @@ const toolCallRecordBaseSchema = z.object({
   resultPayload: toolResultPayloadReferenceSchema.optional(),
   validatedArtifacts: z.array(validatedToolArtifactSchema).max(100).optional(),
   agentProjection: agentProjectionSnapshotSchema.optional(),
+  agentPreview: agentPreviewSnapshotSchema.optional(),
   error: z.string().optional(),
   errorDetails: toolCallErrorDetailsSchema.optional(),
   createdAt: z.string().datetime(),
@@ -398,6 +400,7 @@ export const toolCallTranscriptRecordSchema = toolCallRecordBaseSchema
     resultPayload: true,
     validatedArtifacts: true,
     agentProjection: true,
+    agentPreview: true,
     error: true,
     errorDetails: true,
   })

--- a/packages/contracts/src/domains/tools/tool-agent-projection.schema.ts
+++ b/packages/contracts/src/domains/tools/tool-agent-projection.schema.ts
@@ -216,3 +216,27 @@ export const agentProjectionSnapshotSchema = z
 export type AgentProjectionSnapshot = z.infer<
   typeof agentProjectionSnapshotSchema
 >;
+
+export const agentPreviewBlockSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal("image"),
+    mimeType: z.string().min(1),
+    byteLength: z.number().int().nonnegative().safe(),
+    digest: z.string().regex(/^[a-f0-9]{64}$/),
+    resultContentBlockIndex: z.number().int().nonnegative().safe(),
+  }),
+]);
+export type AgentPreviewBlock = z.infer<typeof agentPreviewBlockSchema>;
+
+/** Exact blocks delivered to the model, with large image bytes referenced. */
+export const agentPreviewSnapshotSchema = z
+  .object({
+    version: z.literal(1),
+    blocks: z.array(agentPreviewBlockSchema).max(256),
+  })
+  .strict();
+export type AgentPreviewSnapshot = z.infer<typeof agentPreviewSnapshotSchema>;

--- a/packages/contracts/src/domains/tools/tool.operations.schema.ts
+++ b/packages/contracts/src/domains/tools/tool.operations.schema.ts
@@ -36,18 +36,61 @@ const toolCallGetParamsSchema = z.object({
   runId: z.string().startsWith("run_").optional(),
 });
 
+export const completeToolResultStatusSchema = z.enum([
+  "inline",
+  "payload",
+  "legacy_bounded",
+  "unavailable",
+  "corrupt",
+]);
+export type CompleteToolResultStatus = z.infer<
+  typeof completeToolResultStatusSchema
+>;
+
+export const completeToolResultDescriptorSchema = z.object({
+  status: completeToolResultStatusSchema,
+  hasResult: z.boolean(),
+  byteLength: z.number().int().nonnegative().safe(),
+  mediaType: z.literal("application/json"),
+  encoding: z.literal("utf-8"),
+  digest: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .optional(),
+});
+export type CompleteToolResultDescriptor = z.infer<
+  typeof completeToolResultDescriptorSchema
+>;
+
 export const toolCallDetailsSchema = z.object({
   toolCall: toolCallRecordSchema,
-  completeResult: z.unknown().optional(),
-  completeResultStatus: z.enum([
-    "inline",
-    "payload",
-    "legacy_bounded",
-    "unavailable",
-    "corrupt",
-  ]),
+  completeResult: completeToolResultDescriptorSchema,
 });
 export type ToolCallDetails = z.infer<typeof toolCallDetailsSchema>;
+
+export const toolCallResultReadParamsSchema = z.object({
+  toolCallId: toolCallIdSchema,
+  byteOffset: z.number().int().nonnegative().safe().default(0),
+  byteLimit: z
+    .number()
+    .int()
+    .min(4)
+    .max(64 * 1024)
+    .default(64 * 1024),
+});
+export type ToolCallResultReadParams = z.infer<
+  typeof toolCallResultReadParamsSchema
+>;
+
+export const toolCallResultChunkSchema = z.object({
+  status: completeToolResultStatusSchema,
+  totalBytes: z.number().int().nonnegative().safe(),
+  byteOffset: z.number().int().nonnegative().safe(),
+  nextByteOffset: z.number().int().nonnegative().safe(),
+  text: z.string(),
+  done: z.boolean(),
+});
+export type ToolCallResultChunk = z.infer<typeof toolCallResultChunkSchema>;
 
 export const toolInteractionResolutionSchema = z.discriminatedUnion("kind", [
   z.object({
@@ -142,6 +185,15 @@ export const toolsOperationDefinitions = [
     "none",
     ["workbench_server"] as const,
     "operation.toolCall.get",
+  ),
+  defineOperation(
+    "toolCall.result.read",
+    toolCallResultReadParamsSchema,
+    toolCallResultChunkSchema,
+    "read",
+    "none",
+    ["workbench_server"] as const,
+    "operation.toolCall.result.read",
   ),
   defineOperation(
     "toolCall.interaction.resolve",

--- a/packages/contracts/test/tool-agent-projection.contract.test.ts
+++ b/packages/contracts/test/tool-agent-projection.contract.test.ts
@@ -102,6 +102,10 @@ describe("agent projection contracts", () => {
       attempt: 1,
       interactions: [],
       validatedArtifacts: [artifact],
+      agentPreview: {
+        version: 1,
+        blocks: [{ type: "text", text: "ok" }],
+      },
       agentProjection: {
         version: 1,
         profile: "source_text",
@@ -123,5 +127,6 @@ describe("agent projection contracts", () => {
     const transcript = toolCallTranscriptRecordSchema.parse(record);
     assert.equal("validatedArtifacts" in transcript, false);
     assert.equal("agentProjection" in transcript, false);
+    assert.equal("agentPreview" in transcript, false);
   });
 });

--- a/packages/tools/src/result-projection/agent-preview-snapshot.ts
+++ b/packages/tools/src/result-projection/agent-preview-snapshot.ts
@@ -1,0 +1,47 @@
+import type { AgentPreviewSnapshot } from "@nervekit/contracts";
+import { createHash } from "node:crypto";
+import type { ProjectableBlock } from "./types.js";
+
+/** Persist the exact model projection without duplicating image payload bytes. */
+export function snapshotAgentPreview(
+  blocks: readonly ProjectableBlock[],
+  result: unknown,
+): AgentPreviewSnapshot {
+  const resultBlocks = contentBlocks(result);
+  return {
+    version: 1,
+    blocks: blocks.map((block) => {
+      if (block.type === "text") return { type: "text", text: block.text };
+      const resultContentBlockIndex = resultBlocks.findIndex(
+        (candidate) =>
+          candidate.type === "image" &&
+          candidate.mimeType === block.mimeType &&
+          candidate.data === block.data,
+      );
+      if (resultContentBlockIndex < 0) {
+        throw new Error(
+          "Agent preview image does not reference a tool-result content block.",
+        );
+      }
+      const bytes = Buffer.from(block.data, "base64");
+      return {
+        type: "image",
+        mimeType: block.mimeType,
+        byteLength: bytes.byteLength,
+        digest: createHash("sha256").update(bytes).digest("hex"),
+        resultContentBlockIndex,
+      };
+    }),
+  };
+}
+
+function contentBlocks(result: unknown): Array<Record<string, unknown>> {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return [];
+  const blocks = (result as Record<string, unknown>).contentBlocks;
+  return Array.isArray(blocks)
+    ? blocks.filter(
+        (block): block is Record<string, unknown> =>
+          Boolean(block) && typeof block === "object" && !Array.isArray(block),
+      )
+    : [];
+}

--- a/packages/tools/src/result-projection/index.ts
+++ b/packages/tools/src/result-projection/index.ts
@@ -1,3 +1,4 @@
+export * from "./agent-preview-snapshot.js";
 export * from "./candidates/web.js";
 export * from "./budget-ledger.js";
 export * from "./fallback.js";

--- a/packages/tools/test/agent-preview-snapshot.test.ts
+++ b/packages/tools/test/agent-preview-snapshot.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { snapshotAgentPreview } from "../src/index.js";
+
+describe("agent preview snapshots", () => {
+  it("keeps exact text and references image bytes in the result", () => {
+    const image = Buffer.from("image bytes").toString("base64");
+    const snapshot = snapshotAgentPreview(
+      [
+        { type: "text", text: "exact projection" },
+        { type: "image", data: image, mimeType: "image/png" },
+      ],
+      {
+        contentBlocks: [
+          { type: "text", text: "exact projection" },
+          { type: "image", data: image, mimeType: "image/png" },
+        ],
+      },
+    );
+    assert.deepEqual(snapshot.blocks[0], {
+      type: "text",
+      text: "exact projection",
+    });
+    assert.deepEqual(snapshot.blocks[1], {
+      type: "image",
+      mimeType: "image/png",
+      byteLength: 11,
+      digest:
+        "de7030234493a8bea844dbe1d8676e68a2c1a4b014c721f0425a22b6df66faec",
+      resultContentBlockIndex: 1,
+    });
+  });
+
+  it("rejects projected images that are not retained in the result", () => {
+    assert.throws(
+      () =>
+        snapshotAgentPreview(
+          [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }],
+          {},
+        ),
+      /does not reference/,
+    );
+  });
+});

--- a/packages/website/src/scripts/run-sim.ts
+++ b/packages/website/src/scripts/run-sim.ts
@@ -289,7 +289,7 @@ function toolItem(tool: ToolCall, state: "running" | "done"): HTMLLIElement {
     <div class="run-tool-out"><pre></pre></div>
     <div class="run-tool-foot">
       <span class="run-tool-lines"></span>
-      <span class="run-tool-more">Show 7 more items</span>
+      <span class="run-tool-more">View details</span>
     </div>`;
 
   const name = item.querySelector(".run-tool-name");

--- a/packages/workbench-app/src/lib/app/composition/conversations/conversation-capabilities.svelte.ts
+++ b/packages/workbench-app/src/lib/app/composition/conversations/conversation-capabilities.svelte.ts
@@ -14,7 +14,10 @@ import {
   chatGptAudioAuth,
 } from "$lib/features/audio";
 import { watchSubagentTranscript } from "$lib/features/agents/subagent-transcript-watcher";
-import { getToolCallDetails } from "$lib/features/tools/api/tools.api";
+import {
+  getToolCallDetails,
+  readToolCallResult,
+} from "$lib/features/tools/api/tools.api";
 import {
   confluenceSiteUrl,
   jiraSiteUrl,
@@ -35,6 +38,8 @@ import { completeFiles } from "$lib/application/workspace/workspace-actions.svel
 export function workbenchConversationUiCapabilities(): ConversationUiCapabilities {
   return {
     fetchToolCall: (toolCallId) => getToolCallDetails(toolCallId),
+    readToolCallResult: (toolCallId, byteOffset, byteLimit) =>
+      readToolCallResult(toolCallId, byteOffset, byteLimit),
     watchSubagentTranscript,
     atlassian: { jiraSiteUrl, confluenceSiteUrl },
     voice: {

--- a/packages/workbench-app/src/lib/features/tools/api/tools.api.ts
+++ b/packages/workbench-app/src/lib/features/tools/api/tools.api.ts
@@ -1,11 +1,13 @@
 import {
   toolCallDetailsSchema,
   toolCallRecordSchema,
+  toolCallResultChunkSchema,
   toolDescriptorSchema,
   type AgentRecord,
   type ConversationRecord,
   type ToolCallDetails,
   type ToolCallRecord,
+  type ToolCallResultChunk,
   type ToolDescriptor,
   type ToolInteractionResolution,
 } from "@nervekit/contracts";
@@ -29,6 +31,21 @@ export async function getToolCallDetails(
 ): Promise<ToolCallDetails> {
   const result = (await protocolRequest("toolCall.get", { toolCallId })).result;
   return toolCallDetailsSchema.parse(result);
+}
+
+export async function readToolCallResult(
+  toolCallId: string,
+  byteOffset: number,
+  byteLimit = 64 * 1024,
+): Promise<ToolCallResultChunk> {
+  const result = (
+    await protocolRequest("toolCall.result.read", {
+      toolCallId,
+      byteOffset,
+      byteLimit,
+    })
+  ).result;
+  return toolCallResultChunkSchema.parse(result);
 }
 
 export async function resolveToolInteraction(

--- a/packages/workbench-app/src/lib/presentation/context.svelte.ts
+++ b/packages/workbench-app/src/lib/presentation/context.svelte.ts
@@ -3,6 +3,7 @@ import type {
   EventEnvelope,
   SubagentTranscriptSnapshot,
   ToolCallDetails,
+  ToolCallResultChunk,
 } from "@nervekit/contracts";
 import type { Component } from "svelte";
 import { getContext, setContext } from "svelte";
@@ -87,8 +88,14 @@ export interface AskReplyComposerCapability {
 }
 
 export interface ConversationUiCapabilities {
-  /** Fetch the canonical tool call and its on-demand complete result. */
+  /** Fetch canonical bounded details without loading the complete result. */
   fetchToolCall?: (toolCallId: string) => Promise<ToolCallDetails>;
+  /** Read one bounded UTF-8 chunk of the complete result. */
+  readToolCallResult?: (
+    toolCallId: string,
+    byteOffset: number,
+    byteLimit?: number,
+  ) => Promise<ToolCallResultChunk>;
   /** Observe one bounded, read-only child transcript while its dialog is open. */
   watchSubagentTranscript?: (
     parentAgentId: string,

--- a/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/ToolCallCard.svelte
@@ -39,6 +39,7 @@ import { getConversationUiCapabilities } from "../../context.svelte";
 import { trimTextPreview } from "@nervekit/ui-kit/core/utils/text-preview";
 import { LatestPresentationScheduler } from "@nervekit/ui-kit/core/utils/latest-presentation-scheduler";
 import { toolCardLayoutRevision } from "../views/tool-card-layout";
+import { VIEW_TOOL_DETAILS_LABEL } from "../views/tool-details-label";
 import CardShell from "./tool-call/CardShell.svelte";
 import ToolExecutingSkeleton from "./tool-call/ToolExecutingSkeleton.svelte";
 import ToolArgumentBody from "./tool-call/ToolArgumentBody.svelte";
@@ -353,15 +354,12 @@ const meta = $derived(activityMeta);
 const detailsAction = $derived(
   toolCall && detailsEnabled
     ? {
-        label: presentation?.detailsAction?.label ?? "Details",
+        label: VIEW_TOOL_DETAILS_LABEL,
+        ariaLabel: `View ${toolCall.toolName} details`,
         onClick: openDetails,
       }
     : undefined,
 );
-const bodyDetailsAction = $derived({
-  label: presentation?.detailsAction?.label ?? "Details",
-  onClick: openDetails,
-});
 const errorPreview = $derived(
   toolCall?.error
     ? trimTextPreview(toolCall.error, {
@@ -452,7 +450,6 @@ async function openDetails() {
       toolName={toolCall.toolName}
       presentation={approvalPresentation}
       includeBody={!activitySections.argumentVisible}
-      detailsAction={bodyDetailsAction}
       {onGrantApproval}
       {onDenyApproval}
     />
@@ -469,7 +466,6 @@ async function openDetails() {
       {view}
       expanded={false}
       {onOpenFile}
-      detailsAction={hilInteractive ? bodyDetailsAction : undefined}
       questionRecord={toolQuestion}
       planReview={toolPlanReview}
       {onAnswerUserQuestion}
@@ -488,22 +484,10 @@ async function openDetails() {
   <ToolCallDetailsDialog
     open={detailsOpen}
     previewToolCall={toolCall}
-    toolCall={fullToolCall?.toolCall}
-    completeResult={fullToolCall?.completeResult}
-    completeResultStatus={fullToolCall?.completeResultStatus}
+    details={fullToolCall}
     loading={detailsLoading}
     error={detailsError}
-    {pendingUserQuestion}
-    {pendingPlanReview}
     {onOpenFile}
-    {planReviewModels}
-    {planReviewModelKey}
-    {planReviewThinkingLevel}
-    {onAnswerUserQuestion}
-    {onDismissUserQuestion}
-    {onAcceptPlanReview}
-    {onAcceptPlanReviewInNewChat}
-    {onRejectPlanReview}
     onRetry={openDetails}
     onOpenChange={(open) => (detailsOpen = open)}
   />

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/AgentPreviewSection.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/AgentPreviewSection.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+import type {
+  AgentPreviewSnapshot,
+  AgentProjectionSnapshot,
+} from "@nervekit/contracts";
+import ResultCodeBlock from "./ResultCodeBlock.svelte";
+
+type Props = {
+  preview?: AgentPreviewSnapshot;
+  projection?: AgentProjectionSnapshot;
+  result?: unknown;
+  open?: boolean;
+};
+let { preview, projection, result, open = false }: Props = $props();
+
+function imageData(index: number, mimeType: string): string | undefined {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return;
+  const blocks = (result as Record<string, unknown>).contentBlocks;
+  if (!Array.isArray(blocks)) return;
+  const block = blocks[index];
+  if (!block || typeof block !== "object" || Array.isArray(block)) return;
+  const record = block as Record<string, unknown>;
+  if (record.type !== "image" || record.mimeType !== mimeType) return;
+  return typeof record.data === "string" ? record.data : undefined;
+}
+
+function supportedImageMime(mimeType: string): boolean {
+  return ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(
+    mimeType,
+  );
+}
+</script>
+
+<details class="rounded-sm border bg-muted/20" {open}>
+  <summary
+    class="cursor-pointer px-2.5 py-2 text-xs font-medium text-muted-foreground"
+  >
+    Agent preview
+  </summary>
+  <div class="grid gap-2 border-t p-2">
+    {#if preview}
+      {#if preview.blocks.length === 0}
+        <p class="m-0 text-sm text-muted-foreground">
+          The agent received an empty result.
+        </p>
+      {:else}
+        {#each preview.blocks as block, index (`${block.type}:${index}`)}
+          {#if block.type === "text"}
+            <ResultCodeBlock code={block.text} maxHeight="22rem" trim={false} />
+          {:else}
+            {@const data = imageData(
+              block.resultContentBlockIndex,
+              block.mimeType,
+            )}
+            <div class="grid gap-2 rounded-sm border bg-background p-2">
+              <p class="m-0 text-xs text-muted-foreground">
+                Image supplied to the agent · {block.mimeType} · {block.byteLength.toLocaleString()}
+                bytes
+              </p>
+              {#if data && supportedImageMime(block.mimeType)}
+                <img
+                  class="max-h-80 max-w-full rounded-sm object-contain"
+                  src={`data:${block.mimeType};base64,${data}`}
+                  alt="Image supplied to the agent"
+                />
+              {/if}
+            </div>
+          {/if}
+        {/each}
+      {/if}
+    {:else}
+      <p class="m-0 text-sm text-muted-foreground">
+        The exact agent preview was not retained for this historical tool call.
+      </p>
+    {/if}
+    {#if projection}
+      <div class="flex flex-wrap gap-1.5 text-xs text-muted-foreground">
+        <span class="rounded-sm border px-1.5 py-0.5">{projection.profile}</span
+        >
+        <span class="rounded-sm border px-1.5 py-0.5"
+          >{projection.strategy}</span
+        >
+        <span class="rounded-sm border px-1.5 py-0.5">
+          {projection.displayedTextLines.toLocaleString()} of {projection.originalTextLines.toLocaleString()}
+          lines
+        </span>
+        {#if projection.recovery !== "none"}
+          <span class="rounded-sm border px-1.5 py-0.5"
+            >Recovery: {projection.recovery.replace("_", " ")}</span
+          >
+        {/if}
+      </div>
+    {/if}
+  </div>
+</details>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ArgumentsSection.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ArgumentsSection.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import ResultCodeBlock from "./ResultCodeBlock.svelte";
+
+type Props = { value: unknown; open?: boolean };
+let { value, open = false }: Props = $props();
+let activated = $state(open);
+
+function serialize(value: unknown): { text: string; language?: string } {
+  if (typeof value === "string") return { text: value };
+  try {
+    return {
+      text: JSON.stringify(value, null, 2) ?? String(value),
+      language: "json",
+    };
+  } catch {
+    return { text: String(value) };
+  }
+}
+
+const content = $derived(activated ? serialize(value) : undefined);
+</script>
+
+<details
+  class="rounded-sm border bg-muted/20"
+  {open}
+  ontoggle={(event) => {
+    if (event.currentTarget.open) activated = true;
+  }}
+>
+  <summary
+    class="cursor-pointer px-2.5 py-2 text-xs font-medium text-muted-foreground"
+  >
+    Arguments
+  </summary>
+  {#if activated && content}
+    <div class="border-t p-2">
+      <ResultCodeBlock
+        code={content.text}
+        language={content.language}
+        maxHeight="22rem"
+        trim={false}
+        highlight={content.text.length <= 256 * 1024}
+      />
+    </div>
+  {/if}
+</details>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/CardShell.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/CardShell.svelte
@@ -15,7 +15,11 @@ type Props = {
   arg?: PrimaryArg;
   error?: string;
   meta?: MetaItem[];
-  detailsAction?: { label: string; onClick: () => void };
+  detailsAction?: {
+    label: string;
+    ariaLabel?: string;
+    onClick: () => void;
+  };
   footer?: boolean;
   bodyVisible?: boolean;
   layoutRevision?: string;

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/CompleteResultSection.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/CompleteResultSection.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+import type {
+  CompleteToolResultDescriptor,
+  ToolCallResultChunk,
+} from "@nervekit/contracts";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import ResultCodeBlock from "./ResultCodeBlock.svelte";
+import LargeResultViewer from "./LargeResultViewer.svelte";
+
+type Props = {
+  toolCallId: string;
+  descriptor: CompleteToolResultDescriptor;
+  read?: (
+    toolCallId: string,
+    byteOffset: number,
+    byteLimit?: number,
+  ) => Promise<ToolCallResultChunk>;
+};
+let { toolCallId, descriptor, read }: Props = $props();
+
+const CHUNK_BYTES = 64 * 1024;
+const SMALL_RESULT_BYTES = 256 * 1024;
+let activated = $state(false);
+let loading = $state(false);
+let text = $state("");
+let nextByteOffset = $state(0);
+let done = $state(false);
+let status = $state(descriptor.status);
+let error = $state<string | undefined>(undefined);
+let requestGeneration = 0;
+
+$effect(() => {
+  void toolCallId;
+  void descriptor.digest;
+  requestGeneration += 1;
+  activated = false;
+  loading = false;
+  text = "";
+  nextByteOffset = 0;
+  done = !descriptor.hasResult;
+  status = descriptor.status;
+  error = undefined;
+});
+
+async function loadOne(generation: number): Promise<boolean> {
+  if (
+    !read ||
+    done ||
+    loading ||
+    status === "unavailable" ||
+    status === "corrupt"
+  )
+    return false;
+  loading = true;
+  error = undefined;
+  try {
+    const chunk = await read(toolCallId, nextByteOffset, CHUNK_BYTES);
+    if (generation !== requestGeneration) return false;
+    status = chunk.status;
+    if (chunk.status === "unavailable" || chunk.status === "corrupt") {
+      text = "";
+      done = true;
+      return false;
+    }
+    text += chunk.text;
+    nextByteOffset = chunk.nextByteOffset;
+    done = chunk.done;
+    return true;
+  } catch (caught) {
+    if (generation === requestGeneration) {
+      error = caught instanceof Error ? caught.message : String(caught);
+    }
+    return false;
+  } finally {
+    if (generation === requestGeneration) loading = false;
+  }
+}
+
+async function loadInitial(): Promise<void> {
+  const generation = requestGeneration;
+  do {
+    const loaded = await loadOne(generation);
+    if (!loaded || generation !== requestGeneration) return;
+  } while (!done && descriptor.byteLength <= SMALL_RESULT_BYTES);
+}
+
+async function loadAll(): Promise<void> {
+  if (
+    descriptor.byteLength > 4 * 1024 * 1024 &&
+    !window.confirm(
+      `Load the complete ${Math.ceil(descriptor.byteLength / 1024 / 1024)} MB result?`,
+    )
+  )
+    return;
+  const generation = requestGeneration;
+  while (!done && generation === requestGeneration) {
+    if (!(await loadOne(generation))) return;
+  }
+}
+
+const notice = $derived(
+  status === "unavailable"
+    ? "The complete result payload is unavailable."
+    : status === "corrupt"
+      ? "The complete result payload failed verification and was not displayed."
+      : status === "legacy_bounded"
+        ? "Only the bounded legacy result is available."
+        : undefined,
+);
+const large = $derived(descriptor.byteLength > SMALL_RESULT_BYTES);
+</script>
+
+<details
+  class="rounded-sm border bg-muted/20"
+  ontoggle={(event) => {
+    if (event.currentTarget.open && !activated) {
+      activated = true;
+      void loadInitial();
+    }
+  }}
+>
+  <summary
+    class="cursor-pointer px-2.5 py-2 text-xs font-medium text-muted-foreground"
+  >
+    Complete result
+    <span class="font-normal"
+      >· {descriptor.byteLength.toLocaleString()} bytes</span
+    >
+  </summary>
+  <div class="grid gap-2 border-t p-2">
+    {#if !descriptor.hasResult}
+      <p class="m-0 text-sm text-muted-foreground">
+        This tool call has no result.
+      </p>
+    {:else if notice}
+      <p class="m-0 text-sm text-warning">{notice}</p>
+    {:else if !read}
+      <p class="m-0 text-sm text-muted-foreground">
+        Complete result loading is unavailable here.
+      </p>
+    {:else if error}
+      <p class="m-0 text-sm text-destructive">{error}</p>
+      <Button
+        size="sm"
+        variant="outline"
+        class="w-fit"
+        onclick={() => void loadInitial()}>Retry</Button
+      >
+    {:else if activated && done && text.length === 0}
+      <p class="m-0 text-sm text-muted-foreground">
+        The complete result is empty.
+      </p>
+    {:else if activated && text.length > 0}
+      {#if large}
+        <LargeResultViewer {text} />
+      {:else}
+        <ResultCodeBlock
+          code={text}
+          language="json"
+          maxHeight="22rem"
+          trim={false}
+        />
+      {/if}
+      {#if !done}
+        <div class="flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={loading}
+            onclick={() => void loadOne(requestGeneration)}
+          >
+            {loading ? "Loading…" : "Load next chunk"}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={loading}
+            onclick={() => void loadAll()}>Load all</Button
+          >
+          <span class="text-xs text-muted-foreground">
+            {nextByteOffset.toLocaleString()} of {descriptor.byteLength.toLocaleString()}
+            bytes loaded
+          </span>
+        </div>
+      {/if}
+    {:else if loading}
+      <p class="m-0 text-sm text-muted-foreground">Loading complete result…</p>
+    {/if}
+  </div>
+</details>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/LargeResultViewer.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/LargeResultViewer.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { VirtualScroller } from "@nervekit/ui-kit/components/ui/virtual-list";
+import { segmentRawText } from "./tool-details-state";
+
+type Props = { text: string; maxHeight?: string };
+let { text, maxHeight = "22rem" }: Props = $props();
+const items = $derived(segmentRawText(text));
+</script>
+
+<div style:--result-max-height={maxHeight}>
+  <VirtualScroller
+    {items}
+    getKey={(item) => item.key}
+    estimateSize={() => 18}
+    viewportAriaLabel="Complete tool result"
+    viewportTabIndex={0}
+    viewportClass="max-h-(--result-max-height) rounded-sm border bg-sidebar p-2 font-mono text-xs text-sidebar-foreground"
+  >
+    {#snippet row({ item })}
+      <div class="whitespace-pre-wrap break-all leading-[1.35]">
+        {item.text}
+      </div>
+    {/snippet}
+  </VirtualScroller>
+</div>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolCallDetailsDialog.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolCallDetailsDialog.svelte
@@ -1,46 +1,29 @@
 <script lang="ts">
 import type {
-  AgentRecord,
-  ModelInfo,
-  PlanReviewRecord,
-  PlanReviewResolveOptions,
   ToolCallDetails,
-  ToolCallRecord,
   ToolCallTranscriptRecord,
-  UserQuestionRecord,
 } from "../../../state/tool-types";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
 import DialogShell from "@nervekit/ui-kit/components/ui/dialog-shell";
 import { toolPresentationCached } from "../../views/tool-presentation";
 import { parseToolViewCached } from "../../views/tool-result-view";
 import { toolViewComponent } from "../../views/registry";
-import ResultCodeBlock from "./ResultCodeBlock.svelte";
+import { getConversationUiCapabilities } from "../../../context.svelte";
+import AgentPreviewSection from "./AgentPreviewSection.svelte";
+import ArgumentsSection from "./ArgumentsSection.svelte";
+import CompleteResultSection from "./CompleteResultSection.svelte";
+import {
+  hasFormattedToolView,
+  initialToolDetailSection,
+} from "./tool-details-state";
 
 type Props = {
   open?: boolean;
   previewToolCall: ToolCallTranscriptRecord;
-  toolCall?: ToolCallRecord;
-  completeResult?: unknown;
-  completeResultStatus?: ToolCallDetails["completeResultStatus"];
+  details?: ToolCallDetails;
   loading?: boolean;
   error?: string;
-  pendingUserQuestion?: UserQuestionRecord;
-  pendingPlanReview?: PlanReviewRecord;
-  planReviewModels?: ModelInfo[];
-  planReviewModelKey?: string;
-  planReviewThinkingLevel?: AgentRecord["thinkingLevel"];
   onOpenFile?: (path: string, line?: number) => void;
-  onAnswerUserQuestion?: (questionId: string, answer: string) => void;
-  onDismissUserQuestion?: (questionId: string) => void;
-  onAcceptPlanReview?: (
-    id: string,
-    options?: PlanReviewResolveOptions,
-  ) => void | Promise<void>;
-  onAcceptPlanReviewInNewChat?: (
-    id: string,
-    options?: PlanReviewResolveOptions,
-  ) => void | Promise<void>;
-  onRejectPlanReview?: (id: string) => void | Promise<void>;
   onRetry?: () => void | Promise<void>;
   onOpenChange?: (open: boolean) => void;
 };
@@ -48,84 +31,25 @@ type Props = {
 let {
   open = $bindable(false),
   previewToolCall,
-  toolCall,
-  completeResult,
-  completeResultStatus,
+  details,
   loading = false,
   error,
-  pendingUserQuestion,
-  pendingPlanReview,
-  planReviewModels = [],
-  planReviewModelKey = "",
-  planReviewThinkingLevel = "off",
   onOpenFile,
-  onAnswerUserQuestion,
-  onDismissUserQuestion,
-  onAcceptPlanReview,
-  onAcceptPlanReviewInNewChat,
-  onRejectPlanReview,
   onRetry,
   onOpenChange,
 }: Props = $props();
 
-const displayToolCall = $derived(toolCall ?? previewToolCall);
+const capabilities = getConversationUiCapabilities();
+const displayToolCall = $derived(details?.toolCall ?? previewToolCall);
 const view = $derived(parseToolViewCached(displayToolCall));
 const presentation = $derived(toolPresentationCached(view, displayToolCall));
 const ToolView = $derived(toolViewComponent(view.kind));
-const toolQuestion = $derived(
-  pendingUserQuestion?.toolCallId === displayToolCall.id
-    ? pendingUserQuestion
-    : undefined,
+const hasStoredPreview = $derived(displayToolCall.resultPreview !== undefined);
+const formatted = $derived(
+  Boolean(details && hasFormattedToolView(view, hasStoredPreview)),
 );
-const toolPlanReview = $derived(
-  pendingPlanReview?.toolCallId === displayToolCall.id
-    ? pendingPlanReview
-    : undefined,
-);
-type PayloadPreview = { text: string; language?: string };
-
-function payloadValue(
-  record: ToolCallRecord | ToolCallTranscriptRecord,
-  fullKey: "args" | "result",
-  previewKey: "argsPreview" | "resultPreview",
-): unknown {
-  const payloads = record as Record<string, unknown>;
-  return payloads[fullKey] ?? payloads[previewKey];
-}
-
-function payloadPreview(value: unknown): PayloadPreview | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value === "string")
-    return value.length > 0 ? { text: value } : undefined;
-  try {
-    const json = JSON.stringify(value, null, 2);
-    if (json !== undefined) return { text: json, language: "json" };
-  } catch {
-    // Fall through to the string representation below.
-  }
-  return { text: String(value) };
-}
-
-const argsPreview = $derived(
-  payloadPreview(payloadValue(displayToolCall, "args", "argsPreview")),
-);
-const resultPreview = $derived(
-  displayToolCall.toolName === "explain_image"
-    ? undefined
-    : payloadPreview(
-        completeResultStatus && completeResult !== undefined
-          ? completeResult
-          : payloadValue(displayToolCall, "result", "resultPreview"),
-      ),
-);
-const completeResultNotice = $derived(
-  completeResultStatus === "unavailable"
-    ? "The complete result payload is unavailable. Showing the stored preview."
-    : completeResultStatus === "corrupt"
-      ? "The complete result payload failed verification. Showing the stored preview."
-      : completeResultStatus === "legacy_bounded"
-        ? "Only the bounded legacy result is available."
-        : undefined,
+const initialSection = $derived(
+  initialToolDetailSection(view, hasStoredPreview),
 );
 const description = $derived(
   [displayToolCall.status, presentation.primaryArg?.text]
@@ -141,13 +65,13 @@ const description = $derived(
   size="wide"
   {onOpenChange}
 >
-  {#if loading && !toolCall}
+  {#if loading && !details}
     <div
       class="flex min-h-40 items-center justify-center text-sm text-muted-foreground"
     >
-      Loading full tool call…
+      Loading tool details…
     </div>
-  {:else if error && !toolCall}
+  {:else if error && !details}
     <div class="grid gap-3">
       <p class="m-0 text-sm text-destructive">{error}</p>
       <Button
@@ -157,11 +81,11 @@ const description = $derived(
         onclick={() => void onRetry?.()}>Retry</Button
       >
     </div>
-  {:else}
+  {:else if details}
     <div class="grid gap-3">
       {#if presentation.meta.length > 0}
         <div class="flex flex-wrap gap-1.5">
-          {#each presentation.meta as item, i (i)}
+          {#each presentation.meta as item, index (index)}
             <span
               class="rounded-sm border bg-muted/30 px-1.5 py-0.5 text-xs text-muted-foreground"
               class:font-mono={item.mono}>{item.text}</span
@@ -169,63 +93,48 @@ const description = $derived(
           {/each}
         </div>
       {/if}
-      <ToolView
-        toolCall={displayToolCall}
-        {view}
-        expanded={true}
-        {onOpenFile}
-        questionRecord={toolQuestion}
-        planReview={toolPlanReview}
-        {onAnswerUserQuestion}
-        {planReviewModels}
-        {planReviewModelKey}
-        {planReviewThinkingLevel}
-        {onDismissUserQuestion}
-        {onAcceptPlanReview}
-        {onAcceptPlanReviewInNewChat}
-        {onRejectPlanReview}
+
+      {#if displayToolCall.error}
+        <p
+          class="m-0 rounded-sm border border-destructive/30 bg-destructive/10 p-2 text-sm text-destructive"
+        >
+          {displayToolCall.error}
+        </p>
+      {/if}
+
+      {#if formatted}
+        <details
+          class="rounded-sm border bg-muted/20"
+          open={initialSection === "formatted"}
+        >
+          <summary
+            class="cursor-pointer px-2.5 py-2 text-xs font-medium text-muted-foreground"
+          >
+            Formatted view
+          </summary>
+          <div class="border-t p-2">
+            <ToolView
+              toolCall={details.toolCall}
+              {view}
+              expanded={true}
+              {onOpenFile}
+            />
+          </div>
+        </details>
+      {/if}
+
+      <AgentPreviewSection
+        preview={details.toolCall.agentPreview}
+        projection={details.toolCall.agentProjection}
+        result={details.toolCall.result}
+        open={initialSection === "agent-preview"}
       />
-      {#if completeResultNotice}
-        <p class="m-0 text-sm text-warning">{completeResultNotice}</p>
-      {/if}
-      {#if argsPreview || resultPreview}
-        <div class="grid gap-2">
-          {#if argsPreview}
-            <details class="rounded-sm border bg-muted/20">
-              <summary
-                class="cursor-pointer px-2.5 py-2 text-xs font-medium text-muted-foreground"
-              >
-                Arguments
-              </summary>
-              <div class="border-t p-2">
-                <ResultCodeBlock
-                  code={argsPreview.text}
-                  language={argsPreview.language}
-                  maxHeight="22rem"
-                  trim={false}
-                />
-              </div>
-            </details>
-          {/if}
-          {#if resultPreview}
-            <details class="rounded-sm border bg-muted/20">
-              <summary
-                class="cursor-pointer px-2.5 py-2 text-xs font-medium text-muted-foreground"
-              >
-                Result
-              </summary>
-              <div class="border-t p-2">
-                <ResultCodeBlock
-                  code={resultPreview.text}
-                  language={resultPreview.language}
-                  maxHeight="22rem"
-                  trim={false}
-                />
-              </div>
-            </details>
-          {/if}
-        </div>
-      {/if}
+      <ArgumentsSection value={details.toolCall.args} />
+      <CompleteResultSection
+        toolCallId={details.toolCall.id}
+        descriptor={details.completeResult}
+        read={capabilities.readToolCallResult}
+      />
     </div>
   {/if}
 </DialogShell>

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolFooter.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/ToolFooter.svelte
@@ -4,7 +4,11 @@ import type { MetaItem } from "../../views/tool-presentation";
 
 type Props = {
   meta?: MetaItem[];
-  detailsAction?: { label: string; onClick: () => void };
+  detailsAction?: {
+    label: string;
+    ariaLabel?: string;
+    onClick: () => void;
+  };
   onOpenFile?: (path: string, line?: number) => void;
   /** Right-aligned action buttons (e.g. HIL accept/reject, reply/dismiss). */
   actions?: Snippet;
@@ -43,7 +47,12 @@ const show = $derived(meta.length > 0 || Boolean(detailsAction) || hasActions);
       </div>
     {/if}
     {#if detailsAction}
-      <button class="more" type="button" onclick={detailsAction.onClick}>
+      <button
+        class="more"
+        type="button"
+        aria-label={detailsAction.ariaLabel}
+        onclick={detailsAction.onClick}
+      >
         {detailsAction.label}
       </button>
     {/if}

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/tool-details-state.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/tool-details-state.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ToolView } from "../../views/tool-result-view.js";
+import {
+  initialToolDetailSection,
+  segmentRawText,
+} from "./tool-details-state.js";
+
+describe("tool details state", () => {
+  it("prioritizes formatted views and otherwise the agent preview", () => {
+    const bash = { kind: "bash", output: "done" } as ToolView;
+    const jira = { kind: "jira" } as ToolView;
+    const generic = { kind: "generic" } as ToolView;
+    assert.equal(initialToolDetailSection(bash), "formatted");
+    assert.equal(initialToolDetailSection(jira, true), "formatted");
+    assert.equal(initialToolDetailSection(generic), "agent-preview");
+  });
+
+  it("segments giant raw-result lines into bounded virtual rows", () => {
+    const rows = segmentRawText(`${"x".repeat(4_500)}\nlast`, 2_000);
+    assert.deepEqual(
+      rows.map((row) => row.text.length),
+      [2_000, 2_000, 500, 4],
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/tool-details-state.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/tool-details-state.ts
@@ -1,0 +1,99 @@
+import type { ToolView } from "../../views/tool-result-view";
+
+export type ToolDetailSection =
+  | "formatted"
+  | "agent-preview"
+  | "arguments"
+  | "complete-result";
+
+export function hasFormattedToolView(
+  view: ToolView,
+  hasStoredPreview = false,
+): boolean {
+  switch (view.kind) {
+    case "read":
+      return Boolean(view.image || view.content?.length);
+    case "bash":
+      return Boolean(view.output.length || view.command);
+    case "python":
+      return Boolean(view.output.length || view.code);
+    case "edit":
+      return Boolean(view.diff);
+    case "write":
+      return Boolean(view.content?.length);
+    case "grep":
+      return view.matchCount > 0;
+    case "find":
+      return view.count > 0;
+    case "ls":
+      return view.total > 0;
+    case "todos":
+      return view.items.length > 0;
+    case "task_action":
+      return Boolean(
+        view.task ||
+        view.tasks?.length ||
+        view.otherActiveTasks?.length ||
+        view.liveLog?.length,
+      );
+    case "task_status":
+      return view.tasks.length > 0;
+    case "task_logs":
+      return view.events.length > 0;
+    case "explore":
+      return Boolean(
+        view.reports.length || view.liveUpdates.length || view.liveLog?.length,
+      );
+    case "web_search":
+      return Boolean(view.answer || view.results.length);
+    case "web_fetch":
+      return Boolean(view.content?.length);
+    case "explain_image":
+      return Boolean(
+        view.explanation?.length ||
+        view.thinking?.length ||
+        view.liveExplanation?.length,
+      );
+    case "jira":
+    case "confluence":
+      return hasStoredPreview;
+    case "ask_user":
+    case "plan_mode":
+      return true;
+    case "generic":
+      return false;
+  }
+}
+
+export function initialToolDetailSection(
+  view: ToolView,
+  hasStoredPreview = false,
+): ToolDetailSection {
+  return hasFormattedToolView(view, hasStoredPreview)
+    ? "formatted"
+    : "agent-preview";
+}
+
+export type RawTextSegment = { key: number; text: string };
+
+export function segmentRawText(
+  text: string,
+  maxChars = 2_000,
+): RawTextSegment[] {
+  if (text.length === 0) return [];
+  const segments: RawTextSegment[] = [];
+  let key = 0;
+  for (const line of text.split("\n")) {
+    if (line.length === 0) {
+      segments.push({ key: key++, text: " " });
+      continue;
+    }
+    for (let offset = 0; offset < line.length; offset += maxChars) {
+      segments.push({
+        key: key++,
+        text: line.slice(offset, offset + maxChars),
+      });
+    }
+  }
+  return segments;
+}

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-details-label.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-details-label.ts
@@ -1,0 +1,1 @@
+export const VIEW_TOOL_DETAILS_LABEL = "View details";

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation-helpers.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-presentation-helpers.ts
@@ -1,4 +1,5 @@
 import type { StatusTone } from "@nervekit/ui-kit/components/ui/status-dot";
+import { VIEW_TOOL_DETAILS_LABEL } from "./tool-details-label";
 import type { DetailsActionInfo, MetaTone } from "./tool-presentation-types";
 import type { ToolCallDisplayRecord } from "./tool-result-parser";
 import { countLogicalLines } from "./tool-view-helpers";
@@ -51,13 +52,11 @@ export function detailsActionFromHidden(
   direction: "head" | "tail" | "mixed" = "head",
 ): DetailsActionInfo | undefined {
   if (!hidden || hidden <= 0) return undefined;
-  const verb = direction === "tail" ? "earlier" : "more";
+  void noun;
+  void direction;
   return {
     hidden,
-    label:
-      direction === "mixed"
-        ? `Show complete tool call (${hidden} more ${noun})`
-        : `Show ${hidden} ${verb} ${noun}`,
+    label: VIEW_TOOL_DETAILS_LABEL,
   };
 }
 

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.atlassian.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.atlassian.test.ts
@@ -35,8 +35,7 @@ describe("normalized Atlassian tool views", () => {
 
     const presentation = toolPresentation(view, call);
     assert.equal(presentation.primaryArg?.text, "project NER · scrum");
-    assert.equal(presentation.detailsAction?.label, "Show 2 more boards");
-    assert.equal(presentation.detailsAction?.label.includes("lines"), false);
+    assert.equal(presentation.detailsAction?.label, "View details");
 
     const summary = jiraToolSummaryBody(call, view);
     assert.match(summary, /Returned: 5 boards/);

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-helpers.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-helpers.ts
@@ -12,7 +12,7 @@ import { trimTextPreview } from "@nervekit/ui-kit/core/utils/text-preview";
 import type { ConversationLiveToolOutputSnapshot } from "@nervekit/contracts";
 import type { GrepMatchView, GroupedMatches } from "./tool-view-types";
 
-/** Lines/items shown before the footer "Show more" toggle expands a body. */
+/** Lines/items shown in the bounded transcript preview. */
 export const COLLAPSED_LINES = 6;
 /** Rich Atlassian result rows shown in a collapsed body. */
 export const ATLASSIAN_COLLAPSED_ITEMS = 3;

--- a/packages/workbench-server/src/domains/tools/tool-call.repository.ts
+++ b/packages/workbench-server/src/domains/tools/tool-call.repository.ts
@@ -3,8 +3,10 @@ import {
   type ConversationJournalEvent,
   type ToolCallDetails,
   type ToolCallRecord,
+  type ToolCallResultChunk,
   type ToolCallTranscriptRecord,
 } from "@nervekit/contracts";
+import { createHash } from "node:crypto";
 import type {
   RuntimeQueryCache,
   ToolCallPreviewQuery,
@@ -13,9 +15,11 @@ import { storagePaths } from "../../infrastructure/storage/paths.js";
 import { ConversationJournalRepository } from "../conversations/conversation-journal.repository.js";
 import { toToolCallTranscriptRecord } from "./tool-call-transcript-preview.js";
 import {
+  serializeToolResult,
   ToolResultPayloadCorruptError,
   type ToolResultPayloadStore,
   ToolResultPayloadUnavailableError,
+  utf8TextRange,
 } from "./tool-result-payload-store.js";
 
 const TERMINAL_CACHE_MAX_BYTES = 16 * 1024 * 1024;
@@ -190,31 +194,103 @@ export class ToolCallRepository {
   async getDetails(toolCallId: string): Promise<ToolCallDetails> {
     const toolCall = await this.getCanonical(toolCallId);
     if (!toolCall.resultPayload) {
+      const serialized = serializedInlineResult(toolCall.result);
       return {
         toolCall,
-        completeResult: toolCall.result,
-        completeResultStatus: "inline",
+        completeResult: {
+          status: "inline",
+          hasResult: toolCall.result !== undefined,
+          byteLength: serialized.byteLength,
+          mediaType: "application/json",
+          encoding: "utf-8",
+          digest: createHash("sha256").update(serialized).digest("hex"),
+        },
+      };
+    }
+    const reference = toolCall.resultPayload;
+    return {
+      toolCall,
+      completeResult: {
+        status: this.payloads
+          ? reference.completeness === "legacy_bounded"
+            ? "legacy_bounded"
+            : "payload"
+          : "unavailable",
+        hasResult: true,
+        byteLength: reference.byteLength,
+        mediaType: reference.mediaType,
+        encoding: reference.encoding,
+        digest: reference.digest,
+      },
+    };
+  }
+
+  async readResult(
+    toolCallId: string,
+    byteOffset: number,
+    byteLimit: number,
+  ): Promise<ToolCallResultChunk> {
+    const toolCall = await this.getCanonical(toolCallId);
+    const reference = toolCall.resultPayload;
+    if (!reference) {
+      const serialized = serializedInlineResult(toolCall.result);
+      const offset = Math.min(byteOffset, serialized.byteLength);
+      const bounded = utf8TextRange(
+        serialized.subarray(
+          offset,
+          Math.min(serialized.byteLength, offset + byteLimit + 6),
+        ),
+        byteLimit,
+      );
+      const actualOffset = offset + bounded.start;
+      const nextByteOffset = offset + bounded.end;
+      return {
+        status: "inline",
+        totalBytes: serialized.byteLength,
+        byteOffset: actualOffset,
+        nextByteOffset,
+        text: bounded.text,
+        done: nextByteOffset >= serialized.byteLength,
       };
     }
     if (!this.payloads) {
-      return { toolCall, completeResultStatus: "unavailable" };
+      return unavailableResultChunk(
+        "unavailable",
+        reference.byteLength,
+        byteOffset,
+      );
     }
     try {
-      const completeResult = await this.payloads.read(toolCall.resultPayload);
+      const range = await this.payloads.readTextRange(
+        reference,
+        byteOffset,
+        byteLimit,
+      );
       return {
-        toolCall,
-        completeResult,
-        completeResultStatus:
-          toolCall.resultPayload.completeness === "legacy_bounded"
+        status:
+          reference.completeness === "legacy_bounded"
             ? "legacy_bounded"
             : "payload",
+        totalBytes: range.totalBytes,
+        byteOffset: range.byteOffset,
+        nextByteOffset: range.nextByteOffset,
+        text: range.text,
+        done: range.nextByteOffset >= range.totalBytes,
       };
     } catch (error) {
       if (error instanceof ToolResultPayloadCorruptError) {
-        return { toolCall, completeResultStatus: "corrupt" };
+        return unavailableResultChunk(
+          "corrupt",
+          reference.byteLength,
+          byteOffset,
+        );
       }
       if (error instanceof ToolResultPayloadUnavailableError) {
-        return { toolCall, completeResultStatus: "unavailable" };
+        return unavailableResultChunk(
+          "unavailable",
+          reference.byteLength,
+          byteOffset,
+        );
       }
       throw error;
     }
@@ -447,6 +523,29 @@ function assertImmutableIdentity(
       throw new Error(`Tool-call identity field '${key}' is immutable.`);
     }
   }
+}
+
+function serializedInlineResult(result: unknown): Buffer {
+  return Buffer.from(
+    result === undefined ? "" : serializeToolResult(result),
+    "utf8",
+  );
+}
+
+function unavailableResultChunk(
+  status: "unavailable" | "corrupt",
+  totalBytes: number,
+  byteOffset: number,
+): ToolCallResultChunk {
+  const offset = Math.min(byteOffset, totalBytes);
+  return {
+    status,
+    totalBytes,
+    byteOffset: offset,
+    nextByteOffset: offset,
+    text: "",
+    done: true,
+  };
 }
 
 function isTerminal(status: ToolCallRecord["status"]): boolean {

--- a/packages/workbench-server/src/domains/tools/tool-executor.service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-executor.service.ts
@@ -144,6 +144,7 @@ export class ToolExecutorService {
                     : {}),
                   validatedArtifacts: failure.validatedArtifacts,
                   agentProjection: failure.agentProjection,
+                  agentPreview: failure.agentPreview,
                 };
               } catch {
                 return base;
@@ -169,6 +170,7 @@ export class ToolExecutorService {
             resultPayload: prepared.resultPayload,
             validatedArtifacts: prepared.validatedArtifacts,
             agentProjection: prepared.agentProjection,
+            agentPreview: prepared.agentPreview,
             error: undefined,
             errorDetails: undefined,
           };

--- a/packages/workbench-server/src/domains/tools/tool-result-payload-store.ts
+++ b/packages/workbench-server/src/domains/tools/tool-result-payload-store.ts
@@ -3,7 +3,16 @@ import type {
   ValidatedToolArtifact,
 } from "@nervekit/contracts";
 import { createHash } from "node:crypto";
-import { chmod, lstat, mkdir, readFile, readdir, rm } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rm,
+} from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
 import { atomicWriteFile } from "../../infrastructure/storage/file-mutations.js";
 import { storagePaths } from "../../infrastructure/storage/paths.js";
@@ -26,6 +35,10 @@ export class ToolResultPayloadCorruptError extends Error {
 
 export class ToolResultPayloadStore {
   readonly root: string;
+  private readonly verified = new Map<
+    string,
+    { byteLength: number; mtimeMs: number }
+  >();
 
   constructor(readonly home: string) {
     this.root = storagePaths(home).payloadsPath;
@@ -141,7 +154,44 @@ export class ToolResultPayloadStore {
   }
 
   async verify(reference: ToolResultPayloadReference): Promise<void> {
-    await this.readVerifiedBytes(reference);
+    await this.verifyStreaming(reference);
+  }
+
+  async readTextRange(
+    reference: ToolResultPayloadReference,
+    byteOffset: number,
+    byteLimit: number,
+  ): Promise<{
+    text: string;
+    byteOffset: number;
+    nextByteOffset: number;
+    totalBytes: number;
+  }> {
+    await this.verifyStreaming(reference);
+    const totalBytes = reference.byteLength;
+    if (byteOffset >= totalBytes) {
+      return {
+        text: "",
+        byteOffset: totalBytes,
+        nextByteOffset: totalBytes,
+        totalBytes,
+      };
+    }
+    const handle = await open(this.path(reference), "r");
+    try {
+      const requested = Math.min(byteLimit + 6, totalBytes - byteOffset);
+      const buffer = Buffer.allocUnsafe(requested);
+      const { bytesRead } = await handle.read(buffer, 0, requested, byteOffset);
+      const bounded = utf8TextRange(buffer.subarray(0, bytesRead), byteLimit);
+      return {
+        text: bounded.text,
+        byteOffset: byteOffset + bounded.start,
+        nextByteOffset: byteOffset + bounded.end,
+        totalBytes,
+      };
+    } finally {
+      await handle.close();
+    }
   }
 
   async removeConversation(conversationId: string): Promise<void> {
@@ -259,9 +309,7 @@ export class ToolResultPayloadStore {
     }
   }
 
-  private async readVerifiedBytes(
-    reference: ToolResultPayloadReference,
-  ): Promise<Buffer> {
+  private async payloadInfo(reference: ToolResultPayloadReference) {
     const path = this.path(reference);
     await this.assertDirectoryChain(
       reference.conversationId,
@@ -281,18 +329,79 @@ export class ToolResultPayloadStore {
         `Tool-result payload '${reference.toolCallId}' is not a regular file.`,
       );
     }
-    const bytes = await readFile(path);
-    const digest = createHash("sha256").update(bytes).digest("hex");
+    return { path, info };
+  }
+
+  private async verifyStreaming(
+    reference: ToolResultPayloadReference,
+  ): Promise<void> {
+    const { path, info } = await this.payloadInfo(reference);
+    const cached = this.verified.get(reference.digest);
     if (
-      bytes.byteLength !== reference.byteLength ||
-      digest !== reference.digest
+      cached?.byteLength === info.size &&
+      cached.mtimeMs === info.mtimeMs &&
+      info.size === reference.byteLength
+    ) {
+      return;
+    }
+    const hash = createHash("sha256");
+    let byteLength = 0;
+    try {
+      for await (const chunk of createReadStream(path)) {
+        const bytes = chunk as Buffer;
+        byteLength += bytes.byteLength;
+        hash.update(bytes);
+      }
+    } catch (cause) {
+      throw new ToolResultPayloadUnavailableError(
+        `Tool-result payload '${reference.toolCallId}' is unavailable.`,
+        { cause },
+      );
+    }
+    if (
+      byteLength !== reference.byteLength ||
+      hash.digest("hex") !== reference.digest
     ) {
       throw new ToolResultPayloadCorruptError(
         `Tool-result payload '${reference.toolCallId}' failed verification.`,
       );
     }
-    return bytes;
+    this.verified.set(reference.digest, {
+      byteLength: info.size,
+      mtimeMs: info.mtimeMs,
+    });
   }
+
+  private async readVerifiedBytes(
+    reference: ToolResultPayloadReference,
+  ): Promise<Buffer> {
+    await this.verifyStreaming(reference);
+    return await readFile(this.path(reference));
+  }
+}
+
+export function utf8TextRange(
+  bytes: Buffer,
+  byteLimit: number,
+): { text: string; start: number; end: number } {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  for (let start = 0; start <= Math.min(3, bytes.byteLength); start += 1) {
+    const maximumEnd = Math.min(bytes.byteLength, start + byteLimit);
+    for (
+      let end = maximumEnd;
+      end >= Math.max(start, maximumEnd - 3);
+      end -= 1
+    ) {
+      try {
+        return { text: decoder.decode(bytes.subarray(start, end)), start, end };
+      } catch {
+        // Try the adjacent UTF-8 boundary.
+      }
+    }
+  }
+  throw new ToolResultPayloadCorruptError(
+    "Tool-result payload range is not valid UTF-8.",
+  );
 }
 
 export function serializeToolResult(result: unknown): string {

--- a/packages/workbench-server/src/domains/tools/tool-result-preparation.ts
+++ b/packages/workbench-server/src/domains/tools/tool-result-preparation.ts
@@ -1,9 +1,11 @@
 import {
   boundText,
   projectAgentResult,
+  snapshotAgentPreview,
   toolDefinitionByName,
 } from "@nervekit/tools";
 import type {
+  AgentPreviewSnapshot,
   AgentProjectionSnapshot,
   ToolCallErrorDetails,
   ToolCallStatus,
@@ -50,6 +52,7 @@ export async function prepareToolResult(
   resultPayload?: ToolResultPayloadReference;
   validatedArtifacts: ValidatedToolArtifact[];
   agentProjection: AgentProjectionSnapshot;
+  agentPreview: AgentPreviewSnapshot;
 }> {
   const claims = artifactClaims(result);
   const validator = new ToolResultArtifactValidator(
@@ -97,18 +100,20 @@ export async function prepareToolResult(
     );
     completePayload = input.payloads.recoveryArtifact(resultPayload);
   }
+  const storedResult = bounded.summary.truncated ? bounded.value : result;
   const projection = completePayload
     ? projectAgentResult(
-        { ...context, completePayload },
+        { ...context, result: storedResult, completePayload },
         definition?.agentResult,
       )
     : firstProjection;
 
   return {
-    result: bounded.summary.truncated ? bounded.value : result,
+    result: storedResult,
     ...(resultPayload ? { resultPayload } : {}),
     validatedArtifacts,
     agentProjection: projection.snapshot,
+    agentPreview: snapshotAgentPreview(projection.blocks, result),
   };
 }
 

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -1032,6 +1032,18 @@ export class ToolService {
     return await this.toolCallRepository.getDetails(toolCallId);
   }
 
+  async readToolCallResult(
+    toolCallId: string,
+    byteOffset: number,
+    byteLimit: number,
+  ) {
+    return await this.toolCallRepository.readResult(
+      toolCallId,
+      byteOffset,
+      byteLimit,
+    );
+  }
+
   toolResultRecoveryArtifact(toolCall: ToolCallRecord) {
     return toolCall.resultPayload
       ? this.resultPayloads.recoveryArtifact(toolCall.resultPayload)

--- a/packages/workbench-server/src/protocol/method-handlers/interaction-method-handlers.ts
+++ b/packages/workbench-server/src/protocol/method-handlers/interaction-method-handlers.ts
@@ -18,6 +18,12 @@ export const interactionMethodHandlers: WorkbenchMethodHandlerMap =
       }),
     "toolCall.get": async (state, params) =>
       await state.registry.tools.getToolCallUiDetails(params.toolCallId),
+    "toolCall.result.read": async (state, params) =>
+      await state.registry.tools.readToolCallResult(
+        params.toolCallId,
+        params.byteOffset ?? 0,
+        params.byteLimit ?? 64 * 1024,
+      ),
     "toolCall.interaction.resolve": async (state, params) => ({
       ...(await state.registry.resolveToolInteraction(params)),
     }),

--- a/packages/workbench-server/test/tool-call.repository.test.ts
+++ b/packages/workbench-server/test/tool-call.repository.test.ts
@@ -141,8 +141,16 @@ describe("canonical ToolCallRepository", () => {
     });
 
     const details = await value.repository.getDetails("tool_payload");
-    assert.equal(details.completeResultStatus, "payload");
-    assert.deepEqual(details.completeResult, { content: "complete output" });
+    assert.equal(details.completeResult.status, "payload");
+    assert.equal(details.completeResult.byteLength, resultPayload.byteLength);
+    const chunk = await value.repository.readResult(
+      "tool_payload",
+      0,
+      64 * 1024,
+    );
+    assert.equal(chunk.status, "payload");
+    assert.match(chunk.text, /complete output/);
+    assert.equal(chunk.done, true);
     assert.deepEqual(
       value.repository.listPreviews({ limit: 10 })[0]?.resultPreview,
       { content: "bounded" },

--- a/packages/workbench-server/test/tool-executor.service.test.ts
+++ b/packages/workbench-server/test/tool-executor.service.test.ts
@@ -271,6 +271,12 @@ describe("ToolExecutorService structured errors", () => {
     assert.equal(completed.resultPayload, undefined);
     assert.deepEqual(completed.validatedArtifacts, []);
     assert.equal(completed.agentProjection?.fastPath, true);
+    assert.deepEqual(completed.agentPreview?.blocks, [
+      {
+        type: "text",
+        text: "legacy head/tail preview with verbose metadata",
+      },
+    ]);
     assert.equal(await readFile(sourcePath, "utf8"), rawText);
   });
 

--- a/packages/workbench-server/test/tool-result-payload-store.test.ts
+++ b/packages/workbench-server/test/tool-result-payload-store.test.ts
@@ -51,6 +51,24 @@ describe("ToolResultPayloadStore", () => {
     assert.match(await readFile(path, "utf8"), /^\{\n {2}"a": "first"/);
   });
 
+  it("reads UTF-8-safe bounded ranges", async () => {
+    const { payloads } = await store();
+    const reference = await payloads.write(
+      "conv_test",
+      "tool_range",
+      "🙂 alpha\n🙂 beta",
+    );
+    const chunks: string[] = [];
+    let offset = 0;
+    while (offset < reference.byteLength) {
+      const chunk = await payloads.readTextRange(reference, offset, 7);
+      assert.ok(chunk.nextByteOffset > offset);
+      chunks.push(chunk.text);
+      offset = chunk.nextByteOffset;
+    }
+    assert.equal(chunks.join(""), '"🙂 alpha\\n🙂 beta"\n');
+  });
+
   it("rejects owner traversal and detects modified bytes", async () => {
     const { payloads } = await store();
     await assert.rejects(


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive system for capturing and displaying what agents see from tool results, plus complete tool result handling with pagination and interaction resolution.

## Changes

### Contracts (packages/contracts)
- **Agent preview snapshot schema**:  with , , artifact roles, access types, formats, and projection counts
- **Complete tool result handling**:  (inline, payload, legacy_bounded, unavailable, corrupt) with descriptor and chunked reading
- **Tool interaction resolution**: Support for approval, user_input, and plan_review interactions with scoping
- **New operations**: , , 

### Tools Package (packages/tools)
- : Creates exact model projection snapshots without duplicating image payload bytes

### Workbench App (packages/workbench-app)
- **New components**: 
  -  - Displays agent preview with text/image blocks and projection metadata
  -  - Tool arguments display
  -  - Full tool result display
  -  - Paginated large result viewer
  -  - State management for tool details dialog
- **Updated components**: , , , 
- **Helpers**: , updated presentation/view helpers

### Workbench Server (packages/workbench-server)
-  - Enhanced with complete result and interaction support
-  - Updated for new result handling
-  - Payload storage with validation
-  - Result preparation logic
-  - Service layer updates
-  - New interaction resolution handlers
- Tests updated for repository, executor, and payload store

### Website (packages/website)
- Updated simulation script

## Testing
- Added tests for agent preview snapshot creation
- Updated existing tests for tool call repository, executor service, and result payload store
- All existing tests should pass