### PR TITLE
fix(permissions): allow external filesystem targets

### DIFF
--- a/docs/permission-rule-sets.md
+++ b/docs/permission-rule-sets.md
@@ -209,6 +209,12 @@ type PermissionTarget =
       relativePath: string;
     }
   | {
+      kind: "path";
+      access: "read" | "write";
+      scope: "exact" | "tree";
+      absolutePath: string;
+    }
+  | {
       kind: "url";
       normalizedUrl: string;
       access: "read" | "write";
@@ -232,7 +238,7 @@ interface PermissionRequest {
 }
 ```
 
-Tools with structured resources must expose every security-relevant path, URL, or agent target. An `all` target matcher requires at least one extracted target and every relevant target must match; an empty target collection never satisfies `all`.
+Tools with structured resources must expose every security-relevant path, URL, or agent target. Paths inside an application-owned symbolic root use the portable rooted form. Paths elsewhere use the canonical absolute runtime form and remain valid permission targets; they are not discarded merely because they are outside the project or Nerve home. Persisted rooted path patterns never contain these machine-specific absolute values. An `all` target matcher requires at least one extracted target and every relevant target must match; an empty target collection never satisfies `all`.
 
 Bash and Python remain opaque. Nerve does not extract command segments or infer script effects. Rules for these tools match the complete validated argument value, such as `args.command` or `args.code`. String equality and glob operators are anchored to the complete value. Automatically suggested rules use exact equality by default; broad globs require an explicit user choice and are presented without any claim that the matched command or program is safe.
 
@@ -451,7 +457,7 @@ The built-in behavior is:
 
 | Rule set   | Stable ID    | Availability  | `interaction` | `read` | Explore | Plan-directory `write` or `edit` | Other base risk |
 | ---------- | ------------ | ------------- | ------------- | ------ | ------- | -------------------------------- | --------------- |
-| Baseline   | `baseline`   | Always active | Allow         | Prompt | Prompt  | Prompt                           | Prompt          |
+| Baseline   | `baseline`   | Always active | Allow         | Allow  | Prompt  | Prompt                           | Prompt          |
 | Read only  | `read_only`  | Coding        | Allow         | Allow  | Allow   | Deny                             | Deny            |
 | Supervised | `supervised` | Coding        | Allow         | Allow  | Prompt  | Prompt                           | Prompt          |
 | Autonomous | `autonomous` | Coding        | Allow         | Allow  | Allow   | Allow                            | Allow           |
@@ -461,16 +467,24 @@ User-question and interaction tools are automatically allowed because their exec
 
 ### Baseline
 
-Baseline is always active at the lowest scope rank and guarantees a total result. It allows interaction tools and prompts for everything else:
+Baseline is always active at the lowest scope rank and guarantees a total result. It allows interaction and read-risk tools, including filesystem reads outside managed roots, and prompts for everything else:
 
 ```json
 [
   {
     "id": "allow-interaction",
     "enabled": true,
-    "priority": 100,
+    "priority": 200,
     "enforcement": "overridable",
     "when": { "baseRisks": ["interaction"] },
+    "decision": "allow"
+  },
+  {
+    "id": "allow-read",
+    "enabled": true,
+    "priority": 100,
+    "enforcement": "overridable",
+    "when": { "baseRisks": ["read"] },
     "decision": "allow"
   },
   {
@@ -575,7 +589,7 @@ Autonomous automatically allows every valid tool request:
 }
 ```
 
-Autonomous does not make malformed, invalid, or unavailable tool calls executable.
+Autonomous includes valid filesystem requests outside the project and Nerve home, so its filesystem tools may read, edit, and write arbitrary host paths. It does not make malformed, invalid, or unavailable tool calls executable.
 
 ### Planning
 
@@ -800,7 +814,7 @@ Future modes follow the same contract.
 
 ## Symbolic path roots
 
-Persisted rules must use portable symbolic roots rather than machine-specific absolute paths.
+Persisted rooted path rules must use portable symbolic roots rather than machine-specific absolute paths. Normalized runtime requests may also contain canonical absolute path targets for filesystem locations outside every registered symbolic root; those targets are evaluated by risk, tool, argument, or generic path rules rather than persisted rooted path patterns.
 
 Required roots are:
 
@@ -1006,7 +1020,7 @@ The target system must support at least the following behaviors:
 8. **Conversation approval:** a prompted decision saved to conversation scope updates the conversation `permissions.json`, survives restarts, and does not modify project or user files.
 9. **Opaque execution:** Bash and Python retain `unknown` risk; an automatically generated permission matches the exact complete argument unless the user explicitly broadens it.
 10. **Structured targets:** a Planning write allow requires at least one write target and every write target under `${plansDir}`.
-11. **Planning:** Planning allows interaction, local reads, Explore, and plan-file `write` or `edit`, while denying other requests by default.
+11. **Planning:** Planning allows interaction, filesystem reads anywhere, Explore, and plan-file `write` or `edit`, while denying other requests by default.
 12. **Portable policy:** moving `NERVE_HOME` does not require rewriting persisted symbolic path rules.
 13. **Explore:** Read only and Planning explicitly allow the parent Explore call; every Explore child uses only the fixed Read only rule set, with no parent overlays.
 14. **Future implementation agent:** a read-only parent may invoke an allowed sub-agent whose persistent configuration selects a writing-capable rule set; the child receives no parent overlays.
@@ -1014,3 +1028,4 @@ The target system must support at least the following behaviors:
 16. **Missing selection:** a missing or invalid selected custom rule set falls back to Baseline with a visible notification.
 17. **Invalid overlay:** one invalid rule causes the complete owning overlay to be ignored and a notification to identify the file and validation error.
 18. **Historical audit:** changing a rule-set or overlay file does not alter the recorded explanation of an earlier tool-call decision.
+19. **External filesystem targets:** every built-in rule set allows `read`, `grep`, `find`, and `ls` against paths outside registered symbolic roots; Autonomous also allows external filesystem writes, while other rule sets retain their normal write decisions.

--- a/packages/contracts/src/domains/permissions/permission-rule-sets.schema.ts
+++ b/packages/contracts/src/domains/permissions/permission-rule-sets.schema.ts
@@ -81,16 +81,46 @@ const relativePathSchema = z
     }
   });
 
-export const permissionTargetSchema = z.discriminatedUnion("kind", [
-  z
-    .object({
-      kind: z.literal("path"),
-      access: z.enum(["read", "write"]),
-      scope: z.enum(["exact", "tree"]),
-      root: pathRootSchema,
-      relativePath: relativePathSchema,
-    })
-    .strict(),
+const rootedPermissionPathTargetSchema = z
+  .object({
+    kind: z.literal("path"),
+    access: z.enum(["read", "write"]),
+    scope: z.enum(["exact", "tree"]),
+    root: pathRootSchema,
+    relativePath: relativePathSchema,
+  })
+  .strict();
+
+const absolutePathSchema = z
+  .string()
+  .min(1)
+  .max(32_768)
+  .superRefine((value, context) => {
+    if (
+      value.includes("\0") ||
+      (!value.startsWith("/") &&
+        !/^[A-Za-z]:[\\/]/.test(value) &&
+        !value.startsWith("\\\\"))
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "External path targets must use absolute platform paths.",
+      });
+    }
+  });
+
+const externalPermissionPathTargetSchema = z
+  .object({
+    kind: z.literal("path"),
+    access: z.enum(["read", "write"]),
+    scope: z.enum(["exact", "tree"]),
+    absolutePath: absolutePathSchema,
+  })
+  .strict();
+
+export const permissionTargetSchema = z.union([
+  rootedPermissionPathTargetSchema,
+  externalPermissionPathTargetSchema,
   z
     .object({
       kind: z.literal("url"),

--- a/packages/contracts/test/permission-rule-sets.schema.test.ts
+++ b/packages/contracts/test/permission-rule-sets.schema.test.ts
@@ -5,6 +5,7 @@ import {
   permissionOverlaySchema,
   permissionRuleSchema,
   permissionRuleSetSchema,
+  permissionTargetSchema,
 } from "../src/index.js";
 
 const rule = {
@@ -87,6 +88,57 @@ test("project and conversation sources reject forbidden authority", () => {
           },
         },
       ],
+    }),
+  );
+});
+
+test("permission targets distinguish portable rooted and external paths", () => {
+  assert.deepEqual(
+    permissionTargetSchema.parse({
+      kind: "path",
+      access: "read",
+      scope: "exact",
+      root: "project",
+      relativePath: "src/index.ts",
+    }),
+    {
+      kind: "path",
+      access: "read",
+      scope: "exact",
+      root: "project",
+      relativePath: "src/index.ts",
+    },
+  );
+  assert.deepEqual(
+    permissionTargetSchema.parse({
+      kind: "path",
+      access: "read",
+      scope: "tree",
+      absolutePath: "/tmp/external",
+    }),
+    {
+      kind: "path",
+      access: "read",
+      scope: "tree",
+      absolutePath: "/tmp/external",
+    },
+  );
+  assert.throws(() =>
+    permissionTargetSchema.parse({
+      kind: "path",
+      access: "read",
+      scope: "exact",
+      root: "project",
+      relativePath: "src/index.ts",
+      absolutePath: "/tmp/external",
+    }),
+  );
+  assert.throws(() =>
+    permissionTargetSchema.parse({
+      kind: "path",
+      access: "read",
+      scope: "tree",
+      absolutePath: "relative/path",
     }),
   );
 });

--- a/packages/tools/src/policy/permission-policy.ts
+++ b/packages/tools/src/policy/permission-policy.ts
@@ -302,11 +302,13 @@ function stringPathTargets(
   cwd: string,
 ): PermissionTarget[] {
   const values = Array.isArray(value) ? value : [value];
-  return values.flatMap((entry) => {
+  return values.flatMap((entry): PermissionTarget[] => {
     if (typeof entry !== "string" || entry.trim().length === 0) return [];
-    const absolutePath = resolve(cwd, entry);
+    const absolutePath = existingRealpath(resolve(cwd, entry));
     const rooted = symbolicPath(absolutePath, roots);
-    return rooted ? [{ kind: "path" as const, access, scope, ...rooted }] : [];
+    return rooted
+      ? [{ kind: "path" as const, access, scope, ...rooted }]
+      : [{ kind: "path" as const, access, scope, absolutePath }];
   });
 }
 
@@ -314,12 +316,11 @@ function symbolicPath(
   absolutePath: string,
   roots: PermissionRootPaths,
 ): { root: PathRoot; relativePath: string } | undefined {
-  const canonicalPath = existingRealpath(absolutePath);
   const candidates = (Object.entries(roots) as [PathRoot, string][])
     .map(([root, path]) => ({ root, path: existingRealpath(resolve(path)) }))
     .sort((left, right) => right.path.length - left.path.length);
   for (const candidate of candidates) {
-    const child = relative(candidate.path, canonicalPath);
+    const child = relative(candidate.path, absolutePath);
     if (
       child === "" ||
       (child !== ".." && !child.startsWith(`..${sep}`) && !isAbsolute(child))
@@ -483,19 +484,23 @@ function targetMatches(
     return false;
   if (
     matcher.root !== undefined &&
-    (target.kind !== "path" || target.root !== matcher.root)
+    (target.kind !== "path" ||
+      !("root" in target) ||
+      target.root !== matcher.root)
   )
     return false;
   if (matcher.pattern === undefined) return true;
   const value =
     target.kind === "path"
-      ? target.relativePath
+      ? "relativePath" in target
+        ? target.relativePath
+        : undefined
       : target.kind === "url"
         ? target.normalizedUrl
         : target.kind === "agent"
           ? target.agentId
           : "*";
-  return patternMatches(value, matcher.pattern);
+  return value !== undefined && patternMatches(value, matcher.pattern);
 }
 
 function allowCoversRequest(
@@ -536,7 +541,7 @@ function suggestPermissionRules(
     return [];
   const when: PermissionRule["when"] = { toolNames: [request.toolName] };
   const target = onlyTarget;
-  if (target?.kind === "path") {
+  if (target?.kind === "path" && "root" in target) {
     when.targets = {
       quantifier: "all",
       matcher: {

--- a/packages/tools/src/policy/rule-sets/baseline.json
+++ b/packages/tools/src/policy/rule-sets/baseline.json
@@ -2,16 +2,24 @@
   "schemaVersion": 1,
   "id": "baseline",
   "name": "Baseline",
-  "description": "Prompt by default while allowing interaction boundaries.",
+  "description": "Allow reads and interaction boundaries; prompt for everything else.",
   "source": "builtin",
   "enabled": true,
   "rules": [
     {
       "id": "allow-interaction",
       "enabled": true,
-      "priority": 100,
+      "priority": 200,
       "enforcement": "overridable",
       "when": { "baseRisks": ["interaction"] },
+      "decision": "allow"
+    },
+    {
+      "id": "allow-read",
+      "enabled": true,
+      "priority": 100,
+      "enforcement": "overridable",
+      "when": { "baseRisks": ["read"] },
       "decision": "allow"
     },
     {

--- a/packages/tools/test/permission-rule-sets.test.ts
+++ b/packages/tools/test/permission-rule-sets.test.ts
@@ -133,6 +133,47 @@ test("built-in coding rule sets implement their complete behavior", () => {
   );
 });
 
+test("all built-in rule sets allow core reads outside managed roots", () => {
+  const requests = [
+    ["read", { path: "/tmp/outside.txt" }],
+    ["grep", { pattern: "needle", path: "/tmp" }],
+    ["find", { pattern: "*.txt", path: "/tmp" }],
+    ["ls", { path: "/tmp" }],
+  ] as const;
+  for (const ruleSet of [
+    "baseline",
+    "read_only",
+    "supervised",
+    "autonomous",
+    "planning",
+  ]) {
+    for (const [toolName, args] of requests) {
+      assert.equal(
+        decision(ruleSet, toolName, args).decision,
+        "allow",
+        `${ruleSet}:${toolName}`,
+      );
+    }
+  }
+});
+
+test("external writes follow each built-in rule set's normal capability", () => {
+  const writeArgs = { path: "/tmp/outside.txt", content: "x" };
+  const editArgs = {
+    path: "/tmp/outside.txt",
+    edits: [{ oldText: "old", newText: "new" }],
+  };
+  for (const [toolName, args] of [
+    ["write", writeArgs],
+    ["edit", editArgs],
+  ] as const) {
+    assert.equal(decision("autonomous", toolName, args).decision, "allow");
+    assert.equal(decision("supervised", toolName, args).decision, "prompt");
+    assert.equal(decision("read_only", toolName, args).decision, "deny");
+    assert.equal(decision("planning", toolName, args).decision, "deny");
+  }
+});
+
 test("planning allows reads, interaction, Explore, and exact plan writes", () => {
   assert.equal(
     decision("planning", "read", { path: "README.md" }).decision,
@@ -279,6 +320,18 @@ test("path suggestions use portable canonical targets", () => {
   });
 });
 
+test("external path suggestions use exact arguments instead of host-specific matchers", () => {
+  const result = decision("supervised", "write", {
+    path: "/tmp/outside.txt",
+    content: "x",
+  });
+  assert.deepEqual(result.suggestedRules[0]?.when.primaryArgument, {
+    operator: "equals",
+    value: "/tmp/outside.txt",
+  });
+  assert.equal(result.suggestedRules[0]?.when.targets, undefined);
+});
+
 test("policy hash is deterministic and changes with effective policy", () => {
   const first = decision("supervised", "write", { path: "a" });
   const second = decision("supervised", "write", { path: "a" });
@@ -294,7 +347,64 @@ test("policy hash is deterministic and changes with effective policy", () => {
   assert.notEqual(first.policySnapshotHash, changed.policySnapshotHash);
 });
 
-test("existing symlinks are canonicalized before path authorization", async () => {
+test("external and mixed grep paths remain distinct permission targets", () => {
+  const request = normalizePermissionRequest({
+    toolName: "grep",
+    args: {
+      pattern: "needle",
+      paths: ["/tmp/first", "/tmp/second", "/workspace/src"],
+    },
+    roots,
+    conversationId: "conv_test",
+  });
+  assert.deepEqual(request.targets, [
+    {
+      kind: "path",
+      access: "read",
+      scope: "tree",
+      absolutePath: "/tmp/first",
+    },
+    {
+      kind: "path",
+      access: "read",
+      scope: "tree",
+      absolutePath: "/tmp/second",
+    },
+    {
+      kind: "path",
+      access: "read",
+      scope: "tree",
+      root: "project",
+      relativePath: "src",
+    },
+  ]);
+
+  const projectOnly = overlay({
+    id: "allow-project-grep",
+    enabled: true,
+    priority: 1,
+    enforcement: "overridable",
+    when: {
+      toolNames: ["grep"],
+      targets: {
+        quantifier: "all",
+        matcher: { kind: "path", root: "project", pattern: "**" },
+      },
+    },
+    decision: "allow",
+  });
+  assert.equal(
+    decision(
+      "supervised",
+      "grep",
+      { paths: ["/tmp/first", "/workspace/src"] },
+      { projectOverlay: projectOnly },
+    ).winningRuleId,
+    "allow-read",
+  );
+});
+
+test("existing symlinks are canonicalized to external targets", async () => {
   const root = await mkdtemp(join(tmpdir(), "nerve-policy-symlink-"));
   try {
     const project = join(root, "project");
@@ -305,19 +415,25 @@ test("existing symlinks are canonicalized before path authorization", async () =
     await writeFile(outside, "secret");
     const link = join(project, "linked.txt");
     await symlink(outside, link);
-    assert.throws(() =>
-      normalizePermissionRequest({
-        toolName: "read",
-        args: { path: link },
-        roots: {
-          project,
-          nerve_home: nerveHome,
-          nerve_data: join(nerveHome, "data"),
-          plans: join(nerveHome, "data", "plans"),
-        },
-        conversationId: "conv_test",
-      }),
-    );
+    const request = normalizePermissionRequest({
+      toolName: "read",
+      args: { path: link },
+      roots: {
+        project,
+        nerve_home: nerveHome,
+        nerve_data: join(nerveHome, "data"),
+        plans: join(nerveHome, "data", "plans"),
+      },
+      conversationId: "conv_test",
+    });
+    assert.deepEqual(request.targets, [
+      {
+        kind: "path",
+        access: "read",
+        scope: "exact",
+        absolutePath: outside,
+      },
+    ]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/workbench-server/src/domains/tools/permission/evaluate-workbench-tool-permission.ts
+++ b/packages/workbench-server/src/domains/tools/permission/evaluate-workbench-tool-permission.ts
@@ -105,11 +105,14 @@ export function evaluateWorkbenchToolPermission(
                     kind: "path" as const,
                     access: target.access,
                     scope: target.scope,
-                    absolutePath: resolve(
-                      context.roots![target.root],
-                      target.relativePath,
-                    ),
-                    ...(target.root === "project"
+                    absolutePath:
+                      "root" in target
+                        ? resolve(
+                            context.roots![target.root],
+                            target.relativePath,
+                          )
+                        : target.absolutePath,
+                    ...("root" in target && target.root === "project"
                       ? { projectRelativePath: target.relativePath }
                       : {}),
                   }

--- a/packages/workbench-server/src/domains/tools/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/tool-service.ts
@@ -192,7 +192,12 @@ async function assertWriteTargetBoundaries(
   roots: PermissionRootPaths,
 ): Promise<void> {
   for (const target of targets) {
-    if (target.kind !== "path" || target.access !== "write") continue;
+    if (
+      target.kind !== "path" ||
+      target.access !== "write" ||
+      !("root" in target)
+    )
+      continue;
     const root = await realpath(roots[target.root]);
     const candidate = resolve(root, target.relativePath);
     let existing = candidate;

--- a/packages/workbench-server/test/policy.test.ts
+++ b/packages/workbench-server/test/policy.test.ts
@@ -8,6 +8,10 @@ import type {
   PermissionLevel,
   LegacyPermissionRule,
 } from "@nervekit/contracts";
+import {
+  builtInPermissionRuleSet,
+  composeEffectivePermissionPolicy,
+} from "@nervekit/tools";
 import { evaluateWorkbenchToolPermission } from "../src/domains/tools/permission/index.js";
 
 function agent(
@@ -32,6 +36,22 @@ function agent(
 }
 
 const context = { dataDir: "/home/test/.nerve" };
+const roots = {
+  project: "/workspace",
+  nerve_home: "/home/test/.nerve",
+  nerve_data: "/home/test/.nerve/data",
+  plans: "/home/test/.nerve/data/plans",
+};
+
+function ruleSetContext(id: "supervised" | "autonomous") {
+  return {
+    ...context,
+    roots,
+    policy: composeEffectivePermissionPolicy({
+      selectedRuleSet: builtInPermissionRuleSet(id),
+    }),
+  };
+}
 
 describe("Workbench tool permission", () => {
   it("delegates coding decisions to the canonical evaluator", () => {
@@ -83,6 +103,48 @@ describe("Workbench tool permission", () => {
       ).decision,
       "allow",
     );
+  });
+
+  it("projects external targets through the permission rule-set evaluator", () => {
+    const read = evaluateWorkbenchToolPermission(
+      agent("supervised"),
+      "read",
+      { path: "/tmp/outside.txt" },
+      ruleSetContext("supervised"),
+    );
+    assert.equal(read.decision, "allow");
+    assert.deepEqual(read.permissionEvaluation?.normalizedTargets, [
+      {
+        kind: "path",
+        access: "read",
+        scope: "exact",
+        absolutePath: "/tmp/outside.txt",
+      },
+    ]);
+    assert.deepEqual(read.supervision?.normalizedTargets, [
+      {
+        kind: "path",
+        access: "read",
+        scope: "exact",
+        absolutePath: "/tmp/outside.txt",
+      },
+    ]);
+
+    const supervisedWrite = evaluateWorkbenchToolPermission(
+      agent("supervised"),
+      "write",
+      { path: "/tmp/outside.txt", content: "x" },
+      ruleSetContext("supervised"),
+    );
+    assert.equal(supervisedWrite.decision, "approval");
+
+    const autonomousWrite = evaluateWorkbenchToolPermission(
+      agent("autonomous"),
+      "write",
+      { path: "/tmp/outside.txt", content: "x" },
+      ruleSetContext("autonomous"),
+    );
+    assert.equal(autonomousWrite.decision, "allow");
   });
 
   it("keeps plan-only tools unavailable in coding mode", () => {


### PR DESCRIPTION
## Summary

- represent filesystem paths outside project and Nerve roots as explicit canonical absolute permission targets
- allow core filesystem reads anywhere in every built-in rule set and preserve each rule set's existing write behavior
- make Autonomous permit external edits and writes while keeping rooted matchers portable and scoped
- update workbench projection, boundary handling, documentation, and regression coverage

## Validation

- `pnpm fix && pnpm check && pnpm run test:full`