### PR TITLE
Fix cross-platform CI and release smoke checks

### DIFF
--- a/packages/desktop-shell/test/desktop-runtime.test.ts
+++ b/packages/desktop-shell/test/desktop-runtime.test.ts
@@ -101,6 +101,7 @@ describe("DesktopRuntime", () => {
     let quitCount = 0;
     let performanceInstallCount = 0;
     let performanceStopCount = 0;
+    const performanceInstalled = Promise.withResolvers<void>();
     const daemon: ManagedDaemon = {
       url: "http://127.0.0.1:4801",
       owned: true,
@@ -161,6 +162,7 @@ describe("DesktopRuntime", () => {
       }),
       installPerformanceMonitor: () => {
         performanceInstallCount += 1;
+        performanceInstalled.resolve();
         return {
           stop: () => {
             performanceStopCount += 1;
@@ -187,12 +189,7 @@ describe("DesktopRuntime", () => {
     );
 
     runtime.start();
-    for (
-      let attempt = 0;
-      attempt < 20 && performanceInstallCount === 0;
-      attempt++
-    )
-      await new Promise((resolve) => setTimeout(resolve, 1));
+    await performanceInstalled.promise;
     assert.equal(performanceInstallCount, 1);
     const beforeQuit = listeners.get("before-quit");
     assert.ok(beforeQuit);

--- a/packages/tools/test/policy/permission-rule-sets.test.ts
+++ b/packages/tools/test/policy/permission-rule-sets.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import {
   permissionOverlayForOriginSchema,
@@ -429,13 +436,13 @@ test("external and mixed grep paths remain distinct permission targets", () => {
       kind: "path",
       access: "read",
       scope: "tree",
-      absolutePath: "/tmp/first",
+      absolutePath: resolve("/tmp/first"),
     },
     {
       kind: "path",
       access: "read",
       scope: "tree",
-      absolutePath: "/tmp/second",
+      absolutePath: resolve("/tmp/second"),
     },
     {
       kind: "path",
@@ -498,7 +505,7 @@ test("existing symlinks are canonicalized to external targets", async () => {
         kind: "path",
         access: "read",
         scope: "exact",
-        absolutePath: outside,
+        absolutePath: await realpath(outside),
       },
     ]);
   } finally {

--- a/scripts/smoke-desktop-release.mjs
+++ b/scripts/smoke-desktop-release.mjs
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { access } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createNodeDaemonPorts } from "../packages/desktop-shell/dist/daemon/node-integration.js";
+import { createNodeDaemonPorts } from "../packages/desktop-shell/dist/daemon/adapters/node-process.js";
 import {
   localConnectUrl,
   normalizeRemoteDaemonUrl,


### PR DESCRIPTION
## Summary
- stabilize the desktop lifecycle test with deterministic startup synchronization
- make permission-path assertions portable across Windows and macOS
- update the desktop release smoke test to the current daemon adapter module

## Validation
- `pnpm fix && pnpm check && pnpm run test:full`