### PR TITLE
Improve Git branch management dialog

### DIFF
--- a/packages/contracts/src/domains/git/git.ts
+++ b/packages/contracts/src/domains/git/git.ts
@@ -123,6 +123,8 @@ export const gitBranchSummarySchema = z.object({
   current: z.boolean(),
   remote: z.boolean(),
   upstream: z.string().nullable(),
+  /** Commit time of the branch tip, when the object is available locally. */
+  updatedAt: z.string().datetime().nullable(),
 });
 export type GitBranchSummary = z.infer<typeof gitBranchSummarySchema>;
 
@@ -144,6 +146,12 @@ export const switchBranchRequestSchema = z.object({
   name: z.string().min(1),
 });
 export type SwitchBranchRequest = z.infer<typeof switchBranchRequestSchema>;
+
+export const deleteBranchRequestSchema = z.object({
+  repo: z.string().default("."),
+  name: z.string().min(1),
+});
+export type DeleteBranchRequest = z.infer<typeof deleteBranchRequestSchema>;
 
 /** Generic remote operation (push / pull / fetch) on the current branch. */
 export const gitRemoteOpRequestSchema = z.object({
@@ -232,6 +240,22 @@ export const githubChecksSummarySchema = z.object({
   runs: z.array(githubCheckRunSchema),
 });
 export type GithubChecksSummary = z.infer<typeof githubChecksSummarySchema>;
+
+export const githubPrHeadSummarySchema = z.object({
+  number: z.number().int().positive(),
+  url: z.string(),
+  headRefName: z.string(),
+  headRepository: z.string().nullable(),
+  isDraft: z.boolean(),
+  updatedAt: z.string(),
+});
+export type GithubPrHeadSummary = z.infer<typeof githubPrHeadSummarySchema>;
+
+export const githubPrHeadsResponseSchema = z.object({
+  repository: z.string(),
+  prs: z.array(githubPrHeadSummarySchema),
+});
+export type GithubPrHeadsResponse = z.infer<typeof githubPrHeadsResponseSchema>;
 
 export const githubPrSchema = z.object({
   number: z.number().int(),

--- a/packages/contracts/src/domains/git/operations.ts
+++ b/packages/contracts/src/domains/git/operations.ts
@@ -1,5 +1,6 @@
 import {
   createBranchRequestSchema,
+  deleteBranchRequestSchema,
   gitBranchListResponseSchema,
   gitDiscoveryResponseSchema,
   gitFileActionRequestSchema,
@@ -21,6 +22,7 @@ import {
   githubPrFilesResponseSchema,
   githubPrInitialSchema,
   githubPrOverviewSchema,
+  githubPrHeadsResponseSchema,
   githubPrListRequestSchema,
   githubPrListResponseSchema,
   githubPrMergeRequestSchema,
@@ -41,6 +43,9 @@ const gitCreateBranchParamsSchema = projectIdParamsSchema.merge(
 );
 const gitSwitchBranchParamsSchema = projectIdParamsSchema.merge(
   switchBranchRequestSchema,
+);
+const gitDeleteBranchParamsSchema = projectIdParamsSchema.merge(
+  deleteBranchRequestSchema,
 );
 const gitFileActionParamsSchema = projectIdParamsSchema.merge(
   gitFileActionRequestSchema,
@@ -124,6 +129,15 @@ export const gitOperationDefinitions = [
     "recommended",
     ["workbench_server"] as const,
     "operation.git.branch.switch",
+  ),
+  defineOperation(
+    "git.branch.delete",
+    gitDeleteBranchParamsSchema,
+    gitMutationResponseSchema,
+    "mutation",
+    "recommended",
+    ["workbench_server"] as const,
+    "operation.git.branch.delete",
   ),
   defineOperation(
     "git.file.diff.get",
@@ -241,6 +255,15 @@ export const gitOperationDefinitions = [
     "none",
     ["workbench_server"] as const,
     "operation.github.status.get",
+  ),
+  defineOperation(
+    "github.pr.heads.list",
+    gitRepoParamsSchema,
+    githubPrHeadsResponseSchema,
+    "read",
+    "none",
+    ["workbench_server"] as const,
+    "operation.github.pr.heads.list",
   ),
   defineOperation(
     "github.pr.list",

--- a/packages/native/native/src/api/git/mod.rs
+++ b/packages/native/native/src/api/git/mod.rs
@@ -41,6 +41,7 @@ pub struct NativeGitReference {
     pub target: Option<String>,
     pub symbolic_target: Option<String>,
     pub upstream: Option<String>,
+    pub commit_timestamp_seconds: Option<f64>,
 }
 
 #[napi(object)]
@@ -423,6 +424,9 @@ impl From<Snapshot> for NativeGitSnapshot {
                     target: value.target,
                     symbolic_target: value.symbolic_target,
                     upstream: value.upstream,
+                    commit_timestamp_seconds: value
+                        .commit_timestamp_seconds
+                        .map(|timestamp| timestamp as f64),
                 })
                 .collect(),
             remotes: value

--- a/packages/native/native/src/git/model.rs
+++ b/packages/native/native/src/git/model.rs
@@ -49,6 +49,7 @@ pub struct Reference {
     pub target: Option<String>,
     pub symbolic_target: Option<String>,
     pub upstream: Option<String>,
+    pub commit_timestamp_seconds: Option<i64>,
 }
 
 #[derive(Clone, Debug)]

--- a/packages/native/native/src/git/repository.rs
+++ b/packages/native/native/src/git/repository.rs
@@ -96,6 +96,8 @@ fn read_refs(repo: &gix::Repository, limit: usize) -> Result<Vec<Reference>, Git
             ));
         }
         let reference = item.map_err(|error| GitReadError::from_gix("read reference", error))?;
+        let name = reference.name().as_bstr().to_str_lossy().into_owned();
+        let is_branch = name.starts_with("refs/heads/") || name.starts_with("refs/remotes/");
         let upstream = match reference.remote_tracking_ref_name(gix::remote::Direction::Fetch) {
             Some(Ok(name)) => Some(name.shorten().to_str_lossy().into_owned()),
             Some(Err(error)) => {
@@ -103,17 +105,26 @@ fn read_refs(repo: &gix::Repository, limit: usize) -> Result<Vec<Reference>, Git
             }
             None => None,
         };
-        let (target, symbolic_target) = match reference.target() {
-            gix::refs::TargetRef::Object(id) => (Some(id.to_string()), None),
+        let (target, symbolic_target, commit_timestamp_seconds) = match reference.target() {
+            gix::refs::TargetRef::Object(id) => {
+                let commit_timestamp_seconds = is_branch
+                    .then(|| repo.find_object(id).ok())
+                    .flatten()
+                    .and_then(|object| object.try_into_commit().ok())
+                    .and_then(|commit| commit.time().ok())
+                    .map(|time| time.seconds);
+                (Some(id.to_string()), None, commit_timestamp_seconds)
+            }
             gix::refs::TargetRef::Symbolic(name) => {
-                (None, Some(name.as_bstr().to_str_lossy().into_owned()))
+                (None, Some(name.as_bstr().to_str_lossy().into_owned()), None)
             }
         };
         refs.push(Reference {
-            name: reference.name().as_bstr().to_str_lossy().into_owned(),
+            name,
             target,
             symbolic_target,
             upstream,
+            commit_timestamp_seconds,
         });
     }
     refs.sort_by(|left, right| left.name.cmp(&right.name));

--- a/packages/native/src/git/contracts.ts
+++ b/packages/native/src/git/contracts.ts
@@ -38,6 +38,7 @@ export interface NativeGitReference {
   target?: string;
   symbolicTarget?: string;
   upstream?: string;
+  commitTimestampSeconds?: number;
 }
 
 export interface NativeGitRemote {

--- a/packages/native/test/git/git-read.test.ts
+++ b/packages/native/test/git/git-read.test.ts
@@ -46,7 +46,9 @@ describe("native Git reads", () => {
       assert.equal(info.bare, false);
       assert.equal(snapshot.headBranch, "main");
       assert.equal(snapshot.recentCommits[0]?.subject, "initial");
-      assert.ok(snapshot.refs.some((ref) => ref.name === "refs/heads/main"));
+      const main = snapshot.refs.find((ref) => ref.name === "refs/heads/main");
+      assert.ok(main);
+      assert.equal(typeof main.commitTimestampSeconds, "number");
       assert.ok(snapshot.files.some((file) => file.path === "tracked.txt"));
       assert.ok(snapshot.files.some((file) => file.path === "new.txt"));
       assert.equal(

--- a/packages/tools/src/git/git-branches.ts
+++ b/packages/tools/src/git/git-branches.ts
@@ -49,6 +49,10 @@ export async function listBranches(
         current: !remote && name === snapshot.branch.head,
         remote,
         upstream: ref.upstream ?? null,
+        updatedAt:
+          ref.commitTimestampSeconds === undefined
+            ? null
+            : new Date(ref.commitTimestampSeconds * 1_000).toISOString(),
       };
     })
     .filter((branch): branch is GitBranchSummary => branch !== null)

--- a/packages/tools/src/git/git-github-service.ts
+++ b/packages/tools/src/git/git-github-service.ts
@@ -10,6 +10,7 @@ import type {
   GithubPrFileDiffRequest,
   GithubPrFileDiffResponse,
   GithubPrFilesResponse,
+  GithubPrHeadsResponse,
   GithubPrInitial,
   GithubPrListFilters,
   GithubPrListResponse,
@@ -70,6 +71,15 @@ type GithubCommitNodeRaw = {
   authors?: { nodes?: Array<{ name?: string } | null> | null } | null;
   statusCheckRollup?: GithubCheckRollupRaw;
 };
+type GithubPrHeadRaw = {
+  number: number;
+  url: string;
+  headRefName: string;
+  headRepository?: { nameWithOwner?: string } | null;
+  isDraft: boolean;
+  updatedAt: string;
+};
+
 type GithubPrDetailRaw = {
   number: number;
   title: string;
@@ -359,6 +369,77 @@ export async function listOpenPrs(
         : [],
     ),
   };
+}
+
+const PR_HEADS_QUERY = `query PullRequestHeads(
+  $owner: String!
+  $repo: String!
+  $after: String
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(
+      states: OPEN
+      first: 100
+      after: $after
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      nodes {
+        number url headRefName isDraft updatedAt
+        headRepository { nameWithOwner }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}`;
+
+export async function listOpenPrHeads(
+  context: GithubServiceContext,
+  projectId: string,
+  relativePath: string,
+): Promise<GithubPrHeadsResponse> {
+  const { repository } = await preparePr(context, projectId, relativePath);
+  const prs: GithubPrHeadsResponse["prs"] = [];
+  let after: string | null = null;
+  let hasNextPage = true;
+  let pageCount = 0;
+  while (hasNextPage && pageCount < 10) {
+    pageCount += 1;
+    const data: {
+      repository?: {
+        pullRequests?: {
+          nodes?: Array<GithubPrHeadRaw | null> | null;
+          pageInfo?: {
+            hasNextPage?: boolean;
+            endCursor?: string | null;
+          } | null;
+        } | null;
+      } | null;
+    } = await context.githubApi.graphql(
+      repository,
+      "list-pull-request-heads",
+      PR_HEADS_QUERY,
+      {
+        owner: repository.owner,
+        repo: repository.repo,
+        after,
+      },
+    );
+    const connection = data.repository?.pullRequests;
+    for (const raw of connection?.nodes ?? []) {
+      if (!raw) continue;
+      prs.push({
+        number: raw.number,
+        url: raw.url,
+        headRefName: raw.headRefName,
+        headRepository: raw.headRepository?.nameWithOwner ?? null,
+        isDraft: raw.isDraft,
+        updatedAt: raw.updatedAt,
+      });
+    }
+    after = connection?.pageInfo?.endCursor ?? null;
+    hasNextPage = connection?.pageInfo?.hasNextPage === true && after !== null;
+  }
+  return { repository: `${repository.owner}/${repository.repo}`, prs };
 }
 
 export function allowedMergeMethods(raw: GithubRepoRaw): GithubPrMergeMethod[] {

--- a/packages/tools/src/git/git-service.ts
+++ b/packages/tools/src/git/git-service.ts
@@ -15,6 +15,7 @@ import type {
   GithubPrFileDiffRequest,
   GithubPrFileDiffResponse,
   GithubPrFilesResponse,
+  GithubPrHeadsResponse,
   GithubPrInitial,
   GithubPrListFilters,
   GithubPrListResponse,
@@ -63,6 +64,7 @@ import {
   prInitial as getGithubPrInitial,
   prOverview as getGithubPrOverview,
   githubStatus as getGithubStatus,
+  listOpenPrHeads as listGithubOpenPrHeads,
   listOpenPrs as listGithubOpenPrs,
 } from "./git-github-service.js";
 import type {
@@ -529,6 +531,56 @@ export class GitService {
     };
   }
 
+  async deleteBranch(
+    projectId: string,
+    relativePath: string,
+    name: string,
+  ): Promise<GitMutationResponse> {
+    const repoDir = this.resolveRepoDir(projectId, relativePath);
+    const branches = await this.listBranches(projectId, relativePath);
+    const target = branches.branches.find((branch) => branch.name === name);
+    if (!target) {
+      throw new GitWorkflowError(
+        404,
+        "GIT_BRANCH_NOT_FOUND",
+        `Branch '${name}' was not found.`,
+      );
+    }
+    if (target.remote) {
+      throw new GitWorkflowError(
+        400,
+        "GIT_REMOTE_BRANCH_DELETE_UNSUPPORTED",
+        "Only local branches can be deleted.",
+      );
+    }
+    if (target.current) {
+      throw new GitWorkflowError(
+        409,
+        "GIT_CURRENT_BRANCH_DELETE",
+        "Switch to another branch before deleting the current branch.",
+      );
+    }
+    const baseBranch = await this.detectBaseBranch(repoDir);
+    if (name === baseBranch) {
+      throw new GitWorkflowError(
+        409,
+        "GIT_BASE_BRANCH_DELETE",
+        `The base branch '${baseBranch}' cannot be deleted.`,
+      );
+    }
+    await this.mapGit(() =>
+      this.runGit(repoDir, ["branch", "--delete", "--", name]),
+    );
+    this.invalidateStableRepoMetadata(repoDir);
+    return {
+      repo: await this.summarizeRepo(
+        repoDir,
+        relativePath,
+        this.repoName(projectId, relativePath),
+      ),
+    };
+  }
+
   async fileDiff(
     projectId: string,
     relativePath: string,
@@ -896,6 +948,13 @@ export class GitService {
     relativePath: string,
   ): Promise<GithubStatusResponse> {
     return getGithubStatus(this.githubContext(), projectId, relativePath);
+  }
+
+  async listOpenPrHeads(
+    projectId: string,
+    relativePath: string,
+  ): Promise<GithubPrHeadsResponse> {
+    return listGithubOpenPrHeads(this.githubContext(), projectId, relativePath);
   }
 
   async listOpenPrs(

--- a/packages/tools/src/git/read/types.ts
+++ b/packages/tools/src/git/read/types.ts
@@ -13,6 +13,7 @@ export interface GitReadRef {
   target?: string;
   symbolicTarget?: string;
   upstream?: string;
+  commitTimestampSeconds?: number;
 }
 
 export interface GitReadRemote {

--- a/packages/tools/test/git/git-branches.test.ts
+++ b/packages/tools/test/git/git-branches.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  listBranches,
+  type GitBranchServicePort,
+} from "../../src/git/git-branches.js";
+import type { GitReadSnapshot } from "../../src/git/read/types.js";
+
+function snapshot(): GitReadSnapshot {
+  return {
+    headOid: "abc",
+    branch: {
+      head: "main",
+      detached: false,
+      upstream: "origin/main",
+      ahead: 0,
+      behind: 0,
+    },
+    refs: [
+      {
+        name: "refs/heads/main",
+        upstream: "origin/main",
+        commitTimestampSeconds: 1_788_220_800,
+      },
+      { name: "refs/heads/unresolved" },
+      {
+        name: "refs/remotes/origin/feature",
+        commitTimestampSeconds: 1_788_307_200,
+      },
+      { name: "refs/remotes/origin/HEAD", symbolicTarget: "origin/main" },
+      { name: "refs/tags/v1" },
+    ],
+    remotes: [],
+    files: [],
+    recentCommits: [],
+    stashes: [],
+  };
+}
+
+test("lists local and remote branches with nullable tip activity", async () => {
+  const service = {
+    resolveRepoDir: () => "/repo",
+    readSnapshot: async () => snapshot(),
+  } as unknown as GitBranchServicePort;
+
+  const result = await listBranches(service, "proj_test", ".");
+
+  assert.deepEqual(result.branches, [
+    {
+      name: "main",
+      current: true,
+      remote: false,
+      upstream: "origin/main",
+      updatedAt: "2026-09-01T00:00:00.000Z",
+    },
+    {
+      name: "unresolved",
+      current: false,
+      remote: false,
+      upstream: null,
+      updatedAt: null,
+    },
+    {
+      name: "origin/feature",
+      current: false,
+      remote: true,
+      upstream: null,
+      updatedAt: "2026-09-02T00:00:00.000Z",
+    },
+  ]);
+});

--- a/packages/tools/test/git/git-github-service.test.ts
+++ b/packages/tools/test/git/git-github-service.test.ts
@@ -5,6 +5,7 @@ import {
   allowedMergeMethods,
   checkoutPr,
   githubPrSearch,
+  listOpenPrHeads,
   listOpenPrs,
   mergePr,
   prFileDiff,
@@ -125,6 +126,54 @@ describe("GitHub PR listing", () => {
     );
     assert.deepEqual(calls, ["list-pull-requests"]);
     assert.equal(result.prs[0]?.checks.status, "passing");
+  });
+});
+
+describe("GitHub PR head listing", () => {
+  it("paginates lightweight head metadata with repository identity", async () => {
+    const afterValues: unknown[] = [];
+    const result = await listOpenPrHeads(
+      context({
+        graphql: (operation, variables) => {
+          assert.equal(operation, "list-pull-request-heads");
+          afterValues.push(variables.after);
+          const secondPage = variables.after === "next";
+          return {
+            repository: {
+              pullRequests: {
+                nodes: [
+                  {
+                    number: secondPage ? 8 : 7,
+                    url: `https://github.com/example/repo/pull/${secondPage ? 8 : 7}`,
+                    headRefName: secondPage ? "fork-feature" : "feature",
+                    headRepository: {
+                      nameWithOwner: secondPage ? "fork/repo" : "example/repo",
+                    },
+                    isDraft: secondPage,
+                    updatedAt: "2026-07-20T00:00:00Z",
+                  },
+                ],
+                pageInfo: secondPage
+                  ? { hasNextPage: false, endCursor: null }
+                  : { hasNextPage: true, endCursor: "next" },
+              },
+            },
+          };
+        },
+      }),
+      "proj_test",
+      ".",
+    );
+
+    assert.deepEqual(afterValues, [null, "next"]);
+    assert.equal(result.repository, "example/repo");
+    assert.deepEqual(
+      result.prs.map((pr) => [pr.number, pr.headRepository]),
+      [
+        [7, "example/repo"],
+        [8, "fork/repo"],
+      ],
+    );
   });
 });
 

--- a/packages/tools/test/git/git-service-workflows.test.ts
+++ b/packages/tools/test/git/git-service-workflows.test.ts
@@ -171,6 +171,51 @@ describe("GitService dirty-worktree workflows", () => {
     });
   });
 
+  it("deletes only merged, non-protected local branches", async () => {
+    await withFixture(async (fixture) => {
+      await command(fixture.service, fixture.work, "switch", "-c", "merged");
+      await command(fixture.service, fixture.work, "switch", "main");
+
+      await fixture.service.deleteBranch("project", ".", "merged");
+      assert.equal(
+        (await fixture.service.listBranches("project", ".")).branches.some(
+          (branch) => branch.name === "merged",
+        ),
+        false,
+      );
+
+      await command(fixture.service, fixture.work, "switch", "-c", "unmerged");
+      await writeFile(join(fixture.work, "unmerged.txt"), "not merged\n");
+      await command(fixture.service, fixture.work, "add", "unmerged.txt");
+      await command(fixture.service, fixture.work, "commit", "-m", "unmerged");
+      await assert.rejects(
+        fixture.service.deleteBranch("project", ".", "unmerged"),
+        (error: unknown) =>
+          error instanceof GitWorkflowError &&
+          error.code === "GIT_CURRENT_BRANCH_DELETE",
+      );
+      await assert.rejects(
+        fixture.service.deleteBranch("project", ".", "main"),
+        (error: unknown) =>
+          error instanceof GitWorkflowError &&
+          error.code === "GIT_BASE_BRANCH_DELETE",
+      );
+      await command(fixture.service, fixture.work, "switch", "main");
+      await assert.rejects(
+        fixture.service.deleteBranch("project", ".", "origin/main"),
+        (error: unknown) =>
+          error instanceof GitWorkflowError &&
+          error.code === "GIT_REMOTE_BRANCH_DELETE_UNSUPPORTED",
+      );
+      await assert.rejects(
+        fixture.service.deleteBranch("project", ".", "unmerged"),
+        (error: unknown) =>
+          error instanceof GitWorkflowError &&
+          error.code === "GIT_COMMAND_FAILED",
+      );
+    });
+  });
+
   it("lets Git reject an overlapping pull without changing the local file", async () => {
     await withFixture(async (fixture) => {
       await writeFile(join(fixture.work, "shared.txt"), "local version\n");

--- a/packages/workbench-app/src/lib/api.ts
+++ b/packages/workbench-app/src/lib/api.ts
@@ -93,6 +93,8 @@ export type {
   GithubPrFileDiffResponse,
   GithubPrFileStatus,
   GithubPrFilesResponse,
+  GithubPrHeadSummary,
+  GithubPrHeadsResponse,
   GithubPrInitial,
   GithubPrListResponse,
   GithubPrMergeMethod,

--- a/packages/workbench-app/src/lib/features/git/api/git.api.ts
+++ b/packages/workbench-app/src/lib/features/git/api/git.api.ts
@@ -11,6 +11,7 @@ import type {
   GithubPrFileDiffResponse,
   GithubPrFileStatus,
   GithubPrFilesResponse,
+  GithubPrHeadsResponse,
   GithubPrInitial,
   GithubPrListFilters,
   GithubPrListResponse,
@@ -87,6 +88,20 @@ export async function switchGitBranch(
 ): Promise<GitMutationResponse> {
   return (
     await protocolRequest("git.branch.switch", {
+      projectId,
+      repo,
+      name,
+    })
+  ).result;
+}
+
+export async function deleteGitBranch(
+  projectId: string,
+  repo: string,
+  name: string,
+): Promise<GitMutationResponse> {
+  return (
+    await protocolRequest("git.branch.delete", {
       projectId,
       repo,
       name,
@@ -246,6 +261,18 @@ export async function getGithubStatus(
 ): Promise<GithubStatusResponse> {
   return (
     await protocolRequest("github.status.get", {
+      projectId,
+      repo,
+    })
+  ).result;
+}
+
+export async function listGithubPrHeads(
+  projectId: string,
+  repo: string,
+): Promise<GithubPrHeadsResponse> {
+  return (
+    await protocolRequest("github.pr.heads.list", {
       projectId,
       repo,
     })

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-mutations.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-mutations.svelte.ts
@@ -8,6 +8,7 @@ import {
   applyGitStash,
   createGitBranch,
   createGitStash,
+  deleteGitBranch,
   discardGitFile,
   dropGitStash,
   fetchGit,
@@ -26,6 +27,7 @@ import {
 import { notify } from "$lib/application/notifications/notify.svelte";
 import { gitFilesInScope, gitPathspecs } from "$lib/features/git";
 import {
+  refreshBranches,
   refreshGitOverview,
   scheduleAutomaticGitRefresh,
 } from "./git-panel-refresh.svelte";
@@ -157,6 +159,32 @@ export async function switchGitRepoBranch(
     return false;
   } finally {
     state.operations.switchingBranch = undefined;
+  }
+}
+
+export async function deleteGitRepoBranch(
+  projectId: string,
+  repo: string,
+  branch: GitBranchSummary,
+): Promise<boolean> {
+  if (branch.current || branch.remote) return false;
+  const state = ensureGitRepoState(projectId, repo);
+  state.operations.deletingBranch = branch.name;
+  try {
+    const result = await deleteGitBranch(projectId, repo, branch.name);
+    mergeRepoSummary(projectId, result.repo);
+    setBranchesIfChanged(state, []);
+    notify.success(`Deleted branch ${branch.name}`);
+    await Promise.all([
+      refreshBranches(projectId, repo, undefined, true),
+      refreshGitOverview(projectId, repo, { force: true, silent: true }),
+    ]);
+    return true;
+  } catch (error) {
+    notifyGitFailure("Delete branch failed", error);
+    return false;
+  } finally {
+    state.operations.deletingBranch = undefined;
   }
 }
 

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-refresh.svelte.ts
@@ -6,6 +6,7 @@ import {
   getGithubStatus,
   getGitOverview,
   listGitBranches,
+  listGithubPrHeads,
   listGithubPrs,
 } from "$lib/api";
 import {
@@ -40,6 +41,7 @@ import {
   setBranchesIfChanged,
   setGithubStatusIfChanged,
   setProjectRepos,
+  setPrHeadsIfChanged,
   setPrsIfChanged,
   storedRepo,
 } from "./git-panel-state.svelte";
@@ -316,12 +318,15 @@ export async function refreshBranches(
   projectId: string,
   repo: string,
   criticalErrorTitle?: string,
+  force = false,
 ): Promise<void> {
   const state = ensureGitRepoState(projectId, repo);
   state.loadingBranches = true;
   try {
+    const queryKey = queryKeys.git.branches(projectId, repo);
+    if (force) await queryClient.invalidateQueries({ queryKey });
     const result = await queryClient.fetchQuery({
-      queryKey: queryKeys.git.branches(projectId, repo),
+      queryKey,
       queryFn: () => listGitBranches(projectId, repo),
       staleTime: GIT_STALE_MS,
     });
@@ -332,6 +337,34 @@ export async function refreshBranches(
     else notify.error(`Could not list branches: ${details}`);
   } finally {
     state.loadingBranches = false;
+  }
+}
+
+export async function refreshPrHeads(
+  projectId: string,
+  repo: string,
+  force = false,
+): Promise<void> {
+  const state = ensureGitRepoState(projectId, repo);
+  if (!repoHasGithubRemote(projectId, repo) || !state.github?.authenticated) {
+    setPrHeadsIfChanged(state, undefined);
+    return;
+  }
+  state.loadingPrHeads = true;
+  try {
+    const queryKey = queryKeys.git.prHeads(projectId, repo);
+    if (force) await queryClient.invalidateQueries({ queryKey });
+    const result = await queryClient.fetchQuery({
+      queryKey,
+      queryFn: () => listGithubPrHeads(projectId, repo),
+      staleTime: GIT_STALE_MS,
+    });
+    setPrHeadsIfChanged(state, result);
+  } catch {
+    // Pull request badges are optional enrichment and must not block branches.
+    setPrHeadsIfChanged(state, undefined);
+  } finally {
+    state.loadingPrHeads = false;
   }
 }
 

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-slices.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-slices.ts
@@ -2,6 +2,7 @@ import { prSummaryFingerprint } from "./pr-sync";
 import type {
   GitBranchSummary,
   GithubPr,
+  GithubPrHeadsResponse,
   GithubStatusResponse,
   GitOverviewResponse,
   GitRecentCommit,
@@ -101,8 +102,16 @@ export function branchesFingerprint(branches: GitBranchSummary[]): string {
       current: branch.current,
       remote: branch.remote,
       upstream: branch.upstream,
+      updatedAt: branch.updatedAt,
     })),
   );
+}
+
+export function prHeadsFingerprint(
+  result: GithubPrHeadsResponse | undefined,
+): string | undefined {
+  if (!result) return undefined;
+  return JSON.stringify(result);
 }
 
 export function githubStatusFingerprint(

--- a/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/git-panel-state.svelte.ts
@@ -4,6 +4,7 @@ import type {
   GithubChecksSummary,
   GithubPr,
   GithubPrCore,
+  GithubPrHeadsResponse,
   GithubStatusResponse,
   GitOverviewResponse,
   GitRecentCommit,
@@ -37,6 +38,7 @@ import {
   type GitChangesState,
   githubStatusFingerprint,
   prsFingerprint,
+  prHeadsFingerprint,
   recentCommitsFingerprint,
   repoSummaryFingerprint,
   stashesFingerprint,
@@ -55,6 +57,7 @@ export type GitPanelOperationsState = {
   syncing: boolean;
   switchingBaseAndPulling: boolean;
   switchingBranch?: string;
+  deletingBranch?: string;
   creatingBranch: boolean;
   fileMutation?: FileMutation;
   bulkMutation?: ScopedFileMutation;
@@ -70,12 +73,14 @@ export type GitPanelRepoState = {
   stashes: GitStashEntry[];
   github?: GithubStatusResponse;
   prs: GithubPr[];
+  prHeads?: GithubPrHeadsResponse;
   prFilters: GitPrFilterConfig;
   branches: GitBranchSummary[];
   collapsedChangeTreeFolders: SvelteSet<string>;
   operations: GitPanelOperationsState;
   loadingOverview: boolean;
   loadingPrs: boolean;
+  loadingPrHeads: boolean;
   prsError?: string;
   loadingBranches: boolean;
   prsRequestInFlight: boolean;
@@ -91,6 +96,7 @@ export type GitPanelRepoState = {
   lastStashesFingerprint?: string;
   lastBranchesFingerprint?: string;
   lastPrsFingerprint?: string;
+  lastPrHeadsFingerprint?: string;
   lastGithubFingerprint?: string;
   loaded: boolean;
   loadedAt?: number;
@@ -169,6 +175,7 @@ function createOperationsState(): GitPanelOperationsState {
     syncing: false,
     switchingBaseAndPulling: false,
     switchingBranch: undefined,
+    deletingBranch: undefined,
     creatingBranch: false,
     fileMutation: undefined,
     bulkMutation: undefined,
@@ -184,6 +191,7 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     stashes: [],
     github: undefined,
     prs: [],
+    prHeads: undefined,
     prFilters:
       projectId && repo
         ? storedPrFilters(projectId, repo)
@@ -195,6 +203,7 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     operations: createOperationsState(),
     loadingOverview: false,
     loadingPrs: false,
+    loadingPrHeads: false,
     prsError: undefined,
     loadingBranches: false,
     prsRequestInFlight: false,
@@ -210,6 +219,7 @@ function createRepoState(projectId?: string, repo?: string): GitPanelRepoState {
     lastStashesFingerprint: undefined,
     lastBranchesFingerprint: undefined,
     lastPrsFingerprint: undefined,
+    lastPrHeadsFingerprint: undefined,
     lastGithubFingerprint: undefined,
     loaded: false,
     loadedAt: undefined,
@@ -373,6 +383,7 @@ export function repoMutationInProgress(
       operations.switchingBaseAndPulling ||
       operations.creatingBranch ||
       operations.switchingBranch ||
+      operations.deletingBranch ||
       operations.fileMutation ||
       operations.bulkMutation ||
       operations.stashMutation),
@@ -481,6 +492,17 @@ export function setGithubStatusIfChanged(
   if (state.lastGithubFingerprint === fingerprint) return false;
   state.github = github;
   state.lastGithubFingerprint = fingerprint;
+  return true;
+}
+
+export function setPrHeadsIfChanged(
+  state: GitPanelRepoState,
+  result: GithubPrHeadsResponse | undefined,
+): boolean {
+  const fingerprint = prHeadsFingerprint(result);
+  if (state.lastPrHeadsFingerprint === fingerprint) return false;
+  state.prHeads = result;
+  state.lastPrHeadsFingerprint = fingerprint;
   return true;
 }
 
@@ -651,6 +673,18 @@ export function clearGithubState(
   if (state.github !== undefined || state.lastGithubFingerprint !== undefined) {
     state.github = undefined;
     state.lastGithubFingerprint = undefined;
+    changed = true;
+  }
+  if (
+    state.prHeads !== undefined ||
+    state.lastPrHeadsFingerprint !== undefined
+  ) {
+    state.prHeads = undefined;
+    state.lastPrHeadsFingerprint = undefined;
+    changed = true;
+  }
+  if (state.loadingPrHeads) {
+    state.loadingPrHeads = false;
     changed = true;
   }
   const emptyPrsFingerprint = prsFingerprint([]);

--- a/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
+++ b/packages/workbench-app/src/lib/features/git/state/workbench-git-panel-adapter.svelte.ts
@@ -25,6 +25,7 @@ import {
   autoRefreshPrsIfStale,
   createGitRepoBranch,
   createGitRepoStash,
+  deleteGitRepoBranch,
   fetchGitRepo,
   dropGitRepoStash,
   gitPanelState,
@@ -37,6 +38,7 @@ import {
   refreshGithub,
   refreshGitOverview,
   refreshGitProject,
+  refreshPrHeads,
   refreshPrs,
   selectGitProject,
   setGitChangeTreeFolderExpanded,
@@ -119,6 +121,7 @@ export function createWorkbenchGitPanelAdapter(
         stashes: current?.stashes ?? [],
         github: current?.github,
         pullRequests: current?.prs ?? [],
+        prHeads: current?.prHeads,
         pullRequestFilters: current?.prFilters ?? defaultGitPrFilterConfig,
         initialLoading:
           Boolean(project && !projectState) ||
@@ -138,6 +141,7 @@ export function createWorkbenchGitPanelAdapter(
         loadingOverview: current?.loadingOverview ?? false,
         loadingBranches: current?.loadingBranches ?? false,
         loadingPullRequests: current?.loadingPrs ?? false,
+        loadingPrHeads: current?.loadingPrHeads ?? false,
         pullRequestError: current?.prsError,
         operations: current?.operations ?? {
           fetching: false,
@@ -185,7 +189,12 @@ export function createWorkbenchGitPanelAdapter(
           project.id,
           repository,
           "Could not refresh branches",
+          true,
         );
+    },
+    refreshPrHeads: (repository) => {
+      const project = activeProject();
+      if (project) return refreshPrHeads(project.id, repository);
     },
     refreshPullRequests: async (repository) => {
       const project = activeProject();
@@ -255,6 +264,12 @@ export function createWorkbenchGitPanelAdapter(
       const project = activeProject();
       return project
         ? switchGitRepoBranch(project.id, repository, branch)
+        : false;
+    },
+    deleteBranch: (repository, branch) => {
+      const project = activeProject();
+      return project
+        ? deleteGitRepoBranch(project.id, repository, branch)
         : false;
     },
     openDiff: (repository, file, area) => {

--- a/packages/workbench-app/src/lib/features/git/views/GitBranchDialog.svelte
+++ b/packages/workbench-app/src/lib/features/git/views/GitBranchDialog.svelte
@@ -1,29 +1,38 @@
 <script lang="ts">
-import Check from "@lucide/svelte/icons/check";
+import Cloud from "@lucide/svelte/icons/cloud";
 import GitBranch from "@lucide/svelte/icons/git-branch";
-import Info from "@lucide/svelte/icons/info";
 import GitBranchPlus from "@lucide/svelte/icons/git-branch-plus";
+import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import type { GitBranchSummary, GitRepoSummary } from "@nervekit/contracts/git";
-import { Badge } from "@nervekit/ui-kit/components/ui/badge";
 import SearchInput from "@nervekit/ui-kit/components/composites/search-input";
-import { Button } from "@nervekit/ui-kit/components/ui/button";
+import ConfirmDialog from "@nervekit/ui-kit/components/composites/confirm-dialog";
 import Dialog from "@nervekit/ui-kit/components/composites/dialog-shell";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
 import { Input } from "@nervekit/ui-kit/components/ui/input";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import GitBranchRow from "./GitBranchRow.svelte";
+import type { GitBranchDialogGroups } from "./git-panel-controller";
 
 type Props = {
   open?: boolean;
   repoSummary: GitRepoSummary;
   selectedRepo: string;
-  filteredBranches: GitBranchSummary[];
-  baseBranchSummary?: GitBranchSummary;
+  branchGroups: GitBranchDialogGroups;
   loadingBranches: boolean;
+  loadingPrHeads: boolean;
   switchingBranch?: string;
+  deletingBranch?: string;
   creatingBranch: boolean;
   branchesEnabled: boolean;
   branchFilter?: string;
   newBranchName?: string;
   onSwitchBranch: (repo: string, branch: GitBranchSummary) => void;
+  onDeleteBranch: (
+    repo: string,
+    branch: GitBranchSummary,
+  ) => boolean | Promise<boolean>;
+  onOpenPullRequest: (repo: string, number: number) => void;
+  onRefreshBranches: () => void;
   onCreateBranch: (repo: string) => void;
 };
 
@@ -31,25 +40,34 @@ let {
   open = $bindable(false),
   repoSummary,
   selectedRepo,
-  filteredBranches,
-  baseBranchSummary,
+  branchGroups,
   loadingBranches,
+  loadingPrHeads,
   switchingBranch,
+  deletingBranch,
   creatingBranch,
   branchesEnabled,
   branchFilter = $bindable(""),
   newBranchName = $bindable(""),
   onSwitchBranch,
+  onDeleteBranch,
+  onOpenPullRequest,
+  onRefreshBranches,
   onCreateBranch,
 }: Props = $props();
 
 let view = $state<"switch" | "create">("switch");
+let showRemoteBranches = $state(false);
+let deleteCandidate = $state<GitBranchSummary>();
+let searchInput = $state<HTMLInputElement | null>(null);
 
 const currentBranchLabel = $derived(repoSummary.currentBranch ?? "detached");
-const baseBranch = $derived(repoSummary.baseBranch);
-const showBaseQuickSwitch = $derived(
-  !repoSummary.detached && Boolean(baseBranch),
+const visibleBranches = $derived(
+  showRemoteBranches
+    ? branchGroups.all
+    : branchGroups.all.filter(({ branch }) => !branch.remote),
 );
+const resultCount = $derived(visibleBranches.length);
 
 // A light client-side guard so the Create button stays disabled for obviously
 // invalid names; git check-ref-format performs the authoritative validation.
@@ -73,104 +91,110 @@ const dialogDescription = $derived(
     ? `Current branch: ${currentBranchLabel}`
     : `Create from: ${currentBranchLabel}`,
 );
+
+$effect(() => {
+  if (!open || view !== "switch") return;
+  queueMicrotask(() => searchInput?.focus());
+});
+
+async function confirmDelete(): Promise<void> {
+  const branch = deleteCandidate;
+  deleteCandidate = undefined;
+  if (branch) await onDeleteBranch(selectedRepo, branch);
+}
+
+function openPullRequest(number: number): void {
+  open = false;
+  onOpenPullRequest(selectedRepo, number);
+}
 </script>
 
 <Dialog
   bind:open
   title={dialogTitle}
   description={dialogDescription}
-  size="sm"
+  size="md"
   onOpenChange={(next) => {
-    if (!next) view = "switch";
+    if (!next) {
+      view = "switch";
+      deleteCandidate = undefined;
+    }
   }}
 >
   {#if view === "switch"}
-    <div class="grid gap-4">
-      {#if repoSummary.dirty}
-        <div
-          class="flex items-start gap-2 rounded-md border border-info/40 bg-info/10 px-3 py-2 text-xs text-muted-foreground"
+    <div class="grid gap-3">
+      <div class="flex min-w-0 flex-wrap items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon-sm"
+          disabled={loadingBranches}
+          ariaLabel="Refresh branches"
+          title="Refresh branches"
+          onclick={onRefreshBranches}
         >
-          <Info class="mt-0.5 size-3.5 shrink-0 text-info" />
-          <p>
-            Local changes move with a compatible switch. Git will stop if the
-            target branch would overwrite them.
-          </p>
-        </div>
-      {/if}
-
-      {#if showBaseQuickSwitch}
-        <div
-          class="flex items-center gap-2 rounded-md border border-info/40 bg-info/10 px-3 py-2"
-        >
-          <GitBranch size={14} class="shrink-0 text-info" />
-          <div class="flex min-w-0 flex-1 flex-col">
-            <span class="text-xs font-medium text-foreground">Base branch</span>
-            <span class="truncate font-mono text-xs text-muted-foreground"
-              >{baseBranch}</span
-            >
-          </div>
-          {#if repoSummary.onBaseBranch}
-            <span class="text-xs text-muted-foreground">You're here</span>
-          {:else if baseBranchSummary}
-            <Button
-              size="xs"
-              disabled={!branchesEnabled ||
-                switchingBranch === baseBranchSummary.name}
-              onclick={() => onSwitchBranch(selectedRepo, baseBranchSummary)}
-            >
-              {#if switchingBranch === baseBranchSummary.name}
-                <Spinner class="size-3" />
-              {:else}
-                <GitBranch />
-              {/if}
-              Switch to base
-            </Button>
+          {#if loadingBranches}
+            <Spinner class="size-3.5" />
+          {:else}
+            <RefreshCw class="size-3.5" aria-hidden="true" />
           {/if}
-        </div>
-      {/if}
-
-      <SearchInput
-        bind:value={branchFilter}
-        placeholder="Filter branches"
-        ariaLabel="Filter branches"
-      />
-
-      <div class="max-h-72 overflow-y-auto rounded-md border">
-        {#if loadingBranches}
-          <div
-            class="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground"
+        </Button>
+        <Button
+          variant={showRemoteBranches ? "default" : "outline"}
+          size="icon-sm"
+          pressed={showRemoteBranches}
+          ariaLabel={showRemoteBranches
+            ? "Hide remote branches"
+            : "Show remote branches"}
+          title={showRemoteBranches
+            ? "Hide remote branches"
+            : "Show remote branches"}
+          onclick={() => (showRemoteBranches = !showRemoteBranches)}
+        >
+          <Cloud class="size-3.5" aria-hidden="true" />
+        </Button>
+        <SearchInput
+          bind:ref={searchInput}
+          bind:value={branchFilter}
+          placeholder="Search branches or PRs"
+          ariaLabel="Search branches or pull requests"
+          size="sm"
+          class="min-w-48 flex-1"
+        />
+        {#if loadingPrHeads && !loadingBranches}
+          <span
+            class="flex size-8 items-center justify-center"
+            title="Loading pull request links"
           >
-            <Spinner class="size-3.5" /> Loading branches…
+            <Spinner class="size-3.5 text-muted-foreground" />
+          </span>
+        {/if}
+      </div>
+
+      <div class="max-h-[60vh] overflow-y-auto rounded-md border">
+        {#if loadingBranches && resultCount === 0}
+          <div
+            class="flex items-center justify-center gap-2 px-3 py-10 text-sm text-muted-foreground"
+          >
+            <Spinner class="size-4" /> Loading branches…
           </div>
-        {:else if filteredBranches.length === 0}
-          <div class="px-3 py-2 text-xs text-muted-foreground">
-            No branches found.
+        {:else if resultCount === 0}
+          <div class="px-3 py-10 text-center text-sm text-muted-foreground">
+            {branchFilter.trim()
+              ? `No branches match “${branchFilter.trim()}”.`
+              : "No branches found."}
           </div>
         {:else}
-          {#each filteredBranches as branch (branch.name)}
-            <button
-              type="button"
-              class="flex w-full items-center gap-2 border-b px-2.5 py-1.5 text-left text-xs last:border-b-0 hover:bg-muted/60 disabled:opacity-60"
-              disabled={branch.current || switchingBranch === branch.name}
-              onclick={() => onSwitchBranch(selectedRepo, branch)}
-            >
-              {#if switchingBranch === branch.name}
-                <Spinner class="text-muted-foreground size-3.5" />
-              {:else if branch.current}
-                <Check size={13} class="text-success" />
-              {:else}
-                <GitBranch size={13} class="text-muted-foreground" />
-              {/if}
-              <span class="min-w-0 flex-1 truncate font-mono text-foreground"
-                >{branch.name}</span
-              >
-              {#if branch.name === baseBranch}
-                <Badge tone="running" size="xs">base</Badge>
-              {/if}
-              {#if branch.remote}
-                <Badge tone="neutral" size="xs">remote</Badge>
-              {/if}
-            </button>
+          {#each visibleBranches as row (row.branch.name)}
+            <GitBranchRow
+              {row}
+              baseBranch={repoSummary.baseBranch}
+              enabled={branchesEnabled}
+              switching={switchingBranch === row.branch.name}
+              deleting={deletingBranch === row.branch.name}
+              onSwitch={(branch) => onSwitchBranch(selectedRepo, branch)}
+              onDelete={(branch) => (deleteCandidate = branch)}
+              onOpenPullRequest={openPullRequest}
+            />
           {/each}
         {/if}
       </div>
@@ -205,9 +229,10 @@ const dialogDescription = $derived(
 
   {#snippet footer()}
     {#if view === "switch"}
-      <Button size="sm" variant="ghost" onclick={() => (open = false)}
-        >Close</Button
-      >
+      <span class="mr-auto text-xs text-muted-foreground tabular-nums">
+        {resultCount}
+        {resultCount === 1 ? "result" : "results"}
+      </span>
       <Button
         size="sm"
         disabled={!branchesEnabled}
@@ -234,3 +259,17 @@ const dialogDescription = $derived(
     {/if}
   {/snippet}
 </Dialog>
+
+<ConfirmDialog
+  open={deleteCandidate !== undefined}
+  title="Delete local branch?"
+  description={deleteCandidate
+    ? `Delete “${deleteCandidate.name}”? Git will only delete it if it is fully merged.`
+    : undefined}
+  confirmLabel="Delete branch"
+  destructive
+  onOpenChange={(next) => {
+    if (!next) deleteCandidate = undefined;
+  }}
+  onConfirm={() => void confirmDelete()}
+/>

--- a/packages/workbench-app/src/lib/features/git/views/GitBranchRow.svelte
+++ b/packages/workbench-app/src/lib/features/git/views/GitBranchRow.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+import Check from "@lucide/svelte/icons/check";
+import GitBranch from "@lucide/svelte/icons/git-branch";
+import GitPullRequest from "@lucide/svelte/icons/git-pull-request";
+import Trash2 from "@lucide/svelte/icons/trash-2";
+import type { GitBranchSummary } from "@nervekit/contracts/git";
+import { Badge } from "@nervekit/ui-kit/components/ui/badge";
+import { Button } from "@nervekit/ui-kit/components/ui/button";
+import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
+import type { GitBranchDialogRow } from "./git-panel-controller";
+
+type Props = {
+  row: GitBranchDialogRow;
+  baseBranch?: string;
+  enabled: boolean;
+  switching: boolean;
+  deleting: boolean;
+  onSwitch: (branch: GitBranchSummary) => void;
+  onDelete: (branch: GitBranchSummary) => void;
+  onOpenPullRequest: (number: number) => void;
+};
+
+let {
+  row,
+  baseBranch,
+  enabled,
+  switching,
+  deleting,
+  onSwitch,
+  onDelete,
+  onOpenPullRequest,
+}: Props = $props();
+
+const branch = $derived(row.branch);
+const isBase = $derived(!branch.remote && branch.name === baseBranch);
+const canDelete = $derived(
+  enabled && !branch.remote && !branch.current && !isBase,
+);
+</script>
+
+<div
+  class="group flex min-w-0 items-center border-b last:border-b-0 hover:bg-muted/50"
+>
+  <button
+    type="button"
+    class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 px-3 py-1.5 text-left disabled:cursor-default"
+    disabled={!enabled || branch.current || switching || deleting}
+    aria-label={branch.current
+      ? `${branch.name}, current branch`
+      : `Switch to ${branch.name}`}
+    onclick={() => onSwitch(branch)}
+  >
+    {#if switching}
+      <Spinner class="size-3.5 text-muted-foreground" />
+    {:else if branch.current}
+      <Check class="size-3.5 text-success" aria-hidden="true" />
+    {:else}
+      <GitBranch class="size-3.5 text-muted-foreground" aria-hidden="true" />
+    {/if}
+    <span class="flex min-w-0 flex-1 items-center gap-2">
+      <span class="truncate font-mono text-xs text-foreground"
+        >{branch.name}</span
+      >
+      <span
+        class="shrink-0 text-xs text-muted-foreground"
+        title={branch.updatedAt ?? undefined}>{row.updatedLabel}</span
+      >
+    </span>
+  </button>
+
+  <div class="flex shrink-0 items-center gap-1 pr-2">
+    {#if branch.current}
+      <Badge tone="good" size="xs">current</Badge>
+    {/if}
+    {#if isBase}
+      <Badge tone="running" size="xs">base</Badge>
+    {/if}
+    {#if row.pullRequest}
+      <Button
+        variant="link"
+        size="xs"
+        class="h-5 px-1"
+        title={`Open pull request #${row.pullRequest.number}${row.pullRequest.isDraft ? " (draft)" : ""}`}
+        ariaLabel={`Open pull request #${row.pullRequest.number}`}
+        onclick={() => onOpenPullRequest(row.pullRequest!.number)}
+      >
+        <GitPullRequest class="size-3" aria-hidden="true" />
+        #{row.pullRequest.number}{row.pullRequest.isDraft ? " draft" : ""}
+      </Button>
+    {/if}
+    {#if deleting}
+      <span
+        class="flex size-6 items-center justify-center"
+        title="Deleting branch"
+      >
+        <Spinner class="size-3.5 text-muted-foreground" />
+      </span>
+    {:else}
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+        disabled={!canDelete}
+        ariaLabel={`Delete branch ${branch.name}`}
+        title={branch.remote
+          ? "Remote branches cannot be deleted here"
+          : branch.current
+            ? "Switch branches before deleting"
+            : isBase
+              ? "The base branch cannot be deleted"
+              : "Delete branch"}
+        onclick={() => onDelete(branch)}
+      >
+        <Trash2 class="size-3.5" aria-hidden="true" />
+      </Button>
+    {/if}
+  </div>
+</div>

--- a/packages/workbench-app/src/lib/features/git/views/GitPanel.svelte
+++ b/packages/workbench-app/src/lib/features/git/views/GitPanel.svelte
@@ -17,7 +17,7 @@ import GitPanelBanner from "./GitPanelBanner.svelte";
 import GitRepositoryControls from "./GitRepositoryControls.svelte";
 import GitStashDialog from "./GitStashDialog.svelte";
 import {
-  filterAndSortBranches,
+  groupBranchesForDialog,
   gitFileGroups,
   gitFilesInScope,
 } from "./git-panel-controller.js";
@@ -62,16 +62,12 @@ let discardCandidate = $state<
 
 const fileGroups = $derived(gitFileGroups(model.changes?.files ?? []));
 const changeCount = $derived(model.changes?.files.length ?? 0);
-const filteredBranches = $derived(
-  filterAndSortBranches(
+const branchGroups = $derived(
+  groupBranchesForDialog(
     model.branches,
     branchFilter,
     model.repositorySummary?.baseBranch,
-  ),
-);
-const baseBranchSummary = $derived(
-  model.branches.find(
-    (branch) => branch.name === model.repositorySummary?.baseBranch,
+    model.prHeads,
   ),
 );
 const remoteBusy = $derived(
@@ -103,6 +99,13 @@ async function switchBranch(
   resetRepositoryUi();
 }
 
+async function deleteBranch(
+  repository: string,
+  branch: (typeof model.branches)[number],
+): Promise<boolean> {
+  return (await actions.deleteBranch(repository, branch)) !== false;
+}
+
 async function createBranch(repository: string): Promise<void> {
   const name = newBranchName.trim();
   if (!name) return;
@@ -112,10 +115,17 @@ async function createBranch(repository: string): Promise<void> {
   resetRepositoryUi();
 }
 
+function refreshBranchDialog(): void {
+  void Promise.all([
+    actions.refreshBranches(model.selectedRepository),
+    actions.refreshPrHeads(model.selectedRepository),
+  ]);
+}
+
 function openBranchDialog(): void {
   branchDialogOpen = true;
   resetRepositoryUi();
-  void actions.refreshBranches(model.selectedRepository);
+  refreshBranchDialog();
 }
 </script>
 
@@ -140,19 +150,24 @@ function openBranchDialog(): void {
       repoSummary={model.repositorySummary}
       repos={[...model.repositories]}
       selectedRepo={model.selectedRepository}
-      {filteredBranches}
+      {branchGroups}
       loadingBranches={model.loadingBranches}
+      loadingPrHeads={model.loadingPrHeads}
       switchingBranch={model.operations.switchingBranch}
+      deletingBranch={model.operations.deletingBranch}
       creatingBranch={model.operations.creatingBranch}
       capabilities={model.capabilities}
       bind:branchFilter
       bind:newBranchName
       bind:branchDialogOpen
-      {baseBranchSummary}
       onSelectRepo={selectRepository}
       onOpenBranchDialog={openBranchDialog}
       onSwitchBranch={(repository, branch) =>
         void switchBranch(repository, branch)}
+      onDeleteBranch={deleteBranch}
+      onOpenPullRequest={(repository, number) =>
+        void actions.openPullRequest(repository, number)}
+      onRefreshBranches={refreshBranchDialog}
       onCreateBranch={(repository) => void createBranch(repository)}
     />
 

--- a/packages/workbench-app/src/lib/features/git/views/GitRepositoryControls.svelte
+++ b/packages/workbench-app/src/lib/features/git/views/GitRepositoryControls.svelte
@@ -3,6 +3,7 @@ import ChevronDown from "@lucide/svelte/icons/chevron-down";
 import GitBranch from "@lucide/svelte/icons/git-branch";
 import type { GitBranchSummary, GitRepoSummary } from "@nervekit/contracts/git";
 import { cn } from "@nervekit/ui-kit/utils";
+import type { GitBranchDialogGroups } from "./git-panel-controller";
 import type { GitPanelCapabilities } from "./git-panel-types";
 import GitBranchDialog from "./GitBranchDialog.svelte";
 import GitRepositorySelector from "./GitRepositorySelector.svelte";
@@ -11,18 +12,25 @@ type Props = {
   repoSummary?: GitRepoSummary;
   repos: GitRepoSummary[];
   selectedRepo: string;
-  filteredBranches: GitBranchSummary[];
+  branchGroups: GitBranchDialogGroups;
   loadingBranches: boolean;
+  loadingPrHeads: boolean;
   switchingBranch?: string;
+  deletingBranch?: string;
   creatingBranch: boolean;
   capabilities: GitPanelCapabilities;
   branchFilter?: string;
   newBranchName?: string;
   branchDialogOpen?: boolean;
-  baseBranchSummary?: GitBranchSummary;
   onSelectRepo: (value: string) => void;
   onOpenBranchDialog: () => void;
   onSwitchBranch: (repo: string, branch: GitBranchSummary) => void;
+  onDeleteBranch: (
+    repo: string,
+    branch: GitBranchSummary,
+  ) => boolean | Promise<boolean>;
+  onOpenPullRequest: (repo: string, number: number) => void;
+  onRefreshBranches: () => void;
   onCreateBranch: (repo: string) => void;
 };
 
@@ -30,18 +38,22 @@ let {
   repoSummary,
   repos,
   selectedRepo,
-  filteredBranches,
+  branchGroups,
   loadingBranches,
+  loadingPrHeads,
   switchingBranch,
+  deletingBranch,
   creatingBranch,
   capabilities,
   branchFilter = $bindable(""),
   newBranchName = $bindable(""),
   branchDialogOpen = $bindable(false),
-  baseBranchSummary,
   onSelectRepo,
   onOpenBranchDialog,
   onSwitchBranch,
+  onDeleteBranch,
+  onOpenPullRequest,
+  onRefreshBranches,
   onCreateBranch,
 }: Props = $props();
 </script>
@@ -88,15 +100,19 @@ let {
       bind:open={branchDialogOpen}
       repoSummary={repo}
       {selectedRepo}
-      {filteredBranches}
-      {baseBranchSummary}
+      {branchGroups}
       {loadingBranches}
+      {loadingPrHeads}
       {switchingBranch}
+      {deletingBranch}
       {creatingBranch}
       branchesEnabled={capabilities.branches.enabled}
       bind:branchFilter
       bind:newBranchName
       {onSwitchBranch}
+      {onDeleteBranch}
+      {onOpenPullRequest}
+      {onRefreshBranches}
       {onCreateBranch}
     />
   {/if}

--- a/packages/workbench-app/src/lib/features/git/views/git-panel-controller.test.ts
+++ b/packages/workbench-app/src/lib/features/git/views/git-panel-controller.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { GitFileChange } from "@nervekit/contracts/git";
+import type {
+  GitBranchSummary,
+  GitFileChange,
+  GithubPrHeadsResponse,
+} from "@nervekit/contracts/git";
 import { buildPanelTree } from "$lib/presentation/panels/panel-tree";
 import {
   gitChangeTreeFolderKey,
   gitExpandedGroupIds,
   gitFilesInScope,
   gitPathspecs,
+  groupBranchesForDialog,
 } from "./git-panel-controller.js";
 
 function change(
@@ -22,6 +27,111 @@ function change(
     ...options,
   };
 }
+
+function branch(
+  name: string,
+  options: Partial<GitBranchSummary> = {},
+): GitBranchSummary {
+  return {
+    name,
+    current: false,
+    remote: false,
+    upstream: null,
+    updatedAt: null,
+    ...options,
+  };
+}
+
+const prHeads: GithubPrHeadsResponse = {
+  repository: "example/repo",
+  prs: [
+    {
+      number: 42,
+      url: "https://github.com/example/repo/pull/42",
+      headRefName: "feature/recent",
+      headRepository: "example/repo",
+      isDraft: false,
+      updatedAt: "2026-09-01T12:00:00.000Z",
+    },
+    {
+      number: 99,
+      url: "https://github.com/fork/repo/pull/99",
+      headRefName: "collision",
+      headRepository: "fork/repo",
+      isDraft: true,
+      updatedAt: "2026-09-02T12:00:00.000Z",
+    },
+  ],
+};
+
+test("groups branches and pins current and base before recent activity", () => {
+  const groups = groupBranchesForDialog(
+    [
+      branch("old", { updatedAt: "2025-01-01T00:00:00.000Z" }),
+      branch("main", { updatedAt: "2024-01-01T00:00:00.000Z" }),
+      branch("feature/recent", {
+        updatedAt: "2026-09-01T00:00:00.000Z",
+      }),
+      branch("working", {
+        current: true,
+        updatedAt: "2023-01-01T00:00:00.000Z",
+      }),
+      branch("origin/old", {
+        remote: true,
+        updatedAt: "2025-01-01T00:00:00.000Z",
+      }),
+      branch("origin/new", {
+        remote: true,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      }),
+      branch("undated"),
+    ],
+    "",
+    "main",
+    prHeads,
+    Date.parse("2026-09-04T00:00:00.000Z"),
+  );
+
+  assert.deepEqual(
+    groups.local.map((row) => row.branch.name),
+    ["working", "main", "feature/recent", "old", "undated"],
+  );
+  assert.deepEqual(
+    groups.remote.map((row) => row.branch.name),
+    ["origin/new", "origin/old"],
+  );
+  assert.equal(groups.local[2]?.pullRequest?.number, 42);
+  assert.equal(groups.local[2]?.updatedLabel, "Updated 3d ago");
+});
+
+test("filters branches by name, upstream, and pull request number", () => {
+  const branches = [
+    branch("feature/recent", { upstream: "origin/feature/recent" }),
+    branch("collision"),
+  ];
+
+  assert.deepEqual(
+    groupBranchesForDialog(
+      branches,
+      "origin/feature",
+      undefined,
+      prHeads,
+    ).local.map((row) => row.branch.name),
+    ["feature/recent"],
+  );
+  assert.deepEqual(
+    groupBranchesForDialog(branches, "#42", undefined, prHeads).local.map(
+      (row) => row.branch.name,
+    ),
+    ["feature/recent"],
+  );
+  assert.equal(
+    groupBranchesForDialog(branches, "", undefined, prHeads).local.find(
+      (row) => row.branch.name === "collision",
+    )?.pullRequest,
+    undefined,
+  );
+});
 
 test("selects staged and unstaged changes independently", () => {
   const files = [

--- a/packages/workbench-app/src/lib/features/git/views/git-panel-controller.ts
+++ b/packages/workbench-app/src/lib/features/git/views/git-panel-controller.ts
@@ -2,6 +2,8 @@ import type {
   GitBranchSummary,
   GitFileChange,
   GithubPr,
+  GithubPrHeadSummary,
+  GithubPrHeadsResponse,
   GitStashArea,
 } from "@nervekit/contracts/git";
 import type {
@@ -66,21 +68,104 @@ export function gitExpandedGroupIds<T>(
   );
 }
 
-export function filterAndSortBranches(
+export type GitBranchDialogRow = {
+  readonly branch: GitBranchSummary;
+  readonly pullRequest?: GithubPrHeadSummary;
+  readonly updatedLabel: string;
+};
+
+export type GitBranchDialogGroups = {
+  readonly all: GitBranchDialogRow[];
+  readonly local: GitBranchDialogRow[];
+  readonly remote: GitBranchDialogRow[];
+};
+
+function branchHeadName(branch: GitBranchSummary): string {
+  if (!branch.remote) return branch.name;
+  const separator = branch.name.indexOf("/");
+  return separator === -1 ? branch.name : branch.name.slice(separator + 1);
+}
+
+function branchTimestamp(branch: GitBranchSummary): number {
+  if (!branch.updatedAt) return Number.NEGATIVE_INFINITY;
+  const timestamp = Date.parse(branch.updatedAt);
+  return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+}
+
+export function formatBranchUpdatedLabel(
+  updatedAt: string | null,
+  now = Date.now(),
+): string {
+  if (!updatedAt) return "Update time unavailable";
+  const timestamp = Date.parse(updatedAt);
+  if (Number.isNaN(timestamp)) return "Update time unavailable";
+  const seconds = Math.max(0, Math.floor((now - timestamp) / 1_000));
+  if (seconds < 60) return "Updated just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `Updated ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `Updated ${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `Updated ${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `Updated ${months}mo ago`;
+  return `Updated ${Math.floor(months / 12)}y ago`;
+}
+
+export function groupBranchesForDialog(
   branches: readonly GitBranchSummary[],
   filter: string,
   baseBranch?: string,
-): GitBranchSummary[] {
+  prHeads?: GithubPrHeadsResponse,
+  now = Date.now(),
+): GitBranchDialogGroups {
+  const eligiblePrs = new Map<string, GithubPrHeadSummary>();
+  if (prHeads) {
+    const repository = prHeads.repository.toLocaleLowerCase();
+    for (const pr of prHeads.prs) {
+      if (pr.headRepository?.toLocaleLowerCase() !== repository) continue;
+      if (!eligiblePrs.has(pr.headRefName)) eligiblePrs.set(pr.headRefName, pr);
+    }
+  }
   const query = filter.trim().toLocaleLowerCase();
-  return branches
-    .filter((branch) => branch.name.toLocaleLowerCase().includes(query))
-    .sort((left, right) => {
-      if (left.current !== right.current) return left.current ? -1 : 1;
-      const leftBase = baseBranch !== undefined && left.name === baseBranch;
-      const rightBase = baseBranch !== undefined && right.name === baseBranch;
-      if (leftBase !== rightBase) return leftBase ? -1 : 1;
-      return left.name.localeCompare(right.name);
+  const rows = branches
+    .map((branch): GitBranchDialogRow => {
+      const pullRequest = eligiblePrs.get(branchHeadName(branch));
+      return {
+        branch,
+        ...(pullRequest ? { pullRequest } : {}),
+        updatedLabel: formatBranchUpdatedLabel(branch.updatedAt, now),
+      };
+    })
+    .filter(({ branch, pullRequest }) => {
+      if (!query) return true;
+      return [
+        branch.name,
+        branch.upstream ?? "",
+        pullRequest ? `#${pullRequest.number}` : "",
+      ].some((value) => value.toLocaleLowerCase().includes(query));
     });
+  const compare = (left: GitBranchDialogRow, right: GitBranchDialogRow) => {
+    if (left.branch.current !== right.branch.current)
+      return left.branch.current ? -1 : 1;
+    const leftBase =
+      !left.branch.remote &&
+      baseBranch !== undefined &&
+      left.branch.name === baseBranch;
+    const rightBase =
+      !right.branch.remote &&
+      baseBranch !== undefined &&
+      right.branch.name === baseBranch;
+    if (leftBase !== rightBase) return leftBase ? -1 : 1;
+    const recency =
+      branchTimestamp(right.branch) - branchTimestamp(left.branch);
+    return recency || left.branch.name.localeCompare(right.branch.name);
+  };
+  return {
+    all: [...rows].sort(compare),
+    local: rows.filter(({ branch }) => !branch.remote).sort(compare),
+    remote: rows.filter(({ branch }) => branch.remote).sort(compare),
+  };
 }
 
 export const defaultGitPrFilterConfig: GitPrFilterConfig = {
@@ -210,6 +295,10 @@ export function createGitPanelActions(
       if (available() && model().capabilities.refresh.enabled)
         return host.refreshBranches(repository);
     },
+    refreshPrHeads: (repository) => {
+      if (available() && model().capabilities.refresh.enabled)
+        return host.refreshPrHeads(repository);
+    },
     refreshPullRequests: (repository) => {
       if (available() && model().capabilities.refresh.enabled)
         return host.refreshPullRequests(repository);
@@ -234,6 +323,11 @@ export function createGitPanelActions(
     switchBranch: (repository, branch) => {
       if (available() && model().capabilities.branches.enabled)
         return host.switchBranch(repository, branch);
+      return false;
+    },
+    deleteBranch: (repository, branch) => {
+      if (available() && model().capabilities.branches.enabled)
+        return host.deleteBranch(repository, branch);
       return false;
     },
     openDiff: (repository, file, area) => {

--- a/packages/workbench-app/src/lib/features/git/views/git-panel-types.ts
+++ b/packages/workbench-app/src/lib/features/git/views/git-panel-types.ts
@@ -3,6 +3,7 @@ import type {
   GitDiffArea,
   GitFileChange,
   GithubPr,
+  GithubPrHeadsResponse,
   GithubStatusResponse,
   GitRepoSummary,
   GitStashArea,
@@ -76,6 +77,7 @@ export interface GitPanelOperationState {
   readonly syncing: boolean;
   readonly switchingBaseAndPulling: boolean;
   readonly switchingBranch?: string;
+  readonly deletingBranch?: string;
   readonly creatingBranch: boolean;
   readonly fileMutation?: FileMutation;
   readonly bulkMutation?: ScopedFileMutation;
@@ -96,6 +98,7 @@ export interface GitPanelModel {
   readonly stashes: readonly GitStashEntry[];
   readonly github?: GithubStatusResponse;
   readonly pullRequests: readonly GithubPr[];
+  readonly prHeads?: GithubPrHeadsResponse;
   readonly pullRequestFilters: GitPrFilterConfig;
   readonly selectedPullRequestNumber?: number;
   readonly initialLoading: boolean;
@@ -104,6 +107,7 @@ export interface GitPanelModel {
   readonly loadingOverview: boolean;
   readonly loadingBranches: boolean;
   readonly loadingPullRequests: boolean;
+  readonly loadingPrHeads: boolean;
   readonly pullRequestError?: string;
   readonly operations: GitPanelOperationState;
   readonly capabilities: GitPanelCapabilities;
@@ -113,6 +117,7 @@ export interface GitPanelActions {
   readonly refreshAll: () => void | Promise<void>;
   readonly refreshRepository: (repository: string) => void | Promise<void>;
   readonly refreshBranches: (repository: string) => void | Promise<void>;
+  readonly refreshPrHeads: (repository: string) => void | Promise<void>;
   readonly refreshPullRequests: (repository: string) => void | Promise<void>;
   readonly configurePullRequests: (
     repository: string,
@@ -125,6 +130,10 @@ export interface GitPanelActions {
     name: string,
   ) => boolean | void | Promise<boolean | void>;
   readonly switchBranch: (
+    repository: string,
+    branch: GitBranchSummary,
+  ) => boolean | void | Promise<boolean | void>;
+  readonly deleteBranch: (
     repository: string,
     branch: GitBranchSummary,
   ) => boolean | void | Promise<boolean | void>;

--- a/packages/workbench-app/src/lib/platform/query/client.ts
+++ b/packages/workbench-app/src/lib/platform/query/client.ts
@@ -28,6 +28,8 @@ export const queryKeys = {
       ["git", projectId, "repo", repo, "branches"] as const,
     githubStatus: (projectId: string, repo: string) =>
       ["git", projectId, "repo", repo, "github-status"] as const,
+    prHeads: (projectId: string, repo: string) =>
+      ["git", projectId, "repo", repo, "pr-heads"] as const,
     prs: (projectId: string, repo: string, filters: string) =>
       ["git", projectId, "repo", repo, "prs", filters] as const,
     pr: (projectId: string, repo: string, number: number) =>

--- a/packages/workbench-server/src/adapters/protocol/handlers/git-method-handlers.ts
+++ b/packages/workbench-server/src/adapters/protocol/handlers/git-method-handlers.ts
@@ -23,6 +23,8 @@ export const gitMethodHandlers: WorkbenchMethodHandlerMapFor<GitMethodContext> =
       state.git.createBranch(params.projectId, repo(params), params.name),
     "git.branch.switch": (state, params) =>
       state.git.switchBranch(params.projectId, repo(params), params.name),
+    "git.branch.delete": (state, params) =>
+      state.git.deleteBranch(params.projectId, repo(params), params.name),
     "git.file.diff.get": (state, params) =>
       state.git.fileDiff(
         params.projectId,
@@ -69,6 +71,8 @@ export const gitMethodHandlers: WorkbenchMethodHandlerMapFor<GitMethodContext> =
       ),
     "github.status.get": (state, params) =>
       state.git.githubStatus(params.projectId, repo(params)),
+    "github.pr.heads.list": (state, params) =>
+      state.git.listOpenPrHeads(params.projectId, repo(params)),
     "github.pr.list": (state, params) =>
       state.git.listOpenPrs(
         params.projectId,

--- a/packages/workbench-server/src/domains/git/git-mutation-publisher.ts
+++ b/packages/workbench-server/src/domains/git/git-mutation-publisher.ts
@@ -4,6 +4,7 @@ import { GitService } from "@nervekit/tools/git";
 const mutationReasons = {
   createBranch: "branch.created",
   switchBranch: "branch.switched",
+  deleteBranch: "branch.deleted",
   stageFile: "file.staged",
   unstageFile: "file.unstaged",
   discardFile: "file.discarded",


### PR DESCRIPTION
## Summary
- redesign the branch switcher as a compact, searchable branch list with recency ordering, remote visibility toggle, and pull request badges
- add safe local branch deletion with confirmation and protections for current, base, remote, and unmerged branches
- expose branch tip timestamps and lightweight GitHub PR-head metadata across native, contracts, server, and workbench layers

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`
- visually verified compact layout, remote active state, light/dark themes, and disabled remote delete alignment