### PR TITLE
Align planning tool permissions

### DIFF
--- a/packages/tools/src/policy/rule-sets/planning.json
+++ b/packages/tools/src/policy/rule-sets/planning.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "planning",
   "name": "Planning",
-  "description": "Allow reads, interaction, Explore, and writes wholly within the plans directory.",
+  "description": "Allow read-only research, interaction, Explore, and plan writes; prompt for local analysis commands.",
   "source": "builtin",
   "enabled": true,
   "compatibleModes": ["planning"],
@@ -37,6 +37,17 @@
       "decision": "allow"
     },
     {
+      "id": "allow-network-research",
+      "enabled": true,
+      "priority": 175,
+      "enforcement": "overridable",
+      "when": {
+        "toolGroups": ["web", "vision", "jira", "confluence"],
+        "baseRisks": ["network"]
+      },
+      "decision": "allow"
+    },
+    {
       "id": "allow-explore",
       "enabled": true,
       "priority": 150,
@@ -51,6 +62,14 @@
       "enforcement": "overridable",
       "when": { "baseRisks": ["read"] },
       "decision": "allow"
+    },
+    {
+      "id": "prompt-local-analysis",
+      "enabled": true,
+      "priority": 50,
+      "enforcement": "overridable",
+      "when": { "toolNames": ["bash", "python_exec"] },
+      "decision": "prompt"
     },
     {
       "id": "deny-everything-else",

--- a/packages/tools/test/policy/permission-rule-sets.test.ts
+++ b/packages/tools/test/policy/permission-rule-sets.test.ts
@@ -176,7 +176,7 @@ test("external writes follow each built-in rule set's normal capability", () => 
   }
 });
 
-test("planning allows reads, interaction, Explore, and exact plan writes", () => {
+test("planning separates research, prompted analysis, and mutations", () => {
   assert.equal(
     decision("planning", "read", { path: "README.md" }).decision,
     "allow",
@@ -193,18 +193,43 @@ test("planning allows reads, interaction, Explore, and exact plan writes", () =>
     }).decision,
     "allow",
   );
-  assert.equal(
-    decision("planning", "edit", { path: "/workspace/a.ts" }).decision,
-    "deny",
-  );
+
+  for (const [toolName, args] of [
+    ["web_search", { query: "Nerve planning" }],
+    ["web_fetch", { url: "https://example.com" }],
+    ["explain_image", { path: "/workspace/screenshot.png" }],
+    ["jira_get_issue", { issue_key: "NERVE-1" }],
+    ["confluence_get_page", { page_id: "123" }],
+  ] as const) {
+    assert.equal(
+      decision("planning", toolName, args).decision,
+      "allow",
+      toolName,
+    );
+  }
+
   assert.equal(
     decision("planning", "bash", { command: "pwd" }).decision,
-    "deny",
+    "prompt",
   );
   assert.equal(
-    decision("planning", "web_fetch", { url: "https://example.com" }).decision,
-    "deny",
+    decision("planning", "python_exec", { code: "print(1)" }).decision,
+    "prompt",
   );
+
+  for (const [toolName, args] of [
+    ["edit", { path: "/workspace/a.ts" }],
+    ["jira_update_issue", { issue_key: "NERVE-1", summary: "Changed" }],
+    ["confluence_create_page", { title: "Changed", body: "content" }],
+    ["task_start", { command: "pnpm dev" }],
+    ["task_control", { task: "dev", action: "stop" }],
+  ] as const) {
+    assert.equal(
+      decision("planning", toolName, args).decision,
+      "deny",
+      toolName,
+    );
+  }
 });
 
 test("guardrails and scope ranks precede numeric priority and decision kind", () => {


### PR DESCRIPTION
## Summary
- allow read-only web, vision, Jira, and Confluence research in planning mode
- prompt for Bash and Python analysis
- keep mutations, task control, and workspace edits denied
- add policy coverage for the new boundaries

## Validation
- pnpm fix && pnpm check && pnpm run test:affected