### PR TITLE
Fix delayed ask_user reply input

### DIFF
--- a/packages/workbench-app/src/lib/presentation/tools/ToolCallCard.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/ToolCallCard.svelte
@@ -44,6 +44,7 @@ import ToolArgumentBody from "./tool-call/ToolArgumentBody.svelte";
 import ToolCallDetailsDialog from "./tool-call/ToolCallDetailsDialog.svelte";
 import ApprovalPrompt from "./tool-call/ApprovalPrompt.svelte";
 import ExploreToolView from "./tool-call/ExploreToolView.svelte";
+import { resolveAskUserQuestion } from "./tool-call/ask-user-state";
 
 type Props = {
   /** Retained live slot used before and during durable-record handoff. */
@@ -273,9 +274,7 @@ const hilInteractive = $derived(
     (view?.kind === "plan_mode" && view.action === "present"),
 );
 const toolQuestion = $derived(
-  toolCall && pendingUserQuestion?.toolCallId === toolCall.id
-    ? pendingUserQuestion
-    : undefined,
+  resolveAskUserQuestion(toolCall, pendingUserQuestion),
 );
 const toolPlanReview = $derived(
   toolCall && pendingPlanReview?.toolCallId === toolCall.id

--- a/packages/workbench-app/src/lib/presentation/tools/tool-call/ask-user-state.test.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/tool-call/ask-user-state.test.ts
@@ -1,0 +1,113 @@
+import type {
+  ToolCallTranscriptRecord,
+  UserQuestionRecord,
+} from "@nervekit/contracts/tools";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveAskUserQuestion } from "./ask-user-state";
+
+const requestedAt = "2026-09-04T20:49:00.000Z";
+const updatedAt = "2026-09-04T20:49:01.000Z";
+
+function askUserToolCall(
+  interaction: ToolCallTranscriptRecord["interactions"][number] = {
+    kind: "user_input",
+    ordinal: 0,
+    status: "pending",
+    requestedAt,
+    updatedAt,
+    request: {
+      question: "Which scope should this support?",
+      context: "Local deletion is safer.",
+      recommendation: "Support local branches first.",
+      required: true,
+    },
+  },
+): NonNullable<Parameters<typeof resolveAskUserQuestion>[0]> {
+  return {
+    id: "tool_ask",
+    agentId: "agent_main",
+    conversationId: "conv_main",
+    projectId: "proj_main",
+    toolName: "ask_user",
+    status: "waiting",
+    interactions: [interaction],
+  };
+}
+
+describe("resolveAskUserQuestion", () => {
+  it("prefers a matching pending workspace projection", () => {
+    const projected: UserQuestionRecord = {
+      id: "question_tool_ask_0",
+      toolCallId: "tool_ask",
+      agentId: "agent_main",
+      conversationId: "conv_main",
+      projectId: "proj_main",
+      question: "Projected question",
+      status: "pending",
+      requestedAt,
+      updatedAt,
+    };
+
+    assert.equal(
+      resolveAskUserQuestion(askUserToolCall(), projected),
+      projected,
+    );
+  });
+
+  it("derives the pending question from the durable interaction during handoff", () => {
+    assert.deepEqual(resolveAskUserQuestion(askUserToolCall(), undefined), {
+      id: "question_tool_ask_0",
+      toolCallId: "tool_ask",
+      agentId: "agent_main",
+      conversationId: "conv_main",
+      projectId: "proj_main",
+      question: "Which scope should this support?",
+      context: "Local deletion is safer.",
+      recommendation: "Support local branches first.",
+      status: "pending",
+      requestedAt,
+      updatedAt,
+    });
+  });
+
+  it("does not expose controls for settled or non-user-input interactions", () => {
+    const resolved = askUserToolCall({
+      kind: "user_input",
+      ordinal: 0,
+      status: "resolved",
+      requestedAt,
+      updatedAt,
+      resolvedAt: updatedAt,
+      request: {
+        question: "Continue?",
+        required: true,
+      },
+      resolution: { action: "answer", answer: "Yes" },
+    });
+    const approval = askUserToolCall({
+      kind: "approval",
+      ordinal: 0,
+      status: "pending",
+      requestedAt,
+      updatedAt,
+      request: {
+        risk: "workspace_write",
+        reason: "Needs approval",
+        offeredScopes: ["single_call"],
+        suggestedExceptions: [],
+        suggestedRules: [],
+      },
+    });
+
+    assert.equal(resolveAskUserQuestion(resolved, undefined), undefined);
+    assert.equal(resolveAskUserQuestion(approval, undefined), undefined);
+    assert.equal(
+      resolveAskUserQuestion(
+        { ...askUserToolCall(), status: "completed" },
+        undefined,
+      ),
+      undefined,
+    );
+  });
+});

--- a/packages/workbench-app/src/lib/presentation/tools/tool-call/ask-user-state.ts
+++ b/packages/workbench-app/src/lib/presentation/tools/tool-call/ask-user-state.ts
@@ -1,0 +1,54 @@
+import type {
+  ToolCallTranscriptRecord,
+  UserQuestionRecord,
+} from "@nervekit/contracts/tools";
+
+type AskUserToolCall = Pick<
+  ToolCallTranscriptRecord,
+  | "id"
+  | "agentId"
+  | "conversationId"
+  | "projectId"
+  | "toolName"
+  | "status"
+  | "interactions"
+>;
+
+/**
+ * Resolves the pending question owned by an ask_user card.
+ *
+ * Transcript tool calls and workspace interaction projections update through
+ * separate stores. Deriving from the durable interaction keeps the card usable
+ * during the brief handoff before the external projection arrives.
+ */
+export function resolveAskUserQuestion(
+  toolCall: AskUserToolCall | undefined,
+  projected: UserQuestionRecord | undefined,
+): UserQuestionRecord | undefined {
+  if (toolCall?.toolName !== "ask_user" || toolCall.status !== "waiting") {
+    return undefined;
+  }
+  const interaction = toolCall.interactions.find(
+    (candidate) => candidate.status === "pending",
+  );
+  if (!interaction || interaction.kind !== "user_input") return undefined;
+
+  const questionId = `question_${toolCall.id}_${interaction.ordinal}`;
+  if (projected?.id === questionId && projected.status === "pending") {
+    return projected;
+  }
+
+  return {
+    id: questionId,
+    toolCallId: toolCall.id,
+    agentId: toolCall.agentId,
+    conversationId: toolCall.conversationId,
+    projectId: toolCall.projectId,
+    question: interaction.request.question,
+    context: interaction.request.context,
+    recommendation: interaction.request.recommendation,
+    status: "pending",
+    requestedAt: interaction.requestedAt,
+    updatedAt: interaction.updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary
- derive pending `ask_user` state from the durable tool interaction during projection handoff
- preserve the workspace-projected question when it is current
- add regression coverage for pending, settled, and wrong-kind interactions

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`