### PR TITLE
Fix remote Markdown badge rendering

### DIFF
--- a/packages/ui-kit/src/lib/renderers/markdown/markdown-render.test.ts
+++ b/packages/ui-kit/src/lib/renderers/markdown/markdown-render.test.ts
@@ -41,6 +41,18 @@ describe("Markdown line breaks", () => {
   });
 });
 
+describe("Markdown images", () => {
+  it("preserves HTTPS image URLs through sanitization", () => {
+    const imageUrl =
+      "https://github.com/ThilinaTLM/nerve/actions/workflows/ci.yml/badge.svg";
+    const html = renderMarkdown(`[![CI](${imageUrl})](${imageUrl})`, {
+      cache: false,
+    });
+
+    assert.ok(html.includes(`<img src="${imageUrl}" alt="CI">`));
+  });
+});
+
 describe("markdown-render caching", () => {
   it("keeps streaming cache bypass output equivalent to finalized decoration", () => {
     const source = `streaming ${Math.random()} with **markdown**`;

--- a/packages/workbench-server/src/adapters/http/static-files.ts
+++ b/packages/workbench-server/src/adapters/http/static-files.ts
@@ -118,7 +118,7 @@ function staticResponseHeaders(
     "content-type": contentType,
     "cache-control": staticCacheControl(pathname, contentType),
     "content-security-policy":
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' data: blob:; connect-src 'self' ws: wss: https:; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; media-src 'self' data: blob:; connect-src 'self' ws: wss: https:; worker-src 'self' blob:; manifest-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
   };
   if (shouldIssueLocalUiCookie(state, clientAddress)) {
     headers["set-cookie"] = cookieHeader(state.storage.localToken);

--- a/packages/workbench-server/test/adapters/http/static-files.test.ts
+++ b/packages/workbench-server/test/adapters/http/static-files.test.ts
@@ -61,10 +61,10 @@ describe("static file serving", () => {
     await fixture();
     const response = await serveStatic("/assets/app.js", state);
     assert.equal(await response.text(), "safe asset");
-    assert.match(
-      response.headers.get("content-security-policy") ?? "",
-      /script-src 'self' 'unsafe-inline'/,
-    );
+    const contentSecurityPolicy =
+      response.headers.get("content-security-policy") ?? "";
+    assert.match(contentSecurityPolicy, /img-src[^;]*https:/);
+    assert.match(contentSecurityPolicy, /script-src 'self' 'unsafe-inline'/);
     assert.doesNotMatch(
       response.headers.get("content-security-policy") ?? "",
       /unsafe-eval/,


### PR DESCRIPTION
## Summary
- allow HTTPS image sources in the workbench CSP so GitHub Actions and shields.io badges render
- add Markdown sanitizer and CSP regression coverage

## Validation
- pnpm fix && pnpm check && pnpm run test:affected