### PR TITLE
Retain agent previews for denied and cancelled tools

### DIFF
--- a/packages/tools/src/result-projection/projector.ts
+++ b/packages/tools/src/result-projection/projector.ts
@@ -191,9 +191,15 @@ function terminalCandidate(
   const interrupted =
     context.phase === "interrupted" ||
     context.errorDetails?.code === "interrupted";
+  const denialHeadline =
+    context.denialSource === "user"
+      ? "User denied the requested tool call. The operation was not performed."
+      : context.denialSource === "policy"
+        ? "Permission policy denied the requested tool call. The operation was not performed."
+        : "The requested tool call was denied. The operation was not performed.";
   const headline =
     context.status === "denied"
-      ? "User denied the requested tool call. The operation was not performed."
+      ? denialHeadline
       : interrupted
         ? "Tool execution was interrupted. No rollback is implied."
         : context.status === "cancelled"

--- a/packages/tools/src/result-projection/types.ts
+++ b/packages/tools/src/result-projection/types.ts
@@ -49,6 +49,8 @@ export type ProjectionCandidate = {
   artifacts: ValidatedToolArtifact[];
 };
 
+export type AgentDenialSource = "user" | "policy";
+
 export type CandidateContext = {
   toolName: string;
   args: unknown;
@@ -57,6 +59,7 @@ export type CandidateContext = {
   phase?: ToolPhase;
   error?: string;
   errorDetails?: ToolCallErrorDetails;
+  denialSource?: AgentDenialSource;
   validatedArtifacts: readonly ValidatedToolArtifact[];
   completePayload?: ValidatedToolArtifact;
 };

--- a/packages/tools/test/result-projection.test.ts
+++ b/packages/tools/test/result-projection.test.ts
@@ -685,6 +685,27 @@ describe("adaptive agent tool-result projection", () => {
     assert.match(output, new RegExp(feedback));
   });
 
+  it("distinguishes denial sources and preserves cancellation outcomes", () => {
+    const terminal = (
+      status: CandidateContext["status"],
+      denialSource?: CandidateContext["denialSource"],
+    ) =>
+      text(
+        projectAgentResult({
+          ...context("bash", undefined),
+          status,
+          phase: status === "cancelled" ? "cancelled" : "denied",
+          error: "Terminal reason.",
+          denialSource,
+        }).blocks,
+      );
+
+    assert.match(terminal("denied", "user"), /^User denied/);
+    assert.match(terminal("denied", "policy"), /^Permission policy denied/);
+    assert.match(terminal("denied"), /^The requested tool call was denied/);
+    assert.match(terminal("cancelled"), /^Tool execution was cancelled/);
+  });
+
   it("projects Explore tasks independently without a call-level ceiling", () => {
     const reports = Array.from({ length: 8 }, (_, index) => ({
       agentId: `agent_${index}`,

--- a/packages/workbench-app/src/lib/presentation/tools/components/tool-call/AgentPreviewSection.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/components/tool-call/AgentPreviewSection.svelte
@@ -70,7 +70,7 @@ function supportedImageMime(mimeType: string): boolean {
       {/if}
     {:else}
       <p class="m-0 text-sm text-muted-foreground">
-        The exact agent preview was not retained for this historical tool call.
+        No retained agent preview is available for this tool call.
       </p>
     {/if}
     {#if projection}

--- a/packages/workbench-server/src/domains/tools/tool-executor.service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-executor.service.ts
@@ -112,7 +112,7 @@ export class ToolExecutorService {
         terminal = this.deps.getToolCall(toolCall.id);
       } else {
         const patch = options.signal?.aborted
-          ? toolTerminationPatch(TOOL_CANCELLED_OUTCOME)
+          ? toolTerminationPatch(toolCall, TOOL_CANCELLED_OUTCOME)
           : await (async () => {
               const details = toolErrorDetails(error);
               const base = {
@@ -158,7 +158,7 @@ export class ToolExecutorService {
 
     if (prepared) {
       const completionPatch = options.signal?.aborted
-        ? toolTerminationPatch(TOOL_CANCELLED_OUTCOME)
+        ? toolTerminationPatch(toolCall, TOOL_CANCELLED_OUTCOME)
         : {
             status: "completed" as const,
             result: prepared.result,

--- a/packages/workbench-server/src/domains/tools/tool-result-preparation.ts
+++ b/packages/workbench-server/src/domains/tools/tool-result-preparation.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentDenialSource,
   boundText,
   projectAgentResult,
   snapshotAgentPreview,
@@ -46,6 +47,7 @@ export async function prepareToolResult(
     phase?: ToolPhase;
     error?: string;
     errorDetails?: ToolCallErrorDetails;
+    denialSource?: AgentDenialSource;
   },
 ): Promise<{
   result: unknown;
@@ -71,6 +73,7 @@ export async function prepareToolResult(
     phase: input.phase,
     error: input.error,
     errorDetails: input.errorDetails,
+    denialSource: input.denialSource,
     validatedArtifacts,
   };
   const firstProjection = projectAgentResult(context, definition?.agentResult);
@@ -112,6 +115,44 @@ export async function prepareToolResult(
     result: storedResult,
     ...(resultPayload ? { resultPayload } : {}),
     validatedArtifacts,
+    agentProjection: projection.snapshot,
+    agentPreview: snapshotAgentPreview(projection.blocks, result),
+  };
+}
+
+export function prepareTerminalProjection(
+  result: unknown,
+  input: {
+    toolName?: string;
+    args?: unknown;
+    status: ToolCallStatus;
+    phase?: ToolPhase;
+    error?: string;
+    errorDetails?: ToolCallErrorDetails;
+    denialSource?: AgentDenialSource;
+  },
+): {
+  agentProjection: AgentProjectionSnapshot;
+  agentPreview: AgentPreviewSnapshot;
+} {
+  const definition = input.toolName
+    ? toolDefinitionByName(input.toolName)
+    : undefined;
+  const projection = projectAgentResult(
+    {
+      toolName: input.toolName ?? "unknown",
+      args: input.args,
+      result,
+      status: input.status,
+      phase: input.phase,
+      error: input.error,
+      errorDetails: input.errorDetails,
+      denialSource: input.denialSource,
+      validatedArtifacts: [],
+    },
+    definition?.agentResult,
+  );
+  return {
     agentProjection: projection.snapshot,
     agentPreview: snapshotAgentPreview(projection.blocks, result),
   };

--- a/packages/workbench-server/src/domains/tools/tool-result-projector.ts
+++ b/packages/workbench-server/src/domains/tools/tool-result-projector.ts
@@ -22,9 +22,22 @@ export function projectToolCallResult(
       phase: toolCall.phase,
       error: toolCall.error,
       errorDetails: toolCall.errorDetails,
+      denialSource: denialSource(toolCall),
       validatedArtifacts: toolCall.validatedArtifacts ?? [],
       completePayload,
     },
     definition?.agentResult,
   );
+}
+
+function denialSource(toolCall: ToolCallRecord): "user" | "policy" | undefined {
+  if (toolCall.status !== "denied") return undefined;
+  if (toolCall.supervision?.source === "user") return "user";
+  if (
+    toolCall.supervision?.source === "policy" ||
+    toolCall.permissionEvaluation?.decision === "deny"
+  ) {
+    return "policy";
+  }
+  return undefined;
 }

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -55,6 +55,7 @@ import { ConversationJournalRepository } from "../conversations/conversation-jou
 import { OrchestrationToolDispatcher } from "./orchestration-tool-dispatcher.js";
 import { toToolCallTranscriptRecord } from "./tool-call-transcript-preview.js";
 import { ToolExecutorService } from "./tool-executor.service.js";
+import { prepareTerminalProjection } from "./tool-result-preparation.js";
 import { ToolResultPayloadStore } from "./tool-result-payload-store.js";
 import {
   toolTerminationPatch,
@@ -639,6 +640,7 @@ export class ToolService {
       const denied = await this.updateToolCall(toolCall.id, {
         status: "denied",
         error: evaluation.reason,
+        ...denialProjection(toolCall, evaluation.reason, "policy"),
       });
       await this.emitToolCallLifecycle(denied, options);
       await this.logger?.warn("Tool denied by policy", {
@@ -851,7 +853,7 @@ export class ToolService {
     return await Promise.all(
       stale.map(async (toolCall) => {
         const settlement = await this.settleToolCallTermination(toolCall.id, {
-          ...toolTerminationPatch(outcome),
+          ...toolTerminationPatch(toolCall, outcome),
           interactions: cancelPendingInteractions(toolCall.interactions),
         });
         if (settlement.owned) {
@@ -883,7 +885,7 @@ export class ToolService {
     for (const toolCall of interrupted) {
       const failed = await this.updateToolCall(
         toolCall.id,
-        toolTerminationPatch({
+        toolTerminationPatch(toolCall, {
           status: "failed",
           code: INTERRUPTED_TOOL_ERROR_CODE,
           message: HOST_RESTART_TOOL_ERROR,
@@ -938,7 +940,12 @@ export class ToolService {
             decidedAt: resolvedAt,
           }
         : undefined,
-      ...(decision === "deny" ? { error: note ?? "Denied by user." } : {}),
+      ...(decision === "deny"
+        ? {
+            error: note ?? "Denied by user.",
+            ...denialProjection(current, note ?? "Denied by user.", "user"),
+          }
+        : {}),
     });
     const decided = this.projectApproval(updated, ordinal);
     return decided;
@@ -1015,7 +1022,24 @@ export class ToolService {
     const next = await this.updateToolCall(current.id, {
       interactions,
       status: denied ? "denied" : "running",
-      ...(denied ? { error: denialNote ?? "Denied by user." } : {}),
+      ...(denied
+        ? {
+            error: denialNote ?? "Denied by user.",
+            supervision: current.supervision
+              ? {
+                  ...current.supervision,
+                  status: "denied" as const,
+                  source: "user" as const,
+                  decidedAt: now,
+                }
+              : undefined,
+            ...denialProjection(
+              current,
+              denialNote ?? "Denied by user.",
+              "user",
+            ),
+          }
+        : {}),
     });
     await this.publishToolCallUpdated(next);
     return next;
@@ -1383,6 +1407,21 @@ function resolvePendingForResume(
     resolvedAt: now,
     resolution: { action, feedback: review?.feedback },
   };
+}
+
+function denialProjection(
+  toolCall: ToolCallRecord,
+  error: string,
+  denialSource: "user" | "policy",
+) {
+  return prepareTerminalProjection(undefined, {
+    toolName: toolCall.toolName,
+    args: toolCall.args,
+    status: "denied",
+    phase: "denied",
+    error,
+    denialSource,
+  });
 }
 
 function phaseForStatus(

--- a/packages/workbench-server/src/domains/tools/tool-termination.ts
+++ b/packages/workbench-server/src/domains/tools/tool-termination.ts
@@ -3,6 +3,7 @@ import {
   INTERRUPTED_TOOL_ERROR_CODE,
   type ToolCallRecord,
 } from "@nervekit/contracts";
+import { prepareTerminalProjection } from "./tool-result-preparation.js";
 
 export type ToolTerminationOutcome = {
   status: "cancelled" | "failed";
@@ -22,18 +23,30 @@ export const RUN_CANCELLED_TOOL_OUTCOME = {
 } as const satisfies ToolTerminationOutcome;
 
 export function toolTerminationPatch(
+  toolCall: ToolCallRecord,
   outcome: ToolTerminationOutcome,
 ): Partial<Omit<ToolCallRecord, "id" | "createdAt">> {
+  const errorDetails = {
+    code: outcome.code,
+    message: outcome.message,
+  };
+  const result = {
+    content: outcome.message,
+    contentBlocks: [{ type: "text" as const, text: outcome.message }],
+  };
+  const projection = prepareTerminalProjection(result, {
+    toolName: toolCall.toolName,
+    args: toolCall.args,
+    status: outcome.status,
+    phase: outcome.status,
+    error: outcome.message,
+    errorDetails,
+  });
   return {
     status: outcome.status,
     error: outcome.message,
-    errorDetails: {
-      code: outcome.code,
-      message: outcome.message,
-    },
-    result: {
-      content: outcome.message,
-      contentBlocks: [{ type: "text", text: outcome.message }],
-    },
+    errorDetails,
+    result,
+    ...projection,
   };
 }

--- a/packages/workbench-server/test/agent-tool-result-preview.test.ts
+++ b/packages/workbench-server/test/agent-tool-result-preview.test.ts
@@ -33,6 +33,7 @@ function terminalToolCall(
   status: "cancelled" | "failed" | "denied",
   error: string,
   code?: string,
+  denialSource?: "user" | "policy",
 ): ToolCallRecord {
   return {
     ...toolCall(undefined),
@@ -41,6 +42,14 @@ function terminalToolCall(
     result: undefined,
     error,
     errorDetails: code ? { code, message: error } : undefined,
+    ...(status === "denied" && denialSource
+      ? {
+          supervision: {
+            status: "denied",
+            source: denialSource,
+          } as ToolCallRecord["supervision"],
+        }
+      : {}),
   };
 }
 
@@ -126,8 +135,20 @@ describe("agent tool-result preview", () => {
       /^Tool execution failed\./,
     );
     assert.match(
-      text(toolCallResultForModel(terminalToolCall("denied", "Not approved."))),
+      text(
+        toolCallResultForModel(
+          terminalToolCall("denied", "Not approved.", undefined, "user"),
+        ),
+      ),
       /^User denied the requested tool call\./,
+    );
+    assert.match(
+      text(
+        toolCallResultForModel(
+          terminalToolCall("denied", "Blocked by rules.", undefined, "policy"),
+        ),
+      ),
+      /^Permission policy denied the requested tool call\./,
     );
   });
 

--- a/packages/workbench-server/test/tool-executor.service.test.ts
+++ b/packages/workbench-server/test/tool-executor.service.test.ts
@@ -6,6 +6,10 @@ import { describe, it } from "node:test";
 import type { ToolCallRecord } from "@nervekit/contracts";
 import { CodedToolError } from "../src/domains/tools/tool-errors.js";
 import { ToolExecutorService } from "../src/domains/tools/tool-executor.service.js";
+import {
+  RUN_CANCELLED_TOOL_OUTCOME,
+  toolTerminationPatch,
+} from "../src/domains/tools/tool-termination.js";
 
 function toolCall(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
   return {
@@ -48,29 +52,24 @@ function cancelledRecord(record: ToolCallRecord): ToolCallRecord {
   const settledAt = "2026-01-02T03:04:07.000Z";
   return {
     ...record,
-    status: "cancelled",
+    ...toolTerminationPatch(record, RUN_CANCELLED_TOOL_OUTCOME),
     phase: "cancelled",
     revision: record.revision + 1,
-    error: "Tool execution was cancelled because the run was cancelled.",
-    errorDetails: {
-      code: "cancelled",
-      message: "Tool execution was cancelled because the run was cancelled.",
-    },
-    result: {
-      content: "Tool execution was cancelled because the run was cancelled.",
-      contentBlocks: [
-        {
-          type: "text",
-          text: "Tool execution was cancelled because the run was cancelled.",
-        },
-      ],
-    },
     execution: record.execution
       ? { ...record.execution, status: "cancelled", endedAt: settledAt }
       : undefined,
     settledAt,
     updatedAt: settledAt,
   };
+}
+
+function cancelledPreview(record: ToolCallRecord): string {
+  return (
+    record.agentPreview?.blocks
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n") ?? ""
+  );
 }
 
 function createExecutor(input: {
@@ -380,6 +379,8 @@ describe("ToolExecutorService structured errors", () => {
     assert.equal(terminal.status, "cancelled");
     assert.equal(terminal.errorDetails?.code, "cancelled");
     assert.equal(terminal.error, "Tool execution was cancelled.");
+    assert.match(cancelledPreview(terminal), /^Tool execution was cancelled\./);
+    assert.equal(terminal.agentProjection?.profile, "terminal_outcome");
     assert.equal(
       JSON.stringify(terminal).includes("Python execution aborted"),
       false,
@@ -401,6 +402,7 @@ describe("ToolExecutorService structured errors", () => {
     });
 
     assert.equal(terminal.status, "cancelled");
+    assert.match(cancelledPreview(terminal), /^Tool execution was cancelled\./);
     assert.equal(JSON.stringify(terminal).includes("late success"), false);
   });
 
@@ -420,6 +422,7 @@ describe("ToolExecutorService structured errors", () => {
 
     assert.equal(terminal.status, "cancelled");
     assert.equal(terminal.errorDetails?.code, "cancelled");
+    assert.match(cancelledPreview(terminal), /^Tool execution was cancelled\./);
     assert.equal(JSON.stringify(terminal).includes("late success"), false);
     assert.deepEqual(lifecycleStatuses, ["running"]);
   });

--- a/packages/workbench-server/test/tool-service-lifecycle.test.ts
+++ b/packages/workbench-server/test/tool-service-lifecycle.test.ts
@@ -4,7 +4,11 @@ import { DatabaseSync } from "node:sqlite";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
-import type { AgentRecord } from "@nervekit/contracts";
+import type {
+  AgentRecord,
+  ToolCallRecord,
+  ToolCallTranscriptRecord,
+} from "@nervekit/contracts";
 import { defaultSettings } from "@nervekit/contracts";
 import { ToolService } from "../src/domains/tools/tool-service.js";
 import { storagePaths } from "../src/infrastructure/storage/index.js";
@@ -179,6 +183,71 @@ describe("tool service lifecycle", () => {
     );
   });
 
+  it("retains agent previews for policy and user denials", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-denials-"));
+    const readOnlyAgent = agent("read_only");
+    const { service } = buildToolService(home, readOnlyAgent);
+
+    const policy = await service.requestTool(readOnlyAgent, "bash", {
+      command: "printf x > file.txt",
+    });
+    assert.equal(policy.toolCall.status, "denied");
+    assert.equal(policy.toolCall.phase, "denied");
+    assert.match(
+      previewText(policy.toolCall),
+      /^Permission policy denied the requested tool call\./,
+    );
+    assert.equal(policy.toolCall.agentProjection?.profile, "terminal_outcome");
+    assert.equal(policy.toolCall.resultPayload, undefined);
+
+    const supervisedAgent = agent("autonomous");
+    const { service: approvalService } = buildToolService(
+      await mkdtemp(join(tmpdir(), "nerve-tool-user-denial-")),
+      supervisedAgent,
+    );
+    const pending = await approvalService.requestTool(
+      supervisedAgent,
+      "todos_set",
+      { todos: [{ todo: "do not apply", done: false }] },
+      { forceApproval: true, durableSuspend: true },
+    );
+    const denied = await approvalService.denyApproval(
+      pending.approval!.id,
+      "Not now.",
+    );
+    assert.equal(denied.status, "denied");
+    assert.equal(denied.supervision?.source, "user");
+    assert.match(previewText(denied), /^User denied the requested tool call\./);
+    assert.equal(denied.resultPayload, undefined);
+  });
+
+  it("retains an agent preview when resolving an approval denial", async () => {
+    const home = await mkdtemp(join(tmpdir(), "nerve-tool-resolution-denial-"));
+    const testAgent = agent("autonomous");
+    const { service } = buildToolService(home, testAgent);
+    const pending = await service.requestTool(
+      testAgent,
+      "todos_set",
+      { todos: [{ todo: "do not apply", done: false }] },
+      { forceApproval: true, durableSuspend: true },
+    );
+
+    const denied = await service.resolveInteraction({
+      toolCallId: pending.toolCall.id,
+      interactionOrdinal: 0,
+      expectedRevision: pending.toolCall.revision,
+      resolutionRequestId: "deny-resolution-1",
+      resolution: { kind: "approval", action: "deny", note: "No." },
+    });
+
+    assert.equal(denied.status, "denied");
+    assert.equal(denied.interactions[0]?.status, "resolved");
+    assert.equal(denied.supervision?.status, "denied");
+    assert.equal(denied.supervision?.source, "user");
+    assert.match(previewText(denied), /^User denied the requested tool call\./);
+    assert.equal(denied.resultPayload, undefined);
+  });
+
   it("cancels pending interactions when terminalizing a run", async () => {
     const home = await mkdtemp(join(tmpdir(), "nerve-tool-terminalize-"));
     const testAgent = agent("autonomous");
@@ -214,8 +283,20 @@ describe("tool service lifecycle", () => {
     assert.equal(terminal?.interactions[0]?.status, "cancelled");
     assert.ok(terminal?.interactions[0]?.cancelledAt);
     assert.ok(terminal?.settledAt);
+    assert.match(previewText(terminal), /^Tool execution was cancelled\./);
+    assert.equal(terminal?.agentProjection?.profile, "terminal_outcome");
+    assert.equal(terminal?.resultPayload, undefined);
   });
 });
+
+function previewText(toolCall: ToolCallRecord | undefined): string {
+  return (
+    toolCall?.agentPreview?.blocks
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n") ?? ""
+  );
+}
 
 function buildToolService(
   home: string,
@@ -226,6 +307,7 @@ function buildToolService(
   },
 ) {
   const events: Array<{ type: string; data: unknown }> = [];
+  const previews = new Map<string, ToolCallTranscriptRecord>();
   const service = new ToolService(
     {
       paths: storagePaths(home),
@@ -237,7 +319,11 @@ function buildToolService(
         events.push({ type, data }),
     }) as never,
     {
-      upsertToolCall: () => undefined,
+      upsertToolCall: (
+        record: ToolCallRecord,
+        preview: ToolCallTranscriptRecord,
+      ) => previews.set(record.id, preview),
+      listToolCallPreviews: () => [...previews.values()],
       upsertApproval: () => undefined,
       writeToolCallSnapshot: () => undefined,
       isToolCallSnapshotValid: () => ({ valid: false, reason: "no-meta" }),


### PR DESCRIPTION
## Summary
- persist exact agent projections for policy denials, user denials, cancellations, and interruptions
- distinguish policy and user denial messages while preserving clear cancellation outcomes
- cover approval resolution and cancellation races with regression tests
- clarify the fallback shown for older calls without retained previews

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`