### PR TITLE
Configure Explore tool and parent model inheritance

### DIFF
--- a/packages/contracts/src/domains/tools/tool-name.ts
+++ b/packages/contracts/src/domains/tools/tool-name.ts
@@ -47,6 +47,7 @@ export const coreToolNameSchema = z.enum([
 export type CoreToolName = z.infer<typeof coreToolNameSchema>;
 
 export const userConfigurableToolNameSchema = z.enum([
+  "explore",
   "web_search",
   "web_fetch",
   "explain_image",

--- a/packages/contracts/test/settings/settings.test.ts
+++ b/packages/contracts/test/settings/settings.test.ts
@@ -119,7 +119,13 @@ describe("settings schema", () => {
         agentBrowser: { enabled: ["core", "dogfood"] },
       },
       tools: {
-        disabled: ["web_search", "web_fetch", "explain_image", "python_exec"],
+        disabled: [
+          "explore",
+          "web_search",
+          "web_fetch",
+          "explain_image",
+          "python_exec",
+        ],
         bash: {
           autoPromotion: { enabled: false, afterMs: 240_000 },
         },
@@ -200,6 +206,7 @@ describe("settings schema", () => {
       "C:\\Program Files\\Git\\bin\\bash.exe",
     );
     assert.deepEqual(parsed.tools?.disabled, [
+      "explore",
       "web_search",
       "web_fetch",
       "explain_image",

--- a/packages/workbench-app/src/lib/app/composition/settings/agents/ExploreAgentSection.svelte
+++ b/packages/workbench-app/src/lib/app/composition/settings/agents/ExploreAgentSection.svelte
@@ -73,11 +73,11 @@ function saveExploreModel(selection: {
     selectedThinkingLevel={settingsDraft.exploreAgent.thinkingLevel}
     summaryTitle={selectedModelInfo
       ? modelDisplayName(selectedModelInfo)
-      : "Default model"}
+      : "Parent agent model"}
     fallbackOption={{
-      label: "Default model",
-      detail: "Use the platform fallback model",
-      actionLabel: "Use default model",
+      label: "Parent agent model",
+      detail: "Use the same model as the parent agent",
+      actionLabel: "Use parent agent model",
     }}
     fallbackThinkingLevels={[...thinkingLevels]}
     dialogTitle="Choose explore model"
@@ -89,7 +89,7 @@ function saveExploreModel(selection: {
       {#if selectedModelInfo}
         {providerDisplayName(selectedModelInfo.provider)}
       {:else}
-        Use the platform fallback model
+        Use the same model as the parent agent
       {/if}
     {/snippet}
     {#snippet policy()}

--- a/packages/workbench-app/src/lib/features/settings/views/pages/tools/tool-catalog.ts
+++ b/packages/workbench-app/src/lib/features/settings/views/pages/tools/tool-catalog.ts
@@ -11,6 +11,7 @@ export type ToolGroupId =
   | "file-editing"
   | "plan-mode"
   | "todos"
+  | "explore"
   | "web"
   | "vision"
   | "tasks"
@@ -28,6 +29,7 @@ export type ToolGroupDef = {
 };
 
 export const configurableToolOrder: ConfigurableToolName[] = [
+  "explore",
   "web_search",
   "web_fetch",
   "explain_image",
@@ -114,6 +116,21 @@ export const toolGroups: ToolGroupDef[] = [
     tools: [
       { name: "todos_set", description: "Set the current task checklist." },
       { name: "todos_get", description: "Read the current task checklist." },
+    ],
+  },
+  {
+    id: "explore",
+    category: "core",
+    label: "Explore",
+    description:
+      "Delegate focused, read-only codebase research to child agents.",
+    configurableTools: ["explore"],
+    tools: [
+      {
+        name: "explore",
+        description:
+          "Launch one or more read-only agents to investigate independent tasks.",
+      },
     ],
   },
   {

--- a/packages/workbench-server/src/domains/agents/execution/subagent-runner.ts
+++ b/packages/workbench-server/src/domains/agents/execution/subagent-runner.ts
@@ -243,7 +243,7 @@ export class SubagentRunner {
               prompt: exploreUserPrompt(task, plan),
               systemPrompt: exploreSystemPrompt(parent.projectDir),
               historyMode: "fresh",
-              model: settings.exploreAgent.model,
+              model: settings.exploreAgent.model ?? parent.model,
               thinkingLevel: settings.exploreAgent.thinkingLevel,
               workspaceScope: parent.workspaceScope,
               task: task.task,

--- a/packages/workbench-server/test/domains/agents/explore-subagent-isolation.test.ts
+++ b/packages/workbench-server/test/domains/agents/explore-subagent-isolation.test.ts
@@ -34,11 +34,6 @@ describe("explore subagent transcript isolation", () => {
     });
     const root = await mkdtemp(join(tmpdir(), "nerve-explore-isolation-"));
     const storage = await initializeStorage(root);
-    await writeSettings(storage, {
-      exploreAgent: {
-        model: { provider, modelId: "scripted-fast" },
-      },
-    });
     const orchestrator = createRuntimeFixture(storage, "127.0.0.1", 0);
     try {
       await orchestrator.lifecycle.hydrate();
@@ -53,6 +48,7 @@ describe("explore subagent transcript isolation", () => {
       const parent = await orchestrator.services.agentLifecycle.createAgent({
         projectId: project.id,
         conversationId: conversation.id,
+        model: { provider, modelId: "scripted-fast" },
       });
       const result = await orchestrator.services.tools.requestTool(
         orchestrator.services.agentLifecycle.getAgent(parent.id),
@@ -80,6 +76,7 @@ describe("explore subagent transcript isolation", () => {
         .listAgents()
         .find((agent) => agent.parentAgentId === parent.id);
       assert.ok(child);
+      assert.deepEqual(child.model, parent.model);
       assert.equal(child.status, "idle");
       assert.ok((child.systemPrompt ?? "").includes(project.dir));
       assert.match(

--- a/packages/workbench-server/test/domains/tools/explore-tool-availability.test.ts
+++ b/packages/workbench-server/test/domains/tools/explore-tool-availability.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AgentRecord } from "@nervekit/contracts/agents";
+import { activeToolNamesForAgent } from "../../../src/domains/tools/orchestration/agent-tool-adapter.js";
+
+function agent(): AgentRecord {
+  return {
+    id: "agent_01HN0000000000000000000000",
+    conversationId: "conv_01HN0000000000000000000000",
+    projectId: "proj_01HN0000000000000000000000",
+    projectDir: "/tmp/project",
+    rootAgentId: "agent_01HN0000000000000000000000",
+    mode: "coding",
+    permissionLevel: "autonomous",
+    workspaceScope: { roots: ["/tmp/project"] },
+    budget: { depth: 0, maxDepth: 3 },
+    status: "idle",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("explore availability", () => {
+  it("is enabled by default and can be disabled", () => {
+    const enabled = activeToolNamesForAgent(agent());
+    const disabled = activeToolNamesForAgent(agent(), {
+      disabledToolNames: ["explore"],
+    });
+
+    assert.equal(enabled.includes("explore"), true);
+    assert.equal(disabled.includes("explore"), false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Explore to Settings > Tools with an enabled-by-default toggle
- use the parent agent model when no dedicated Explore model is selected
- update model picker copy and add availability/inheritance coverage

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`
- UI smoke-tested Explore toggle and parent-model option in light and dark modes