### PR TITLE
fix: strictly validate task definition files

### DIFF
--- a/docs/nerve-home-storage-architecture.md
+++ b/docs/nerve-home-storage-architecture.md
@@ -760,12 +760,15 @@ type IntegrationsConfig = {
     ├── APPEND_SYSTEM.md
     ├── skills/                     # Nerve-specific project skills
     ├── tasks/
+    │   └── definitions.json        # Portable saved task definitions
     └── suggestions/
 ```
 
 Nerve supports context from project and ancestor `AGENTS.md` files. It discovers project skills from `.nerve/skills/` and applicable project/ancestor `.agents/skills/` directories.
 
 Project configuration contains only project-portable values. Credentials, daemon settings, runtime state, conversation history, and machine identity never belong in a project directory. Project provider definitions may reference user-owned credential names but cannot contain credential values.
+
+Every file inside `<project>/.nerve/` derives its project scope from its enclosing project directory. It must not persist, require, compare, or trust a Nerve `projectId`, because project IDs belong to one local installation. Storage boundaries inject the active local project ID when constructing runtime or API objects and remove it before writing project-resident files. Project-scoped relational and runtime state under `NERVE_HOME` remains ID-based because it is installation-owned rather than repository-portable.
 
 ### Project permission safety
 

--- a/packages/contracts/src/domains/task-definitions/task-definition.schema.ts
+++ b/packages/contracts/src/domains/task-definitions/task-definition.schema.ts
@@ -26,6 +26,26 @@ export const taskDefinitionSchema = z.object({
 });
 export type TaskDefinition = z.infer<typeof taskDefinitionSchema>;
 
+/**
+ * Project-resident definitions derive their project identity from the enclosing
+ * directory. The non-strict scope intentionally projects legacy runtime-shaped
+ * files by discarding their obsolete projectId.
+ */
+export const persistedTaskDefinitionSchema = taskDefinitionSchema.extend({
+  scope: z.object({ kind: z.literal("project") }),
+});
+export type PersistedTaskDefinition = z.infer<
+  typeof persistedTaskDefinitionSchema
+>;
+
+export const taskDefinitionFileSchema = z
+  .object({
+    version: z.literal(1),
+    definitions: z.array(persistedTaskDefinitionSchema),
+  })
+  .strict();
+export type TaskDefinitionFile = z.infer<typeof taskDefinitionFileSchema>;
+
 export const createTaskDefinitionRequestSchema = z.object({
   label: z.string().min(1).optional(),
   command: z.string().min(1),

--- a/packages/contracts/test/task-definition.schema.test.ts
+++ b/packages/contracts/test/task-definition.schema.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   createTaskDefinitionRequestSchema,
+  taskDefinitionFileSchema,
   taskDefinitionSchema,
 } from "../src/index.js";
 
@@ -18,6 +19,33 @@ test("task definitions default to a single active run", () => {
     updatedAt: new Date().toISOString(),
   });
   assert.equal(definition.runPolicy, "single");
+});
+
+test("project task definition files derive scope from their location", () => {
+  const portable = taskDefinitionFileSchema.parse({
+    version: 1,
+    definitions: [
+      {
+        id: "taskdef_portable",
+        scope: { kind: "project" },
+        command: "pnpm check",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ],
+  });
+  assert.deepEqual(portable.definitions[0]?.scope, { kind: "project" });
+
+  const projected = taskDefinitionFileSchema.parse({
+    version: 1,
+    definitions: [
+      {
+        ...portable.definitions[0],
+        scope: { kind: "project", projectId: "proj_foreign" },
+      },
+    ],
+  });
+  assert.deepEqual(projected.definitions[0]?.scope, { kind: "project" });
 });
 
 test("task definitions accept an optional guarded TCP port", () => {

--- a/packages/workbench-server/src/domains/task-definitions/task-definition.repository.ts
+++ b/packages/workbench-server/src/domains/task-definitions/task-definition.repository.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import {
   projectRecordSchema,
+  taskDefinitionFileSchema,
   taskDefinitionSchema,
   type TaskDefinition,
 } from "@nervekit/contracts";
@@ -21,12 +22,17 @@ export class TaskDefinitionRepository {
         throw error;
       },
     );
-    const record = raw as { version?: unknown; definitions?: unknown };
-    if (record.version !== 1 || !Array.isArray(record.definitions)) {
-      throw new Error(`Invalid project task definitions at ${path}.`);
+    const parsed = taskDefinitionFileSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new Error(`Invalid project task definitions at ${path}.`, {
+        cause: parsed.error,
+      });
     }
-    return record.definitions.map((definition) =>
-      taskDefinitionSchema.parse(definition),
+    return parsed.data.definitions.map((definition) =>
+      taskDefinitionSchema.parse({
+        ...definition,
+        scope: { kind: "project", projectId },
+      }),
     );
   }
 
@@ -36,12 +42,7 @@ export class TaskDefinitionRepository {
   ): Promise<void> {
     await atomicWriteJson(
       await this.path(projectId),
-      {
-        version: 1,
-        definitions: definitions.map((definition) =>
-          taskDefinitionSchema.parse(definition),
-        ),
-      },
+      taskDefinitionFileSchema.parse({ version: 1, definitions }),
       0o600,
     );
   }

--- a/packages/workbench-server/test/task-definition.repository.test.ts
+++ b/packages/workbench-server/test/task-definition.repository.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import type { ProjectRecord } from "@nervekit/contracts";
+import { TaskDefinitionRepository } from "../src/domains/task-definitions/task-definition.repository.js";
+import { ProjectRepository } from "../src/domains/projects/project.repository.js";
+import { initializeStorage } from "../src/infrastructure/storage/index.js";
+
+const roots: string[] = [];
+const stores: Array<{ close(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((store) => store.close()));
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("project task definition storage", () => {
+  it("derives runtime scope from the local project and writes portable files", async () => {
+    const { project, repository } = await setup();
+    const path = join(project.dir, ".nerve", "tasks", "definitions.json");
+    await mkdir(join(project.dir, ".nerve", "tasks"), { recursive: true });
+    const now = new Date().toISOString();
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        version: 1,
+        definitions: [
+          {
+            id: "taskdef_foreign",
+            scope: { kind: "project", projectId: "proj_other_installation" },
+            command: "pnpm check",
+            createdAt: now,
+            updatedAt: now,
+          },
+          {
+            id: "taskdef_portable",
+            scope: { kind: "project" },
+            command: "pnpm test",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      })}\n`,
+    );
+
+    const loaded = await repository.list(project.id);
+    assert.deepEqual(
+      loaded.map((definition) => definition.scope),
+      [
+        { kind: "project", projectId: project.id },
+        { kind: "project", projectId: project.id },
+      ],
+    );
+
+    await repository.replace(project.id, loaded);
+    const persisted = JSON.parse(await readFile(path, "utf8")) as {
+      definitions: Array<{ scope: Record<string, unknown> }>;
+    };
+    assert.deepEqual(
+      persisted.definitions.map((definition) => definition.scope),
+      [{ kind: "project" }, { kind: "project" }],
+    );
+  });
+
+  it("rejects unsupported project task definition files", async () => {
+    const { project, repository } = await setup();
+    const dir = join(project.dir, ".nerve", "tasks");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "definitions.json"),
+      `${JSON.stringify({ version: 2, definitions: [] })}\n`,
+    );
+
+    await assert.rejects(
+      repository.list(project.id),
+      /Invalid project task definitions.*definitions\.json/,
+    );
+  });
+});
+
+async function setup(): Promise<{
+  project: ProjectRecord;
+  repository: TaskDefinitionRepository;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "nerve-task-definitions-"));
+  roots.push(root);
+  const storage = await initializeStorage(join(root, "home"));
+  stores.push(storage.canonicalStore);
+  const now = new Date().toISOString();
+  const project: ProjectRecord = {
+    id: "proj_local_installation",
+    name: "Portable project",
+    dir: join(root, "project"),
+    createdAt: now,
+    updatedAt: now,
+  };
+  await mkdir(project.dir, { recursive: true });
+  await new ProjectRepository(storage).write(project);
+  return { project, repository: new TaskDefinitionRepository(storage) };
+}


### PR DESCRIPTION
## Summary
- preserve schema validation causes when loading project task definitions
- reject unsupported task definition files with clearer diagnostics
- add repository and schema coverage and document the storage behavior

## Validation
- `pnpm fix` passed
- `pnpm check` passed with existing Svelte warnings
- `pnpm test` ran 502/503 workbench-server tests successfully; `conversation-journal.repository.test.ts` timed out in the full parallel suite