### PR TITLE
Safely migrate tool-result payload references

### DIFF
--- a/packages/website/src/content/docs/operations/storage-migration.md
+++ b/packages/website/src/content/docs/operations/storage-migration.md
@@ -15,6 +15,12 @@ Settings reports readable files across the complete Nerve home, including canoni
 
 Conversation pruning skips running or awaiting agents and conversations with active tasks before removing associated inactive records and managed files.
 
+## Current-home data migrations
+
+Startup applies recorded, idempotent data migrations to recognized `nerve-home` v1 homes before runtime hydration. The tool-result payload reference migration converts the former `payloads/conversations/conv_…/tool-calls/tool_…` descriptor and file layout to the compact `conversations/…/tool-calls/…` v2 format. It verifies and rechains affected conversation journals, updates durable event copies and canonical projections, discards affected entries from the bounded RPC replay cache, and records completion in `migrations/ledger.json`. Normal runtime contracts continue to accept only the current v2 descriptor.
+
+These migrations apply only to an otherwise valid current home with the exact canonical schema ledger. Database journals and filesystem conflicts are preflighted before legacy payload files are changed. Unknown schemas and malformed or checksum-corrupt journals still fail closed.
+
 ## Legacy v2 migration
 
 Ordinary startup never guesses or repairs an unknown home. The sole import path is an explicit offline migration from the immediately preceding marker:
@@ -26,7 +32,7 @@ Ordinary startup never guesses or repairs an unknown home. The sole import path 
 }
 ```
 
-Local desktop mode detects this format and asks for confirmation. The only supported source is the released Nerve 0.26 layout with its checksummed migration ledger ending at `0012-remove-workers`. It migrates directly to the `nerve-home` v1 and canonical SQLite schema-v1 baselines—do **not** install or run `0013-canonical-storage` first. Homes produced by unreleased intermediate development builds are not supported. Remote desktop mode does not inspect local `NERVE_HOME`. Unknown, malformed, partial, checksum-modified, intermediate, and newer layouts remain untouched.
+Local desktop mode detects this format and asks for confirmation. The only supported import source is the released Nerve 0.26 layout with its checksummed migration ledger ending at `0012-remove-workers`. It migrates directly to the `nerve-home` v1 and canonical SQLite schema-v1 baselines—do **not** install or run `0013-canonical-storage` first. Apart from explicitly recorded current-home data migrations, homes produced by unreleased intermediate development builds are not supported. Remote desktop mode does not inspect local `NERVE_HOME`. Unknown, malformed, partial, checksum-modified, intermediate, and newer layouts remain untouched.
 
 Before migration, quit every Nerve process that uses the source home. Migration then:
 

--- a/packages/workbench-server/src/infrastructure/migrations/index.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/index.ts
@@ -1,2 +1,3 @@
 export * from "./legacy-v2.js";
 export * from "./migrate-legacy-v2-home.js";
+export * from "./tool-result-payload-reference-v2.js";

--- a/packages/workbench-server/src/infrastructure/migrations/tool-result-payload-files-v2.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/tool-result-payload-files-v2.ts
@@ -1,0 +1,346 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  rename,
+  rm,
+  stat,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { StoragePaths } from "../storage-bootstrap/paths.js";
+
+export async function preflightLegacyPayloadFiles(
+  paths: StoragePaths,
+): Promise<void> {
+  await copyLegacyPayloadFiles(paths, true);
+}
+
+export async function copyLegacyPayloadFiles(
+  paths: StoragePaths,
+  validateOnly = false,
+): Promise<void> {
+  const legacyConversations = join(paths.dataPath, "payloads", "conversations");
+  const legacyKind = await pathKind(legacyConversations);
+  if (legacyKind === "invalid") {
+    throw new Error(
+      `Legacy conversation payload root '${legacyConversations}' is not a directory.`,
+    );
+  }
+  if (legacyKind === "directory") {
+    await copyNormalizedConversationTree(
+      legacyConversations,
+      paths.conversationsPath,
+      validateOnly,
+    );
+  }
+  await copyNormalizedConversationTree(
+    paths.conversationsPath,
+    paths.conversationsPath,
+    validateOnly,
+  );
+}
+
+async function copyNormalizedConversationTree(
+  sourceRoot: string,
+  targetRoot: string,
+  validateOnly: boolean,
+): Promise<void> {
+  await mkdir(sourceRoot, { recursive: true, mode: 0o700 });
+  for (const entry of await readdir(sourceRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      throw new Error(
+        `Invalid conversation storage entry '${join(sourceRoot, entry.name)}'.`,
+      );
+    }
+    const conversationSegment = compactOwnerSegment(
+      entry.name,
+      "conv_",
+      "conversation",
+      sourceRoot,
+    );
+    const sourceConversation = join(sourceRoot, entry.name);
+    const targetConversation = join(targetRoot, conversationSegment);
+    await copyDirectory(sourceConversation, targetConversation, validateOnly);
+
+    const sourceToolCalls = join(sourceConversation, "tool-calls");
+    const toolCallsKind = await pathKind(sourceToolCalls);
+    if (toolCallsKind === "missing") continue;
+    if (toolCallsKind !== "directory") {
+      throw new Error(`Invalid tool-call storage path '${sourceToolCalls}'.`);
+    }
+    for (const call of await readdir(sourceToolCalls, {
+      withFileTypes: true,
+    })) {
+      if (!call.isDirectory() || call.isSymbolicLink()) {
+        throw new Error(
+          `Invalid tool-call storage entry '${join(sourceToolCalls, call.name)}'.`,
+        );
+      }
+      const callSegment = compactOwnerSegment(
+        call.name,
+        "tool_",
+        "tool call",
+        sourceToolCalls,
+      );
+      await copyDirectory(
+        join(sourceToolCalls, call.name),
+        join(targetConversation, "tool-calls", callSegment),
+        validateOnly,
+      );
+    }
+  }
+}
+
+function compactOwnerSegment(
+  name: string,
+  prefix: "conv_" | "tool_",
+  label: string,
+  root: string,
+): string {
+  const compact = name.startsWith(prefix) ? name.slice(prefix.length) : name;
+  if (!compact || !/^[A-Za-z0-9_-]+$/.test(compact)) {
+    throw new Error(
+      `Invalid ${label} storage directory '${join(root, name)}'.`,
+    );
+  }
+  return compact;
+}
+
+async function copyDirectory(
+  source: string,
+  target: string,
+  validateOnly: boolean,
+): Promise<void> {
+  if (source === target) {
+    await validateDirectoryEntries(source);
+    return;
+  }
+  const sourceKind = await pathKind(source);
+  if (sourceKind !== "directory") {
+    throw new Error(`Managed migration source '${source}' is not a directory.`);
+  }
+  const targetKind = await pathKind(target);
+  if (targetKind === "invalid") {
+    throw new Error(`Managed migration target '${target}' is not a directory.`);
+  }
+  if (targetKind === "missing" && !validateOnly) {
+    await mkdir(target, { recursive: true, mode: 0o700 });
+  }
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    const sourceEntry = join(source, entry.name);
+    const targetEntry = join(target, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Managed migration rejects symlink '${sourceEntry}'.`);
+    }
+    if (entry.isDirectory()) {
+      await copyDirectory(sourceEntry, targetEntry, validateOnly);
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(
+        `Managed migration rejects special file '${sourceEntry}'.`,
+      );
+    }
+    const targetInfo = await lstat(targetEntry).catch(
+      (error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return undefined;
+        throw error;
+      },
+    );
+    if (targetInfo) {
+      if (
+        targetInfo.isSymbolicLink() ||
+        !targetInfo.isFile() ||
+        !(await filesEqual(sourceEntry, targetEntry))
+      ) {
+        throw new Error(`Managed migration file conflict at '${targetEntry}'.`);
+      }
+    } else if (!validateOnly) {
+      await mkdir(dirname(targetEntry), { recursive: true, mode: 0o700 });
+      await copyFile(sourceEntry, targetEntry);
+    }
+  }
+}
+
+async function validateDirectoryEntries(path: string): Promise<void> {
+  for (const entry of await readdir(path, { withFileTypes: true })) {
+    const entryPath = join(path, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Managed migration rejects symlink '${entryPath}'.`);
+    }
+    if (entry.isDirectory()) await validateDirectoryEntries(entryPath);
+    else if (!entry.isFile()) {
+      throw new Error(`Managed migration rejects special file '${entryPath}'.`);
+    }
+  }
+}
+
+export async function migrateLegacyPayloadFiles(
+  paths: StoragePaths,
+): Promise<void> {
+  const legacyPayloads = join(paths.dataPath, "payloads");
+  const legacyConversations = join(legacyPayloads, "conversations");
+  if ((await pathKind(legacyConversations)) === "directory") {
+    await normalizeConversationTree(legacyConversations);
+    await mergeDirectory(legacyConversations, paths.conversationsPath);
+    await removeIfEmpty(legacyConversations);
+  } else if ((await pathKind(legacyConversations)) === "invalid") {
+    throw new Error(
+      `Legacy conversation payload root '${legacyConversations}' is not a directory.`,
+    );
+  }
+  await normalizeConversationTree(paths.conversationsPath);
+  await removeIfEmpty(legacyPayloads);
+}
+
+async function normalizeConversationTree(root: string): Promise<void> {
+  await mkdir(root, { recursive: true, mode: 0o700 });
+  const conversations = await readdir(root, { withFileTypes: true });
+  for (const entry of conversations) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      throw new Error(
+        `Invalid conversation storage entry '${join(root, entry.name)}'.`,
+      );
+    }
+    const conversationPath = await normalizeOwnerDirectory(
+      root,
+      entry.name,
+      "conv_",
+      "conversation",
+    );
+    const toolCallsPath = join(conversationPath, "tool-calls");
+    const toolCallsKind = await pathKind(toolCallsPath);
+    if (toolCallsKind === "missing") continue;
+    if (toolCallsKind !== "directory") {
+      throw new Error(`Invalid tool-call storage path '${toolCallsPath}'.`);
+    }
+    const calls = await readdir(toolCallsPath, { withFileTypes: true });
+    for (const call of calls) {
+      if (!call.isDirectory() || call.isSymbolicLink()) {
+        throw new Error(
+          `Invalid tool-call storage entry '${join(toolCallsPath, call.name)}'.`,
+        );
+      }
+      await normalizeOwnerDirectory(
+        toolCallsPath,
+        call.name,
+        "tool_",
+        "tool call",
+      );
+    }
+  }
+}
+
+async function normalizeOwnerDirectory(
+  root: string,
+  name: string,
+  prefix: "conv_" | "tool_",
+  label: string,
+): Promise<string> {
+  const compact = name.startsWith(prefix) ? name.slice(prefix.length) : name;
+  if (!compact || !/^[A-Za-z0-9_-]+$/.test(compact)) {
+    throw new Error(
+      `Invalid ${label} storage directory '${join(root, name)}'.`,
+    );
+  }
+  const source = join(root, name);
+  const target = join(root, compact);
+  if (source === target) return target;
+  await mergeDirectory(source, target);
+  await removeIfEmpty(source);
+  return target;
+}
+
+async function mergeDirectory(source: string, target: string): Promise<void> {
+  const sourceKind = await pathKind(source);
+  if (sourceKind === "missing") return;
+  if (sourceKind !== "directory") {
+    throw new Error(`Managed migration source '${source}' is not a directory.`);
+  }
+  const targetKind = await pathKind(target);
+  if (targetKind === "missing") {
+    await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+    await rename(source, target);
+    return;
+  }
+  if (targetKind !== "directory") {
+    throw new Error(`Managed migration target '${target}' is not a directory.`);
+  }
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      throw new Error(
+        `Managed migration rejects symlink '${join(source, entry.name)}'.`,
+      );
+    }
+    const sourceEntry = join(source, entry.name);
+    const targetEntry = join(target, entry.name);
+    const existing = await pathKind(targetEntry);
+    if (entry.isDirectory()) {
+      if (existing === "invalid") {
+        throw new Error(`Managed migration path conflict at '${targetEntry}'.`);
+      }
+      await mergeDirectory(sourceEntry, targetEntry);
+      await removeIfEmpty(sourceEntry);
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(
+        `Managed migration rejects special file '${sourceEntry}'.`,
+      );
+    }
+    if (existing === "missing") {
+      await rename(sourceEntry, targetEntry);
+      continue;
+    }
+    const targetInfo = await lstat(targetEntry);
+    if (
+      targetInfo.isSymbolicLink() ||
+      !targetInfo.isFile() ||
+      !(await filesEqual(sourceEntry, targetEntry))
+    ) {
+      throw new Error(`Managed migration file conflict at '${targetEntry}'.`);
+    }
+    await rm(sourceEntry, { force: true });
+  }
+  await removeIfEmpty(source);
+}
+
+async function filesEqual(left: string, right: string): Promise<boolean> {
+  const [leftInfo, rightInfo] = await Promise.all([stat(left), stat(right)]);
+  if (!leftInfo.isFile() || !rightInfo.isFile()) return false;
+  if (leftInfo.size !== rightInfo.size) return false;
+  const [leftDigest, rightDigest] = await Promise.all([
+    fileDigest(left),
+    fileDigest(right),
+  ]);
+  return leftDigest === rightDigest;
+}
+
+function fileDigest(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function removeIfEmpty(path: string): Promise<void> {
+  if ((await pathKind(path)) !== "directory") return;
+  if ((await readdir(path)).length === 0) await rm(path, { recursive: true });
+}
+
+async function pathKind(
+  path: string,
+): Promise<"missing" | "directory" | "invalid"> {
+  const info = await lstat(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  if (!info) return "missing";
+  return info.isDirectory() && !info.isSymbolicLink() ? "directory" : "invalid";
+}

--- a/packages/workbench-server/src/infrastructure/migrations/tool-result-payload-reference-v2.ts
+++ b/packages/workbench-server/src/infrastructure/migrations/tool-result-payload-reference-v2.ts
@@ -1,0 +1,707 @@
+import { createHash } from "node:crypto";
+import {
+  CONVERSATION_JOURNAL_EPOCH,
+  conversationJournalCommitSchema,
+  type ConversationJournalCommit,
+} from "@nervekit/contracts/conversations";
+import {
+  toolCallRecordSchema,
+  type ToolCallRecord,
+} from "@nervekit/contracts/tools";
+import { z } from "zod";
+import { CanonicalDatabase } from "../persistence/canonical-sqlite/canonical-database.js";
+import {
+  decode,
+  encode,
+} from "../persistence/canonical-sqlite/payload-codecs.js";
+import { atomicWriteJson, readJsonFile } from "../storage-bootstrap/json.js";
+import { managedOwnerPathSegment } from "../storage-bootstrap/managed-owner-path.js";
+import {
+  copyLegacyPayloadFiles,
+  migrateLegacyPayloadFiles,
+  preflightLegacyPayloadFiles,
+} from "./tool-result-payload-files-v2.js";
+import type { StoragePaths } from "../storage-bootstrap/paths.js";
+
+export const TOOL_RESULT_PAYLOAD_REFERENCE_V2_MIGRATION =
+  "tool-result-payload-reference-v2";
+
+const LEGACY_REFERENCE_MARKER = '"version":1,"kind":"tool_result"';
+const ZERO_CHECKSUM = `sha256:${"0".repeat(64)}`;
+
+const legacyToolResultPayloadReferenceSchema = z
+  .object({
+    version: z.literal(1),
+    kind: z.literal("tool_result"),
+    conversationId: z.string().startsWith("conv_").max(256),
+    toolCallId: z.string().startsWith("tool_").max(256),
+    logicalPath: z
+      .string()
+      .regex(
+        /^payloads\/conversations\/[^/]+\/tool-calls\/[^/]+\/result\.json$/,
+      ),
+    digest: z.string().regex(/^[a-f0-9]{64}$/),
+    byteLength: z.number().int().nonnegative().safe(),
+    mediaType: z.literal("application/json"),
+    encoding: z.literal("utf-8"),
+    completeness: z.enum(["complete", "legacy_bounded"]),
+  })
+  .strict();
+
+type JsonObject = Record<string, unknown>;
+type MigrationLedger = {
+  format: "nerve-home-migrations";
+  version: 1;
+  entries: Array<{ id?: unknown; [key: string]: unknown }>;
+};
+
+export interface ToolResultPayloadReferenceMigrationResult {
+  applied: boolean;
+  conversations: number;
+  journalCommits: number;
+  snapshots: number;
+  durableEvents: number;
+  conversationRecords: number;
+  fileAssets: number;
+  rpcIdempotencyEntries: number;
+}
+
+export async function migrateToolResultPayloadReferences(
+  paths: StoragePaths,
+  options: { onStart?: () => void } = {},
+): Promise<ToolResultPayloadReferenceMigrationResult> {
+  const ledger = await readMigrationLedger(paths.migrationLedgerPath);
+  if (hasMigration(ledger)) return emptyResult(false);
+  options.onStart?.();
+
+  const canonical = new CanonicalDatabase(paths.sqlitePath);
+  let result: ToolResultPayloadReferenceMigrationResult;
+  try {
+    canonical.assertSchemaCompatible();
+    preflightCanonicalPayloadReferences(canonical);
+    await preflightLegacyPayloadFiles(paths);
+    await copyLegacyPayloadFiles(paths);
+    result = migrateCanonicalPayloadReferences(canonical);
+    await migrateLegacyPayloadFiles(paths);
+  } finally {
+    canonical.close();
+  }
+
+  ledger.entries.push({
+    id: TOOL_RESULT_PAYLOAD_REFERENCE_V2_MIGRATION,
+    appliedAt: new Date().toISOString(),
+    counts: {
+      conversations: result.conversations,
+      journalCommits: result.journalCommits,
+      snapshots: result.snapshots,
+      durableEvents: result.durableEvents,
+      conversationRecords: result.conversationRecords,
+      fileAssets: result.fileAssets,
+      rpcIdempotencyEntries: result.rpcIdempotencyEntries,
+    },
+  });
+  await atomicWriteJson(paths.migrationLedgerPath, ledger, 0o600);
+  return result;
+}
+
+export function currentHomeMigrationEntries(
+  appliedAt: string,
+): Array<{ id: string; appliedAt: string }> {
+  return [
+    { id: "nerve-home-v1", appliedAt },
+    { id: TOOL_RESULT_PAYLOAD_REFERENCE_V2_MIGRATION, appliedAt },
+  ];
+}
+
+function preflightCanonicalPayloadReferences(
+  canonical: CanonicalDatabase,
+): void {
+  migrateCanonicalPayloadReferencesInTransactions(canonical, true);
+}
+
+function migrateCanonicalPayloadReferences(
+  canonical: CanonicalDatabase,
+): ToolResultPayloadReferenceMigrationResult {
+  return migrateCanonicalPayloadReferencesInTransactions(canonical);
+}
+
+function migrateCanonicalPayloadReferencesInTransactions(
+  canonical: CanonicalDatabase,
+  validateOnly = false,
+): ToolResultPayloadReferenceMigrationResult {
+  const conversationIds = canonical.transaction((database) => {
+    const unexpected = database
+      .prepare(
+        `SELECT namespace FROM domain_documents
+         WHERE namespace NOT IN (
+           'conversation_state', 'conversation_journal_commit'
+         ) AND instr(CAST(data AS TEXT), ?) > 0
+         ORDER BY namespace LIMIT 1`,
+      )
+      .get(LEGACY_REFERENCE_MARKER) as { namespace: string } | undefined;
+    if (unexpected) {
+      throw new Error(
+        `Legacy tool-result payload references remain in domain_documents.data (${unexpected.namespace}).`,
+      );
+    }
+    const unexpectedRecord = database
+      .prepare(
+        `SELECT kind FROM conversation_records
+         WHERE kind <> 'tool_call'
+           AND instr(CAST(data AS TEXT), ?) > 0
+         ORDER BY kind LIMIT 1`,
+      )
+      .get(LEGACY_REFERENCE_MARKER) as { kind: string } | undefined;
+    if (unexpectedRecord) {
+      throw new Error(
+        `Legacy tool-result payload references remain in conversation_records.data (${unexpectedRecord.kind}).`,
+      );
+    }
+    const unexpectedProjection = database
+      .prepare(
+        `SELECT 1 AS present FROM conversation_record_projections
+         WHERE instr(CAST(data AS TEXT), ?) > 0 LIMIT 1`,
+      )
+      .get(LEGACY_REFERENCE_MARKER) as { present?: number } | undefined;
+    if (unexpectedProjection?.present === 1) {
+      throw new Error(
+        "Legacy tool-result payload references remain in conversation_record_projections.data.",
+      );
+    }
+    const rows = database
+      .prepare(
+        `SELECT DISTINCT scope_id FROM domain_documents
+         WHERE namespace IN (
+           'conversation_state', 'conversation_journal_commit'
+         ) AND instr(CAST(data AS TEXT), ?) > 0
+         ORDER BY scope_id`,
+      )
+      .all(LEGACY_REFERENCE_MARKER) as unknown as Array<{ scope_id: string }>;
+    return rows.map((row) => row.scope_id);
+  });
+
+  let journalCommits = 0;
+  let snapshots = 0;
+  for (const conversationId of conversationIds) {
+    const counts = migrationTransaction(
+      canonical,
+      (database) => migrateConversation(database, conversationId),
+      validateOnly,
+    );
+    journalCommits += counts.journalCommits;
+    snapshots += counts.snapshots;
+  }
+
+  const copies = migrationTransaction(
+    canonical,
+    (database) => {
+      let durableEvents = 0;
+      const durableRows = database
+        .prepare(
+          `SELECT row_id, data FROM durable_events
+         WHERE instr(CAST(data AS TEXT), ?) > 0 ORDER BY row_id`,
+        )
+        .all(LEGACY_REFERENCE_MARKER) as unknown as Array<{
+        row_id: number;
+        data: Uint8Array | string;
+      }>;
+      const updateDurable = database.prepare(
+        `UPDATE durable_events SET data = ? WHERE row_id = ?`,
+      );
+      for (const row of durableRows) {
+        const normalized = normalizeEventContainer(decode(row.data));
+        if (!normalized.changed) continue;
+        updateDurable.run(encode(normalized.value), row.row_id);
+        durableEvents += 1;
+      }
+
+      let conversationRecords = 0;
+      const recordRows = database
+        .prepare(
+          `SELECT id, data FROM conversation_records
+         WHERE kind = 'tool_call'
+           AND instr(CAST(data AS TEXT), ?) > 0 ORDER BY id`,
+        )
+        .all(LEGACY_REFERENCE_MARKER) as unknown as Array<{
+        id: string;
+        data: Uint8Array | string;
+      }>;
+      const updateRecord = database.prepare(
+        `UPDATE conversation_records SET data = ? WHERE id = ?`,
+      );
+      for (const row of recordRows) {
+        const wrapper = objectValue(decode(row.data), "tool-call record");
+        const normalized = normalizeToolCall(wrapper.toolCall);
+        if (!normalized.changed) continue;
+        wrapper.toolCall = normalized.value;
+        updateRecord.run(encode(wrapper), row.id);
+        conversationRecords += 1;
+      }
+
+      let fileAssets = 0;
+      const assetRows = database
+        .prepare(
+          `SELECT id, conversation_id, tool_call_id, logical_path
+         FROM file_assets
+         WHERE category = 'payload'
+           AND logical_path LIKE 'payloads/conversations/%/tool-calls/%/result.json'
+         ORDER BY id`,
+        )
+        .all() as unknown as Array<{
+        id: string;
+        conversation_id: string | null;
+        tool_call_id: string | null;
+        logical_path: string;
+      }>;
+      const updateAsset = database.prepare(
+        `UPDATE file_assets SET logical_path = ? WHERE id = ?`,
+      );
+      for (const row of assetRows) {
+        if (!row.conversation_id || !row.tool_call_id) {
+          throw new Error(
+            `Legacy payload asset '${row.id}' has no conversation/tool-call owner.`,
+          );
+        }
+        const logicalPath = currentLogicalPath(
+          row.conversation_id,
+          row.tool_call_id,
+        );
+        updateAsset.run(logicalPath, row.id);
+        fileAssets += 1;
+      }
+
+      const rpcIdempotencyEntries = Number(
+        database
+          .prepare(
+            `DELETE FROM rpc_idempotency
+           WHERE instr(CAST(outcome AS TEXT), ?) > 0`,
+          )
+          .run(LEGACY_REFERENCE_MARKER).changes,
+      );
+
+      if (!validateOnly) assertNoLegacyReferences(database);
+      return {
+        durableEvents,
+        conversationRecords,
+        fileAssets,
+        rpcIdempotencyEntries,
+      };
+    },
+    validateOnly,
+  );
+
+  return {
+    applied: true,
+    conversations: conversationIds.length,
+    journalCommits,
+    snapshots,
+    ...copies,
+  };
+}
+
+function migrationTransaction<T>(
+  canonical: CanonicalDatabase,
+  operation: (database: import("node:sqlite").DatabaseSync) => T,
+  validateOnly: boolean,
+): T {
+  if (!validateOnly) return canonical.transaction(operation);
+  const rollback = new Error(
+    "rollback tool-result payload migration preflight",
+  );
+  let result: T | undefined;
+  try {
+    canonical.transaction((database) => {
+      result = operation(database);
+      throw rollback;
+    });
+  } catch (error) {
+    if (error !== rollback) throw error;
+  }
+  return result as T;
+}
+
+function migrateConversation(
+  database: import("node:sqlite").DatabaseSync,
+  conversationId: string,
+): { journalCommits: number; snapshots: number } {
+  const snapshotRow = database
+    .prepare(
+      `SELECT revision, data FROM domain_documents
+       WHERE namespace = 'conversation_state'
+         AND scope_id = ? AND document_id = 'state'`,
+    )
+    .get(conversationId) as
+    | { revision: number; data: Uint8Array | string }
+    | undefined;
+
+  let snapshotRevision = 0;
+  let oldPreviousChecksum: string | undefined;
+  let newPreviousChecksum: string | undefined;
+  let snapshots = 0;
+  if (snapshotRow) {
+    const snapshot = objectValue(
+      decode(snapshotRow.data),
+      "conversation state",
+    );
+    if (
+      snapshot.conversationId !== conversationId ||
+      snapshot.revision !== snapshotRow.revision
+    ) {
+      throw new Error(
+        `Conversation snapshot '${conversationId}' identity/revision mismatch.`,
+      );
+    }
+    snapshotRevision = snapshotRow.revision;
+    oldPreviousChecksum = optionalChecksum(snapshot.checksum);
+    newPreviousChecksum = oldPreviousChecksum;
+    const normalized = normalizeConversationSnapshot(snapshot);
+    if (normalized.changed) {
+      database
+        .prepare(
+          `UPDATE domain_documents SET data = ?
+           WHERE namespace = 'conversation_state'
+             AND scope_id = ? AND document_id = 'state'`,
+        )
+        .run(encode(normalized.value), conversationId);
+      snapshots = 1;
+    }
+    database
+      .prepare(
+        `DELETE FROM domain_documents
+         WHERE namespace = 'conversation_journal_commit'
+           AND scope_id = ? AND CAST(document_id AS INTEGER) <= ?`,
+      )
+      .run(conversationId, snapshotRevision);
+  }
+
+  const commitRows = database
+    .prepare(
+      `SELECT document_id, data FROM domain_documents
+       WHERE namespace = 'conversation_journal_commit'
+         AND scope_id = ? AND CAST(document_id AS INTEGER) > ?
+       ORDER BY document_id`,
+    )
+    .all(conversationId, snapshotRevision) as unknown as Array<{
+    document_id: string;
+    data: Uint8Array | string;
+  }>;
+  const updateCommit = database.prepare(
+    `UPDATE domain_documents SET data = ?
+     WHERE namespace = 'conversation_journal_commit'
+       AND scope_id = ? AND document_id = ?`,
+  );
+
+  let revision = snapshotRevision;
+  let journalCommits = 0;
+  for (const row of commitRows) {
+    const raw = objectValue(decode(row.data), "conversation journal commit");
+    verifyRawCommit(
+      raw,
+      conversationId,
+      revision,
+      oldPreviousChecksum,
+      row.document_id,
+    );
+    const oldChecksum = String(raw.checksum);
+    const normalized = normalizeCommit(raw, newPreviousChecksum);
+    revision = normalized.revision;
+    oldPreviousChecksum = oldChecksum;
+    newPreviousChecksum = normalized.checksum;
+    if (JSON.stringify(raw) !== JSON.stringify(normalized)) {
+      updateCommit.run(encode(normalized), conversationId, row.document_id);
+      journalCommits += 1;
+    }
+  }
+
+  const headRow = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_journal_head'
+         AND scope_id = ? AND document_id = 'head'`,
+    )
+    .get(conversationId) as { data: Uint8Array | string } | undefined;
+  if (!headRow && commitRows.length > 0) {
+    throw new Error(`Conversation journal '${conversationId}' has no head.`);
+  }
+  if (headRow) {
+    const head = objectValue(decode(headRow.data), "conversation journal head");
+    if (
+      head.revision !== revision ||
+      optionalChecksum(head.checksum) !== oldPreviousChecksum
+    ) {
+      throw new Error(
+        `Conversation journal '${conversationId}' does not match its head.`,
+      );
+    }
+    if (newPreviousChecksum !== oldPreviousChecksum) {
+      database
+        .prepare(
+          `UPDATE domain_documents SET data = ?
+           WHERE namespace = 'conversation_journal_head'
+             AND scope_id = ? AND document_id = 'head'`,
+        )
+        .run(
+          encode({ revision, checksum: newPreviousChecksum }),
+          conversationId,
+        );
+    }
+  }
+
+  return { journalCommits, snapshots };
+}
+
+function verifyRawCommit(
+  raw: JsonObject,
+  conversationId: string,
+  previousRevision: number,
+  previousChecksum: string | undefined,
+  documentId: string,
+): void {
+  if (
+    raw.epoch !== CONVERSATION_JOURNAL_EPOCH ||
+    raw.conversationId !== conversationId ||
+    raw.previousRevision !== previousRevision ||
+    raw.revision !== previousRevision + 1 ||
+    optionalChecksum(raw.previousChecksum) !== previousChecksum ||
+    documentId !== String(raw.revision).padStart(20, "0")
+  ) {
+    throw new Error(
+      `Conversation journal '${conversationId}' has an invalid commit chain.`,
+    );
+  }
+  const checksum = requiredChecksum(raw.checksum);
+  if (journalChecksum(withoutChecksum(raw)) !== checksum) {
+    throw new Error(
+      `Conversation journal '${conversationId}' has a checksum mismatch.`,
+    );
+  }
+}
+
+function normalizeCommit(
+  raw: JsonObject,
+  previousChecksum: string | undefined,
+): ConversationJournalCommit {
+  const copy = structuredClone(raw);
+  const events = normalizeEvents(copy.events);
+  copy.events = events.value;
+  if (previousChecksum === undefined) delete copy.previousChecksum;
+  else copy.previousChecksum = previousChecksum;
+  copy.checksum = ZERO_CHECKSUM;
+  const parsed = conversationJournalCommitSchema.parse(copy);
+  const base = withoutChecksum(parsed as unknown as JsonObject);
+  return conversationJournalCommitSchema.parse({
+    ...base,
+    checksum: journalChecksum(base),
+  });
+}
+
+function normalizeConversationSnapshot(snapshot: JsonObject): {
+  value: JsonObject;
+  changed: boolean;
+} {
+  const copy = structuredClone(snapshot);
+  let changed = false;
+  if (!Array.isArray(copy.toolCalls)) {
+    throw new Error("Conversation snapshot toolCalls must be an array.");
+  }
+  copy.toolCalls = copy.toolCalls.map((value) => {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new Error(
+        "Conversation snapshot contains an invalid tool-call entry.",
+      );
+    }
+    const normalized = normalizeToolCall(value[1]);
+    changed ||= normalized.changed;
+    return [value[0], normalized.value];
+  });
+  if (!Array.isArray(copy.idempotencyKeys)) {
+    throw new Error("Conversation snapshot idempotencyKeys must be an array.");
+  }
+  copy.idempotencyKeys = copy.idempotencyKeys.map((value) => {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw new Error(
+        "Conversation snapshot contains an invalid idempotency entry.",
+      );
+    }
+    const commit = objectValue(value[1], "idempotency commit");
+    const events = normalizeEvents(commit.events);
+    if (!events.changed) return value;
+    verifyStandaloneCommitChecksum(commit);
+    commit.events = events.value;
+    commit.checksum = ZERO_CHECKSUM;
+    const parsed = conversationJournalCommitSchema.parse(commit);
+    const base = withoutChecksum(parsed as unknown as JsonObject);
+    const normalized = conversationJournalCommitSchema.parse({
+      ...base,
+      checksum: journalChecksum(base),
+    });
+    changed = true;
+    return [value[0], normalized];
+  });
+  return { value: copy, changed };
+}
+
+function normalizeEventContainer(value: unknown): {
+  value: JsonObject;
+  changed: boolean;
+} {
+  const container = objectValue(value, "durable event");
+  const normalized = normalizeEvents(container.events);
+  container.events = normalized.value;
+  return { value: container, changed: normalized.changed };
+}
+
+function normalizeEvents(value: unknown): {
+  value: unknown[];
+  changed: boolean;
+} {
+  if (!Array.isArray(value))
+    throw new Error("Journal events must be an array.");
+  let changed = false;
+  const events = value.map((candidate) => {
+    const event = objectValue(candidate, "journal event");
+    if (event.kind !== "tool_call.upserted") return event;
+    const normalized = normalizeToolCall(event.toolCall);
+    if (!normalized.changed) return event;
+    event.toolCall = normalized.value;
+    changed = true;
+    return event;
+  });
+  return { value: events, changed };
+}
+
+function normalizeToolCall(value: unknown): {
+  value: ToolCallRecord;
+  changed: boolean;
+} {
+  const toolCall = objectValue(structuredClone(value), "tool call");
+  const reference = toolCall.resultPayload;
+  if (!isObject(reference) || reference.version !== 1) {
+    return { value: toolCallRecordSchema.parse(toolCall), changed: false };
+  }
+  const legacy = legacyToolResultPayloadReferenceSchema.parse(reference);
+  const expectedPath = `payloads/conversations/${legacy.conversationId}/tool-calls/${legacy.toolCallId}/result.json`;
+  if (legacy.logicalPath !== expectedPath) {
+    throw new Error(
+      "Legacy tool-result payload path does not match its owners.",
+    );
+  }
+  toolCall.resultPayload = {
+    ...legacy,
+    version: 2,
+    logicalPath: currentLogicalPath(legacy.conversationId, legacy.toolCallId),
+  };
+  return { value: toolCallRecordSchema.parse(toolCall), changed: true };
+}
+
+function currentLogicalPath(
+  conversationId: string,
+  toolCallId: string,
+): string {
+  return `conversations/${managedOwnerPathSegment(
+    conversationId,
+    "conv_",
+  )}/tool-calls/${managedOwnerPathSegment(toolCallId, "tool_")}/result.json`;
+}
+
+function verifyStandaloneCommitChecksum(commit: JsonObject): void {
+  const checksum = requiredChecksum(commit.checksum);
+  if (journalChecksum(withoutChecksum(commit)) !== checksum) {
+    throw new Error("Conversation idempotency commit has a checksum mismatch.");
+  }
+}
+
+function withoutChecksum(value: JsonObject): JsonObject {
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => key !== "checksum"),
+  );
+}
+
+function journalChecksum(value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(value))
+    .digest("hex")}`;
+}
+
+function requiredChecksum(value: unknown): string {
+  const checksum = optionalChecksum(value);
+  if (!checksum) throw new Error("Conversation journal checksum is missing.");
+  return checksum;
+}
+
+function optionalChecksum(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value)) {
+    throw new Error("Conversation journal checksum is invalid.");
+  }
+  return value;
+}
+
+function assertNoLegacyReferences(
+  database: import("node:sqlite").DatabaseSync,
+): void {
+  const locations = [
+    ["domain_documents", "data"],
+    ["conversation_records", "data"],
+    ["conversation_record_projections", "data"],
+    ["durable_events", "data"],
+    ["rpc_idempotency", "outcome"],
+  ] as const;
+  for (const [table, column] of locations) {
+    const row = database
+      .prepare(
+        `SELECT 1 AS present FROM ${table}
+         WHERE instr(CAST(${column} AS TEXT), ?) > 0 LIMIT 1`,
+      )
+      .get(LEGACY_REFERENCE_MARKER) as { present?: number } | undefined;
+    if (row?.present === 1) {
+      throw new Error(
+        `Legacy tool-result payload references remain in ${table}.${column}.`,
+      );
+    }
+  }
+}
+
+async function readMigrationLedger(path: string): Promise<MigrationLedger> {
+  const value = await readJsonFile<unknown>(path);
+  if (!isObject(value)) throw new Error("Nerve migration ledger is invalid.");
+  if (
+    value.format !== "nerve-home-migrations" ||
+    value.version !== 1 ||
+    !Array.isArray(value.entries) ||
+    !value.entries.every(isObject)
+  ) {
+    throw new Error("Nerve migration ledger is invalid.");
+  }
+  return value as MigrationLedger;
+}
+
+function hasMigration(ledger: MigrationLedger): boolean {
+  return ledger.entries.some(
+    (entry) => entry.id === TOOL_RESULT_PAYLOAD_REFERENCE_V2_MIGRATION,
+  );
+}
+
+function emptyResult(
+  applied: boolean,
+): ToolResultPayloadReferenceMigrationResult {
+  return {
+    applied,
+    conversations: 0,
+    journalCommits: 0,
+    snapshots: 0,
+    durableEvents: 0,
+    conversationRecords: 0,
+    fileAssets: 0,
+    rpcIdempotencyEntries: 0,
+  };
+}
+
+function objectValue(value: unknown, label: string): JsonObject {
+  if (!isObject(value)) throw new Error(`${label} must be an object.`);
+  return value;
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/workbench-server/src/infrastructure/storage-bootstrap/initialize.ts
+++ b/packages/workbench-server/src/infrastructure/storage-bootstrap/initialize.ts
@@ -25,6 +25,10 @@ import {
 import { inspectNerveHome } from "./state-layout.js";
 import { acquireStorageStartupLock } from "./startup-lock.js";
 import { EncryptedFileSecretProvider } from "../secrets/index.js";
+import {
+  currentHomeMigrationEntries,
+  migrateToolResultPayloadReferences,
+} from "../migrations/tool-result-payload-reference-v2.js";
 
 const HOME_DIRECTORIES: Array<[keyof StoragePaths, number]> = [
   ["configPath", 0o755],
@@ -132,6 +136,20 @@ export async function initializeStorage(
         message: `Upgrading Nerve storage schema from v${schemaInspection.version}`,
       });
     }
+    const dataMigrationStartedAt = performance.now();
+    const dataMigration = fresh
+      ? undefined
+      : await migrateToolResultPayloadReferences(paths, {
+          onStart: () =>
+            options.reportStartupProgress?.({
+              type: "nerve.startup.progress",
+              phase: "storage-migration",
+              message: "Upgrading tool-result payload references",
+            }),
+        });
+    const dataMigrationMs = Math.round(
+      performance.now() - dataMigrationStartedAt,
+    );
     const canonicalOpenStartedAt = performance.now();
     const canonicalStore = new CanonicalStore(paths.sqlitePath);
     await canonicalStore.initialize();
@@ -139,19 +157,16 @@ export async function initializeStorage(
       performance.now() - canonicalOpenStartedAt,
     );
     const sqliteMigrationApplyMs =
-      schemaInspection.kind === "migration-required" ? canonicalOpenMs : 0;
+      (schemaInspection.kind === "migration-required" ? canonicalOpenMs : 0) +
+      (dataMigration?.applied ? dataMigrationMs : 0);
     if (fresh) {
+      const appliedAt = new Date().toISOString();
       await atomicWriteJson(
         paths.migrationLedgerPath,
         {
           format: "nerve-home-migrations",
           version: 1,
-          entries: [
-            {
-              id: "nerve-home-v1",
-              appliedAt: new Date().toISOString(),
-            },
-          ],
+          entries: currentHomeMigrationEntries(appliedAt),
         },
         0o600,
       );

--- a/packages/workbench-server/test/infrastructure/persistence/legacy-v2-home-migration.test.ts
+++ b/packages/workbench-server/test/infrastructure/persistence/legacy-v2-home-migration.test.ts
@@ -248,7 +248,11 @@ test("migrates legacy v2 configuration, conversations, credentials, payloads, an
   ) as { entries: Array<{ id: string }> };
   assert.deepEqual(
     homeMigrations.entries.map((entry) => entry.id),
-    ["nerve-home-v1", "legacy-v2-to-nerve-home-v1"],
+    [
+      "nerve-home-v1",
+      "tool-result-payload-reference-v2",
+      "legacy-v2-to-nerve-home-v1",
+    ],
   );
   assert.equal(storage.settings.defaultThinkingLevel, "high");
   assert.equal(

--- a/packages/workbench-server/test/infrastructure/persistence/nerve-home-storage.test.ts
+++ b/packages/workbench-server/test/infrastructure/persistence/nerve-home-storage.test.ts
@@ -58,7 +58,7 @@ test("initializes the required v1 home and keeps optional directories lazy", asy
     {
       format: "nerve-home-migrations",
       version: 1,
-      entries: ["nerve-home-v1"],
+      entries: ["nerve-home-v1", "tool-result-payload-reference-v2"],
     },
   );
   for (const path of [

--- a/packages/workbench-server/test/infrastructure/persistence/tool-result-payload-reference-migration.test.ts
+++ b/packages/workbench-server/test/infrastructure/persistence/tool-result-payload-reference-migration.test.ts
@@ -1,0 +1,617 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import type {
+  ConversationJournalCommit,
+  ConversationRecord,
+} from "@nervekit/contracts/conversations";
+import {
+  toolResultPayloadReferenceSchema,
+  type ToolCallRecord,
+} from "@nervekit/contracts/tools";
+import { ConversationJournalRepository } from "../../../src/domains/conversations/conversation-journal.repository.js";
+import {
+  initializeStorage,
+  storagePaths,
+} from "../../../src/infrastructure/storage-bootstrap/index.js";
+
+const conversationId = "conv_payload_migration";
+const now = "2026-09-03T00:00:00.000Z";
+const payload = Buffer.from('{"complete":true}\n', "utf8");
+const digest = createHash("sha256").update(payload).digest("hex");
+
+function conversation(title: string): ConversationRecord {
+  return {
+    id: conversationId,
+    projectId: "proj_payload_migration",
+    title,
+    mode: "coding",
+    permissionLevel: "supervised",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function toolCall(id: string): ToolCallRecord {
+  const segment = id.slice("tool_".length);
+  return {
+    id,
+    agentId: "agent_payload_migration",
+    conversationId,
+    projectId: "proj_payload_migration",
+    toolName: "bash",
+    risk: "command",
+    args: { command: "printf test" },
+    cwd: "/tmp/project",
+    status: "completed",
+    phase: "completed",
+    revision: 1,
+    attempt: 1,
+    interactions: [],
+    result: { stdout: "bounded" },
+    resultPayload: {
+      version: 2,
+      kind: "tool_result",
+      conversationId,
+      toolCallId: id,
+      logicalPath: `conversations/payload_migration/tool-calls/${segment}/result.json`,
+      digest,
+      byteLength: payload.byteLength,
+      mediaType: "application/json",
+      encoding: "utf-8",
+      completeness: "complete",
+    },
+    createdAt: now,
+    updatedAt: now,
+    settledAt: now,
+  };
+}
+
+async function legacyFixture(): Promise<{
+  home: string;
+  corruptLatestChecksum(): void;
+  addLegacyRpcIdempotencyEntries(): void;
+}> {
+  const home = await mkdtemp(join(tmpdir(), "nerve-payload-reference-v1-"));
+  const storage = await initializeStorage(home);
+  const journal = new ConversationJournalRepository(storage);
+  await journal.commit(conversationId, {
+    kind: "conversation.created",
+    committedAt: now,
+    events: [
+      {
+        kind: "conversation.upserted",
+        conversationId,
+        conversation: conversation("Before migration"),
+      },
+    ],
+  });
+  await journal.commit(conversationId, {
+    kind: "tool_call.revised",
+    committedAt: now,
+    events: [
+      {
+        kind: "tool_call.upserted",
+        conversationId,
+        toolCall: toolCall("tool_snapshot"),
+      },
+    ],
+  });
+  await journal.checkpointLoaded();
+  await journal.commit(conversationId, {
+    kind: "tool_call.revised",
+    committedAt: now,
+    events: [
+      {
+        kind: "tool_call.upserted",
+        conversationId,
+        toolCall: toolCall("tool_commit"),
+      },
+    ],
+  });
+  await journal.commit(conversationId, {
+    kind: "conversation.updated",
+    committedAt: now,
+    events: [
+      {
+        kind: "conversation.upserted",
+        conversationId,
+        conversation: conversation("After migration"),
+      },
+    ],
+  });
+  await storage.canonicalStore.close();
+
+  const paths = storagePaths(home);
+  const legacyResult = join(
+    paths.dataPath,
+    "payloads",
+    "conversations",
+    conversationId,
+    "tool-calls",
+    "tool_snapshot",
+    "result.json",
+  );
+  await mkdir(join(legacyResult, ".."), { recursive: true });
+  await writeFile(legacyResult, payload);
+
+  const database = new DatabaseSync(paths.sqlitePath);
+  downgradeDatabase(database);
+  database.close();
+
+  const ledger = JSON.parse(
+    await readFile(paths.migrationLedgerPath, "utf8"),
+  ) as { entries: Array<{ id: string }> };
+  ledger.entries = ledger.entries.filter(
+    (entry) => entry.id !== "tool-result-payload-reference-v2",
+  );
+  await writeFile(paths.migrationLedgerPath, `${JSON.stringify(ledger)}\n`);
+
+  return {
+    home,
+    corruptLatestChecksum() {
+      const corrupt = new DatabaseSync(paths.sqlitePath);
+      const row = corrupt
+        .prepare(
+          `SELECT data FROM domain_documents
+           WHERE namespace = 'conversation_journal_commit'
+             AND scope_id = ? ORDER BY document_id DESC LIMIT 1`,
+        )
+        .get(conversationId) as { data: Uint8Array };
+      const commit = decode(row.data) as Record<string, unknown>;
+      commit.checksum = `sha256:${"f".repeat(64)}`;
+      corrupt
+        .prepare(
+          `UPDATE domain_documents SET data = ?
+           WHERE namespace = 'conversation_journal_commit'
+             AND scope_id = ? AND document_id = ?`,
+        )
+        .run(
+          encode(commit),
+          conversationId,
+          String(commit.revision).padStart(20, "0"),
+        );
+      corrupt.close();
+    },
+    addLegacyRpcIdempotencyEntries() {
+      const database = new DatabaseSync(paths.sqlitePath);
+      const insert = database.prepare(
+        `INSERT INTO rpc_idempotency (
+           scope, key, method, params_hash, outcome, expires_at_ms, created_at_ms
+         ) VALUES (?, ?, 'tool.test', 'hash', ?, ?, ?)`,
+      );
+      const outcome = encode({
+        status: "success",
+        result: downgradeToolCall(toolCall("tool_snapshot")),
+      });
+      insert.run("session", "expired", outcome, 1, 0);
+      insert.run("session", "unexpired", outcome, 9_999_999_999_999, 1);
+      database.close();
+    },
+  };
+}
+
+test("migrates legacy payload references and rechains conversation journals", async (t) => {
+  const fixture = await legacyFixture();
+  const cleanup: {
+    storage?: Awaited<ReturnType<typeof initializeStorage>>;
+  } = {};
+  t.after(async () => {
+    await cleanup.storage?.canonicalStore.close();
+    await rm(fixture.home, { recursive: true, force: true });
+  });
+
+  const progress: string[] = [];
+  const storage = await initializeStorage(fixture.home, {
+    reportStartupProgress: (event) => progress.push(event.phase),
+  });
+  cleanup.storage = storage;
+
+  assert.deepEqual(progress, ["storage-check", "storage-migration"]);
+  assert.ok(storage.timings.sqliteMigrationApplyMs >= 0);
+  const ledger = JSON.parse(
+    await readFile(storage.paths.migrationLedgerPath, "utf8"),
+  ) as {
+    entries: Array<{
+      id: string;
+      counts?: Record<string, number>;
+    }>;
+  };
+  const entry = ledger.entries.find(
+    (candidate) => candidate.id === "tool-result-payload-reference-v2",
+  );
+  assert.deepEqual(entry?.counts, {
+    conversations: 1,
+    journalCommits: 2,
+    snapshots: 1,
+    durableEvents: 2,
+    conversationRecords: 2,
+    fileAssets: 1,
+    rpcIdempotencyEntries: 0,
+  });
+
+  const repository = new ConversationJournalRepository(storage);
+  const state = await repository.load(conversationId);
+  assert.equal(state.revision, 4);
+  assert.equal(state.conversation?.title, "After migration");
+  assert.deepEqual(
+    [...state.toolCalls.values()].map(
+      (record) => record.resultPayload?.logicalPath,
+    ),
+    [
+      "conversations/payload_migration/tool-calls/snapshot/result.json",
+      "conversations/payload_migration/tool-calls/commit/result.json",
+    ],
+  );
+
+  assert.equal(
+    toolResultPayloadReferenceSchema.safeParse({
+      ...toolCall("tool_snapshot").resultPayload,
+      version: 1,
+      logicalPath:
+        "payloads/conversations/conv_payload_migration/tool-calls/tool_snapshot/result.json",
+    }).success,
+    false,
+  );
+  const currentResult = join(
+    storage.paths.conversationsPath,
+    "payload_migration",
+    "tool-calls",
+    "snapshot",
+    "result.json",
+  );
+  assert.equal(await readFile(currentResult, "utf8"), payload.toString("utf8"));
+  await assert.rejects(stat(join(storage.paths.dataPath, "payloads")), {
+    code: "ENOENT",
+  });
+
+  const database = new DatabaseSync(storage.paths.sqlitePath, {
+    readOnly: true,
+  });
+  const legacyRows = database
+    .prepare(
+      `SELECT (
+         SELECT COUNT(*) FROM domain_documents
+         WHERE instr(CAST(data AS TEXT), '"version":1,"kind":"tool_result"') > 0
+       ) + (
+         SELECT COUNT(*) FROM durable_events
+         WHERE instr(CAST(data AS TEXT), '"version":1,"kind":"tool_result"') > 0
+       ) + (
+         SELECT COUNT(*) FROM conversation_records
+         WHERE instr(CAST(data AS TEXT), '"version":1,"kind":"tool_result"') > 0
+       ) AS count`,
+    )
+    .get() as { count: number };
+  const asset = database
+    .prepare(`SELECT logical_path FROM file_assets WHERE id = 'asset_legacy'`)
+    .get() as { logical_path: string };
+  database.close();
+  assert.equal(legacyRows.count, 0);
+  assert.equal(
+    asset.logical_path,
+    "conversations/payload_migration/tool-calls/snapshot/result.json",
+  );
+
+  const repeated = await initializeStorage(fixture.home, {
+    reportStartupProgress: (event) => progress.push(event.phase),
+  });
+  await repeated.canonicalStore.close();
+  assert.deepEqual(progress, [
+    "storage-check",
+    "storage-migration",
+    "storage-check",
+  ]);
+});
+
+test("migrates imported snapshots that have no journal head", async (t) => {
+  const fixture = await legacyFixture();
+  const cleanup: {
+    storage?: Awaited<ReturnType<typeof initializeStorage>>;
+  } = {};
+  t.after(async () => {
+    await cleanup.storage?.canonicalStore.close();
+    await rm(fixture.home, { recursive: true, force: true });
+  });
+  const paths = storagePaths(fixture.home);
+  const database = new DatabaseSync(paths.sqlitePath);
+  database
+    .prepare(
+      `DELETE FROM domain_documents
+       WHERE scope_id = ? AND namespace IN (
+         'conversation_journal_commit', 'conversation_journal_head'
+       )`,
+    )
+    .run(conversationId);
+  database.close();
+
+  const storage = await initializeStorage(fixture.home);
+  cleanup.storage = storage;
+  const state = await new ConversationJournalRepository(storage).load(
+    conversationId,
+  );
+  assert.equal(state.revision, 2);
+  assert.equal(state.toolCalls.get("tool_snapshot")?.resultPayload?.version, 2);
+});
+
+test("fails closed on a corrupt legacy journal without changing payload files", async (t) => {
+  const fixture = await legacyFixture();
+  t.after(() => rm(fixture.home, { recursive: true, force: true }));
+  fixture.corruptLatestChecksum();
+  const paths = storagePaths(fixture.home);
+  const legacyResult = join(
+    paths.dataPath,
+    "payloads",
+    "conversations",
+    conversationId,
+    "tool-calls",
+    "tool_snapshot",
+    "result.json",
+  );
+  const currentResult = join(
+    paths.conversationsPath,
+    "payload_migration",
+    "tool-calls",
+    "snapshot",
+    "result.json",
+  );
+
+  await assert.rejects(initializeStorage(fixture.home), /checksum mismatch/);
+  assert.equal(await readFile(legacyResult, "utf8"), payload.toString("utf8"));
+  await assert.rejects(stat(currentResult), { code: "ENOENT" });
+  await assertMigrationNotRecorded(fixture.home);
+});
+
+test("discards legacy RPC idempotency outcomes during migration", async (t) => {
+  const fixture = await legacyFixture();
+  t.after(() => rm(fixture.home, { recursive: true, force: true }));
+  fixture.addLegacyRpcIdempotencyEntries();
+
+  const storage = await initializeStorage(fixture.home);
+  await storage.canonicalStore.close();
+  const database = new DatabaseSync(storage.paths.sqlitePath, {
+    readOnly: true,
+  });
+  const count = database
+    .prepare(`SELECT COUNT(*) AS count FROM rpc_idempotency`)
+    .get() as { count: number };
+  database.close();
+  assert.equal(count.count, 0);
+
+  const ledger = JSON.parse(
+    await readFile(storage.paths.migrationLedgerPath, "utf8"),
+  ) as { entries: Array<{ id: string; counts?: Record<string, number> }> };
+  assert.equal(
+    ledger.entries.find(
+      (entry) => entry.id === "tool-result-payload-reference-v2",
+    )?.counts?.rpcIdempotencyEntries,
+    2,
+  );
+});
+
+test("resumes when legacy and current payload files are identical", async (t) => {
+  const fixture = await legacyFixture();
+  t.after(() => rm(fixture.home, { recursive: true, force: true }));
+  const currentResult = join(
+    storagePaths(fixture.home).conversationsPath,
+    "payload_migration",
+    "tool-calls",
+    "snapshot",
+    "result.json",
+  );
+  await mkdir(join(currentResult, ".."), { recursive: true });
+  await writeFile(currentResult, payload);
+
+  const storage = await initializeStorage(fixture.home);
+  await storage.canonicalStore.close();
+  assert.equal(await readFile(currentResult, "utf8"), payload.toString("utf8"));
+  await assert.rejects(stat(join(storage.paths.dataPath, "payloads")), {
+    code: "ENOENT",
+  });
+});
+
+test("fails closed when legacy and current payload files conflict", async (t) => {
+  const fixture = await legacyFixture();
+  t.after(() => rm(fixture.home, { recursive: true, force: true }));
+  const currentResult = join(
+    storagePaths(fixture.home).conversationsPath,
+    "payload_migration",
+    "tool-calls",
+    "snapshot",
+    "result.json",
+  );
+  await mkdir(join(currentResult, ".."), { recursive: true });
+  await writeFile(currentResult, "different payload");
+
+  await assert.rejects(initializeStorage(fixture.home), /file conflict/);
+  assert.equal(
+    await readFile(
+      join(
+        storagePaths(fixture.home).dataPath,
+        "payloads",
+        "conversations",
+        conversationId,
+        "tool-calls",
+        "tool_snapshot",
+        "result.json",
+      ),
+      "utf8",
+    ),
+    payload.toString("utf8"),
+  );
+  await assertMigrationNotRecorded(fixture.home);
+});
+
+async function assertMigrationNotRecorded(home: string): Promise<void> {
+  const ledger = JSON.parse(
+    await readFile(storagePaths(home).migrationLedgerPath, "utf8"),
+  ) as { entries: Array<{ id: string }> };
+  assert.equal(
+    ledger.entries.some(
+      (entry) => entry.id === "tool-result-payload-reference-v2",
+    ),
+    false,
+  );
+}
+
+function downgradeDatabase(database: DatabaseSync): void {
+  const snapshotRow = database
+    .prepare(
+      `SELECT data FROM domain_documents
+       WHERE namespace = 'conversation_state'
+         AND scope_id = ? AND document_id = 'state'`,
+    )
+    .get(conversationId) as { data: Uint8Array };
+  const snapshot = decode(snapshotRow.data) as {
+    checksum: string;
+    toolCalls: Array<[string, ToolCallRecord]>;
+  };
+  snapshot.toolCalls = snapshot.toolCalls.map(([id, record]) => [
+    id,
+    downgradeToolCall(record),
+  ]);
+  database
+    .prepare(
+      `UPDATE domain_documents SET data = ?
+       WHERE namespace = 'conversation_state'
+         AND scope_id = ? AND document_id = 'state'`,
+    )
+    .run(encode(snapshot), conversationId);
+
+  let previousChecksum: string | undefined = snapshot.checksum;
+  const rows = database
+    .prepare(
+      `SELECT document_id, data FROM domain_documents
+       WHERE namespace = 'conversation_journal_commit'
+         AND scope_id = ? ORDER BY document_id`,
+    )
+    .all(conversationId) as unknown as Array<{
+    document_id: string;
+    data: Uint8Array;
+  }>;
+  for (const row of rows) {
+    const commit = decode(row.data) as ConversationJournalCommit;
+    commit.events = commit.events.map((event) =>
+      event.kind === "tool_call.upserted"
+        ? { ...event, toolCall: downgradeToolCall(event.toolCall) }
+        : event,
+    );
+    commit.previousChecksum = previousChecksum;
+    const base = Object.fromEntries(
+      Object.entries(commit).filter(([key]) => key !== "checksum"),
+    );
+    commit.checksum = checksum(base);
+    previousChecksum = commit.checksum;
+    database
+      .prepare(
+        `UPDATE domain_documents SET data = ?
+         WHERE namespace = 'conversation_journal_commit'
+           AND scope_id = ? AND document_id = ?`,
+      )
+      .run(encode(commit), conversationId, row.document_id);
+  }
+  database
+    .prepare(
+      `UPDATE domain_documents SET data = ?
+       WHERE namespace = 'conversation_journal_head'
+         AND scope_id = ? AND document_id = 'head'`,
+    )
+    .run(encode({ revision: 4, checksum: previousChecksum }), conversationId);
+
+  const durableRows = database
+    .prepare(
+      `SELECT row_id, data FROM durable_events
+       WHERE conversation_id = ? ORDER BY row_id`,
+    )
+    .all(conversationId) as unknown as Array<{
+    row_id: number;
+    data: Uint8Array;
+  }>;
+  for (const row of durableRows) {
+    const data = decode(row.data) as {
+      version: number;
+      events: ConversationJournalCommit["events"];
+    };
+    data.events = data.events.map((event) =>
+      event.kind === "tool_call.upserted"
+        ? { ...event, toolCall: downgradeToolCall(event.toolCall) }
+        : event,
+    );
+    database
+      .prepare(`UPDATE durable_events SET data = ? WHERE row_id = ?`)
+      .run(encode(data), row.row_id);
+  }
+
+  const recordRows = database
+    .prepare(
+      `SELECT id, data FROM conversation_records
+       WHERE conversation_id = ? AND kind = 'tool_call'`,
+    )
+    .all(conversationId) as unknown as Array<{
+    id: string;
+    data: Uint8Array;
+  }>;
+  for (const row of recordRows) {
+    const data = decode(row.data) as {
+      version: number;
+      toolCall: ToolCallRecord;
+    };
+    data.toolCall = downgradeToolCall(data.toolCall);
+    database
+      .prepare(`UPDATE conversation_records SET data = ? WHERE id = ?`)
+      .run(encode(data), row.id);
+  }
+
+  database
+    .prepare(
+      `INSERT INTO file_assets (
+         id, category, logical_path, conversation_id, tool_call_id, task_id,
+         digest, byte_length, media_type, created_at_ms, updated_at_ms
+       ) VALUES (
+         'asset_legacy', 'payload', ?, ?, 'tool_snapshot', NULL,
+         ?, ?, 'application/json', 1, 1
+       )`,
+    )
+    .run(
+      "payloads/conversations/conv_payload_migration/tool-calls/tool_snapshot/result.json",
+      conversationId,
+      digest,
+      payload.byteLength,
+    );
+}
+
+function downgradeToolCall(record: ToolCallRecord): ToolCallRecord {
+  if (!record.resultPayload) return record;
+  return {
+    ...record,
+    resultPayload: {
+      ...record.resultPayload,
+      version: 1,
+      logicalPath: `payloads/conversations/${record.conversationId}/tool-calls/${record.id}/result.json`,
+    } as never,
+  };
+}
+
+function checksum(value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(value))
+    .digest("hex")}`;
+}
+
+function encode(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(value), "utf8");
+}
+
+function decode(value: Uint8Array): unknown {
+  return JSON.parse(Buffer.from(value).toString("utf8")) as unknown;
+}


### PR DESCRIPTION
## Summary
- migrate legacy tool-result payload references and compact managed-file paths during startup
- preflight journals and filesystem conflicts before mutation, with resumable non-destructive file copying
- discard affected bounded RPC idempotency cache entries and record migration counts
- add migration coverage and update storage documentation

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`