### PR TITLE
Align CI/CD workflows with current architecture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,16 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       testable: ${{ steps.filter.outputs.testable }}
+      website: ${{ steps.filter.outputs.website }}
       workbench: ${{ steps.filter.outputs.workbench }}
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Classify changed files
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           base: ${{ github.event_name == 'push' && github.event.before || '' }}
           predicate-quantifier: "some-with-excludes"
@@ -42,7 +43,15 @@ jobs:
               - '!README.md'
               - '!NOTICE'
               - '!packages/website/**'
+            website:
+              - '.github/workflows/ci.yml'
+              - 'packages/website/**'
+              - 'packages/ui-kit/src/styles/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
             workbench:
+              - '.github/workflows/ci.yml'
               - 'packages/workbench-server/**'
               - 'packages/workbench-app/**'
               - 'packages/ui-kit/**'
@@ -51,6 +60,8 @@ jobs:
               - 'packages/harness/**'
               - 'packages/tools/**'
               - 'packages/native/**'
+              - 'scripts/copy-workbench-app-dist-to-workbench-server.mjs'
+              - 'scripts/smoke-workbench-release.mjs'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -67,17 +78,17 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
         with:
           toolchain: 1.97.1
 
@@ -95,18 +106,18 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
         with:
           toolchain: 1.97.1
           components: clippy,rustfmt
@@ -132,3 +143,62 @@ jobs:
       - name: Smoke built workbench HTTP and WebSocket parity
         if: github.event_name != 'pull_request' || needs.paths.outputs.workbench == 'true'
         run: node scripts/smoke-workbench-release.mjs
+
+  website:
+    name: Check and build website
+    runs-on: ubuntu-latest
+    needs: paths
+    if: github.event_name != 'pull_request' || needs.paths.outputs.website == 'true'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Check website
+        run: pnpm --filter @nervekit/website check
+      - name: Test website
+        run: pnpm --filter @nervekit/website test
+      - name: Build website
+        run: pnpm --filter @nervekit/website build
+
+  gate:
+    name: CI gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - paths
+      - storage-windows
+      - validate
+      - website
+
+    steps:
+      - name: Require successful CI jobs
+        shell: bash
+        env:
+          PATHS_RESULT: ${{ needs.paths.result }}
+          STORAGE_RESULT: ${{ needs.storage-windows.result }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          WEBSITE_RESULT: ${{ needs.website.result }}
+        run: |
+          set -euo pipefail
+          if [ "${PATHS_RESULT}" != "success" ] || [ "${VALIDATE_RESULT}" != "success" ]; then
+            echo "Required CI job failed: paths=${PATHS_RESULT}, validate=${VALIDATE_RESULT}" >&2
+            exit 1
+          fi
+          for result in "${STORAGE_RESULT}" "${WEBSITE_RESULT}"; do
+            if [ "${result}" != "success" ] && [ "${result}" != "skipped" ]; then
+              echo "Conditional CI job failed: storage=${STORAGE_RESULT}, website=${WEBSITE_RESULT}" >&2
+              exit 1
+            fi
+          done
+          echo "CI passed: paths=${PATHS_RESULT}, validate=${VALIDATE_RESULT}, storage=${STORAGE_RESULT}, website=${WEBSITE_RESULT}"

--- a/.github/workflows/native-host.yml
+++ b/.github/workflows/native-host.yml
@@ -2,18 +2,6 @@ name: Native host tests
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/native-host.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "packages/native/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - "packages/tools/**"
-      - "packages/workbench-server/**"
-      - "packages/desktop-shell/**"
   push:
     branches:
       - main
@@ -22,8 +10,49 @@ permissions:
   contents: read
 
 jobs:
+  paths:
+    name: Detect native-impacting changes
+    runs-on: ubuntu-latest
+    outputs:
+      native: ${{ steps.filter.outputs.native }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Classify changed files
+        id: filter
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          filters: |
+            native:
+              - '.github/workflows/native-host.yml'
+              - 'packages/contracts/**'
+              - 'packages/native/**'
+              - 'packages/protocol/**'
+              - 'packages/harness/**'
+              - 'packages/tools/**'
+              - 'packages/ui-kit/**'
+              - 'packages/workbench-server/**'
+              - 'packages/workbench-app/**'
+              - 'packages/desktop-shell/**'
+              - 'scripts/copy-workbench-app-dist-to-workbench-server.mjs'
+              - 'scripts/generate-brand-assets.mjs'
+              - 'assets/brand/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig*.json'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.nvmrc'
+
   test:
     name: Native ${{ matrix.suite }} tests (${{ matrix.os }})
+    needs: paths
+    if: github.event_name != 'pull_request' || needs.paths.outputs.native == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -34,18 +63,18 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
         with:
           toolchain: 1.97.1
           components: clippy,rustfmt
@@ -77,3 +106,29 @@ jobs:
         if: matrix.suite == 'desktop'
         timeout-minutes: 8
         run: pnpm --filter @nervekit/desktop-shell test
+
+  gate:
+    name: Native host gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - paths
+      - test
+
+    steps:
+      - name: Require successful native host jobs
+        shell: bash
+        env:
+          PATHS_RESULT: ${{ needs.paths.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          set -euo pipefail
+          if [ "${PATHS_RESULT}" != "success" ]; then
+            echo "Native path detection failed: ${PATHS_RESULT}" >&2
+            exit 1
+          fi
+          if [ "${TEST_RESULT}" != "success" ] && [ "${TEST_RESULT}" != "skipped" ]; then
+            echo "Native test matrix failed: ${TEST_RESULT}" >&2
+            exit 1
+          fi
+          echo "Native host CI passed: paths=${PATHS_RESULT}, tests=${TEST_RESULT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,11 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
       # Pre-releases: v1.2.3-rc.1, v1.2.3-beta.2, etc.
       - "v[0-9]+.[0-9]+.[0-9]+-*"
-  repository_dispatch:
-    types:
-      - release-tagged
-
 env:
-  RELEASE_TAG: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.tag || github.ref_name }}
+  RELEASE_TAG: ${{ github.ref_name }}
 
 concurrency:
-  group: release-${{ github.event_name == 'repository_dispatch' && github.event.client_payload.tag || github.ref_name }}
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -36,12 +32,12 @@ jobs:
           fi
 
       - name: Check out release commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -76,14 +72,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
         with:
           toolchain: 1.97.1
           targets: ${{ matrix.target }}
@@ -97,7 +93,7 @@ jobs:
         run: pnpm exec napi build --cwd native --package-json-path ../package.json --platform --release --target ${{ matrix.target }} --output-dir ../prebuilds
       - name: Test native prebuild
         run: pnpm --filter @nervekit/native test
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: native-prebuild-${{ matrix.target }}
           path: packages/native/prebuilds/*.node
@@ -113,19 +109,19 @@ jobs:
 
     steps:
       - name: Check out release commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-05
         with:
           toolchain: 1.97.1
           components: clippy,rustfmt
@@ -134,7 +130,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download native prebuilds
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: native-prebuild-*
           path: packages/native/prebuilds
@@ -171,7 +167,7 @@ jobs:
         run: node scripts/pack-npm.mjs
 
       - name: Upload verified npm tarball
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-package
           path: release/npm/*.tgz
@@ -192,14 +188,14 @@ jobs:
 
     steps:
       - name: Check out release commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -207,7 +203,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download native prebuilds
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: native-prebuild-*
           path: packages/native/prebuilds
@@ -247,14 +243,14 @@ jobs:
 
     steps:
       - name: Check out release commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: pnpm
@@ -269,7 +265,7 @@ jobs:
         run: pnpm --filter @nervekit/website build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: packages/website/dist
 
@@ -286,7 +282,7 @@ jobs:
 
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -310,7 +306,7 @@ jobs:
           fi
 
       - name: Download verified npm tarball
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-package
           path: release/npm
@@ -357,7 +353,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
   github-release:
     name: Create GitHub release
@@ -370,7 +366,7 @@ jobs:
 
     steps:
       - name: Download verified npm tarball
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-package
           path: release/npm

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,19 +19,27 @@ jobs:
   tag-release:
     name: Bump version and create tag
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
+      - name: Require release push token
+        shell: bash
+        env:
+          RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
+        run: |
+          if [ -z "${RELEASE_PUSH_TOKEN}" ]; then
+            echo "RELEASE_PUSH_TOKEN is not configured" >&2
+            exit 1
+          fi
+
       - name: Check out default branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PUSH_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -127,17 +135,3 @@ jobs:
           git push --atomic origin \
             "HEAD:refs/heads/${DEFAULT_BRANCH}" \
             "refs/tags/${release_tag}"
-
-      - name: Request release publication
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: |
-          gh api --method POST "repos/${GH_REPO}/dispatches" --input - <<EOF
-          {
-            "event_type": "release-tagged",
-            "client_payload": { "tag": "v${RELEASE_VERSION}" }
-          }
-          EOF

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -47,20 +47,11 @@ node scripts/smoke-desktop-package.mjs
 
 ## Automated release flow
 
-Run the **Tag Release** workflow manually with the exact version to publish. It updates all workspace versions on protected `main`, creates the signed release commit and annotated `v<version>` tag, atomically pushes both refs, and emits the internal `release-tagged` event for that immutable tag.
+Run the **Tag Release** workflow manually with the exact version to publish. It requires `RELEASE_PUSH_TOKEN`, updates all workspace versions on protected `main`, creates the signed release commit and annotated `v<version>` tag, and atomically pushes both refs.
 
-The **Publish Release** workflow responds to that event, validates the tag, and builds the native runtime on architecture-matched runners for Linux x64/ARM64, Windows 11 x64/ARM64, macOS Intel, and macOS Apple Silicon. Every runner executes the generated addon before the artifacts are merged. Representative Linux, Windows, and macOS jobs then run the complete quality and Electron package smokes against the merged inventory. The workflow builds and deploys the website to GitHub Pages, publishes to npm through OIDC, and creates the GitHub release. Website deployment occurs only after release validation and npm publication. Direct pushes of matching SemVer tags also start Publish Release automatically.
+The authenticated SemVer tag push starts the **Publish Release** workflow. It validates the tag and builds the native runtime on architecture-matched runners for Linux x64/ARM64, Windows 11 x64/ARM64, macOS Intel, and macOS Apple Silicon. Every runner executes the generated addon before the artifacts are merged. Representative Linux, Windows, and macOS jobs then run the complete quality and Electron package smokes against the merged inventory. The workflow builds and deploys the website to GitHub Pages, publishes to npm through OIDC, and creates the GitHub release. Website deployment occurs only after release validation and npm publication.
 
-If Tag Release pushes the commit and tag but emitting the event fails, re-emit it for the existing immutable tag. Do not recreate or move the tag:
-
-```sh
-gh api --method POST "repos/ThilinaTLM/nerve/dispatches" --input - <<'EOF'
-{
-  "event_type": "release-tagged",
-  "client_payload": { "tag": "vX.Y.Z" }
-}
-EOF
-```
+If publication fails after the immutable tag has started Publish Release, use GitHub Actions to re-run the failed jobs or the complete existing run. Do not recreate or move the tag.
 
 ## Storage and migration testing
 


### PR DESCRIPTION
## Summary

- add website build coverage and stable CI/native gate jobs
- expand native-host change detection to the current workspace dependency graph
- upgrade and SHA-pin every GitHub Action, with weekly Dependabot updates
- simplify release publication to the authenticated tag-push path and document it

## Validation

- `pnpm fix && pnpm check && pnpm run test:full`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `pnpm --filter @nervekit/website build`
- verified every pinned Action SHA through the GitHub API
