### PR TITLE
Allow dirty-worktree pull and branch switch with Git-native safety

### DIFF
--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -729,16 +729,6 @@ export class GitService {
     }
 
     if ((repo.behind ?? 0) > 0) {
-      const { files } = parsePorcelainV2(
-        (await this.runGit(repoDir, ["status", "--porcelain=v2"])).stdout,
-      );
-      if (files.length > 0) {
-        throw new GitWorkflowError(
-          409,
-          "GIT_DIRTY_WORKTREE",
-          "Working tree has uncommitted changes. Commit or stash them before syncing.",
-        );
-      }
       await this.mapGit(() => this.runGit(repoDir, ["pull", "--ff-only"]));
       repo = await this.summarizeRepo(repoDir, relativePath, repoName);
     }
@@ -762,13 +752,6 @@ export class GitService {
       relativePath,
       this.repoName(projectId, relativePath),
     );
-    if (repo.dirty) {
-      throw new GitWorkflowError(
-        409,
-        "GIT_DIRTY_WORKTREE",
-        "Working tree has uncommitted changes. Commit or stash them before switching branches.",
-      );
-    }
     if (!repo.hasRemote) {
       throw new GitWorkflowError(
         409,
@@ -861,16 +844,6 @@ export class GitService {
         409,
         "GIT_NO_UPSTREAM",
         "Current branch has no upstream to pull from.",
-      );
-    }
-    const { files } = parsePorcelainV2(
-      (await this.runGit(repoDir, ["status", "--porcelain=v2"])).stdout,
-    );
-    if (files.length > 0) {
-      throw new GitWorkflowError(
-        409,
-        "GIT_DIRTY_WORKTREE",
-        "Working tree has uncommitted changes. Commit or stash them before pulling.",
       );
     }
     await this.mapGit(() => this.runGit(repoDir, ["pull", "--ff-only"]));

--- a/packages/tools/test/git-service-workflows.test.ts
+++ b/packages/tools/test/git-service-workflows.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { GitWorkflowError } from "../src/git/git-errors.js";
+import { GitService } from "../src/git/git-service.js";
+
+type RepositoryFixture = {
+  root: string;
+  work: string;
+  updater: string;
+  service: GitService;
+};
+
+async function command(
+  service: GitService,
+  cwd: string,
+  ...args: string[]
+): Promise<void> {
+  await service.runGit(cwd, args);
+}
+
+async function configureUser(service: GitService, cwd: string): Promise<void> {
+  await command(service, cwd, "config", "user.name", "Nerve Test");
+  await command(service, cwd, "config", "user.email", "nerve@example.test");
+}
+
+async function createFixture(): Promise<RepositoryFixture> {
+  const root = await mkdtemp(join(tmpdir(), "nerve-git-workflow-"));
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  const work = join(root, "work");
+  const updater = join(root, "updater");
+  const service = new GitService(() => ({ dir: work, name: "work" }));
+
+  await command(
+    service,
+    root,
+    "init",
+    "--bare",
+    "--initial-branch=main",
+    remote,
+  );
+  await command(service, root, "init", "--initial-branch=main", seed);
+  await configureUser(service, seed);
+  await writeFile(join(seed, "local.txt"), "initial local\n");
+  await writeFile(join(seed, "shared.txt"), "initial shared\n");
+  await writeFile(join(seed, "upstream.txt"), "initial upstream\n");
+  await command(service, seed, "add", ".");
+  await command(service, seed, "commit", "-m", "initial");
+  await command(service, seed, "remote", "add", "origin", remote);
+  await command(service, seed, "push", "-u", "origin", "main");
+  await command(service, root, "clone", remote, work);
+  await command(service, root, "clone", remote, updater);
+  await configureUser(service, work);
+  await configureUser(service, updater);
+
+  return { root, work, updater, service };
+}
+
+async function pushUpstreamChange(
+  fixture: RepositoryFixture,
+  path: string,
+  content: string,
+): Promise<void> {
+  await writeFile(join(fixture.updater, path), content);
+  await command(fixture.service, fixture.updater, "add", path);
+  await command(
+    fixture.service,
+    fixture.updater,
+    "commit",
+    "-m",
+    `update ${path}`,
+  );
+  await command(fixture.service, fixture.updater, "push");
+}
+
+async function withFixture(
+  run: (fixture: RepositoryFixture) => Promise<void>,
+): Promise<void> {
+  const fixture = await createFixture();
+  try {
+    await run(fixture);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+}
+
+describe("GitService dirty-worktree workflows", () => {
+  it("pulls a fast-forward while preserving a non-overlapping local change", async () => {
+    await withFixture(async (fixture) => {
+      await writeFile(join(fixture.work, "local.txt"), "local edit\n");
+      await pushUpstreamChange(fixture, "upstream.txt", "upstream edit\n");
+
+      const result = await fixture.service.pull("project", ".");
+
+      assert.equal(result.repo.dirty, true);
+      assert.equal(
+        await readFile(join(fixture.work, "local.txt"), "utf8"),
+        "local edit\n",
+      );
+      assert.equal(
+        await readFile(join(fixture.work, "upstream.txt"), "utf8"),
+        "upstream edit\n",
+      );
+    });
+  });
+
+  it("switches to base and pulls while preserving a compatible local change", async () => {
+    await withFixture(async (fixture) => {
+      await command(fixture.service, fixture.work, "switch", "-c", "feature");
+      await writeFile(join(fixture.work, "local.txt"), "feature edit\n");
+      await pushUpstreamChange(fixture, "upstream.txt", "updated on main\n");
+
+      const result = await fixture.service.switchBaseAndPull("project", ".");
+
+      assert.equal(result.repo.currentBranch, "main");
+      assert.equal(result.repo.dirty, true);
+      assert.equal(
+        await readFile(join(fixture.work, "local.txt"), "utf8"),
+        "feature edit\n",
+      );
+      assert.equal(
+        await readFile(join(fixture.work, "upstream.txt"), "utf8"),
+        "updated on main\n",
+      );
+    });
+  });
+
+  it("syncs a behind branch while preserving a non-overlapping local change", async () => {
+    await withFixture(async (fixture) => {
+      await writeFile(join(fixture.work, "local.txt"), "local sync edit\n");
+      await pushUpstreamChange(fixture, "upstream.txt", "synced upstream\n");
+
+      const result = await fixture.service.syncBranch("project", ".");
+
+      assert.equal(result.repo.dirty, true);
+      assert.equal(
+        await readFile(join(fixture.work, "local.txt"), "utf8"),
+        "local sync edit\n",
+      );
+      assert.equal(
+        await readFile(join(fixture.work, "upstream.txt"), "utf8"),
+        "synced upstream\n",
+      );
+    });
+  });
+
+  it("lets Git reject an overlapping pull without changing the local file", async () => {
+    await withFixture(async (fixture) => {
+      await writeFile(join(fixture.work, "shared.txt"), "local version\n");
+      await pushUpstreamChange(fixture, "shared.txt", "upstream version\n");
+
+      await assert.rejects(
+        fixture.service.pull("project", "."),
+        (error: unknown) =>
+          error instanceof GitWorkflowError &&
+          error.code === "GIT_COMMAND_FAILED",
+      );
+      assert.equal(
+        await readFile(join(fixture.work, "shared.txt"), "utf8"),
+        "local version\n",
+      );
+    });
+  });
+});

--- a/packages/workbench-app/src/lib/features/git/ui/GitBranchDialog.svelte
+++ b/packages/workbench-app/src/lib/features/git/ui/GitBranchDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Check from "@lucide/svelte/icons/check";
 import GitBranch from "@lucide/svelte/icons/git-branch";
+import Info from "@lucide/svelte/icons/info";
 import GitBranchPlus from "@lucide/svelte/icons/git-branch-plus";
 import type { GitBranchSummary, GitRepoSummary } from "@nervekit/contracts";
 import { Badge } from "@nervekit/ui-kit/components/ui/badge";
@@ -85,6 +86,18 @@ const dialogDescription = $derived(
 >
   {#if view === "switch"}
     <div class="grid gap-4">
+      {#if repoSummary.dirty}
+        <div
+          class="flex items-start gap-2 rounded-md border border-info/40 bg-info/10 px-3 py-2 text-xs text-muted-foreground"
+        >
+          <Info class="mt-0.5 size-3.5 shrink-0 text-info" />
+          <p>
+            Local changes move with a compatible switch. Git will stop if the
+            target branch would overwrite them.
+          </p>
+        </div>
+      {/if}
+
       {#if showBaseQuickSwitch}
         <div
           class="flex items-center gap-2 rounded-md border border-info/40 bg-info/10 px-3 py-2"

--- a/packages/workbench-app/src/lib/features/git/ui/GitPanel.svelte
+++ b/packages/workbench-app/src/lib/features/git/ui/GitPanel.svelte
@@ -194,7 +194,7 @@ function openBranchDialog(): void {
             variant="outline"
             showLabel
             title={repo.dirty
-              ? "Commit or stash changes before pulling"
+              ? "Pull with local changes; Git stops if files would be overwritten"
               : "Pull current branch with fast-forward only"}
             loading={model.operations.pulling}
             disabled={!model.capabilities.remote.pull.enabled ||
@@ -226,7 +226,9 @@ function openBranchDialog(): void {
             ? "Add a remote before syncing"
             : repo.detached
               ? "Check out a branch before syncing"
-              : "Fetch, then pull and push the current branch when needed"}
+              : repo.dirty
+                ? "Sync with local changes; Git stops if files would be overwritten"
+                : "Fetch, then pull and push the current branch when needed"}
           loading={model.operations.syncing}
           disabled={!model.capabilities.remote.sync.enabled ||
             syncDisabled(repo, remoteBusy)}
@@ -240,7 +242,7 @@ function openBranchDialog(): void {
             variant="outline"
             showLabel
             title={repo.dirty
-              ? "Commit or stash changes before switching branches"
+              ? `Switch to ${repo.baseBranch} and pull with local changes; Git stops if files would be overwritten`
               : `Switch to ${repo.baseBranch} and pull with fast-forward only`}
             loading={model.operations.switchingBaseAndPulling}
             disabled={!model.capabilities.remote["switch-base-and-pull"]

--- a/packages/workbench-app/src/lib/features/git/ui/git-remote-actions.test.ts
+++ b/packages/workbench-app/src/lib/features/git/ui/git-remote-actions.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { GitRepoSummary } from "@nervekit/contracts";
+import {
+  basePullDisabled,
+  pullDisabled,
+  remoteActionDisabled,
+} from "./git-remote-actions.js";
+
+function repo(overrides: Partial<GitRepoSummary> = {}): GitRepoSummary {
+  return {
+    relativePath: ".",
+    absDir: "/repo",
+    name: "repo",
+    isRepo: true,
+    currentBranch: "feature",
+    detached: false,
+    ahead: 0,
+    behind: 1,
+    hasUpstream: true,
+    hasRemote: true,
+    hasGithubRemote: false,
+    baseBranch: "main",
+    onBaseBranch: false,
+    mergedToBase: false,
+    dirty: false,
+    changeCount: 0,
+    ...overrides,
+  };
+}
+
+test("allows pull and base switching with compatible local changes", () => {
+  const dirtyRepo = repo({ dirty: true, changeCount: 1 });
+
+  assert.equal(pullDisabled(dirtyRepo, false), false);
+  assert.equal(basePullDisabled(dirtyRepo, false), false);
+});
+
+test("keeps actual remote-operation prerequisites disabled", () => {
+  assert.equal(remoteActionDisabled(repo({ hasRemote: false }), false), true);
+  assert.equal(pullDisabled(repo({ hasUpstream: false }), false), true);
+  assert.equal(pullDisabled(repo({ detached: true }), false), true);
+  assert.equal(pullDisabled(repo(), true), true);
+  assert.equal(basePullDisabled(repo({ hasRemote: false }), false), true);
+  assert.equal(basePullDisabled(repo(), true), true);
+});

--- a/packages/workbench-app/src/lib/features/git/ui/git-remote-actions.ts
+++ b/packages/workbench-app/src/lib/features/git/ui/git-remote-actions.ts
@@ -14,8 +14,7 @@ export function pullDisabled(
   return (
     remoteActionDisabled(repo, remoteActionInProgress) ||
     repo.detached ||
-    !repo.hasUpstream ||
-    repo.dirty
+    !repo.hasUpstream
   );
 }
 
@@ -41,7 +40,7 @@ export function basePullDisabled(
   repo: GitRepoSummary,
   remoteActionInProgress: boolean,
 ): boolean {
-  return remoteActionDisabled(repo, remoteActionInProgress) || repo.dirty;
+  return remoteActionDisabled(repo, remoteActionInProgress);
 }
 
 export function showPull(repo: GitRepoSummary): boolean {

--- a/packages/workbench-server/test/git-service-sync.test.ts
+++ b/packages/workbench-server/test/git-service-sync.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 import { promisify } from "node:util";
 import type { ProjectRecord } from "@nervekit/contracts";
-import { GitService, GitWorkflowError } from "@nervekit/tools";
+import { GitService } from "@nervekit/tools";
 
 const execFileAsync = promisify(execFile);
 
@@ -134,19 +134,22 @@ describe("GitService.syncBranch", () => {
     });
   });
 
-  it("rejects behind sync on a dirty worktree", async () => {
+  it("pulls a behind branch while preserving a dirty worktree", async () => {
     await withRemoteFixture(async ({ root, remoteDir, localDir, service }) => {
       await pushRemoteOnlyCommit(root, remoteDir, "behind.txt");
       await writeFile(join(localDir, "dirty.txt"), "dirty\n");
 
-      await assert.rejects(
-        () => service.syncBranch("project", "."),
-        (error) =>
-          error instanceof GitWorkflowError &&
-          error.code === "GIT_DIRTY_WORKTREE",
-      );
+      const result = await service.syncBranch("project", ".");
 
-      await assert.rejects(() => git(localDir, ["show", "HEAD:behind.txt"]));
+      assert.equal(result.repo.dirty, true);
+      assert.equal(
+        await git(localDir, ["show", "HEAD:behind.txt"]),
+        "remote change\n",
+      );
+      assert.match(
+        await git(localDir, ["status", "--short"]),
+        /\?\? dirty\.txt/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Enable **pull**, **sync**, and **switch-to-base-and-pull** while the working tree has uncommitted changes. Git already refuses to overwrite conflicting local files, so the blanket `GIT_DIRTY_WORKTREE` rejection (in `pull`, `syncBranch`'s pull phase, and `switchBaseAndPull`) is removed; the `--ff-only` pull and `git switch` overwrite checks remain the authority.
- Keep UI disables only for genuine blockers: an operation already in progress, no remote, no upstream, or a detached HEAD. The `pullDisabled` / `basePullDisabled` predicates no longer treat `repo.dirty` as a disabled condition.
- Update toolbar tooltips (Pull, Sync, base+pull) and add an info note in the branch-switch dialog so users understand that compatible local changes move with the operation and Git stops when a target would overwrite them.

## Behavior

- Compatible local edits are preserved across pull/sync/branch switch.
- Overlapping edits are rejected by Git (`GIT_COMMAND_FAILED`) and surfaced through the existing critical-error flow; local files are left untouched.
- No merge commits or conflict-resolution states are introduced because pulls remain `--ff-only`.

## Validation

- `pnpm fix && pnpm check && pnpm test` passes.
- New tests cover dirty-worktree pull/sync/switch (compatible and overlapping) using isolated temporary repositories, plus UI disable-predicate coverage for prerequisites vs. dirty state.
- Updated `packages/workbench-server/test/git-service-sync.test.ts` to assert a dirty behind-sync now fast-forwards while preserving local changes.

No API, schema, protocol, storage, or migration changes.