### PR TITLE
Retain scroll positions across center tabs

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/CenterTabScrollLayer.svelte
+++ b/packages/workbench-app/src/lib/app/shell/CenterTabScrollLayer.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import { retainCenterTabScroll } from "./center-tab-scroll-restoration";
+
+let {
+  tabKey,
+  hidden = false,
+  children,
+}: {
+  tabKey: string;
+  hidden?: boolean;
+  children: Snippet;
+} = $props();
+</script>
+
+<div
+  use:retainCenterTabScroll={{ tabKey, active: !hidden }}
+  class="size-full min-h-0 min-w-0"
+  {hidden}
+>
+  {@render children()}
+</div>

--- a/packages/workbench-app/src/lib/app/shell/WorkbenchEditorHost.svelte
+++ b/packages/workbench-app/src/lib/app/shell/WorkbenchEditorHost.svelte
@@ -9,6 +9,7 @@ import {
 } from "$lib/app/composition/center-views";
 import LazyViewPending from "$lib/app/shell/LazyViewPending.svelte";
 import {
+  centerTabKey,
   centerTabsExcept,
   centerTabsToLeftOf,
   centerTabsToRightOf,
@@ -35,6 +36,8 @@ import {
   type ConversationPaneTab,
 } from "./keep-mounted-conversation-panes";
 import { refreshCenterTab } from "./refresh-center-tab.svelte";
+import CenterTabScrollLayer from "./CenterTabScrollLayer.svelte";
+import { scheduleCenterTabScrollSnapshotPrune } from "./center-tab-scroll-restoration";
 
 const status = $derived(workspaceSelectors.status);
 const centerTabs = $derived(workspaceSelectors.centerTabs);
@@ -52,6 +55,12 @@ const renderedConversationPaneTabs = $derived(
     activeConversationPaneTab,
   ),
 );
+
+$effect(() => {
+  scheduleCenterTabScrollSnapshotPrune(
+    new Set(openCenterTabs.map((tab) => centerTabKey(tab))),
+  );
+});
 
 $effect(() => {
   const nextMountedConversationPaneTabs = updateMountedConversationPaneTabs(
@@ -112,62 +121,68 @@ function closeCenterTabsLeft(tab: CenterTabIdentity) {
   {/snippet}
   {#snippet content()}
     <div class="center-workspace-content h-full">
-      {#if activeCenterTab?.kind === "task"}
-        {#await loadedCenterViews.task}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
-      {:else if activeCenterTab?.kind === "file"}
-        {#await loadedCenterViews.file}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
-      {:else if activeCenterTab?.kind === "mermaid"}
-        {#await loadedCenterViews.mermaid}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
-      {:else if activeCenterTab?.kind === "pr"}
-        {#await loadedCenterViews.pr}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
-      {:else if activeCenterTab?.kind === "diff"}
-        {#await loadedCenterViews.diff}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
-      {:else if activeCenterTab?.kind === "settings"}
-        {#await loadedCenterViews.settings}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
-      {:else if activeCenterTab?.kind === "logs"}
-        {#await loadedCenterViews.logs}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
-      {:else if activeCenterTab?.kind === "discover"}
-        {#await loadedCenterViews.discover}
-          <LazyViewPending />
-        {:then module}
-          {@const Component = module?.default}
-          {#if Component}<Component />{/if}
-        {/await}
+      {#if activeCenterTab && !isConversationPaneTab(activeCenterTab)}
+        {#key centerTabKey(activeCenterTab)}
+          <CenterTabScrollLayer tabKey={centerTabKey(activeCenterTab)}>
+            {#if activeCenterTab.kind === "task"}
+              {#await loadedCenterViews.task}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {:else if activeCenterTab.kind === "file"}
+              {#await loadedCenterViews.file}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {:else if activeCenterTab.kind === "mermaid"}
+              {#await loadedCenterViews.mermaid}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {:else if activeCenterTab.kind === "pr"}
+              {#await loadedCenterViews.pr}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {:else if activeCenterTab.kind === "diff"}
+              {#await loadedCenterViews.diff}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {:else if activeCenterTab.kind === "settings"}
+              {#await loadedCenterViews.settings}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {:else if activeCenterTab.kind === "logs"}
+              {#await loadedCenterViews.logs}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {:else if activeCenterTab.kind === "discover"}
+              {#await loadedCenterViews.discover}
+                <LazyViewPending />
+              {:then module}
+                {@const Component = module?.default}
+                {#if Component}<Component />{/if}
+              {/await}
+            {/if}
+          </CenterTabScrollLayer>
+        {/key}
       {/if}
 
       {#if renderedConversationPaneTabs.length > 0}
@@ -176,9 +191,12 @@ function closeCenterTabsLeft(tab: CenterTabIdentity) {
             activeConversationPaneTab,
             tab,
           )}
-          <div class="conversation-pane-layer" hidden={!tabActive}>
+          <CenterTabScrollLayer
+            tabKey={conversationPaneTabKey(tab)}
+            hidden={!tabActive}
+          >
             <ConversationCenterHost {tab} active={tabActive} />
-          </div>
+          </CenterTabScrollLayer>
         {/each}
       {:else if !activeCenterTab}
         <ConversationCenterHost active />
@@ -198,14 +216,5 @@ function closeCenterTabsLeft(tab: CenterTabIdentity) {
 .center-workspace-content > :global(*) {
   min-height: 0;
   min-width: 0;
-}
-
-.conversation-pane-layer {
-  min-height: 0;
-  min-width: 0;
-}
-
-.conversation-pane-layer[hidden] {
-  display: none;
 }
 </style>

--- a/packages/workbench-app/src/lib/app/shell/center-tab-scroll-restoration.test.ts
+++ b/packages/workbench-app/src/lib/app/shell/center-tab-scroll-restoration.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  CenterTabScrollSnapshotStore,
+  type ScrollPosition,
+} from "./center-tab-scroll-restoration.js";
+
+function position(
+  path: readonly number[],
+  top: number,
+  left: number,
+  signature = "slot:scroll-area-viewport",
+  ordinal = 0,
+): ScrollPosition {
+  return { path, signature, ordinal, top, left };
+}
+
+test("keeps vertical and horizontal positions isolated by center tab", () => {
+  const store = new CenterTabScrollSnapshotStore();
+  store.record("file:a", position([0, 1], 480, 72));
+  store.record("diff:b", position([0, 1], 920, 144));
+
+  assert.deepEqual(store.positions("file:a"), [position([0, 1], 480, 72)]);
+  assert.deepEqual(store.positions("diff:b"), [position([0, 1], 920, 144)]);
+});
+
+test("retains multiple independently located scrollports in one pane", () => {
+  const store = new CenterTabScrollSnapshotStore();
+  store.record(
+    "pr:42",
+    position([1, 0], 300, 0, "slot:scroll-area-viewport", 0),
+  );
+  store.record("pr:42", position([1, 2], 640, 18, "codemirror", 0));
+
+  assert.deepEqual(store.positions("pr:42"), [
+    position([1, 0], 300, 0, "slot:scroll-area-viewport", 0),
+    position([1, 2], 640, 18, "codemirror", 0),
+  ]);
+});
+
+test("updates a scrollport snapshot without duplicating its stable path", () => {
+  const store = new CenterTabScrollSnapshotStore();
+  store.record(
+    "logs:application",
+    position([0, 0], 120, 0, "virtual:Application logs"),
+  );
+  store.record(
+    "logs:application",
+    position([0, 0], 360, 0, "virtual:Application logs"),
+  );
+
+  assert.deepEqual(store.positions("logs:application"), [
+    position([0, 0], 360, 0, "virtual:Application logs"),
+  ]);
+});
+
+test("prunes closed tabs without affecting open tab snapshots", () => {
+  const store = new CenterTabScrollSnapshotStore();
+  store.record("file:open", position([0], 40, 0));
+  store.record("file:closed", position([0], 80, 0));
+
+  store.prune(new Set(["file:open"]));
+
+  assert.equal(store.positions("file:closed").length, 0);
+  assert.deepEqual(store.positions("file:open"), [position([0], 40, 0)]);
+});

--- a/packages/workbench-app/src/lib/app/shell/center-tab-scroll-restoration.ts
+++ b/packages/workbench-app/src/lib/app/shell/center-tab-scroll-restoration.ts
@@ -1,0 +1,266 @@
+import type { Action } from "svelte/action";
+
+export type ScrollPosition = {
+  path: readonly number[];
+  signature: string;
+  ordinal: number;
+  top: number;
+  left: number;
+};
+
+export class CenterTabScrollSnapshotStore {
+  readonly #snapshots = new Map<string, Map<string, ScrollPosition>>();
+
+  positions(tabKey: string): readonly ScrollPosition[] {
+    return [...(this.#snapshots.get(tabKey)?.values() ?? [])];
+  }
+
+  record(tabKey: string, position: ScrollPosition): void {
+    let tabSnapshot = this.#snapshots.get(tabKey);
+    if (!tabSnapshot) {
+      tabSnapshot = new Map();
+      this.#snapshots.set(tabKey, tabSnapshot);
+    }
+    tabSnapshot.set(positionKey(position), {
+      ...position,
+      path: [...position.path],
+    });
+  }
+
+  prune(openTabKeys: ReadonlySet<string>): void {
+    for (const tabKey of this.#snapshots.keys()) {
+      if (!openTabKeys.has(tabKey)) this.#snapshots.delete(tabKey);
+    }
+  }
+
+  clear(): void {
+    this.#snapshots.clear();
+  }
+}
+
+const scrollSnapshots = new CenterTabScrollSnapshotStore();
+const SCROLLPORT_SELECTOR = [
+  '[data-slot="scroll-area-viewport"]',
+  ".virtual-scroller-viewport",
+  ".cm-scroller",
+  "[data-center-scrollport]",
+].join(",");
+const RESTORE_FRAME_LIMIT = 24;
+let pruneTimer: ReturnType<typeof setTimeout> | undefined;
+
+function positionKey(position: Pick<ScrollPosition, "path">): string {
+  return position.path.join(".");
+}
+
+function elementSignature(element: HTMLElement): string {
+  const slot = element.dataset.slot;
+  if (slot) return `slot:${slot}`;
+  if (element.classList.contains("virtual-scroller-viewport")) {
+    return `virtual:${element.getAttribute("aria-label") ?? ""}`;
+  }
+  if (element.classList.contains("cm-scroller")) return "codemirror";
+  const explicit = element.dataset.centerScrollport;
+  if (explicit !== undefined) return `explicit:${explicit}`;
+  return `${element.tagName.toLowerCase()}:${element.getAttribute("role") ?? ""}:${element.getAttribute("aria-label") ?? ""}`;
+}
+
+function elementPath(
+  root: HTMLElement,
+  element: HTMLElement,
+): number[] | undefined {
+  const path: number[] = [];
+  let current: HTMLElement | null = element;
+  while (current && current !== root) {
+    const parent: HTMLElement | null = current.parentElement;
+    if (!parent) return undefined;
+    const index = Array.prototype.indexOf.call(parent.children, current);
+    if (index < 0) return undefined;
+    path.unshift(index);
+    current = parent;
+  }
+  return current === root ? path : undefined;
+}
+
+function elementAtPath(
+  root: HTMLElement,
+  path: readonly number[],
+): HTMLElement | undefined {
+  let current: HTMLElement = root;
+  for (const index of path) {
+    const child = current.children.item(index);
+    if (!(child instanceof HTMLElement)) return undefined;
+    current = child;
+  }
+  return current;
+}
+
+function scrollports(root: HTMLElement): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>(SCROLLPORT_SELECTOR)];
+}
+
+function snapshotForElement(
+  root: HTMLElement,
+  element: HTMLElement,
+): ScrollPosition | undefined {
+  const path = elementPath(root, element);
+  if (!path) return undefined;
+  const signature = elementSignature(element);
+  const matching = scrollports(root).filter(
+    (candidate) => elementSignature(candidate) === signature,
+  );
+  return {
+    path,
+    signature,
+    ordinal: Math.max(0, matching.indexOf(element)),
+    top: element.scrollTop,
+    left: element.scrollLeft,
+  };
+}
+
+function resolveScrollport(
+  root: HTMLElement,
+  position: ScrollPosition,
+): HTMLElement | undefined {
+  const exact = elementAtPath(root, position.path);
+  if (exact && elementSignature(exact) === position.signature) return exact;
+  return scrollports(root).filter(
+    (candidate) => elementSignature(candidate) === position.signature,
+  )[position.ordinal];
+}
+
+type RetainCenterTabScrollOptions = {
+  tabKey: string;
+  active: boolean;
+};
+
+export const retainCenterTabScroll: Action<
+  HTMLElement,
+  RetainCenterTabScrollOptions
+> = (root, options) => {
+  const { tabKey } = options;
+  let active = options.active;
+  let restoring = active && scrollSnapshots.positions(tabKey).length > 0;
+  let restoreFrame: number | undefined;
+  let restoreAttempts = 0;
+  let stableFrames = 0;
+  let destroyed = false;
+
+  const stopRestore = () => {
+    restoring = false;
+    if (restoreFrame !== undefined) cancelAnimationFrame(restoreFrame);
+    restoreFrame = undefined;
+  };
+
+  const restore = () => {
+    restoreFrame = undefined;
+    if (destroyed || !restoring) return;
+    restoreAttempts += 1;
+    const positions = scrollSnapshots.positions(tabKey);
+    let complete = positions.length > 0;
+    let alreadyRestored = true;
+
+    for (const position of positions) {
+      const element = resolveScrollport(root, position);
+      if (!element) {
+        complete = false;
+        alreadyRestored = false;
+        continue;
+      }
+      if (
+        Math.abs(element.scrollTop - position.top) > 1 ||
+        Math.abs(element.scrollLeft - position.left) > 1
+      ) {
+        alreadyRestored = false;
+        element.scrollTop = position.top;
+        element.scrollLeft = position.left;
+      }
+    }
+
+    stableFrames = complete && alreadyRestored ? stableFrames + 1 : 0;
+    if (stableFrames >= 2) {
+      stopRestore();
+      return;
+    }
+    // Pause rather than abandon restoration when an async or virtualized view
+    // has not reached its final scroll extent yet. Its next DOM mutation will
+    // start another bounded attempt window.
+    if (restoreAttempts >= RESTORE_FRAME_LIMIT) return;
+    restoreFrame = requestAnimationFrame(restore);
+  };
+
+  const scheduleRestore = () => {
+    if (!active || !restoring || restoreFrame !== undefined) return;
+    restoreFrame = requestAnimationFrame(restore);
+  };
+
+  const observer = new MutationObserver(() => {
+    restoreAttempts = 0;
+    scheduleRestore();
+  });
+  observer.observe(root, {
+    attributes: true,
+    attributeFilter: ["style"],
+    childList: true,
+    subtree: true,
+  });
+
+  const handleScroll = (event: Event) => {
+    if (!active || restoring || !(event.target instanceof HTMLElement)) return;
+    if (!event.target.matches(SCROLLPORT_SELECTOR)) return;
+    const position = snapshotForElement(root, event.target);
+    if (position) scrollSnapshots.record(tabKey, position);
+  };
+  const handleUserIntent = () => stopRestore();
+
+  root.addEventListener("scroll", handleScroll, true);
+  root.addEventListener("wheel", handleUserIntent, {
+    capture: true,
+    passive: true,
+  });
+  root.addEventListener("touchstart", handleUserIntent, {
+    capture: true,
+    passive: true,
+  });
+  root.addEventListener("pointerdown", handleUserIntent, {
+    capture: true,
+    passive: true,
+  });
+  root.addEventListener("keydown", handleUserIntent, true);
+  scheduleRestore();
+
+  return {
+    update(nextOptions) {
+      if (nextOptions.active === active) return;
+      active = nextOptions.active;
+      if (!active) {
+        stopRestore();
+        return;
+      }
+      restoring = scrollSnapshots.positions(tabKey).length > 0;
+      restoreAttempts = 0;
+      stableFrames = 0;
+      scheduleRestore();
+    },
+    destroy() {
+      destroyed = true;
+      stopRestore();
+      observer.disconnect();
+      root.removeEventListener("scroll", handleScroll, true);
+      root.removeEventListener("wheel", handleUserIntent, true);
+      root.removeEventListener("touchstart", handleUserIntent, true);
+      root.removeEventListener("pointerdown", handleUserIntent, true);
+      root.removeEventListener("keydown", handleUserIntent, true);
+    },
+  };
+};
+
+export function scheduleCenterTabScrollSnapshotPrune(
+  openTabKeys: ReadonlySet<string>,
+): void {
+  if (pruneTimer !== undefined) clearTimeout(pruneTimer);
+  const keys = new Set(openTabKeys);
+  pruneTimer = setTimeout(() => {
+    pruneTimer = undefined;
+    scrollSnapshots.prune(keys);
+  }, 0);
+}

--- a/packages/workbench-app/src/lib/application/workspace/index.ts
+++ b/packages/workbench-app/src/lib/application/workspace/index.ts
@@ -6,6 +6,7 @@ export {
   closeCenterTabs,
 } from "./center-tab-actions.svelte";
 export {
+  centerTabKey,
   closeCenterTab,
   reorderCenterTab,
   selectCenterTab,


### PR DESCRIPTION
## Summary
- retain horizontal and vertical scroll positions per open center tab
- restore nested ScrollArea, CodeMirror, and virtualized viewports after tab switches
- preserve conversation transcript positions across hidden and remounted panes
- prune snapshots when tabs close and add snapshot registry tests

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`
- agent-browser verification for Markdown and conversation tab switching