### PR TITLE
Improve application log detail and signal

### DIFF
--- a/packages/tools/src/git/git-github-api-client.ts
+++ b/packages/tools/src/git/git-github-api-client.ts
@@ -49,7 +49,7 @@ export class GithubApiClient {
     variables: Readonly<Record<string, unknown>>,
   ): Promise<T> {
     const envelope = await this.#request<GraphqlEnvelope<T>>(
-      repository.hostname,
+      repository,
       "https://api.github.com/graphql",
       {
         method: "POST",
@@ -87,7 +87,7 @@ export class GithubApiClient {
     options: RestOptions,
   ): Promise<T> {
     return this.#request<T>(
-      repository.hostname,
+      repository,
       `https://api.github.com${path}`,
       options,
     );
@@ -134,17 +134,18 @@ export class GithubApiClient {
   }
 
   async #request<T>(
-    hostname: string,
+    repository: GithubRepositoryRef,
     url: string,
     options: RestOptions,
   ): Promise<T> {
+    const method = options.method ?? "GET";
     let lastStatus: number | undefined;
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const startedAt = performance.now();
       try {
-        const token = await this.token(hostname);
+        const token = await this.token(repository.hostname);
         const response = await this.#fetch(url, {
-          method: options.method ?? "GET",
+          method,
           headers: {
             Accept: "application/vnd.github+json",
             Authorization: `Bearer ${token}`,
@@ -159,20 +160,48 @@ export class GithubApiClient {
         });
         lastStatus = response.status;
         if (response.status === 401 && attempt === 0) {
-          this.#tokens.delete(hostname);
-          this.#observe(options.operation, startedAt, false, response.status);
+          this.#tokens.delete(repository.hostname);
+          this.#observe(
+            repository,
+            options.operation,
+            method,
+            startedAt,
+            false,
+            response.status,
+          );
           continue;
         }
         if (!response.ok) throw apiError(response.status, response.headers);
         const value = (await response.json()) as T;
-        this.#observe(options.operation, startedAt, true, response.status);
+        this.#observe(
+          repository,
+          options.operation,
+          method,
+          startedAt,
+          true,
+          response.status,
+        );
         return value;
       } catch (error) {
         if (error instanceof GitWorkflowError) {
-          this.#observe(options.operation, startedAt, false, lastStatus);
+          this.#observe(
+            repository,
+            options.operation,
+            method,
+            startedAt,
+            false,
+            lastStatus,
+          );
           throw error;
         }
-        this.#observe(options.operation, startedAt, false, lastStatus);
+        this.#observe(
+          repository,
+          options.operation,
+          method,
+          startedAt,
+          false,
+          lastStatus,
+        );
         throw new GitWorkflowError(
           503,
           "GH_API_UNAVAILABLE",
@@ -190,7 +219,9 @@ export class GithubApiClient {
   }
 
   #observe(
+    repository: GithubRepositoryRef,
     operation: string,
+    method: "GET" | "POST" | "PUT",
     startedAt: number,
     succeeded: boolean,
     status?: number,
@@ -198,6 +229,10 @@ export class GithubApiClient {
     try {
       this.options.onRequestCompleted?.({
         operation,
+        method,
+        hostname: repository.hostname,
+        owner: repository.owner,
+        repository: repository.repo,
         durationMs: performance.now() - startedAt,
         succeeded,
         status,

--- a/packages/tools/src/git/git-observability.ts
+++ b/packages/tools/src/git/git-observability.ts
@@ -8,18 +8,25 @@ export type GitWorkspaceRef = {
 export interface GitCommandObservation {
   readonly bin: "git" | "gh";
   readonly command: string;
+  readonly cwd: string;
   readonly durationMs: number;
   readonly succeeded: boolean;
 }
 
 export interface GithubRequestObservation {
   readonly operation: string;
+  readonly method: "GET" | "POST" | "PUT";
+  readonly hostname: string;
+  readonly owner: string;
+  readonly repository: string;
   readonly durationMs: number;
   readonly succeeded: boolean;
   readonly status?: number;
 }
 
 export interface GitOverviewObservation {
+  readonly projectId: string;
+  readonly relativePath: string;
   readonly durationMs: number;
   readonly succeeded: boolean;
 }
@@ -27,6 +34,7 @@ export interface GitOverviewObservation {
 export interface GitReadObservation {
   readonly backend: "native";
   readonly operation: string;
+  readonly repoDir?: string;
   readonly durationMs: number;
   readonly succeeded: boolean;
 }

--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -146,6 +146,7 @@ export class GitService {
       this.observeCommand({
         bin,
         command: observedCommand(args),
+        cwd,
         durationMs: performance.now() - startedAt,
         succeeded: true,
       });
@@ -154,6 +155,7 @@ export class GitService {
       this.observeCommand({
         bin,
         command: observedCommand(args),
+        cwd,
         durationMs: performance.now() - startedAt,
         succeeded: false,
       });
@@ -396,6 +398,8 @@ export class GitService {
       return result;
     } finally {
       this.observeOverview({
+        projectId,
+        relativePath,
         durationMs: performance.now() - startedAt,
         succeeded,
       });

--- a/packages/tools/src/git/read/observed-backend.ts
+++ b/packages/tools/src/git/read/observed-backend.ts
@@ -14,8 +14,10 @@ export class ObservedGitReadBackend implements GitReadBackend {
 
   async isRepository(repoDir: string): Promise<boolean> {
     try {
-      return await this.run("repository-info", () =>
-        this.backend.isRepository(repoDir),
+      return await this.run(
+        "repository-info",
+        () => this.backend.isRepository(repoDir),
+        repoDir,
       );
     } catch (error) {
       if (
@@ -30,8 +32,10 @@ export class ObservedGitReadBackend implements GitReadBackend {
     repoDir: string,
     includeIgnored?: boolean,
   ): Promise<GitReadSnapshot> {
-    return this.run("snapshot", () =>
-      this.backend.snapshot(repoDir, includeIgnored),
+    return this.run(
+      "snapshot",
+      () => this.backend.snapshot(repoDir, includeIgnored),
+      repoDir,
     );
   }
   isAncestor(
@@ -39,13 +43,17 @@ export class ObservedGitReadBackend implements GitReadBackend {
     ancestor: string,
     descendant: string,
   ): Promise<boolean> {
-    return this.run("ancestry", () =>
-      this.backend.isAncestor(repoDir, ancestor, descendant),
+    return this.run(
+      "ancestry",
+      () => this.backend.isAncestor(repoDir, ancestor, descendant),
+      repoDir,
     );
   }
   resolveRevision(repoDir: string, revision: string): Promise<string> {
-    return this.run("resolve-revision", () =>
-      this.backend.resolveRevision(repoDir, revision),
+    return this.run(
+      "resolve-revision",
+      () => this.backend.resolveRevision(repoDir, revision),
+      repoDir,
     );
   }
   validateBranchName(name: string): Promise<boolean> {
@@ -58,14 +66,17 @@ export class ObservedGitReadBackend implements GitReadBackend {
     original: NativeGitDocumentSource,
     modified: NativeGitDocumentSource,
   ): Promise<NativeGitFileDiff> {
-    return this.run("file-diff", () =>
-      this.backend.fileDiff(repoDir, original, modified),
+    return this.run(
+      "file-diff",
+      () => this.backend.fileDiff(repoDir, original, modified),
+      repoDir,
     );
   }
 
   private async run<T>(
     operation: string,
     invoke: () => Promise<T>,
+    repoDir?: string,
   ): Promise<T> {
     const startedAt = performance.now();
     try {
@@ -73,6 +84,7 @@ export class ObservedGitReadBackend implements GitReadBackend {
       this.report({
         backend: "native",
         operation,
+        repoDir,
         durationMs: performance.now() - startedAt,
         succeeded: true,
       });
@@ -81,6 +93,7 @@ export class ObservedGitReadBackend implements GitReadBackend {
       this.report({
         backend: "native",
         operation,
+        repoDir,
         durationMs: performance.now() - startedAt,
         succeeded: false,
       });

--- a/packages/tools/test/git-github-api-client.test.ts
+++ b/packages/tools/test/git-github-api-client.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { GithubApiClient } from "../src/git/git-github-api-client.js";
+import type { GithubRequestObservation } from "../src/git/git-observability.js";
 import {
   parseGithubRepositoryRemote,
   parseGithubRepositoryUrl,
@@ -65,9 +66,10 @@ describe("GithubApiClient", () => {
     assert.deepEqual(headers, ["Bearer secret-token", "Bearer secret-token"]);
   });
 
-  it("reacquires once after a 401", async () => {
+  it("reacquires once after a 401 and reports safe repository details", async () => {
     let tokenCalls = 0;
     let requests = 0;
+    const observations: GithubRequestObservation[] = [];
     const client = new GithubApiClient({
       tokenProvider: async () => `token-${++tokenCalls}`,
       fetch: async () => {
@@ -76,22 +78,68 @@ describe("GithubApiClient", () => {
           ? new Response(null, { status: 401 })
           : Response.json({ login: "octocat" });
       },
+      onRequestCompleted: (observation) => observations.push(observation),
     });
     const result = await client.rest<{ login: string }>(repository, "/user", {
       operation: "status",
     });
     assert.equal(result.login, "octocat");
     assert.equal(tokenCalls, 2);
+    assert.deepEqual(
+      observations.map((observation) => ({
+        operation: observation.operation,
+        method: observation.method,
+        hostname: observation.hostname,
+        owner: observation.owner,
+        repository: observation.repository,
+        succeeded: observation.succeeded,
+        status: observation.status,
+      })),
+      [
+        {
+          operation: "status",
+          method: "GET",
+          hostname: "github.com",
+          owner: "example",
+          repository: "repo",
+          succeeded: false,
+          status: 401,
+        },
+        {
+          operation: "status",
+          method: "GET",
+          hostname: "github.com",
+          owner: "example",
+          repository: "repo",
+          succeeded: true,
+          status: 200,
+        },
+      ],
+    );
+    assert.equal(
+      observations.every((observation) => observation.durationMs >= 0),
+      true,
+    );
+    assert.equal(JSON.stringify(observations).includes("token-"), false);
   });
 
-  it("never includes a token in API errors", async () => {
+  it("never includes a token in API errors or observations", async () => {
+    const observations: GithubRequestObservation[] = [];
     const client = new GithubApiClient({
       tokenProvider: async () => "highly-secret-token",
       fetch: async () => new Response("highly-secret-token", { status: 403 }),
+      onRequestCompleted: (observation) => observations.push(observation),
     });
     await assert.rejects(
       client.rest(repository, "/user", { operation: "status" }),
       (error: Error) => !error.message.includes("highly-secret-token"),
+    );
+    assert.equal(observations.length, 1);
+    assert.equal(observations[0]?.succeeded, false);
+    assert.equal(observations[0]?.status, 403);
+    assert.equal(
+      JSON.stringify(observations).includes("highly-secret-token"),
+      false,
     );
   });
 });

--- a/packages/tools/test/git-service-overview.test.ts
+++ b/packages/tools/test/git-service-overview.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import type { GitOverviewObservation } from "../src/git/git-observability.js";
 import { GitService } from "../src/git/git-service.js";
 
 describe("GitService overview snapshots", () => {
@@ -7,10 +8,7 @@ describe("GitService overview snapshots", () => {
     const calls: string[][] = [];
     let now = 1_000;
     let snapshotCalls = 0;
-    const overviewObservations: Array<{
-      durationMs: number;
-      succeeded: boolean;
-    }> = [];
+    const overviewObservations: GitOverviewObservation[] = [];
     const service = new GitService(() => ({ dir: "/repo", name: "repo" }), {
       now: () => now,
       stableMetadataTtlMs: 30_000,
@@ -104,7 +102,11 @@ describe("GitService overview snapshots", () => {
     assert.equal(overviewObservations.length, 4);
     assert.equal(
       overviewObservations.every(
-        (observation) => observation.succeeded && observation.durationMs >= 0,
+        (observation) =>
+          observation.succeeded &&
+          observation.durationMs >= 0 &&
+          observation.projectId === "proj_test" &&
+          observation.relativePath === ".",
       ),
       true,
     );
@@ -126,7 +128,8 @@ describe("GitService overview snapshots", () => {
     assert.match(result.stdout, /^git version /);
     assert.deepEqual(
       observations.map((observation) => Object.keys(observation as object)),
-      [["bin", "command", "durationMs", "succeeded"]],
+      [["bin", "command", "cwd", "durationMs", "succeeded"]],
     );
+    assert.equal((observations[0] as { cwd: string }).cwd, process.cwd());
   });
 });

--- a/packages/workbench-app/src/lib/features/logs/state/logs-pane-controller.test.ts
+++ b/packages/workbench-app/src/lib/features/logs/state/logs-pane-controller.test.ts
@@ -12,9 +12,12 @@ import {
   type LogsPaneDependencies,
 } from "./logs-pane-controller";
 import {
+  formatApplicationLog,
   hasLogDetail,
   logContextEntries,
+  logErrorEntries,
   logReferences,
+  logSummaryAttributes,
 } from "$lib/presentation/logs/log-entry";
 
 function log(
@@ -219,18 +222,88 @@ describe("logs pane controller", () => {
 });
 
 describe("log entry helpers", () => {
-  it("projects references, context, and detail state", () => {
+  it("projects labeled references, context, and detail state", () => {
     const entry = log("3", {
       requestId: "request",
-      context: { count: 2, label: "ok" },
+      toolCallId: "tool_test",
+      context: { count: 2, displayLabel: "ok" },
     });
 
-    assert.deepEqual(logReferences(entry), ["request"]);
+    assert.deepEqual(logReferences(entry), [
+      { key: "requestId", label: "request", value: "request" },
+      { key: "toolCallId", label: "tool call", value: "tool_test" },
+    ]);
     assert.deepEqual(logContextEntries(entry), [
-      ["count", "2"],
-      ["label", "ok"],
+      { key: "count", label: "count", value: "2" },
+      { key: "displayLabel", label: "display label", value: "ok" },
     ]);
     assert.equal(hasLogDetail(entry), true);
     assert.equal(hasLogDetail(log("4")), false);
+  });
+
+  it("prioritizes identifying scalar attributes and skips message duplicates", () => {
+    const entry = log("5", {
+      message: "Slow GitHub request: github-status",
+      context: {
+        status: 200,
+        outcome: "slow",
+        operation: "github-status",
+        repository: "nervekit/nerve",
+        ignoredObject: { count: 1 },
+      },
+    });
+
+    assert.deepEqual(logSummaryAttributes(entry), [
+      {
+        key: "repository",
+        label: "repository",
+        value: "nervekit/nerve",
+      },
+      { key: "status", label: "status", value: "200" },
+    ]);
+  });
+
+  it("safely bounds nested context and preserves complete error details", () => {
+    const circular: Record<string, unknown> = { label: "root" };
+    circular.self = circular;
+    const entry = log("6", {
+      context: { circular, long: "x".repeat(4_100) },
+      error: {
+        name: "TypeError",
+        message: "kaput",
+        cause: "upstream",
+        stack: "TypeError: kaput\n at test",
+      },
+    });
+
+    assert.match(logContextEntries(entry)[0]?.value ?? "", /\[Circular\]/);
+    assert.equal(logContextEntries(entry)[1]?.value.endsWith("…"), true);
+    assert.deepEqual(logErrorEntries(entry), [
+      { key: "error", label: "error", value: "TypeError: kaput" },
+      { key: "cause", label: "cause", value: "upstream" },
+      {
+        key: "stack",
+        label: "stack",
+        value: "TypeError: kaput\n at test",
+      },
+    ]);
+  });
+
+  it("serializes rich records in readable visible order", () => {
+    const first = log("7", {
+      requestId: "request_7",
+      durationMs: 42,
+      context: { method: "GET", status: 200 },
+      error: { message: "problem" },
+    });
+    const second = log("8");
+
+    assert.equal(
+      serializeApplicationLogs([first, second]),
+      `${formatApplicationLog(first)}\n\n${formatApplicationLog(second)}`,
+    );
+    assert.match(formatApplicationLog(first), / 42ms\n {2}request: request_7/);
+    assert.match(formatApplicationLog(first), /\n {2}method: GET/);
+    assert.match(formatApplicationLog(first), /\n {2}error: problem$/);
   });
 });

--- a/packages/workbench-app/src/lib/features/logs/state/logs-pane-controller.ts
+++ b/packages/workbench-app/src/lib/features/logs/state/logs-pane-controller.ts
@@ -6,6 +6,7 @@ import type {
   ApplicationLogRecord,
   ApplicationLogSource,
 } from "@nervekit/contracts";
+import { formatApplicationLog } from "$lib/presentation/logs/log-entry";
 
 export type LogLevelFilter = ApplicationLogLevel | "all";
 export type LogSourceFilter = ApplicationLogSource | "all";
@@ -35,12 +36,7 @@ export function logsFilterRequest(input: {
 }
 
 export function serializeApplicationLogs(logs: ApplicationLogRecord[]): string {
-  return logs
-    .map(
-      (log) =>
-        `${log.ts} ${log.level.toUpperCase()} ${log.source}/${log.component} ${log.message}`,
-    )
-    .join("\n");
+  return logs.map(formatApplicationLog).join("\n\n");
 }
 
 export class LogsPaneController {

--- a/packages/workbench-app/src/lib/presentation/logs/LogRow.svelte
+++ b/packages/workbench-app/src/lib/presentation/logs/LogRow.svelte
@@ -2,7 +2,14 @@
 import ChevronRight from "@lucide/svelte/icons/chevron-right";
 import type { ApplicationLogRecord } from "@nervekit/contracts";
 import { timeLabel } from "@nervekit/ui-kit/core/utils/time";
-import { hasLogDetail, logContextEntries, logReferences } from "./log-entry";
+import {
+  formatApplicationLog,
+  hasLogDetail,
+  logContextEntries,
+  logErrorEntries,
+  logReferences,
+  logSummaryAttributes,
+} from "./log-entry";
 
 type Props = {
   log: ApplicationLogRecord;
@@ -13,8 +20,10 @@ type Props = {
 let { log, open, onToggle }: Props = $props();
 
 const detail = $derived(hasLogDetail(log));
+const summaryAttributes = $derived(logSummaryAttributes(log));
 const references = $derived(open ? logReferences(log) : []);
 const contextEntries = $derived(open ? logContextEntries(log) : []);
+const errorEntries = $derived(open ? logErrorEntries(log) : []);
 const levelClass = $derived(
   log.level === "warn"
     ? "text-warning"
@@ -24,9 +33,7 @@ const levelClass = $derived(
         ? "text-foreground"
         : "text-muted-foreground",
 );
-const summaryTitle = $derived(
-  `${timeLabel(log.ts)} ${log.level.toUpperCase()} ${log.source}/${log.component} ${log.message}${log.durationMs === undefined ? "" : ` ${log.durationMs}ms`}`,
-);
+const summaryTitle = $derived(formatApplicationLog(log));
 </script>
 
 {#snippet summary()}
@@ -38,6 +45,11 @@ const summaryTitle = $derived(
     {log.source}/{log.component}
   </span>
   <span class="text-foreground">{log.message}</span>
+  {#each summaryAttributes as attribute (attribute.key)}
+    <span class="ml-2 text-muted-foreground">
+      {attribute.label}=<span class="text-foreground">{attribute.value}</span>
+    </span>
+  {/each}
   {#if log.durationMs !== undefined}
     <span class="ml-2 tabular-nums text-muted-foreground">
       {log.durationMs}ms
@@ -72,26 +84,33 @@ const summaryTitle = $derived(
 
   {#if detail && open}
     <div class="flex select-text flex-col gap-1 px-2 pb-1.5 pl-7 text-xs">
-      {#if references.length > 0}
-        <div class="flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground">
-          {#each references as reference (reference)}
-            <span>{reference}</span>
-          {/each}
-        </div>
-      {/if}
-      {#if contextEntries.length > 0}
+      {#if references.length > 0 || contextEntries.length > 0}
         <dl
           class="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-0.5"
         >
-          {#each contextEntries as [key, value] (key)}
-            <dt class="text-muted-foreground">{key}</dt>
-            <dd class="m-0 break-words text-foreground">{value}</dd>
+          {#each references as entry (entry.key)}
+            <dt class="text-muted-foreground">{entry.label}</dt>
+            <dd class="m-0 whitespace-pre-wrap break-words text-foreground">
+              {entry.value}
+            </dd>
+          {/each}
+          {#each contextEntries as entry (entry.key)}
+            <dt class="text-muted-foreground">{entry.label}</dt>
+            <dd class="m-0 whitespace-pre-wrap break-words text-foreground">
+              {entry.value}
+            </dd>
           {/each}
         </dl>
       {/if}
-      {#if log.error}
-        <pre class="m-0 whitespace-pre-wrap text-xs text-destructive">{log.error
-            .stack ?? log.error.message}</pre>
+      {#if errorEntries.length > 0}
+        <dl
+          class="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-0.5 text-destructive"
+        >
+          {#each errorEntries as entry (entry.key)}
+            <dt>{entry.label}</dt>
+            <dd class="m-0 whitespace-pre-wrap break-words">{entry.value}</dd>
+          {/each}
+        </dl>
       {/if}
     </div>
   {/if}

--- a/packages/workbench-app/src/lib/presentation/logs/log-entry.ts
+++ b/packages/workbench-app/src/lib/presentation/logs/log-entry.ts
@@ -1,39 +1,193 @@
 import type { ApplicationLogRecord } from "@nervekit/contracts";
 
-export function logReferences(log: ApplicationLogRecord): string[] {
-  return [
-    log.requestId,
-    log.projectId,
-    log.conversationId,
-    log.agentId,
-    log.runId,
-    log.toolCallId,
-    log.taskId,
-  ].filter((value): value is string => Boolean(value));
+export type LogDisplayEntry = {
+  key: string;
+  label: string;
+  value: string;
+};
+
+const referenceFields = [
+  ["requestId", "request"],
+  ["projectId", "project"],
+  ["conversationId", "conversation"],
+  ["agentId", "agent"],
+  ["runId", "run"],
+  ["toolCallId", "tool call"],
+  ["taskId", "task"],
+] as const;
+
+const summaryPriority = [
+  "operation",
+  "repository",
+  "repoDir",
+  "relativePath",
+  "command",
+  "toolName",
+  "model",
+  "provider",
+  "method",
+  "path",
+  "status",
+  "outcome",
+  "mode",
+  "attempt",
+] as const;
+
+const SUMMARY_ATTRIBUTE_LIMIT = 3;
+const SUMMARY_VALUE_LIMIT = 96;
+const DETAIL_VALUE_LIMIT = 4_000;
+
+export function logReferences(log: ApplicationLogRecord): LogDisplayEntry[] {
+  return referenceFields.flatMap(([key, label]) => {
+    const value = log[key];
+    return value ? [{ key, label, value }] : [];
+  });
 }
 
 export function logContextEntries(
   log: ApplicationLogRecord,
-): Array<[string, string]> {
+): LogDisplayEntry[] {
   if (!log.context) return [];
-  return Object.entries(log.context).map(([key, value]) => [
+  return Object.entries(log.context).map(([key, value]) => ({
     key,
-    typeof value === "string" ? value : JSON.stringify(value),
-  ]);
+    label: humanizeKey(key),
+    value: formatLogValue(value),
+  }));
+}
+
+export function logSummaryAttributes(
+  log: ApplicationLogRecord,
+): LogDisplayEntry[] {
+  if (!log.context) return [];
+  const keys = [
+    ...summaryPriority.filter((key) => key in (log.context ?? {})),
+    ...Object.keys(log.context).filter(
+      (key) =>
+        !summaryPriority.includes(key as (typeof summaryPriority)[number]),
+    ),
+  ];
+  const entries: LogDisplayEntry[] = [];
+  for (const key of keys) {
+    const value = log.context[key];
+    if (!isSummaryValue(value)) continue;
+    const formatted = formatLogValue(value, SUMMARY_VALUE_LIMIT);
+    if (messageContainsValue(log.message, formatted)) continue;
+    entries.push({ key, label: humanizeKey(key), value: formatted });
+    if (entries.length === SUMMARY_ATTRIBUTE_LIMIT) break;
+  }
+  return entries;
+}
+
+export function logErrorEntries(log: ApplicationLogRecord): LogDisplayEntry[] {
+  if (!log.error) return [];
+  const nameAndMessage = log.error.name
+    ? `${log.error.name}: ${log.error.message}`
+    : log.error.message;
+  return [
+    {
+      key: "error",
+      label: "error",
+      value: truncate(nameAndMessage, DETAIL_VALUE_LIMIT),
+    },
+    ...(log.error.cause
+      ? [
+          {
+            key: "cause",
+            label: "cause",
+            value: truncate(log.error.cause, DETAIL_VALUE_LIMIT),
+          },
+        ]
+      : []),
+    ...(log.error.stack
+      ? [
+          {
+            key: "stack",
+            label: "stack",
+            value: truncate(log.error.stack, DETAIL_VALUE_LIMIT),
+          },
+        ]
+      : []),
+  ];
+}
+
+export function formatApplicationLog(log: ApplicationLogRecord): string {
+  const duration = log.durationMs === undefined ? "" : ` ${log.durationMs}ms`;
+  const lines = [
+    `${log.ts} ${log.level.toUpperCase()} ${log.source}/${log.component} ${log.message}${duration}`,
+  ];
+  for (const entry of [
+    ...logReferences(log),
+    ...logContextEntries(log),
+    ...logErrorEntries(log),
+  ]) {
+    lines.push(formatDetailLine(entry.label, entry.value));
+  }
+  return lines.join("\n");
 }
 
 export function hasLogDetail(log: ApplicationLogRecord): boolean {
   return (
     Boolean(log.error) ||
     Boolean(log.context && Object.keys(log.context).length > 0) ||
-    Boolean(
-      log.requestId ||
-      log.projectId ||
-      log.conversationId ||
-      log.agentId ||
-      log.runId ||
-      log.toolCallId ||
-      log.taskId,
-    )
+    logReferences(log).length > 0
   );
+}
+
+function formatLogValue(
+  value: unknown,
+  maxLength = DETAIL_VALUE_LIMIT,
+): string {
+  let formatted: string;
+  if (typeof value === "string") formatted = value;
+  else if (value === undefined) formatted = "undefined";
+  else {
+    try {
+      const seen = new WeakSet<object>();
+      formatted =
+        JSON.stringify(
+          value,
+          (_key, child: unknown) => {
+            if (typeof child === "bigint") return child.toString();
+            if (child && typeof child === "object") {
+              if (seen.has(child)) return "[Circular]";
+              seen.add(child);
+            }
+            return child;
+          },
+          2,
+        ) ?? String(value);
+    } catch {
+      formatted = String(value);
+    }
+  }
+  return truncate(formatted, maxLength);
+}
+
+function formatDetailLine(label: string, value: string): string {
+  const indented = value.replaceAll("\n", "\n    ");
+  return `  ${label}: ${indented}`;
+}
+
+function humanizeKey(key: string): string {
+  return key
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replaceAll(/[_-]+/g, " ")
+    .toLowerCase();
+}
+
+function isSummaryValue(value: unknown): boolean {
+  return (
+    value === null ||
+    ["string", "number", "boolean", "bigint"].includes(typeof value)
+  );
+}
+
+function messageContainsValue(message: string, value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 1 && message.toLowerCase().includes(normalized);
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 1))}…`;
 }

--- a/packages/workbench-server/src/app/runtime/composition.ts
+++ b/packages/workbench-server/src/app/runtime/composition.ts
@@ -91,6 +91,12 @@ import type { RuntimeQueryCache } from "../../infrastructure/query-cache/index.j
 import type { ProviderCatalogStore } from "../../domains/providers/provider-catalog.store.js";
 import type { SecretProvider } from "../../infrastructure/secrets/index.js";
 import type { InitializedStorage } from "../../infrastructure/storage/index.js";
+import {
+  gitCommandDiagnostic,
+  githubRequestDiagnostic,
+  gitOverviewDiagnostic,
+  gitReadDiagnostic,
+} from "./git-logging.js";
 import type { RuntimeState } from "./state.js";
 import type { AppendEntryInput, AppendEntryOptions } from "./types.js";
 
@@ -434,52 +440,21 @@ export function composeRuntime(
     services.agentLifecycle.setAgentModeInternal(agentId, mode, reason),
   );
   const gitLogger = logger.child({ component: "git" });
+  const writeGitDiagnostic = (
+    diagnostic: ReturnType<typeof gitCommandDiagnostic>,
+  ) => {
+    if (!diagnostic) return;
+    void gitLogger[diagnostic.level](diagnostic.message, diagnostic.details);
+  };
   const gitService = new GitService(getProject, {
-    onCommandCompleted: (observation) => {
-      if (observation.durationMs < 250) return;
-      void gitLogger.warn("Slow Git command", {
-        durationMs: Math.round(observation.durationMs),
-        context: {
-          bin: observation.bin,
-          command: observation.command,
-          succeeded: observation.succeeded,
-        },
-      });
-    },
-    onReadCompleted: (observation) => {
-      if (observation.succeeded && observation.durationMs < 250) return;
-      void gitLogger.warn(
-        observation.succeeded
-          ? "Slow native Git read"
-          : "Native Git read failed",
-        {
-          durationMs: Math.round(observation.durationMs),
-          context: {
-            backend: observation.backend,
-            operation: observation.operation,
-            succeeded: observation.succeeded,
-          },
-        },
-      );
-    },
-    onGithubRequestCompleted: (observation) => {
-      if (observation.durationMs < 250) return;
-      void gitLogger.warn("Slow GitHub API request", {
-        durationMs: Math.round(observation.durationMs),
-        context: {
-          operation: observation.operation,
-          status: observation.status,
-          succeeded: observation.succeeded,
-        },
-      });
-    },
-    onOverviewCompleted: (observation) => {
-      if (observation.durationMs < 500) return;
-      void gitLogger.warn("Slow Git overview", {
-        durationMs: Math.round(observation.durationMs),
-        context: { succeeded: observation.succeeded },
-      });
-    },
+    onCommandCompleted: (observation) =>
+      writeGitDiagnostic(gitCommandDiagnostic(observation)),
+    onReadCompleted: (observation) =>
+      writeGitDiagnostic(gitReadDiagnostic(observation)),
+    onGithubRequestCompleted: (observation) =>
+      writeGitDiagnostic(githubRequestDiagnostic(observation)),
+    onOverviewCompleted: (observation) =>
+      writeGitDiagnostic(gitOverviewDiagnostic(observation)),
   });
   services.gitRepositoryWatcher = new GitRepositoryWatcher(events, {
     diagnostics: performanceDiagnostics.enabled

--- a/packages/workbench-server/src/app/runtime/git-logging.ts
+++ b/packages/workbench-server/src/app/runtime/git-logging.ts
@@ -1,0 +1,122 @@
+import type {
+  GitCommandObservation,
+  GitOverviewObservation,
+  GitReadObservation,
+  GithubRequestObservation,
+} from "@nervekit/tools";
+import type { ApplicationLogLevel } from "@nervekit/contracts";
+import type { ApplicationLogContext } from "../../infrastructure/diagnostics/index.js";
+
+export const GIT_COMMAND_SLOW_MS = 1_000;
+export const GIT_READ_SLOW_MS = 1_000;
+export const GITHUB_REQUEST_SLOW_MS = 1_500;
+export const GIT_OVERVIEW_SLOW_MS = 2_000;
+
+type GitDiagnostic = {
+  level: ApplicationLogLevel;
+  message: string;
+  details: ApplicationLogContext;
+};
+
+export function gitCommandDiagnostic(
+  observation: GitCommandObservation,
+): GitDiagnostic | undefined {
+  if (observation.succeeded && observation.durationMs < GIT_COMMAND_SLOW_MS) {
+    return undefined;
+  }
+  const command = `${observation.bin} ${observation.command}`;
+  return diagnostic(
+    observation.succeeded
+      ? `Slow Git command: ${command}`
+      : `Git command failed: ${command}`,
+    observation.durationMs,
+    {
+      bin: observation.bin,
+      command: observation.command,
+      cwd: observation.cwd,
+      outcome: observation.succeeded ? "slow" : "failed",
+    },
+  );
+}
+
+export function gitReadDiagnostic(
+  observation: GitReadObservation,
+): GitDiagnostic | undefined {
+  if (observation.succeeded && observation.durationMs < GIT_READ_SLOW_MS) {
+    return undefined;
+  }
+  return diagnostic(
+    observation.succeeded
+      ? `Slow native Git read: ${observation.operation}`
+      : `Native Git read failed: ${observation.operation}`,
+    observation.durationMs,
+    {
+      backend: observation.backend,
+      operation: observation.operation,
+      repoDir: observation.repoDir,
+      outcome: observation.succeeded ? "slow" : "failed",
+    },
+  );
+}
+
+export function githubRequestDiagnostic(
+  observation: GithubRequestObservation,
+): GitDiagnostic | undefined {
+  if (
+    observation.succeeded &&
+    observation.durationMs < GITHUB_REQUEST_SLOW_MS
+  ) {
+    return undefined;
+  }
+  const repository = `${observation.owner}/${observation.repository}`;
+  return diagnostic(
+    observation.succeeded
+      ? `Slow GitHub request: ${observation.operation}`
+      : `GitHub request failed: ${observation.operation}`,
+    observation.durationMs,
+    {
+      operation: observation.operation,
+      method: observation.method,
+      hostname: observation.hostname,
+      repository,
+      status: observation.status,
+      outcome: observation.succeeded ? "slow" : "failed",
+    },
+  );
+}
+
+export function gitOverviewDiagnostic(
+  observation: GitOverviewObservation,
+): GitDiagnostic | undefined {
+  if (observation.succeeded && observation.durationMs < GIT_OVERVIEW_SLOW_MS) {
+    return undefined;
+  }
+  return diagnostic(
+    observation.succeeded
+      ? `Slow Git overview: ${observation.relativePath}`
+      : `Git overview failed: ${observation.relativePath}`,
+    observation.durationMs,
+    {
+      relativePath: observation.relativePath,
+      outcome: observation.succeeded ? "slow" : "failed",
+    },
+    { projectId: observation.projectId },
+  );
+}
+
+function diagnostic(
+  message: string,
+  durationMs: number,
+  context: Record<string, unknown>,
+  references: Pick<ApplicationLogContext, "projectId"> = {},
+): GitDiagnostic {
+  return {
+    level: "warn",
+    message,
+    details: {
+      ...references,
+      durationMs: Math.round(durationMs),
+      context,
+    },
+  };
+}

--- a/packages/workbench-server/src/app/server.ts
+++ b/packages/workbench-server/src/app/server.ts
@@ -166,12 +166,14 @@ export function createApp(state: WorkbenchState): Hono {
         const status = c.res.status;
         const durationMs = Math.round(performance.now() - started);
         const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
-        await logger[level]("HTTP request completed", {
+        const method = c.req.method;
+        const path = new URL(c.req.url).pathname;
+        await logger[level](`${method} ${path} completed (${status})`, {
           durationMs,
           context: {
             status,
-            method: c.req.method,
-            path: new URL(c.req.url).pathname,
+            method,
+            path,
           },
         }).catch(() => undefined);
         clearRequestContext(c.req.raw);

--- a/packages/workbench-server/src/http/auth-middleware.ts
+++ b/packages/workbench-server/src/http/auth-middleware.ts
@@ -33,13 +33,18 @@ export function unauthorized() {
 export function createApiAuthMiddleware(token: string): MiddlewareHandler {
   return async (c, next) => {
     if (!isAuthorized(c.req.raw, token)) {
-      await requestContextFor(c)?.logger.warn("API authorization failed", {
-        context: {
-          method: c.req.method,
-          path: new URL(c.req.url).pathname,
-          mode: clientAuthMode(c.req.raw, token),
+      const method = c.req.method;
+      const path = new URL(c.req.url).pathname;
+      await requestContextFor(c)?.logger.warn(
+        `${method} ${path} authorization failed`,
+        {
+          context: {
+            method,
+            path,
+            mode: clientAuthMode(c.req.raw, token),
+          },
         },
-      });
+      );
       return c.body(await unauthorized().text(), 401, {
         "content-type": "application/json",
       });

--- a/packages/workbench-server/src/http/responses.ts
+++ b/packages/workbench-server/src/http/responses.ts
@@ -9,13 +9,15 @@ export function routeHandler(
     try {
       return await handler(c);
     } catch (error) {
-      await requestContextFor(c)?.logger.error("Route handler failed", {
-        error,
-        context: {
-          method: c.req.method,
-          path: new URL(c.req.url).pathname,
+      const method = c.req.method;
+      const path = new URL(c.req.url).pathname;
+      await requestContextFor(c)?.logger.error(
+        `${method} ${path} handler failed`,
+        {
+          error,
+          context: { method, path },
         },
-      });
+      );
       return errorResponse(error);
     }
   };

--- a/packages/workbench-server/test/application-logging-gate.test.ts
+++ b/packages/workbench-server/test/application-logging-gate.test.ts
@@ -30,6 +30,39 @@ describe("application logging gate", () => {
     const logsResponse = await app.request("/api/logs", { headers });
     assert.equal(logsResponse.status, 200);
     const logs = (await logsResponse.json()) as ApplicationLogQueryResponse;
-    assert.ok(logs.logs.length >= 1);
+    const configLog = logs.logs.find(
+      (log) => log.message === "GET /api/client-config completed (200)",
+    );
+    assert.ok(configLog);
+    assert.equal(configLog.component, "http");
+    assert.match(configLog.requestId ?? "", /^log_/);
+    assert.ok((configLog.durationMs ?? -1) >= 0);
+    assert.deepEqual(configLog.context, {
+      method: "GET",
+      path: "/api/client-config",
+      status: 200,
+    });
+  });
+
+  it("identifies authorization failures by method and path", async () => {
+    const { app, state } = await createAuthenticatedApp("127.0.0.1", {
+      applicationLogsEnabled: true,
+    });
+
+    const response = await app.request("/api/client-config");
+    assert.equal(response.status, 401);
+    const logs = await state.logger.query({ component: "http", limit: 10 });
+    const authorization = logs.logs.find((log) =>
+      log.message.includes("authorization failed"),
+    );
+    assert.equal(
+      authorization?.message,
+      "GET /api/client-config authorization failed",
+    );
+    assert.deepEqual(authorization?.context, {
+      method: "GET",
+      path: "/api/client-config",
+      mode: "none",
+    });
   });
 });

--- a/packages/workbench-server/test/git-logging.test.ts
+++ b/packages/workbench-server/test/git-logging.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  GITHUB_REQUEST_SLOW_MS,
+  GIT_COMMAND_SLOW_MS,
+  GIT_OVERVIEW_SLOW_MS,
+  GIT_READ_SLOW_MS,
+  gitCommandDiagnostic,
+  githubRequestDiagnostic,
+  gitOverviewDiagnostic,
+  gitReadDiagnostic,
+} from "../src/app/runtime/git-logging.js";
+
+describe("Git application log diagnostics", () => {
+  it("omits routine successful observations and reports threshold boundaries", () => {
+    assert.equal(
+      gitCommandDiagnostic({
+        bin: "git",
+        command: "status",
+        cwd: "/workspace/repo",
+        durationMs: GIT_COMMAND_SLOW_MS - 1,
+        succeeded: true,
+      }),
+      undefined,
+    );
+    assert.equal(
+      gitReadDiagnostic({
+        backend: "native",
+        operation: "snapshot",
+        repoDir: "/workspace/repo",
+        durationMs: GIT_READ_SLOW_MS - 1,
+        succeeded: true,
+      }),
+      undefined,
+    );
+    assert.equal(
+      githubRequestDiagnostic({
+        operation: "github-status",
+        method: "POST",
+        hostname: "github.com",
+        owner: "nervekit",
+        repository: "nerve",
+        durationMs: GITHUB_REQUEST_SLOW_MS - 1,
+        succeeded: true,
+        status: 200,
+      }),
+      undefined,
+    );
+    assert.equal(
+      gitOverviewDiagnostic({
+        projectId: "proj_test",
+        relativePath: ".",
+        durationMs: GIT_OVERVIEW_SLOW_MS - 1,
+        succeeded: true,
+      }),
+      undefined,
+    );
+
+    const command = gitCommandDiagnostic({
+      bin: "git",
+      command: "pull",
+      cwd: "/workspace/repo",
+      durationMs: GIT_COMMAND_SLOW_MS,
+      succeeded: true,
+    });
+    assert.equal(command?.level, "warn");
+    assert.equal(command?.message, "Slow Git command: git pull");
+    assert.deepEqual(command?.details, {
+      durationMs: GIT_COMMAND_SLOW_MS,
+      context: {
+        bin: "git",
+        command: "pull",
+        cwd: "/workspace/repo",
+        outcome: "slow",
+      },
+    });
+  });
+
+  it("reports failures regardless of duration with useful identity", () => {
+    const github = githubRequestDiagnostic({
+      operation: "merge-pull-request",
+      method: "PUT",
+      hostname: "github.com",
+      owner: "nervekit",
+      repository: "nerve",
+      durationMs: 12.4,
+      succeeded: false,
+      status: 403,
+    });
+    assert.equal(github?.message, "GitHub request failed: merge-pull-request");
+    assert.deepEqual(github?.details, {
+      durationMs: 12,
+      context: {
+        operation: "merge-pull-request",
+        method: "PUT",
+        hostname: "github.com",
+        repository: "nervekit/nerve",
+        status: 403,
+        outcome: "failed",
+      },
+    });
+
+    const overview = gitOverviewDiagnostic({
+      projectId: "proj_test",
+      relativePath: "packages/app",
+      durationMs: 25,
+      succeeded: false,
+    });
+    assert.equal(overview?.message, "Git overview failed: packages/app");
+    assert.equal(overview?.details.projectId, "proj_test");
+    assert.deepEqual(overview?.details.context, {
+      relativePath: "packages/app",
+      outcome: "failed",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- enrich Git observations with repository, path, operation, and outcome context
- reduce routine Git polling noise while retaining slow and failed operations
- make HTTP log messages self-identifying with method, path, and status
- add compact structured previews, labeled references, richer error details, and complete copy output to the Logs pane
- add focused coverage for Git diagnostics, HTTP correlation, and log formatting

## Validation
- `pnpm fix`
- `pnpm check`
- full workspace tests passed sequentially with `pnpm build:native && node --test "scripts/**/*.test.mjs" && pnpm --workspace-concurrency=1 -r --if-present test`

The standard parallel `pnpm run test:full` reached the environment process limit (`EAGAIN`); the equivalent sequential run passed.
