### PR TITLE
Restore plan previews after revisiting a conversation

### DIFF
--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/PlanModeToolView.svelte
@@ -123,6 +123,7 @@ $effect(() => {
   const content = planReviewContent(
     displayedReview?.content,
     planReview?.content,
+    displayedReview?.summary ?? view.planPreview,
   );
   if (content.trim()) retainedReviewContent = content;
 });
@@ -131,7 +132,7 @@ const previewContent = $derived(
   planReviewContent(
     displayedReview?.content,
     planReview?.content,
-    retainedReviewContent || displayedReview?.summary,
+    retainedReviewContent || displayedReview?.summary || view.planPreview,
   ),
 );
 const preview = $derived(

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-parser.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-parser.ts
@@ -592,6 +592,9 @@ export function parseToolView(
     case "plan_mode_present": {
       const resultRecord = asRecord(rawResult);
       const review = asRecord(resultRecord.review);
+      const interactionSummary = toolCall.interactions.find(
+        (interaction) => interaction.kind === "plan_review",
+      )?.request.summary;
       const planPath =
         stringField(review.planPath) ?? stringField(args.file_path);
       const outcome =
@@ -601,6 +604,10 @@ export function parseToolView(
         action: "present",
         summary:
           stringField(resultRecord.feedback) ?? firstTextBlock(rawResult),
+        planPreview:
+          stringField(review.content) ??
+          stringField(review.summary) ??
+          interactionSummary,
         planPath,
         outcome,
       };

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.orchestration.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-result-view.orchestration.test.ts
@@ -35,6 +35,56 @@ describe("parseToolView ask_user/todos/task/explore", () => {
     assert.equal(view.kind === "ask_user" && view.dismissed, true);
   });
 
+  it("restores a resolved plan preview from the durable interaction", () => {
+    const planPreview = [
+      "# Implementation plan",
+      "",
+      "## Goal",
+      "",
+      "Keep the plan visible after revisiting the conversation.",
+      "Validate the resolved transcript path.",
+    ].join("\n");
+    const view = parseToolView(
+      transcriptToolCall(
+        "plan_mode_present",
+        { file_path: "/tmp/plans/example.md" },
+        {
+          review: {
+            id: "plan_review_01H0000000000000000000000",
+            status: "accepted",
+          },
+          outcome: "accepted",
+          feedback: "Looks good.",
+        },
+        {
+          interactions: [
+            {
+              ordinal: 0,
+              kind: "plan_review",
+              status: "resolved",
+              requestedAt: "2026-01-01T00:00:00.000Z",
+              updatedAt: "2026-01-01T00:01:00.000Z",
+              resolvedAt: "2026-01-01T00:01:00.000Z",
+              request: {
+                planPath: "/tmp/plans/example.md",
+                slug: "example",
+                title: "example.md",
+                summary: planPreview,
+                allowNewConversation: true,
+              },
+              resolution: { action: "accept" },
+            },
+          ],
+        },
+      ),
+    );
+
+    assert.equal(view.kind, "plan_mode");
+    if (view.kind !== "plan_mode") return;
+    assert.equal(view.planPreview, planPreview);
+    assert.equal(view.summary, "Looks good.");
+  });
+
   it("parses a task_start action while keeping tool completion separate from process state", () => {
     const tc = toolCall(
       "task_start",

--- a/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/views/tool-view-types.ts
@@ -307,6 +307,7 @@ export type ToolView =
       kind: "plan_mode";
       action: "enter" | "present" | "force_exit";
       summary?: string;
+      planPreview?: string;
       planPath?: string;
       outcome?: string;
     }


### PR DESCRIPTION
## Summary

- The collapsed `plan_mode_present` card lost its plan preview after the review was accepted/rejected and the user navigated away from and back to the conversation.
- The server already persists the first six lines of the plan as the plan-review interaction `request.summary`. While a review is pending the card receives a hydrated record, but after resolution the app exposes only pending reviews, so remounting dropped the preview.
- Parse a durable `planPreview` fallback from the plan-review interaction summary (separate from resolution feedback) and use it in `PlanModeToolView` when no hydrated or retained content is available.
- Add a regression test for a resolved transcript record whose result no longer contains plan content.

## Validation

- `pnpm fix` and `pnpm check` pass.
- New targeted regression test passes (`restores a resolved plan preview from the durable interaction`).
- No storage or schema migration required; existing plan-review interactions already store the six-line summary.

## Notes

- A concurrent, unrelated `conversation-journal.repository.test.ts` worker failed intermittently during the full `pnpm test` sweep; that test (and `nerve-home-storage.test.ts`) pass when run directly.