### PR TITLE
chore: upgrade pi-ai to 0.84.4

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -57,7 +57,7 @@
     "test": "tsx --test \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.84.3",
+    "@earendil-works/pi-ai": "0.84.4",
     "@nervekit/contracts": "workspace:*",
     "@nervekit/native": "workspace:*",
     "ignore": "7.0.5",

--- a/packages/workbench-server/package.json
+++ b/packages/workbench-server/package.json
@@ -35,7 +35,7 @@
     "test:native": "tsx --test test/infrastructure/persistence/file-mutations.test.ts test/domains/tasks/process-runtime-driver.test.ts test/domains/tasks/task-port-inspector.test.ts test/domains/tasks/task-scope.test.ts test/domains/tasks/task-supervisor.test.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.84.3",
+    "@earendil-works/pi-ai": "0.84.4",
     "@hono/node-server": "2.0.12",
     "@nervekit/contracts": "workspace:*",
     "@nervekit/harness": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
   packages/harness:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.84.3
-        version: 0.84.3(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.84.4
+        version: 0.84.4(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
       '@nervekit/contracts':
         specifier: workspace:*
         version: link:../contracts
@@ -488,8 +488,8 @@ importers:
   packages/workbench-server:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: 0.84.3
-        version: 0.84.3(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
+        specifier: 0.84.4
+        version: 0.84.4(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)
       '@hono/node-server':
         specifier: 2.0.12
         version: 2.0.12(hono@4.12.34)
@@ -1465,13 +1465,13 @@ packages:
   '@dagrejs/graphlib@4.0.1':
     resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
-  '@earendil-works/pi-ai@0.84.3':
-    resolution: {integrity: sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==}
+  '@earendil-works/pi-ai@0.84.4':
+    resolution: {integrity: sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-telemetry@0.84.3':
-    resolution: {integrity: sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==}
+  '@earendil-works/pi-telemetry@0.84.4':
+    resolution: {integrity: sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==}
     engines: {node: '>=22.19.0'}
 
   '@electron-internal/extract-zip@1.0.5':
@@ -8915,11 +8915,11 @@ snapshots:
 
   '@dagrejs/graphlib@4.0.1': {}
 
-  '@earendil-works/pi-ai@0.84.3(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)':
+  '@earendil-works/pi-ai@0.84.4(supports-color@7.2.0)(ws@8.21.0)(zod@4.1.12)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.1.12)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@earendil-works/pi-telemetry': 0.84.3
+      '@earendil-works/pi-telemetry': 0.84.4
       '@google/genai': 1.52.0(supports-color@7.2.0)
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2(supports-color@7.2.0)
@@ -8935,7 +8935,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-telemetry@0.84.3': {}
+  '@earendil-works/pi-telemetry@0.84.4': {}
 
   '@electron-internal/extract-zip@1.0.5': {}
 


### PR DESCRIPTION
## Summary
- upgrade @earendil-works/pi-ai to 0.84.4
- refresh the lockfile and pi-telemetry resolution

## Validation
- pnpm fix && pnpm check && pnpm run test:affected