### PR TITLE
Batch task log persistence

### DIFF
--- a/packages/workbench-server/src/domains/tasks/application/task-log.service.ts
+++ b/packages/workbench-server/src/domains/tasks/application/task-log.service.ts
@@ -12,7 +12,7 @@ import { dirname } from "node:path";
 import type { StreamLogRegistry } from "../../../infrastructure/events/index.js";
 import type { PerformanceDiagnosticsPort } from "../../../core/ports/diagnostics.js";
 import {
-  appendJsonLine,
+  appendJsonLines,
   readJsonLines,
 } from "../../../infrastructure/storage-bootstrap/index.js";
 
@@ -277,6 +277,7 @@ export class TaskLogService {
     const combined = Buffer.concat([previous, chunk]);
     const combinedStart = cursor.streamBytes[stream] - previous.byteLength;
     cursor.streamBytes[stream] += chunk.byteLength;
+    const events: TaskLogEvent[] = [];
     let position = 0;
     for (;;) {
       const newline = combined.indexOf(0x0a, position);
@@ -284,8 +285,7 @@ export class TaskLogService {
       const hasCr = newline > position && combined[newline - 1] === 0x0d;
       const contentEnd = hasCr ? newline - 1 : newline;
       const end = newline + 1;
-      await this.emitLogLine(
-        record,
+      const event = this.createLogLine(
         cursor,
         stream,
         combined.subarray(position, contentEnd).toString("utf8"),
@@ -295,8 +295,8 @@ export class TaskLogService {
           terminatorBytes: hasCr ? 2 : 1,
           fidelity: "captured",
         },
-        onLog,
       );
+      if (event) events.push(event);
       position = end;
     }
     cursor.rawBuffers[stream] = Buffer.from(combined.subarray(position));
@@ -306,20 +306,15 @@ export class TaskLogService {
       const start = cursor.streamBytes[stream] - raw.byteLength;
       cursor.rawBuffers[stream] = Buffer.alloc(0);
       cursor.lineBuffers[stream] = "";
-      await this.emitLogLine(
-        record,
-        cursor,
-        stream,
-        raw.toString("utf8"),
-        {
-          start,
-          end: cursor.streamBytes[stream],
-          terminatorBytes: 0,
-          fidelity: "captured",
-        },
-        onLog,
-      );
+      const event = this.createLogLine(cursor, stream, raw.toString("utf8"), {
+        start,
+        end: cursor.streamBytes[stream],
+        terminatorBytes: 0,
+        fidelity: "captured",
+      });
+      if (event) events.push(event);
     }
+    await this.persistLogLines(record, events, onLog);
   }
 
   private async flushOutputNow(
@@ -332,19 +327,13 @@ export class TaskLogService {
     cursor.rawBuffers[stream] = Buffer.alloc(0);
     cursor.lineBuffers[stream] = "";
     if (raw.byteLength === 0) return;
-    await this.emitLogLine(
-      record,
-      cursor,
-      stream,
-      raw.toString("utf8"),
-      {
-        start: cursor.streamBytes[stream] - raw.byteLength,
-        end: cursor.streamBytes[stream],
-        terminatorBytes: 0,
-        fidelity: "captured",
-      },
-      onLog,
-    );
+    const event = this.createLogLine(cursor, stream, raw.toString("utf8"), {
+      start: cursor.streamBytes[stream] - raw.byteLength,
+      end: cursor.streamBytes[stream],
+      terminatorBytes: 0,
+      fidelity: "captured",
+    });
+    await this.persistLogLines(record, event ? [event] : [], onLog);
   }
 
   private async persistTail(
@@ -355,19 +344,17 @@ export class TaskLogService {
     cursor.tailDirtyBytes = 0;
   }
 
-  private async emitLogLine(
-    record: TaskRecord,
+  private createLogLine(
     cursor: TaskLogCursor,
     stream: TaskLogStream,
     line: string,
     raw: NonNullable<TaskLogEvent["raw"]>,
-    onLog: (event: TaskLogEvent) => Promise<void>,
-  ): Promise<void> {
+  ): TaskLogEvent | undefined {
     const cleaned = line.trimEnd();
-    if (cleaned.length === 0) return;
+    if (cleaned.length === 0) return undefined;
 
     cursor.logSeq += 1;
-    const event: TaskLogEvent = {
+    return {
       seq: cursor.logSeq,
       ts: new Date().toISOString(),
       stream,
@@ -375,17 +362,27 @@ export class TaskLogService {
       line: cleaned,
       raw,
     };
-    await appendJsonLine(record.logsPath, event, 0o600);
-    this.options.diagnostics?.count("task.outputLine");
-    if (this.options.publishOutputEvents !== false) {
-      await this.events.publish("task.output", {
-        taskId: record.id,
-        stream,
-        text: cleaned.slice(-16_384),
-      });
-      this.options.diagnostics?.count("task.outputPublication");
+  }
+
+  private async persistLogLines(
+    record: TaskRecord,
+    events: readonly TaskLogEvent[],
+    onLog: (event: TaskLogEvent) => Promise<void>,
+  ): Promise<void> {
+    if (events.length === 0) return;
+    await appendJsonLines(record.logsPath, events, 0o600);
+    for (const event of events) {
+      this.options.diagnostics?.count("task.outputLine");
+      if (this.options.publishOutputEvents !== false) {
+        await this.events.publish("task.output", {
+          taskId: record.id,
+          stream: event.stream,
+          text: event.line.slice(-16_384),
+        });
+        this.options.diagnostics?.count("task.outputPublication");
+      }
+      await onLog(event);
     }
-    await onLog(event);
   }
 }
 

--- a/packages/workbench-server/src/infrastructure/storage-bootstrap/json.ts
+++ b/packages/workbench-server/src/infrastructure/storage-bootstrap/json.ts
@@ -263,8 +263,17 @@ export function appendJsonLine(
   value: unknown,
   mode?: number,
 ): Promise<void> {
+  return appendJsonLines(path, [value], mode);
+}
+
+export function appendJsonLines(
+  path: string,
+  values: readonly unknown[],
+  mode?: number,
+): Promise<void> {
+  if (values.length === 0) return Promise.resolve();
   return withFileMutation(path, (resolvedPath) =>
-    appendJsonLineDirect(resolvedPath, value, mode),
+    appendJsonLinesDirect(resolvedPath, values, mode),
   );
 }
 
@@ -277,15 +286,16 @@ export function rewriteJsonLines(
   return atomicWriteFile(path, text ? `${text}\n` : "", { mode });
 }
 
-async function appendJsonLineDirect(
+async function appendJsonLinesDirect(
   path: string,
-  value: unknown,
+  values: readonly unknown[],
   mode?: number,
 ): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
+  const contents = values.map((value) => `${JSON.stringify(value)}\n`).join("");
   const handle = await open(path, "a", mode);
   try {
-    await handle.write(`${JSON.stringify(value)}\n`, undefined, "utf8");
+    await handle.write(contents, undefined, "utf8");
     await handle.sync();
   } finally {
     await handle.close();

--- a/packages/workbench-server/test/domains/tasks/task-log.service.test.ts
+++ b/packages/workbench-server/test/domains/tasks/task-log.service.test.ts
@@ -145,6 +145,71 @@ describe("task log service line buffering", () => {
     assert.equal(older.hasMoreBefore, true);
   });
 
+  it("persists a Cargo-sized output burst in order", async () => {
+    const { record, service, cursor, onLog, emitted } = await createFixture({
+      publishOutputEvents: false,
+    });
+    const lines = Array.from(
+      { length: 750 },
+      (_, index) => `      Adding crate-${index} v1.0.0`,
+    );
+    const raw = Buffer.from(`${lines.join("\n")}\n`, "utf8");
+
+    await service.captureOutput(record, cursor, "stderr", raw, onLog);
+
+    const events = await service.readLogEvents(record.logsPath);
+    assert.equal(events.length, lines.length);
+    assert.deepEqual(
+      events.map((event) => event.seq),
+      lines.map((_, index) => index + 1),
+    );
+    assert.deepEqual(
+      events.map((event) => event.line),
+      lines,
+    );
+    assert.deepEqual(emitted, events);
+    assert.deepEqual(events[0]?.raw, {
+      start: 0,
+      end: Buffer.byteLength(`${lines[0]}\n`),
+      terminatorBytes: 1,
+      fidelity: "captured",
+    });
+    assert.equal(events.at(-1)?.raw?.end, raw.byteLength);
+    assert.deepEqual(await readFile(record.stderrPath), raw);
+  });
+
+  it("completes buffered lines across chunks without reordering", async () => {
+    const { record, service, cursor, onLog, emitted } = await createFixture();
+
+    await service.captureOutput(
+      record,
+      cursor,
+      "stdout",
+      "one\ntwo-par",
+      onLog,
+    );
+    await service.captureOutput(
+      record,
+      cursor,
+      "stdout",
+      "tial\nthree\n",
+      onLog,
+    );
+
+    assert.deepEqual(
+      emitted.map((event) => [event.seq, event.line]),
+      [
+        [1, "one"],
+        [2, "two-partial"],
+        [3, "three"],
+      ],
+    );
+    assert.equal(
+      await readFile(record.stdoutPath, "utf8"),
+      "one\ntwo-partial\nthree\n",
+    );
+  });
+
   it("indexes exact raw UTF-8 byte ranges after durable stream capture", async () => {
     const { record, service, cursor, onLog } = await createFixture();
     const raw = Buffer.from("α\r\nβ🙂\n", "utf8");
@@ -188,7 +253,9 @@ describe("task log service line buffering", () => {
   });
 });
 
-async function createFixture(): Promise<{
+async function createFixture(
+  options: { publishOutputEvents?: boolean } = {},
+): Promise<{
   record: TaskRecord;
   service: TaskLogService;
   cursor: ReturnType<typeof createTaskLogCursor>;
@@ -218,6 +285,7 @@ async function createFixture(): Promise<{
   const metrics = new PerformanceMetricsCollector();
   const service = new TaskLogService(new StreamLogRegistry(root), {
     diagnostics: metrics,
+    ...options,
   });
   return {
     record,

--- a/packages/workbench-server/test/infrastructure/persistence/storage-json.test.ts
+++ b/packages/workbench-server/test/infrastructure/persistence/storage-json.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
-import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, describe, it } from "node:test";
 import {
+  appendJsonLines,
   forEachJsonLineReverse,
+  readJsonLines,
   readJsonLinesTail,
   readTextFileConsistent,
   withFileMutation,
@@ -23,6 +25,35 @@ async function tempPath(): Promise<string> {
   roots.push(root);
   return join(root, "records.jsonl");
 }
+
+describe("appendJsonLines", () => {
+  it("appends each batch contiguously in mutation order", async () => {
+    const path = await tempPath();
+
+    const first = appendJsonLines(path, [{ value: 1 }, { value: 2 }]);
+    const second = appendJsonLines(path, [{ value: 3 }, { value: 4 }]);
+    await Promise.all([first, second]);
+
+    assert.deepEqual(await readJsonLines(path), [
+      { value: 1 },
+      { value: 2 },
+      { value: 3 },
+      { value: 4 },
+    ]);
+    assert.equal(
+      await readFile(path, "utf8"),
+      '{"value":1}\n{"value":2}\n{"value":3}\n{"value":4}\n',
+    );
+  });
+
+  it("does not create a file for an empty batch", async () => {
+    const path = await tempPath();
+
+    await appendJsonLines(path, []);
+
+    await assert.rejects(readFile(path), { code: "ENOENT" });
+  });
+});
 
 describe("readTextFileConsistent", () => {
   it("waits for an in-process append before reading", async () => {


### PR DESCRIPTION
## Summary
- batch task-output JSONL index writes per process-output chunk
- preserve durability, ordering, callbacks, and raw byte indexing
- add high-volume Cargo-style and cross-chunk regression coverage

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`