### PR TITLE
Fix permission validation for empty search paths

### DIFF
--- a/packages/tools/src/policy/permission-policy.ts
+++ b/packages/tools/src/policy/permission-policy.ts
@@ -254,9 +254,9 @@ function extractTargets(
   }
   if (treeReadPathTools.has(toolName)) {
     const values =
-      toolName === "grep"
-        ? (args.paths ?? args.path ?? ".")
-        : (args.path ?? ".");
+      toolName === "grep" && args.paths !== undefined
+        ? args.paths
+        : singletonSearchPath(args.path);
     return stringPathTargets(values, "read", "tree", roots, cwd);
   }
   if (toolName === "plan_mode_present") {
@@ -292,6 +292,13 @@ function extractTargets(
   );
   if (fileTargets.length > 0) return fileTargets;
   return [{ kind: "whole_tool" }];
+}
+
+function singletonSearchPath(value: unknown): unknown {
+  return value === undefined ||
+    (typeof value === "string" && value.trim().length === 0)
+    ? "."
+    : value;
 }
 
 function stringPathTargets(

--- a/packages/tools/test/policy/permission-rule-sets.test.ts
+++ b/packages/tools/test/policy/permission-rule-sets.test.ts
@@ -159,6 +159,46 @@ test("all built-in rule sets allow core reads outside managed roots", () => {
   }
 });
 
+test("blank singleton search paths target the current project directory", () => {
+  const requests = [
+    ["grep", { pattern: "needle", path: "" }],
+    ["find", { pattern: "*.ts", path: "" }],
+    ["ls", { path: "" }],
+  ] as const;
+
+  for (const [toolName, args] of requests) {
+    const request = normalizePermissionRequest({
+      toolName,
+      args,
+      roots,
+      conversationId: "conv_test",
+    });
+    assert.deepEqual(request.targets, [
+      {
+        kind: "path",
+        access: "read",
+        scope: "tree",
+        root: "project",
+        relativePath: "",
+      },
+    ]);
+    assert.equal(decision("read_only", toolName, args).decision, "allow");
+  }
+});
+
+test("an empty grep paths collection does not default to the project", () => {
+  assert.throws(
+    () =>
+      normalizePermissionRequest({
+        toolName: "grep",
+        args: { pattern: "needle", paths: [] },
+        roots,
+        conversationId: "conv_test",
+      }),
+    /Required permission targets could not be derived for grep/,
+  );
+});
+
 test("external writes follow each built-in rule set's normal capability", () => {
   const writeArgs = { path: "/tmp/outside.txt", content: "x" };
   const editArgs = {


### PR DESCRIPTION
## Summary
- Align permission targets for blank `grep`, `find`, and `ls` paths with executor defaults.
- Preserve fail-closed behavior for empty `grep.paths` collections.
- Add regression coverage.

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`