### PR TITLE
chore: add test:affected and test:full commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Run complete test suite
         if: github.event_name != 'pull_request' || needs.paths.outputs.testable == 'true'
-        run: pnpm test
+        run: pnpm run test:full
 
       - name: Build workbench runtime
         if: github.event_name != 'pull_request' || needs.paths.outputs.workbench == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         run: pnpm check
 
       - name: Run complete test suite
-        run: pnpm test
+        run: pnpm run test:full
 
       - name: Remove developer native prebuild
         run: rm -rf packages/native/prebuilds/local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,6 @@
 - Use official shadcn-svelte components from `packages/ui-kit/src/lib/components/ui` and `@lucide/svelte` icons. Style with theme-token Tailwind utilities, including `success`/`warning`/`info`; use `destructive` for readable red text/tints and `destructive-solid` with `destructive-solid-foreground` for opaque destructive fills. Use monospace only for code, logs, and paths.
 - Shared CSS and tokens live in `packages/ui-kit/src/styles/`, with `app.css` as the entrypoint. Global classes must be deliberate cross-component contracts used by at least two components; `scripts/lib/style-policy.mjs` is the authoritative partial allowlist. Follow `packages/workbench-app/AGENTS.md` for its full styling model.
 - Add automated tests for important behavior, not static exports, pass-through adapters, cosmetic details, or behavior already covered at its owning layer.
-- Before completing code changes, run `pnpm fix && pnpm check && pnpm test` in one Bash invocation. Fix failures, then rerun the full chain.
+- Before completing package-scoped code changes, run `pnpm fix && pnpm check && pnpm run test:affected` in one Bash invocation. Use `pnpm run test:full` instead when changing root, workspace, or test infrastructure, or when broad validation is required. Fix failures, then rerun the same chain.
 - Run the UI against an existing daemon with `NERVE_API_TARGET=http://127.0.0.1:3747 pnpm dev:ui`.
 - Use the `gh` CLI for GitHub operations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,10 @@ Install Node.js 24+, pnpm 11.20.0, and rustup. The repository pins its Rust tool
 pnpm install
 pnpm fix
 pnpm check
-pnpm test
+pnpm run test:affected
 ```
+
+Use `pnpm run test:full` when changing root, workspace, or test infrastructure, and before release validation.
 
 ## Guidelines
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -23,7 +23,7 @@ pnpm install --frozen-lockfile
 node scripts/verify-release-tag.mjs v0.13.0
 pnpm fix
 pnpm check
-pnpm test
+pnpm run test:full
 pnpm build
 node scripts/pack-npm.mjs
 ```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:workbench-runtime": "pnpm --filter @nervekit/workbench-app... --filter @nervekit/workbench-server... build && node scripts/copy-workbench-app-dist-to-workbench-server.mjs",
     "fix": "pnpm --filter @nervekit/native fix:native && oxfmt && eslint . --fix && oxfmt",
     "check": "oxfmt --check && eslint . && node scripts/check-package-boundaries.mjs && pnpm -r check",
-    "test": "pnpm build:native && node --test \"scripts/**/*.test.mjs\" && pnpm -r --if-present test",
+    "test:affected": "pnpm build:native && node --test \"scripts/**/*.test.mjs\" && pnpm --filter \"...[origin/main]\" --if-present test",
+    "test:full": "pnpm build:native && node --test \"scripts/**/*.test.mjs\" && pnpm -r --if-present test",
     "dev": "pnpm build:native && pnpm --filter @nervekit/contracts --filter @nervekit/protocol --filter @nervekit/harness --filter @nervekit/tools build && pnpm --parallel --stream --filter @nervekit/workbench-server --filter @nervekit/workbench-app dev",
     "dev:ui": "pnpm --filter @nervekit/contracts --filter @nervekit/protocol --filter @nervekit/harness --filter @nervekit/tools build && pnpm --filter @nervekit/workbench-app dev",
     "desktop": "pnpm --filter @nervekit/desktop-shell dev --"

--- a/packages/website/content-strategy.md
+++ b/packages/website/content-strategy.md
@@ -418,7 +418,7 @@ During implementation, validate incrementally with focused package commands, the
    - no request to localhost/runtime APIs from the static site.
 4. Review command snippets on Linux syntax and retain separate PowerShell blocks where needed.
 5. Grep for stale/high-risk phrases: wire “ACK,” “scratch notes in tabs,” generic “file upload,” “all pi-ai providers,” “sandboxed,” “safe public Internet,” and old migration exclusions.
-6. Run in one Bash invocation: `pnpm fix && pnpm check && pnpm test`. Fix failures and rerun the complete chain.
+6. Run in one Bash invocation: `pnpm fix && pnpm check && pnpm run test:full`. Fix failures and rerun the complete chain.
 7. Run `pnpm build` to verify the website composes with all workspace builds and the existing workbench asset staging step.
 8. After repository merge and external Pages/DNS setup, verify `https://nerve.tlmtech.dev`, HTTPS certificate issuance, redirect/canonical behavior, sitemap/search assets, and a clean browser load.
 

--- a/packages/website/src/content/docs/developers/development.md
+++ b/packages/website/src/content/docs/developers/development.md
@@ -24,7 +24,8 @@ pnpm build                  # TypeScript packages and staged Workbench assets
 pnpm build:native           # host Rust addon in packages/native/prebuilds/local
 pnpm fix                    # Rust, TypeScript, Svelte, and ESLint fixes
 pnpm check                  # formatting, lint, boundaries, package and Rust checks
-pnpm test                   # build the host addon, then run package and Rust tests
+pnpm run test:affected      # test changed packages and their dependents
+pnpm run test:full          # run the complete package and Rust test suite
 ```
 
 `pnpm dev` and `pnpm desktop` build the host native addon automatically. Release prebuilds are separate architecture-specific files and are produced by GitHub Actions.
@@ -49,7 +50,7 @@ pnpm --filter @nervekit/website build
 
 Use explicit `NERVE_HOME`, ports, and Electron profile overrides for tests that can migrate or mutate state. The normal profile intentionally sits outside `NERVE_HOME`; changing only one does not fully isolate a desktop test.
 
-Before completing code changes, repository policy requires `pnpm fix && pnpm check && pnpm test`, then a rerun after fixes.
+Before completing package-scoped code changes, repository policy requires `pnpm fix && pnpm check && pnpm run test:affected`. Use `pnpm run test:full` for root, workspace, or test-infrastructure changes and for broad validation. Rerun the same chain after fixes.
 
 ## Next steps
 

--- a/packages/website/src/content/docs/developers/protocol/v1/feature-coverage.md
+++ b/packages/website/src/content/docs/developers/protocol/v1/feature-coverage.md
@@ -19,4 +19,4 @@ sidebar:
 | HTTP/WebSocket parity                   | workbench dispatcher and release smoke tests                     |
 | Cross-platform host semantics           | shared real-host parity matrix                                   |
 
-Run `pnpm fix && pnpm check && pnpm test` for the complete repository gate.
+Run `pnpm fix && pnpm check && pnpm run test:full` for the complete repository gate.


### PR DESCRIPTION
## Summary
- Replace the single root `test` script with `pnpm run test:affected` and `pnpm run test:full`.
- `test:affected` builds the native binding, runs the root script suite, then tests packages changed since `origin/main` and their transitive dependents using pnpm's Git filter.
- `test:full` preserves the previous exhaustive suite exactly.
- Update `AGENTS.md`, `CONTRIBUTING.md`, developer docs, and CI/release workflows to use the new commands; CI and release continue to run the full suite.

## Why
Running the complete suite after every change is expensive. Local development can scope tests to affected packages and dependents, while CI and release keep authoritative full coverage.

## Validation
- Verified pnpm dependent selection for `contracts`, `ui-kit`, and `workbench-server`.
- `pnpm run test:affected` passed on the current branch.
- `pnpm fix && pnpm check && pnpm run test:full` passed.

## Notes
- Root/shared configuration changes are not a workspace package; guidance requires `test:full` for those changes.
- Package-scoped `test`, `test:native`, and `test:migrations` scripts are unchanged.