### PR TITLE
fix(ci): stabilize Windows release smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
 
-  storage-windows:
-    name: Storage migrations (Windows)
+  windows-checks:
+    name: Tools and storage checks (Windows)
     runs-on: windows-latest
     needs: paths
     if: github.event_name != 'pull_request' || needs.paths.outputs.workbench == 'true'
@@ -96,6 +96,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build native host and type dependencies
         run: pnpm build:native && pnpm --filter @nervekit/workbench-server... check
+      - name: Run tools tests on native Windows filesystems
+        run: pnpm --filter @nervekit/tools test
       - name: Run storage migration tests on native Windows filesystems
         run: pnpm --filter @nervekit/workbench-server test:migrations
 
@@ -177,7 +179,7 @@ jobs:
     if: always()
     needs:
       - paths
-      - storage-windows
+      - windows-checks
       - validate
       - website
 
@@ -186,7 +188,7 @@ jobs:
         shell: bash
         env:
           PATHS_RESULT: ${{ needs.paths.result }}
-          STORAGE_RESULT: ${{ needs.storage-windows.result }}
+          WINDOWS_RESULT: ${{ needs.windows-checks.result }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
           WEBSITE_RESULT: ${{ needs.website.result }}
         run: |
@@ -195,10 +197,10 @@ jobs:
             echo "Required CI job failed: paths=${PATHS_RESULT}, validate=${VALIDATE_RESULT}" >&2
             exit 1
           fi
-          for result in "${STORAGE_RESULT}" "${WEBSITE_RESULT}"; do
+          for result in "${WINDOWS_RESULT}" "${WEBSITE_RESULT}"; do
             if [ "${result}" != "success" ] && [ "${result}" != "skipped" ]; then
-              echo "Conditional CI job failed: storage=${STORAGE_RESULT}, website=${WEBSITE_RESULT}" >&2
+              echo "Conditional CI job failed: windows=${WINDOWS_RESULT}, website=${WEBSITE_RESULT}" >&2
               exit 1
             fi
           done
-          echo "CI passed: paths=${PATHS_RESULT}, validate=${VALIDATE_RESULT}, storage=${STORAGE_RESULT}, website=${WEBSITE_RESULT}"
+          echo "CI passed: paths=${PATHS_RESULT}, validate=${VALIDATE_RESULT}, windows=${WINDOWS_RESULT}, website=${WEBSITE_RESULT}"

--- a/packages/tools/test/git/git-service-workflows.test.ts
+++ b/packages/tools/test/git/git-service-workflows.test.ts
@@ -57,8 +57,26 @@ async function createFixture(): Promise<RepositoryFixture> {
   await command(service, seed, "commit", "-m", "initial");
   await command(service, seed, "remote", "add", "origin", remote);
   await command(service, seed, "push", "-u", "origin", "main");
-  await command(service, root, "clone", remote, work);
-  await command(service, root, "clone", remote, updater);
+  // Apply the deterministic line-ending policy before clone writes the initial
+  // working trees; configuring it afterward leaves Windows checkout CRLFs dirty.
+  await command(
+    service,
+    root,
+    "-c",
+    "core.autocrlf=false",
+    "clone",
+    remote,
+    work,
+  );
+  await command(
+    service,
+    root,
+    "-c",
+    "core.autocrlf=false",
+    "clone",
+    remote,
+    updater,
+  );
   await configureRepository(service, work);
   await configureRepository(service, updater);
 

--- a/packages/tools/test/git/git-service-workflows.test.ts
+++ b/packages/tools/test/git/git-service-workflows.test.ts
@@ -21,7 +21,13 @@ async function command(
   await service.runGit(cwd, args);
 }
 
-async function configureUser(service: GitService, cwd: string): Promise<void> {
+async function configureRepository(
+  service: GitService,
+  cwd: string,
+): Promise<void> {
+  // These tests assert exact working-tree bytes. Disable Windows Git's default
+  // LF-to-CRLF conversion so Git rewrites the fixtures consistently.
+  await command(service, cwd, "config", "core.autocrlf", "false");
   await command(service, cwd, "config", "user.name", "Nerve Test");
   await command(service, cwd, "config", "user.email", "nerve@example.test");
 }
@@ -43,7 +49,7 @@ async function createFixture(): Promise<RepositoryFixture> {
     remote,
   );
   await command(service, root, "init", "--initial-branch=main", seed);
-  await configureUser(service, seed);
+  await configureRepository(service, seed);
   await writeFile(join(seed, "local.txt"), "initial local\n");
   await writeFile(join(seed, "shared.txt"), "initial shared\n");
   await writeFile(join(seed, "upstream.txt"), "initial upstream\n");
@@ -53,8 +59,8 @@ async function createFixture(): Promise<RepositoryFixture> {
   await command(service, seed, "push", "-u", "origin", "main");
   await command(service, root, "clone", remote, work);
   await command(service, root, "clone", remote, updater);
-  await configureUser(service, work);
-  await configureUser(service, updater);
+  await configureRepository(service, work);
+  await configureRepository(service, updater);
 
   return { root, work, updater, service };
 }

--- a/packages/tools/test/policy/permission-rule-sets.test.ts
+++ b/packages/tools/test/policy/permission-rule-sets.test.ts
@@ -1,12 +1,6 @@
 import assert from "node:assert/strict";
-import {
-  mkdtemp,
-  mkdir,
-  realpath,
-  rm,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
@@ -505,7 +499,7 @@ test("existing symlinks are canonicalized to external targets", async () => {
         kind: "path",
         access: "read",
         scope: "exact",
-        absolutePath: await realpath(outside),
+        absolutePath: realpathSync(outside),
       },
     ]);
   } finally {


### PR DESCRIPTION
## Summary
- make Git workflow fixtures deterministic on Windows
- align symlink path assertions with production canonicalization
- run the tools suite in Windows CI before release smoke tests

## Validation
- `pnpm --dir packages/tools exec tsx --test test/git/git-service-workflows.test.ts test/policy/permission-rule-sets.test.ts`
- `pnpm fix && pnpm check && pnpm run test:full`