### PR TITLE
Show minimaps in CodeMirror file and diff panes

### DIFF
--- a/packages/workbench-app/src/lib/features/git/ui/CodeMirrorGitDiff.svelte
+++ b/packages/workbench-app/src/lib/features/git/ui/CodeMirrorGitDiff.svelte
@@ -39,7 +39,6 @@ import {
 import {
   loadCodeLanguage,
   readOnlyCodeExtensions,
-  shouldShowCodeMinimap,
 } from "$lib/presentation/components/code/code-mirror-config";
 
 type Props = {
@@ -292,7 +291,6 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
 function baseExtensions(): Extension[] {
   return readOnlyCodeExtensions({
     ariaLabel: `Diff for ${path}`,
-    minimap: shouldShowCodeMinimap(modified, wrap),
     highlightSelectionMatches,
     foldMarkerDOM: codeFoldMarker,
   });

--- a/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorViewer.svelte
+++ b/packages/workbench-app/src/lib/presentation/components/code/CodeMirrorViewer.svelte
@@ -38,7 +38,6 @@ import {
   loadCodeLanguage,
   localLineNumber,
   readOnlyCodeExtensions,
-  shouldShowCodeMinimap,
 } from "./code-mirror-config";
 
 type Props = {
@@ -297,7 +296,6 @@ function baseExtensions(): Extension[] {
   return readOnlyCodeExtensions({
     lineStart,
     ariaLabel,
-    minimap: shouldShowCodeMinimap(text, wrap),
     highlightSelectionMatches,
     foldMarkerDOM: codeFoldMarker,
   });

--- a/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.test.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.test.ts
@@ -14,7 +14,6 @@ import {
   codeLanguageId,
   loadCodeLanguage,
   localLineNumber,
-  shouldShowCodeMinimap,
 } from "./code-mirror-config";
 
 const newLanguageIds: CodeLanguageId[] = [
@@ -92,16 +91,6 @@ describe("CodeMirror viewer helpers", () => {
       const tree = await ensureSyntaxTree(state, doc.length, 10_000);
       assert.equal(tree?.length, doc.length, id);
     }
-  });
-
-  it("shows the minimap only for long, unwrapped documents", () => {
-    const lines = (count: number) =>
-      Array.from({ length: count }, () => "x").join("\n");
-
-    assert.equal(shouldShowCodeMinimap(lines(100), false), false);
-    assert.equal(shouldShowCodeMinimap(lines(101), false), true);
-    assert.equal(shouldShowCodeMinimap(lines(101), true), false);
-    assert.equal(shouldShowCodeMinimap("", false), false);
   });
 
   it("maps external lines into a windowed document", () => {

--- a/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/code-mirror-config.ts
@@ -316,7 +316,7 @@ export const codeMirrorTheme = EditorView.theme({
     padding: "0 calc(var(--spacing) * 4) 0 calc(var(--spacing) * 2)",
   },
   ".cm-gutters": {
-    backgroundColor: "color-mix(in oklab, var(--background) 72%, var(--card))",
+    backgroundColor: "var(--background)",
     color: "var(--muted-foreground)",
     borderRight:
       "1px solid color-mix(in oklab, var(--background) 55%, var(--border))",
@@ -383,18 +383,6 @@ export const codeMirrorTheme = EditorView.theme({
   },
 });
 
-const CODE_MINIMAP_LINE_THRESHOLD = 100;
-
-export function shouldShowCodeMinimap(text: string, wrap: boolean): boolean {
-  if (wrap) return false;
-  let lines = 1;
-  for (let index = 0; index < text.length; index += 1) {
-    if (text.charCodeAt(index) === 10) lines += 1;
-    if (lines > CODE_MINIMAP_LINE_THRESHOLD) return true;
-  }
-  return false;
-}
-
 function codeMinimapExtension(): Extension {
   return showMinimap.of({
     create: () => {
@@ -425,7 +413,6 @@ export function editableCodeExtensions(ariaLabel: string): Extension[] {
 export function readOnlyCodeExtensions(input: {
   lineStart?: number;
   ariaLabel: string;
-  minimap?: boolean;
   highlightSelectionMatches?: boolean;
   foldMarkerDOM?: (open: boolean) => HTMLElement;
 }): Extension[] {
@@ -447,7 +434,7 @@ export function readOnlyCodeExtensions(input: {
     input.highlightSelectionMatches ? highlightSelectionMatches() : [],
     syntaxHighlighting(codeHighlightStyle),
     keymap.of(foldKeymap),
-    input.minimap ? codeMinimapExtension() : [],
+    codeMinimapExtension(),
     codeMirrorTheme,
   ];
 }

--- a/packages/workbench-app/src/lib/presentation/components/code/index.ts
+++ b/packages/workbench-app/src/lib/presentation/components/code/index.ts
@@ -7,5 +7,4 @@ export {
   loadCodeLanguage,
   localLineNumber,
   readOnlyCodeExtensions,
-  shouldShowCodeMinimap,
 } from "./code-mirror-config.js";


### PR DESCRIPTION
## Summary
- always show the CodeMirror minimap in read-only file and Git diff panes
- match line-number and fold gutter backgrounds to the editor content
- preserve the subtle gutter separator and remove obsolete threshold logic

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`