### PR TITLE
Remove unused canonical_meta and permission_rules tables

### DIFF
--- a/docs/nerve-home-storage-architecture.md
+++ b/docs/nerve-home-storage-architecture.md
@@ -770,17 +770,14 @@ Project configuration contains only project-portable values. Credentials, daemon
 
 Every file inside `<project>/.nerve/` derives its project scope from its enclosing project directory. It must not persist, require, compare, or trust a Nerve `projectId`, because project IDs belong to one local installation. Storage boundaries inject the active local project ID when constructing runtime or API objects and remove it before writing project-resident files. Project-scoped relational and runtime state under `NERVE_HOME` remains ID-based because it is installation-owned rather than repository-portable.
 
-### Project permission safety
+### Project permissions
 
-Project configuration is repository-controlled input and cannot silently grant itself authority merely because a repository was cloned or opened.
+Permission configuration has two authoritative file-backed sources:
 
-Nerve distinguishes:
+- project rules from `<project>/.nerve/config/permissions.json`;
+- user rules from `<NERVE_HOME>/config/permissions.json`.
 
-- project-requested rules from `<project>/.nerve/config/permissions.json`;
-- user-owned rules from `<NERVE_HOME>/config/permissions.json`;
-- hard application constraints that neither source can override.
-
-Project deny rules may take effect directly. Project allow rules require an explicit trust decision or user approval before they expand authority. User denies and hard constraints always win.
+Enabled rules from both sources participate directly in policy evaluation. Project configuration is repository-controlled input, so opening a project also accepts its enabled permission rules. User denies, deny precedence, and hard application constraints still apply and cannot be displaced by project allows.
 
 ## Configuration precedence
 

--- a/docs/storage-migrations.md
+++ b/docs/storage-migrations.md
@@ -10,7 +10,7 @@ The framework covers all Nerve-owned durable data, but not all data belongs phys
 | -------------------------------------------------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
 | Settings and UI preferences                                                            | Canonical SQLite                       | Schema or versioned payload migration                                  |
 | Projects, conversations, agents, records, and durable events                           | Canonical SQLite                       | Schema or versioned record migration                                   |
-| Permission rules                                                                       | Canonical SQLite                       | Schema or versioned payload migration                                  |
+| User and project permission rules                                                      | `config/permissions.json` files        | Versioned configuration migration                                      |
 | Task definitions/state, scratch notes, provider profiles, and other queryable metadata | Canonical SQLite                       | Schema or versioned payload migration                                  |
 | API keys, OAuth tokens, and integration credentials                                    | `SecretProvider`, not plaintext SQLite | Explicit secret-name/format migration                                  |
 | Secret encryption key and local daemon authentication token                            | Restricted secret/bootstrap storage    | Explicit security migration; never copied into ordinary tables         |

--- a/packages/contracts/src/domains/permissions/permissions.schema.ts
+++ b/packages/contracts/src/domains/permissions/permissions.schema.ts
@@ -100,7 +100,7 @@ export const permissionExceptionSchema = z
   });
 export type PermissionException = z.infer<typeof permissionExceptionSchema>;
 
-/** Canonical scoped permission rule persisted independently of settings. */
+/** Scoped permission rule normalized for policy evaluation. */
 export const permissionRuleScopeSchema = z.enum(["user", "project"]);
 export type PermissionRuleScope = z.infer<typeof permissionRuleScopeSchema>;
 
@@ -127,10 +127,6 @@ export const permissionRuleSchema = z
     toolName: z.string().trim().min(1).max(128),
     matcherKind: permissionRuleMatcherKindSchema,
     pattern: z.string().trim().min(1).max(1_024),
-    sourceDigest: z
-      .string()
-      .regex(/^[a-f0-9]{64}$/)
-      .optional(),
     enabled: z.boolean(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),

--- a/packages/website/src/content/docs/developers/tools-policy.md
+++ b/packages/website/src/content/docs/developers/tools-policy.md
@@ -20,7 +20,7 @@ The server evaluates mode, permission, risk, tool availability, and request deta
 - Read only allows local inspection and interaction, but denies commands, network access, mutations, and child spawning;
 - Supervised automatically allows safe local reads and audited read-only integrations, then requests approval for other risks unless an exact-risk allow exception covers the complete request;
 - Autonomous permits allowed risks without normal approval, but explicit block exceptions still apply;
-- effective exceptions are the deduplicated union of global settings and host-side project permissions under `~/.nerve/projects/<project-id>/permissions.json`; workspace `.nerve` files are never authoritative permission sources;
+- effective exceptions are the deduplicated union of user permissions under `~/.nerve/config/permissions.json` and project permissions under `<project>/.nerve/config/permissions.json`;
 - planning adds path-constrained writes, tool omissions, and shell guardrails before generic permission evaluation.
 
 The permission engine combines manifest and argument-sensitive risk, normalized request targets, permission level, hard host constraints, and typed user exceptions to produce `allow`, `approval`, or `deny`. Block exceptions win across scopes. Allow exceptions cannot expand Read only or bypass planning restrictions. Compound Bash calls are parsed into segments, and every mutating segment must match an exact-risk command-prefix exception before the call can run without approval. Python execution remains opaque and never receives a durable allow suggestion.

--- a/packages/workbench-server/src/domains/permissions/permission-exceptions.service.ts
+++ b/packages/workbench-server/src/domains/permissions/permission-exceptions.service.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import type {
   PermissionException,
   PermissionRule,
@@ -41,19 +40,6 @@ function toRule(
     toolName: exception.tool,
     matcherKind: matcherKind(exception),
     pattern: exception.rule,
-    ...(scope === "project"
-      ? {
-          sourceDigest: createHash("sha256")
-            .update(
-              JSON.stringify({
-                effect: exception.effect,
-                tool: exception.tool,
-                rule: exception.rule,
-              }),
-            )
-            .digest("hex"),
-        }
-      : {}),
     enabled: true,
     createdAt: timestamp,
     updatedAt: timestamp,
@@ -70,18 +56,6 @@ function toException(rule: PermissionRule): PermissionException {
     effect: rule.effect,
     rule: rule.pattern,
   };
-}
-
-function sameRule(left: PermissionRule, right: PermissionRule): boolean {
-  return (
-    left.id === right.id &&
-    left.effect === right.effect &&
-    left.toolName === right.toolName &&
-    left.matcherKind === right.matcherKind &&
-    left.pattern === right.pattern &&
-    left.sourceDigest === right.sourceDigest &&
-    left.enabled === right.enabled
-  );
 }
 
 export type DurableExceptionScope = "project" | "user";
@@ -108,16 +82,6 @@ export class PermissionExceptionService {
     this.getProject(projectId);
     return this.exclusive(`project:${projectId}`, async () => {
       const saved = await this.projects.replace(projectId, permissions);
-      const timestamp = new Date().toISOString();
-      // This protocol mutation is an explicit trust decision. The canonical
-      // copy is a hash-equivalent trust record; later file edits stop matching.
-      await this.storage.canonicalStore.replacePermissionRules(
-        "project",
-        projectId,
-        saved.exceptions.map((exception) =>
-          toRule(exception, "project", projectId, timestamp),
-        ),
-      );
       await this.events.publish("project.permissions.updated", {
         projectId,
         permissions: saved,
@@ -132,20 +96,11 @@ export class PermissionExceptionService {
     const userRules = this.storage.settings.permissions.exceptions.map(
       (exception) => toRule(exception, "user", undefined, now),
     );
-    const requested = (await this.projects.get(projectId)).exceptions.map(
+    const projectRules = (await this.projects.get(projectId)).exceptions.map(
       (exception) => toRule(exception, "project", projectId, now),
     );
-    const trusted = (
-      await this.storage.canonicalStore.listPermissionRules(projectId)
-    ).filter((rule) => rule.scope === "project");
-    const effectiveProject = requested.filter(
-      (rule) =>
-        rule.effect === "deny" ||
-        trusted.some((candidate) => sameRule(rule, candidate)),
-    );
-    // User deny rules are evaluated first by the policy layer and cannot be
-    // displaced by project allows.
-    return [...userRules, ...effectiveProject];
+    // Deny precedence and hard constraints remain enforced by the policy layer.
+    return [...userRules, ...projectRules];
   }
 
   async effective(projectId: string): Promise<PermissionException[]> {

--- a/packages/workbench-server/src/infrastructure/canonical-store/canonical-database.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/canonical-database.ts
@@ -1,7 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import type { PermissionRule } from "@nervekit/contracts";
 import type { ConversationJournalCommit } from "@nervekit/contracts";
 import {
   deserializeState,
@@ -9,7 +8,6 @@ import {
   type ConversationPersistenceDelta,
   type SerializedConversationState,
 } from "../../domains/conversations/conversation-state-materializer.js";
-import { permissionRuleSchema } from "@nervekit/contracts";
 import {
   checkpointConversationStateInTransaction,
   listConversationJournalIds,
@@ -19,9 +17,13 @@ import {
 } from "./conversation-journal-database.js";
 import { decode, encode } from "./payload-codecs.js";
 import {
+  CANONICAL_BASELINE_NAME,
   CANONICAL_SCHEMA_CHECKSUM,
   CANONICAL_SCHEMA_SQL,
+  CANONICAL_SCHEMA_V1_CHECKSUM,
   CANONICAL_SCHEMA_VERSION,
+  CANONICAL_V1_TO_V2_MIGRATION_NAME,
+  CANONICAL_V1_TO_V2_MIGRATION_SQL,
 } from "./schema.js";
 
 export interface CanonicalDocument<T = unknown> {
@@ -67,47 +69,89 @@ export class CanonicalDatabase {
          WHERE type = 'table' AND name = 'schema_migrations'`,
       )
       .get() as { present?: number } | undefined;
-    if (hasLedger?.present === 1) this.assertSchemaCompatible();
-    this.database.exec(CANONICAL_SCHEMA_SQL);
-    const applied = this.database
-      .prepare(`SELECT version FROM schema_migrations WHERE version = ?`)
-      .get(CANONICAL_SCHEMA_VERSION) as { version: number } | undefined;
-    if (!applied) {
+    if (hasLedger?.present !== 1) {
+      this.database.exec(CANONICAL_SCHEMA_SQL);
       this.database
         .prepare(
           `INSERT INTO schema_migrations (
              version, name, checksum, applied_at_ms, duration_ms
-           ) VALUES (?, 'canonical-baseline', ?, ?, 0)`,
+           ) VALUES (?, ?, ?, ?, 0)`,
         )
-        .run(CANONICAL_SCHEMA_VERSION, CANONICAL_SCHEMA_CHECKSUM, Date.now());
+        .run(
+          CANONICAL_SCHEMA_VERSION,
+          CANONICAL_BASELINE_NAME,
+          CANONICAL_SCHEMA_CHECKSUM,
+          Date.now(),
+        );
+      return;
     }
+
+    const rows = this.schemaMigrationRows();
+    this.assertSchemaCompatible(rows);
+    if (rows.at(-1)?.version === 1) this.migrateV1ToV2();
   }
 
-  assertSchemaCompatible(): void {
-    const rows = this.database
-      .prepare(
-        `SELECT version, checksum FROM schema_migrations ORDER BY version`,
-      )
-      .all() as unknown as Array<{ version: number; checksum: string }>;
+  assertSchemaCompatible(
+    rows: Array<{
+      version: number;
+      checksum: string;
+    }> = this.schemaMigrationRows(),
+  ): void {
     const newest = rows.at(-1);
-    if (newest && newest.version > CANONICAL_SCHEMA_VERSION) {
+    if (!newest) throw new Error("Storage schema migration ledger is empty.");
+    if (newest.version > CANONICAL_SCHEMA_VERSION) {
       throw new Error(
         `Storage schema ${newest.version} is newer than supported schema ${CANONICAL_SCHEMA_VERSION}.`,
       );
     }
-    const current = rows.find(
-      (row) => row.version === CANONICAL_SCHEMA_VERSION,
-    );
-    if (!current && newest) {
-      throw new Error(
-        `Storage schema ${newest.version} requires migration to ${CANONICAL_SCHEMA_VERSION}.`,
-      );
+    const checksums = new Map([
+      [1, CANONICAL_SCHEMA_V1_CHECKSUM],
+      [CANONICAL_SCHEMA_VERSION, CANONICAL_SCHEMA_CHECKSUM],
+    ]);
+    for (const row of rows) {
+      const expected = checksums.get(row.version);
+      if (!expected) {
+        throw new Error(
+          `Storage schema version ${row.version} is unsupported.`,
+        );
+      }
+      if (row.checksum !== expected) {
+        throw new Error(
+          `Storage schema checksum drift at version ${row.version}.`,
+        );
+      }
     }
-    if (current && current.checksum !== CANONICAL_SCHEMA_CHECKSUM) {
-      throw new Error(
-        `Storage schema checksum drift at version ${CANONICAL_SCHEMA_VERSION}.`,
-      );
-    }
+  }
+
+  private schemaMigrationRows(): Array<{
+    version: number;
+    checksum: string;
+  }> {
+    return this.database
+      .prepare(
+        `SELECT version, checksum FROM schema_migrations ORDER BY version`,
+      )
+      .all() as unknown as Array<{ version: number; checksum: string }>;
+  }
+
+  private migrateV1ToV2(): void {
+    const startedAt = Date.now();
+    this.transaction((database) => {
+      database.exec(CANONICAL_V1_TO_V2_MIGRATION_SQL);
+      database
+        .prepare(
+          `INSERT INTO schema_migrations (
+             version, name, checksum, applied_at_ms, duration_ms
+           ) VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          CANONICAL_SCHEMA_VERSION,
+          CANONICAL_V1_TO_V2_MIGRATION_NAME,
+          CANONICAL_SCHEMA_CHECKSUM,
+          Date.now(),
+          Date.now() - startedAt,
+        );
+    });
   }
 
   close(checkpoint = true): void {
@@ -288,64 +332,6 @@ export class CanonicalDatabase {
          WHERE namespace = ? AND scope_id = ? AND document_id = ?`,
       )
       .run(namespace, scopeId, documentId);
-  }
-
-  listPermissionRules(projectId?: string): PermissionRule[] {
-    const rows = this.database
-      .prepare(
-        `SELECT * FROM permission_rules
-         WHERE enabled = 1 AND (scope = 'user' OR project_id = ?)
-         ORDER BY CASE scope WHEN 'user' THEN 0 ELSE 1 END, id`,
-      )
-      .all(projectId ?? null) as unknown as PermissionRuleRow[];
-    return rows.map(decodePermissionRule);
-  }
-
-  replacePermissionRules(
-    scope: "user" | "project",
-    projectId: string | undefined,
-    rules: readonly PermissionRule[],
-  ): void {
-    for (const rule of rules) permissionRuleSchema.parse(rule);
-    this.transaction((database) => {
-      if (scope === "user") {
-        database
-          .prepare(`DELETE FROM permission_rules WHERE scope = 'user'`)
-          .run();
-      } else {
-        database
-          .prepare(
-            `DELETE FROM permission_rules WHERE scope = 'project' AND project_id = ?`,
-          )
-          .run(projectId ?? null);
-      }
-      const insert = database.prepare(
-        `INSERT INTO permission_rules (
-           id, scope, project_id, effect, tool_name, matcher_kind, pattern,
-           source_digest, enabled, created_at_ms, updated_at_ms
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      );
-      for (const rule of rules) {
-        if (rule.scope !== scope || rule.projectId !== projectId) {
-          throw new Error(
-            "Permission rule scope does not match replacement scope.",
-          );
-        }
-        insert.run(
-          rule.id,
-          rule.scope,
-          rule.projectId ?? null,
-          rule.effect,
-          rule.toolName,
-          rule.matcherKind,
-          rule.pattern,
-          rule.sourceDigest ?? null,
-          rule.enabled ? 1 : 0,
-          Date.parse(rule.createdAt),
-          Date.parse(rule.updatedAt),
-        );
-      }
-    });
   }
 
   appendDurableEvent(input: {
@@ -664,20 +650,6 @@ interface DurableEventRow {
   occurred_at_ms: number;
 }
 
-interface PermissionRuleRow {
-  id: string;
-  scope: "user" | "project";
-  project_id: string | null;
-  effect: "allow" | "deny";
-  tool_name: string;
-  matcher_kind: PermissionRule["matcherKind"];
-  pattern: string;
-  source_digest: string | null;
-  enabled: number;
-  created_at_ms: number;
-  updated_at_ms: number;
-}
-
 function decodeDocument<T>(
   namespace: string,
   scopeId: string,
@@ -707,19 +679,4 @@ function decodeDurableEvent(row: DurableEventRow) {
   };
 }
 
-function decodePermissionRule(row: PermissionRuleRow): PermissionRule {
-  return permissionRuleSchema.parse({
-    id: row.id,
-    scope: row.scope,
-    projectId: row.project_id ?? undefined,
-    effect: row.effect,
-    toolName: row.tool_name,
-    matcherKind: row.matcher_kind,
-    pattern: row.pattern,
-    sourceDigest: row.source_digest ?? undefined,
-    enabled: row.enabled === 1,
-    createdAt: new Date(row.created_at_ms).toISOString(),
-    updatedAt: new Date(row.updated_at_ms).toISOString(),
-  });
-}
 export { decode, encode } from "./payload-codecs.js";

--- a/packages/workbench-server/src/infrastructure/canonical-store/canonical-store.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/canonical-store.ts
@@ -1,5 +1,4 @@
 import { Worker } from "node:worker_threads";
-import type { PermissionRule } from "@nervekit/contracts";
 import type { CanonicalDocument } from "./canonical-database.js";
 import type {
   CanonicalCommand,
@@ -165,22 +164,6 @@ export class CanonicalStore {
         documentId,
         expectedRevision,
       },
-      true,
-    );
-  }
-  listPermissionRules(projectId?: string) {
-    return this.request<PermissionRule[]>({
-      kind: "list_permission_rules",
-      projectId,
-    });
-  }
-  replacePermissionRules(
-    scope: "user" | "project",
-    projectId: string | undefined,
-    rules: PermissionRule[],
-  ) {
-    return this.request<void>(
-      { kind: "replace_permission_rules", scope, projectId, rules },
       true,
     );
   }

--- a/packages/workbench-server/src/infrastructure/canonical-store/schema.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/schema.ts
@@ -1,7 +1,16 @@
-export const CANONICAL_SCHEMA_VERSION = 1;
-export const CANONICAL_BASELINE_NAME = "nerve-home-v1";
-export const CANONICAL_SCHEMA_CHECKSUM =
+export const CANONICAL_SCHEMA_VERSION = 2;
+export const CANONICAL_BASELINE_NAME = "nerve-home-v2";
+export const CANONICAL_SCHEMA_V1_CHECKSUM =
   "c6bfbb3901f4a51992de7baf11d11fa797ecc8063fa883d1fb6fb7d2e07d8433";
+export const CANONICAL_SCHEMA_CHECKSUM =
+  "368532728f350a7ac8d76ef5a91b7b76f902024c2096be65e37eef121e4402b0";
+export const CANONICAL_V1_TO_V2_MIGRATION_NAME =
+  "drop-redundant-canonical-tables";
+export const CANONICAL_V1_TO_V2_MIGRATION_SQL = `
+DROP INDEX IF EXISTS permission_rules_scope_tool;
+DROP TABLE IF EXISTS permission_rules;
+DROP TABLE IF EXISTS canonical_meta;
+`;
 export const CANONICAL_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS schema_migrations (
   version INTEGER PRIMARY KEY,
@@ -9,11 +18,6 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
   checksum TEXT NOT NULL CHECK(length(checksum) = 64),
   applied_at_ms INTEGER NOT NULL,
   duration_ms INTEGER NOT NULL CHECK(duration_ms >= 0)
-) STRICT;
-
-CREATE TABLE IF NOT EXISTS canonical_meta (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL
 ) STRICT;
 
 CREATE TABLE IF NOT EXISTS conversation_records (
@@ -76,23 +80,6 @@ CREATE INDEX IF NOT EXISTS durable_events_stream_sequence
   ON durable_events(stream, stream_sequence);
 CREATE INDEX IF NOT EXISTS durable_events_conversation_sequence
   ON durable_events(conversation_id, stream_sequence);
-
-CREATE TABLE IF NOT EXISTS permission_rules (
-  id TEXT PRIMARY KEY,
-  scope TEXT NOT NULL CHECK(scope IN ('user','project')),
-  project_id TEXT,
-  effect TEXT NOT NULL CHECK(effect IN ('allow','deny')),
-  tool_name TEXT NOT NULL,
-  matcher_kind TEXT NOT NULL CHECK(matcher_kind IN ('whole_tool','path_glob','command_glob','url_glob')),
-  pattern TEXT NOT NULL,
-  source_digest TEXT CHECK(source_digest IS NULL OR length(source_digest) = 64),
-  enabled INTEGER NOT NULL CHECK(enabled IN (0,1)),
-  created_at_ms INTEGER NOT NULL,
-  updated_at_ms INTEGER NOT NULL,
-  CHECK((scope = 'project' AND project_id IS NOT NULL) OR (scope = 'user' AND project_id IS NULL))
-) STRICT;
-CREATE INDEX IF NOT EXISTS permission_rules_scope_tool
-  ON permission_rules(scope, project_id, tool_name, enabled);
 
 CREATE TABLE IF NOT EXISTS file_assets (
   id TEXT PRIMARY KEY,

--- a/packages/workbench-server/src/infrastructure/canonical-store/worker-handler.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/worker-handler.ts
@@ -28,15 +28,6 @@ export function executeCanonicalCommand(
         command.documentId,
       );
       return undefined;
-    case "list_permission_rules":
-      return database.listPermissionRules(command.projectId);
-    case "replace_permission_rules":
-      database.replacePermissionRules(
-        command.scope,
-        command.projectId,
-        command.rules,
-      );
-      return undefined;
     case "append_durable_event":
       return database.appendDurableEvent(command.input);
     case "durable_event_for_intent":

--- a/packages/workbench-server/src/infrastructure/canonical-store/worker-protocol.ts
+++ b/packages/workbench-server/src/infrastructure/canonical-store/worker-protocol.ts
@@ -1,4 +1,3 @@
-import type { PermissionRule } from "@nervekit/contracts";
 import type { ConversationJournalCommit } from "@nervekit/contracts";
 import type {
   ConversationPersistenceDelta,
@@ -33,13 +32,6 @@ export type CanonicalCommand =
       scopeId: string;
       documentId: string;
       expectedRevision?: number;
-    }
-  | { kind: "list_permission_rules"; projectId?: string }
-  | {
-      kind: "replace_permission_rules";
-      scope: "user" | "project";
-      projectId?: string;
-      rules: PermissionRule[];
     }
   | {
       kind: "append_durable_event";
@@ -99,7 +91,6 @@ export const READ_COMMANDS = new Set<CanonicalCommand["kind"]>([
   "list_documents",
   "list_conversation_journal_ids",
   "read_conversation_journal",
-  "list_permission_rules",
   "durable_event_for_intent",
   "read_durable_events",
   "durable_event_bounds",

--- a/packages/workbench-server/test/canonical-store.test.ts
+++ b/packages/workbench-server/test/canonical-store.test.ts
@@ -9,13 +9,113 @@ import { CanonicalStore } from "../src/infrastructure/canonical-store/index.js";
 import {
   CANONICAL_SCHEMA_CHECKSUM,
   CANONICAL_SCHEMA_SQL,
+  CANONICAL_SCHEMA_V1_CHECKSUM,
+  CANONICAL_SCHEMA_VERSION,
 } from "../src/infrastructure/canonical-store/schema.js";
 
-test("canonical schema checksum matches the v1 SQL", () => {
+test("canonical schema checksum matches the v2 SQL", () => {
   assert.equal(
     createHash("sha256").update(CANONICAL_SCHEMA_SQL).digest("hex"),
     CANONICAL_SCHEMA_CHECKSUM,
   );
+});
+
+test("fresh canonical stores use v2 without removed tables", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-canonical-v2-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const path = join(home, "data", "nerve.sqlite");
+  const store = new CanonicalStore(path);
+  await store.initialize();
+  await store.close();
+
+  const database = new DatabaseSync(path, { readOnly: true });
+  const objects = database
+    .prepare(
+      `SELECT name FROM sqlite_master
+       WHERE name IN (
+         'canonical_meta', 'permission_rules', 'permission_rules_scope_tool'
+       ) ORDER BY name`,
+    )
+    .all();
+  const versions = (
+    database
+      .prepare(`SELECT version FROM schema_migrations ORDER BY version`)
+      .all() as Array<{ version: number }>
+  ).map((row) => row.version);
+  database.close();
+  assert.deepEqual(objects, []);
+  assert.deepEqual(versions, [CANONICAL_SCHEMA_VERSION]);
+});
+
+test("canonical v1 stores migrate transactionally to v2", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-canonical-v1-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const path = join(home, "nerve.sqlite");
+  const database = new DatabaseSync(path);
+  database.exec(CANONICAL_SCHEMA_SQL);
+  database.exec(`
+    CREATE TABLE canonical_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    ) STRICT;
+    CREATE TABLE permission_rules (
+      id TEXT PRIMARY KEY,
+      scope TEXT NOT NULL,
+      project_id TEXT,
+      effect TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      matcher_kind TEXT NOT NULL,
+      pattern TEXT NOT NULL,
+      source_digest TEXT,
+      enabled INTEGER NOT NULL,
+      created_at_ms INTEGER NOT NULL,
+      updated_at_ms INTEGER NOT NULL
+    ) STRICT;
+    CREATE INDEX permission_rules_scope_tool
+      ON permission_rules(scope, project_id, tool_name, enabled);
+  `);
+  database
+    .prepare(
+      `INSERT INTO schema_migrations
+       (version, name, checksum, applied_at_ms, duration_ms)
+       VALUES (1, 'canonical-baseline', ?, 1, 0)`,
+    )
+    .run(CANONICAL_SCHEMA_V1_CHECKSUM);
+  database
+    .prepare(
+      `INSERT INTO domain_documents (
+         namespace, scope_id, document_id, revision, payload_version, data,
+         created_at_ms, updated_at_ms
+       ) VALUES ('test', 'global', 'preserved', 1, 1, ?, 1, 1)`,
+    )
+    .run(Buffer.from(JSON.stringify({ preserved: true })));
+  database.close();
+
+  const store = new CanonicalStore(path);
+  await store.initialize();
+  await store.close();
+
+  const migrated = new DatabaseSync(path, { readOnly: true });
+  const objects = migrated
+    .prepare(
+      `SELECT name FROM sqlite_master
+       WHERE name IN (
+         'canonical_meta', 'permission_rules', 'permission_rules_scope_tool'
+       ) ORDER BY name`,
+    )
+    .all();
+  const versions = (
+    migrated
+      .prepare(`SELECT version FROM schema_migrations ORDER BY version`)
+      .all() as Array<{ version: number }>
+  ).map((row) => row.version);
+  const documents = migrated
+    .prepare(`SELECT COUNT(*) AS count FROM domain_documents`)
+    .get() as { count: number };
+  migrated.close();
+  assert.deepEqual(objects, []);
+  assert.deepEqual(versions, [1, 2]);
+  assert.equal(documents.count, 1);
 });
 
 test("canonical documents use revision compare-and-swap", async (t) => {
@@ -115,7 +215,7 @@ test("canonical events are dense per stream and idempotent by durable intent", a
   await store.close();
 });
 
-test("newer and checksum-drifted SQLite schemas are refused", async (t) => {
+test("newer SQLite schemas are refused", async (t) => {
   const home = await mkdtemp(join(tmpdir(), "nerve-canonical-version-"));
   t.after(() => rm(home, { recursive: true, force: true }));
   const path = join(home, "data", "nerve.sqlite");
@@ -134,4 +234,24 @@ test("newer and checksum-drifted SQLite schemas are refused", async (t) => {
   const future = new CanonicalStore(path);
   await assert.rejects(future.initialize(), /newer than supported/i);
   await future.close();
+});
+
+test("checksum-drifted v1 schemas are refused before migration", async (t) => {
+  const home = await mkdtemp(join(tmpdir(), "nerve-canonical-drift-"));
+  t.after(() => rm(home, { recursive: true, force: true }));
+  const path = join(home, "nerve.sqlite");
+  const database = new DatabaseSync(path);
+  database.exec(CANONICAL_SCHEMA_SQL);
+  database
+    .prepare(
+      `INSERT INTO schema_migrations
+       (version, name, checksum, applied_at_ms, duration_ms)
+       VALUES (1, 'canonical-baseline', ?, 1, 0)`,
+    )
+    .run("f".repeat(64));
+  database.close();
+
+  const store = new CanonicalStore(path);
+  await assert.rejects(store.initialize(), /checksum drift at version 1/i);
+  await store.close();
 });

--- a/packages/workbench-server/test/legacy-v2-home-migration.test.ts
+++ b/packages/workbench-server/test/legacy-v2-home-migration.test.ts
@@ -115,6 +115,22 @@ async function createCanonicalV3Home(home: string): Promise<void> {
       data BLOB NOT NULL,
       updated_at_ms INTEGER NOT NULL
     ) STRICT;
+    CREATE TABLE permission_rules (
+      id TEXT PRIMARY KEY,
+      scope TEXT NOT NULL CHECK(scope IN ('user','project')),
+      project_id TEXT,
+      effect TEXT NOT NULL CHECK(effect IN ('allow','deny')),
+      tool_name TEXT NOT NULL,
+      matcher_kind TEXT NOT NULL CHECK(matcher_kind IN ('whole_tool','path_glob','command_glob','url_glob')),
+      pattern TEXT NOT NULL,
+      source_digest TEXT CHECK(source_digest IS NULL OR length(source_digest) = 64),
+      enabled INTEGER NOT NULL CHECK(enabled IN (0,1)),
+      created_at_ms INTEGER NOT NULL,
+      updated_at_ms INTEGER NOT NULL,
+      CHECK((scope = 'project' AND project_id IS NOT NULL) OR (scope = 'user' AND project_id IS NULL))
+    ) STRICT;
+    CREATE INDEX permission_rules_scope_tool
+      ON permission_rules(scope, project_id, tool_name, enabled);
     DELETE FROM schema_migrations;
   `);
   database

--- a/packages/workbench-server/test/project-permissions.test.ts
+++ b/packages/workbench-server/test/project-permissions.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -20,7 +20,7 @@ afterEach(async () => {
 });
 
 describe("project permission exceptions", () => {
-  it("stores scoped canonical rules and unions user exceptions", async () => {
+  it("uses user and project permission files as authoritative sources", async () => {
     const root = await mkdtemp(join(tmpdir(), "nerve-project-permissions-"));
     roots.push(root);
     const storage = await initializeStorage(root);
@@ -91,17 +91,47 @@ describe("project permission exceptions", () => {
       projectException,
     ]);
     assert.deepEqual(await service.effective("proj_two"), [userException]);
+    const projectPermissionsPath = await repository.file("proj_one");
     assert.deepEqual(
-      (await storage.canonicalStore.listPermissionRules("proj_one"))
-        .filter((rule) => rule.scope === "project")
-        .map((rule) => ({
-          id: `exception_${rule.id.replace(/^rule_project_?/, "")}`,
-          tool: rule.toolName,
-          effect: rule.effect,
-          rule: rule.pattern,
-        })),
-      [projectException],
+      JSON.parse(await readFile(projectPermissionsPath, "utf8")),
+      {
+        version: 1,
+        rules: [
+          {
+            id: "project",
+            effect: "allow",
+            tool: "bash",
+            matcher: { kind: "command_glob", pattern: "gh pr view*" },
+            enabled: true,
+          },
+        ],
+      },
     );
+
+    await writeFile(
+      projectPermissionsPath,
+      JSON.stringify({
+        version: 1,
+        rules: [
+          {
+            id: "manual",
+            effect: "allow",
+            tool: "bash",
+            matcher: { kind: "command_glob", pattern: "gh issue view*" },
+            enabled: true,
+          },
+        ],
+      }),
+    );
+    assert.deepEqual(await service.effective("proj_one"), [
+      userException,
+      {
+        id: "exception_manual",
+        tool: "bash",
+        effect: "allow",
+        rule: "gh issue view*",
+      },
+    ]);
     assert.equal(published.includes("project.permissions.updated"), true);
     assert.equal(published.includes("settings.updated"), true);
   });


### PR DESCRIPTION
## Summary

- Drop `canonical_meta` and `permission_rules` from the current canonical SQLite schema and advance it to v2. Existing v1 databases transactionally drop both tables on startup, preserving unrelated data.
- Remove the SQLite permission trust copy and its source-digest comparison. Permissions are now owned by the file-backed configuration sources:
  - user scope: `~/.nerve/config/permissions.json`
  - project scope: `<project>/.nerve/config/permissions.json`
- Enabled project rules now participate directly in policy evaluation; deny precedence and hard constraints remain enforced.
- Preserve legacy canonical-v3 import compatibility (its historical source `permission_rules` reader is retained, with the test fixture explicitly creating the legacy table).

## Test plan

- `packages/workbench-server/test/canonical-store.test.ts`: fresh v2 schema has neither removed table/index; v1 stores migrate transactionally to v2 with unrelated documents intact; tampered v1 checksums and future versions are refused.
- `packages/workbench-server/test/project-permissions.test.ts`: project/user permission files are authoritative, including manual project-file edits becoming immediately effective.
- `packages/workbench-server/test/legacy-v2-home-migration.test.ts`: canonical-v3 import still succeeds.
- `pnpm fix && pnpm check && pnpm test` pass.

## Notes

This is a behavior change: project allow rules no longer require a separate SQLite trust decision. That matches the requested authoritative-file model and is documented/tested.

🤖 Generated with [Nerve](https://github.com/ThilinaTLM/nerve)