### PR TITLE
Reconcile interrupted approvals on conversation refresh

### DIFF
--- a/packages/workbench-server/src/adapters/protocol/snapshots.ts
+++ b/packages/workbench-server/src/adapters/protocol/snapshots.ts
@@ -41,9 +41,10 @@ export async function getConversationSnapshotResponse(
   conversationId: string,
 ): Promise<ConversationSnapshotResponse<ConversationSnapshot>> {
   const stream = conversationStream(conversationId);
-  const captured = await state.events.withCursor(stream, () =>
-    state.conversationQuery.getConversationSnapshot(conversationId),
-  );
+  const captured = await state.events.withCursor(stream, async () => {
+    await state.humanInput.recoverReadyApprovalBatches(conversationId);
+    return state.conversationQuery.getConversationSnapshot(conversationId);
+  });
   return {
     snapshot: { ...captured.value, cursorSeq: captured.cursor.processedSeq },
     cursor: { streams: [captured.cursor] },

--- a/packages/workbench-server/src/app/bootstrap/create-server-adapter-contexts.ts
+++ b/packages/workbench-server/src/app/bootstrap/create-server-adapter-contexts.ts
@@ -55,6 +55,7 @@ export function createServerAdapterContexts(
     projectLifecycle: services.projectLifecycle,
     conversationLifecycle: services.conversationLifecycle,
     conversationQuery: services.conversationQuery,
+    humanInput: services.humanInput,
     agentLifecycle: services.agentLifecycle,
     tasks: services.tasks,
     tools: services.tools,

--- a/packages/workbench-server/src/domains/human-input/approval-batch-resolution.ts
+++ b/packages/workbench-server/src/domains/human-input/approval-batch-resolution.ts
@@ -97,39 +97,47 @@ export class ApprovalBatchResolutionService {
     );
   }
 
-  async recoverReadyBatches(): Promise<void> {
-    const recovered = new Set<string>();
-    for (const approval of this.deps.tools.listApprovals()) {
+  async recoverReadyBatches(conversationId?: string): Promise<void> {
+    for (const approval of this.deps.tools.listApprovals("pending")) {
+      if (conversationId && approval.conversationId !== conversationId)
+        continue;
       const toolCall = await this.deps.tools.getToolCallDetails(
         approval.toolCallId,
       );
       if (!toolCall.runId) continue;
-      if (approval.status === "pending") {
-        try {
-          await this.deps.runs.assertPendingInteractionForToolCall(
+      try {
+        await this.deps.runs.assertPendingInteractionForToolCall(
+          toolCall.id,
+          toolCall.runId,
+        );
+      } catch (error) {
+        if (
+          error instanceof ApplicationError &&
+          error.code === "RUN_INTERACTION_NOT_PENDING"
+        ) {
+          await this.deps.tools.abandonPendingInteraction(
             toolCall.id,
-            toolCall.runId,
+            "Approval was cancelled because its source run did not suspend.",
           );
-        } catch (error) {
-          if (
-            error instanceof ApplicationError &&
-            error.code === "RUN_INTERACTION_NOT_PENDING"
-          ) {
-            await this.deps.tools.abandonPendingInteraction(
-              toolCall.id,
-              "Approval was cancelled because its source run did not suspend.",
-            );
-            continue;
-          }
-          throw error;
+          continue;
         }
-        continue;
+        throw error;
       }
+    }
+
+    const recovered = new Set<string>();
+    const pendingInteractions =
+      await this.deps.runs.listPendingApprovalInteractions(conversationId);
+    for (const interaction of pendingInteractions) {
+      const approval = await this.deps.tools.getApprovalForToolCallDetails(
+        interaction.toolCallId,
+      );
+      if (!approval || approval.status === "pending") continue;
       let batch: ApprovalInteractionBatch;
       try {
         batch = await this.deps.runs.approvalBatchForToolCall(
-          toolCall.id,
-          toolCall.runId,
+          interaction.toolCallId,
+          interaction.runId,
         );
       } catch {
         continue;
@@ -137,26 +145,24 @@ export class ApprovalBatchResolutionService {
       const key = `${batch.runId}:${batch.checkpointId}`;
       if (recovered.has(key)) continue;
       recovered.add(key);
-      if (
-        !batch.interactions.some(
-          (interaction) => interaction.status === "pending",
-        ) ||
-        !(await this.batchReady(batch))
-      ) {
-        continue;
-      }
+      if (!(await this.batchReady(batch))) continue;
       await this.exclusive(key, async () => {
-        const current = await this.deps.runs.approvalBatchForToolCall(
-          toolCall.id,
-          toolCall.runId,
-        );
+        let current: ApprovalInteractionBatch;
+        try {
+          current = await this.deps.runs.approvalBatchForToolCall(
+            interaction.toolCallId,
+            interaction.runId,
+          );
+        } catch {
+          return;
+        }
         if (
           current.interactions.some(
-            (interaction) => interaction.status === "pending",
+            (candidate) => candidate.status === "pending",
           ) &&
           (await this.batchReady(current))
         ) {
-          await this.drain(current, toolCall.id);
+          await this.drain(current, interaction.toolCallId);
         }
       });
     }
@@ -202,7 +208,8 @@ export class ApprovalBatchResolutionService {
 
   private async batchReady(batch: ApprovalInteractionBatch): Promise<boolean> {
     for (const toolCallId of batch.batchToolCallIds) {
-      const approval = this.approvalForToolCall(toolCallId);
+      const approval =
+        await this.deps.tools.getApprovalForToolCallDetails(toolCallId);
       if (approval) {
         if (approval.status === "pending") return false;
         continue;
@@ -221,11 +228,17 @@ export class ApprovalBatchResolutionService {
     // validation is intentionally not sufficient because it runs after tools.
     await this.deps.runs.assertApprovalBatchContextUnchanged(batch);
     const toolCalls: ToolCallRecord[] = [];
+    const approvalsByToolCallId = new Map<string, ApprovalRecord>();
     for (const toolCallId of batch.batchToolCallIds) {
-      const approval = this.approvalForToolCall(toolCallId);
-      const toolCall = approval
-        ? await this.deps.tools.finalizeDecidedApproval(approval.id)
-        : await this.deps.tools.getToolCallDetails(toolCallId);
+      const approval =
+        await this.deps.tools.getApprovalForToolCallDetails(toolCallId);
+      if (approval) approvalsByToolCallId.set(toolCallId, approval);
+      const current = await this.deps.tools.getToolCallDetails(toolCallId);
+      const toolCall = isTerminalToolCall(current)
+        ? current
+        : approval
+          ? await this.deps.tools.finalizeDecidedApproval(approval.id)
+          : current;
       if (!isTerminalToolCall(toolCall)) {
         throw new Error(
           `Approval batch member ${toolCall.id} did not reach a terminal state.`,
@@ -246,7 +259,7 @@ export class ApprovalBatchResolutionService {
       );
     }
     const members = batch.interactions.map((interaction) => {
-      const approval = this.approvalForToolCall(interaction.toolCallId);
+      const approval = approvalsByToolCallId.get(interaction.toolCallId);
       if (!approval || approval.status === "pending") {
         throw new Error(
           `Approval decision for ${interaction.toolCallId} is not durable.`,
@@ -265,16 +278,10 @@ export class ApprovalBatchResolutionService {
       entries,
       toolCalls: toolCalls.map(toToolCallTranscriptRecord),
       resolutionRequestId: resolutionRequestId(batch, (toolCallId) =>
-        this.approvalForToolCall(toolCallId),
+        approvalsByToolCallId.get(toolCallId),
       ),
     });
     return this.deps.tools.getToolCallDetails(targetToolCallId);
-  }
-
-  private approvalForToolCall(toolCallId: string): ApprovalRecord | undefined {
-    return this.deps.tools
-      .listApprovals()
-      .find((approval) => approval.toolCallId === toolCallId);
   }
 
   private exclusive<T>(key: string, action: () => Promise<T>): Promise<T> {

--- a/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
+++ b/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
@@ -365,8 +365,8 @@ export class HumanInputResolutionService {
     );
   }
 
-  recoverReadyApprovalBatches(): Promise<void> {
-    return this.approvalBatches.recoverReadyBatches();
+  recoverReadyApprovalBatches(conversationId?: string): Promise<void> {
+    return this.approvalBatches.recoverReadyBatches(conversationId);
   }
 
   async recoverAcceptedPlanReviews(): Promise<void> {

--- a/packages/workbench-server/src/domains/runs/application/workbench-run.service.ts
+++ b/packages/workbench-server/src/domains/runs/application/workbench-run.service.ts
@@ -52,6 +52,22 @@ export class WorkbenchRunService {
     private readonly features: WorkbenchRunFeatureMechanics,
   ) {}
 
+  async listPendingApprovalInteractions(
+    conversationId?: string,
+  ): Promise<RunInteractionRecord[]> {
+    const states = await this.unitOfWork.listActive();
+    return states.flatMap((state) =>
+      state.run.status === "waiting" &&
+      (!conversationId || state.run.conversationId === conversationId)
+        ? state.interactions.filter(
+            (interaction) =>
+              interaction.kind === "approval" &&
+              interaction.status === "pending",
+          )
+        : [],
+    );
+  }
+
   async listQueuedPrompts(agentId: string) {
     const agent = this.requireAgent(agentId);
     const state = await this.unitOfWork.findActive(this.scopeId(agent));

--- a/packages/workbench-server/src/domains/tools/execution/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/execution/tool-service.ts
@@ -1132,6 +1132,18 @@ export class ToolService {
     return await this.toolCallRepository.getCanonical(toolCallId);
   }
 
+  async getApprovalForToolCallDetails(
+    toolCallId: string,
+  ): Promise<ApprovalRecord | undefined> {
+    const toolCall = await this.getToolCallDetails(toolCallId);
+    const interaction = toolCall.interactions.find(
+      (candidate) => candidate.kind === "approval",
+    );
+    return interaction
+      ? this.projectApproval(toolCall, interaction.ordinal)
+      : undefined;
+  }
+
   async getToolCallUiDetails(toolCallId: string): Promise<ToolCallDetails> {
     return await this.toolCallRepository.getDetails(toolCallId);
   }

--- a/packages/workbench-server/test/adapters/protocol/snapshots.test.ts
+++ b/packages/workbench-server/test/adapters/protocol/snapshots.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { conversationStream } from "@nervekit/contracts/events";
+import { getConversationSnapshotResponse } from "../../../src/adapters/protocol/snapshots.js";
+
+test("conversation snapshot reconciles its pending approvals before querying", async () => {
+  const conversationId = "conv_test";
+  const order: string[] = [];
+  const state = {
+    events: {
+      withCursor: async (stream: string, action: () => Promise<unknown>) => {
+        assert.equal(stream, conversationStream(conversationId));
+        order.push("cursor:start");
+        const value = await action();
+        order.push("cursor:end");
+        return {
+          value,
+          cursor: { stream, processedSeq: 42, earliestSeq: 1 },
+        };
+      },
+    },
+    humanInput: {
+      recoverReadyApprovalBatches: async (scope?: string) => {
+        assert.equal(scope, conversationId);
+        order.push("reconcile");
+      },
+    },
+    conversationQuery: {
+      getConversationSnapshot: async (scope: string) => {
+        assert.equal(scope, conversationId);
+        order.push("query");
+        return { conversation: { id: conversationId } };
+      },
+    },
+  };
+
+  const response = await getConversationSnapshotResponse(
+    state as never,
+    conversationId,
+  );
+
+  assert.deepEqual(order, ["cursor:start", "reconcile", "query", "cursor:end"]);
+  assert.equal(response.snapshot.cursorSeq, 42);
+  assert.equal(response.cursor.streams[0]?.processedSeq, 42);
+});

--- a/packages/workbench-server/test/domains/agents/approval-batch-resolution.test.ts
+++ b/packages/workbench-server/test/domains/agents/approval-batch-resolution.test.ts
@@ -54,8 +54,10 @@ test("startup recovery loads evicted terminal approval tool calls asynchronously
 
   const canonicalLoads: string[] = [];
   let resolutions = 0;
+  let finalizations = 0;
   const tools = {
-    listApprovals: () => [approval],
+    listApprovals: (status?: ApprovalRecord["status"]) =>
+      status === "pending" ? [] : [approval],
     getToolCall: () => {
       throw new Error("Tool call is not active; load it asynchronously.");
     },
@@ -63,9 +65,15 @@ test("startup recovery loads evicted terminal approval tool calls asynchronously
       canonicalLoads.push(toolCallId);
       return toolCallId === decided.id ? decided : policyTerminal;
     },
-    finalizeDecidedApproval: async () => decided,
+    getApprovalForToolCallDetails: async (toolCallId: string) =>
+      toolCallId === decided.id ? approval : undefined,
+    finalizeDecidedApproval: async () => {
+      finalizations += 1;
+      return decided;
+    },
   } as unknown as ToolService;
   const runs = {
+    listPendingApprovalInteractions: async () => batch.interactions,
     approvalBatchForToolCall: async () => batch,
     assertApprovalBatchContextUnchanged: async () => undefined,
     resolveInteractionBatchForToolCalls: async () => {
@@ -82,6 +90,7 @@ test("startup recovery loads evicted terminal approval tool calls asynchronously
   await service.recoverReadyBatches();
 
   assert.equal(resolutions, 1);
+  assert.equal(finalizations, 0, "terminal tools must not execute again");
   assert.ok(canonicalLoads.includes(decided.id));
   assert.ok(canonicalLoads.includes(policyTerminal.id));
 });

--- a/packages/workbench-server/test/domains/runs/workbench-run-pending-interactions.test.ts
+++ b/packages/workbench-server/test/domains/runs/workbench-run-pending-interactions.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { WorkbenchRunService } from "../../../src/domains/runs/application/workbench-run.service.js";
+
+function state(input: {
+  runId: string;
+  conversationId: string;
+  status: "waiting" | "running";
+  interactionKind: "approval" | "user_input";
+  interactionStatus: "pending" | "resolved";
+}) {
+  return {
+    run: {
+      runId: input.runId,
+      conversationId: input.conversationId,
+      status: input.status,
+    },
+    interactions: [
+      {
+        id: `interaction_${input.runId}`,
+        runId: input.runId,
+        toolCallId: `tool_${input.runId}`,
+        kind: input.interactionKind,
+        status: input.interactionStatus,
+      },
+    ],
+  };
+}
+
+test("pending approval recovery candidates are active and conversation scoped", async () => {
+  const wanted = state({
+    runId: "wanted",
+    conversationId: "conv_target",
+    status: "waiting",
+    interactionKind: "approval",
+    interactionStatus: "pending",
+  });
+  const service = new WorkbenchRunService(
+    {} as never,
+    {} as never,
+    {
+      listActive: async () => [
+        wanted,
+        state({
+          runId: "other_conversation",
+          conversationId: "conv_other",
+          status: "waiting",
+          interactionKind: "approval",
+          interactionStatus: "pending",
+        }),
+        state({
+          runId: "wrong_kind",
+          conversationId: "conv_target",
+          status: "waiting",
+          interactionKind: "user_input",
+          interactionStatus: "pending",
+        }),
+        state({
+          runId: "resolved",
+          conversationId: "conv_target",
+          status: "waiting",
+          interactionKind: "approval",
+          interactionStatus: "resolved",
+        }),
+        state({
+          runId: "not_waiting",
+          conversationId: "conv_target",
+          status: "running",
+          interactionKind: "approval",
+          interactionStatus: "pending",
+        }),
+      ],
+    } as never,
+    {} as never,
+  );
+
+  const interactions =
+    await service.listPendingApprovalInteractions("conv_target");
+
+  assert.deepEqual(
+    interactions.map((interaction) => interaction.id),
+    [wanted.interactions[0]?.id],
+  );
+});


### PR DESCRIPTION
## Summary
- discover recoverable approvals from pending run interactions and canonically load terminal tool calls
- reconcile a conversation before producing its snapshot so opening or refreshing repairs interrupted approval workflows
- avoid re-executing terminal tools and add regression coverage for recovery scope and snapshot ordering

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`