### PR TITLE
Scope permission overlays to rule sets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Root `docs/` is for maintainers working across package boundaries. Public produc
 
 ## Active proposals
 
-- [Permission rule sets](proposals/permission-rule-sets.md) — target permission architecture that is not yet implemented.
+- [Permission rule sets](proposals/permission-rule-sets.md) — implemented permission architecture and rule-set-scoped overlay model.
 
 ## Maintainer runbooks
 

--- a/docs/proposals/permission-rule-sets.md
+++ b/docs/proposals/permission-rule-sets.md
@@ -1,20 +1,12 @@
 # Permission rules and rule sets
 
-> **Status:** Active target proposal; not implemented. Current behavior is defined by the permission contracts, tool policy implementation, tests, and the public [Tools and approval policy](https://nerve.tlmtech.dev/developers/tools-policy/) page.
+> **Status:** Implemented architecture. Current behavior is defined by the permission contracts, tool policy implementation, tests, and the public [Tools and approval policy](https://nerve.tlmtech.dev/developers/tools-policy/) page.
 
-## Current versus target
+## Implementation ownership
 
-The shipped evaluator currently combines:
+The shipped evaluator combines named permission rule sets, catalog and argument-sensitive risk assessment, normalized targets, and rule-set-bound user/project/conversation overlays. Policy decisions are `allow`, `prompt`, or `deny`; the host projects `prompt` to an approval interaction.
 
-- permission levels `autonomous`, `supervised`, and `read_only`;
-- catalog and argument-sensitive risk assessment;
-- normalized request targets and host/mode constraints;
-- user and project `allow`/`deny` exceptions;
-- outcomes `allow`, `approval`, or `deny`.
-
-Current implementation is owned by [`permissions.ts`](../../packages/contracts/src/domains/permissions/permissions.ts), [`evaluate-tool-permission.ts`](../../packages/tools/src/policy/evaluate-tool-permission.ts), and [`evaluate-tool-supervision.ts`](../../packages/tools/src/policy/evaluate-tool-supervision.ts).
-
-This proposal would replace mode-specific baselines and exception composition with named, versioned rule sets and scoped overlays. In the target terminology, the outcomes are `allow`, `prompt`, or `deny`; target `prompt` corresponds to the current evaluator's `approval` boundary. The proposal must not be read as shipped behavior.
+The transport-neutral contracts live in [`permission-rule-sets.ts`](../../packages/contracts/src/domains/permissions/permission-rule-sets.ts), pure composition and evaluation live in [`permission-policy.ts`](../../packages/tools/src/policy/permission-policy.ts), and storage/trust resolution lives in [`permission-policy.service.ts`](../../packages/workbench-server/src/domains/permissions/permission-policy.service.ts).
 
 ## Purpose
 
@@ -22,7 +14,7 @@ Use one generic permission framework for every agent-callable tool. The framewor
 
 Product concepts such as Read only, Supervised, Autonomous, Planning, and future custom agents select or compose rule sets. They do not add special branches inside the generic evaluator.
 
-The target system must be:
+The system is designed to be:
 
 - deterministic and fail-closed;
 - independent of tool execution and agent mode implementation;
@@ -34,16 +26,16 @@ The target system must be:
 
 ## Concepts
 
-| Concept             | Target meaning                                                                                                                                                |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Permission rule     | Filters plus one `allow`, `prompt`, or `deny` decision.                                                                                                       |
-| Permission rule set | Named, versioned, ordered collection of permission rules with source and compatibility metadata.                                                              |
-| Built-in rule set   | Immutable application-owned Baseline, Read only, Supervised, Autonomous, or Planning policy.                                                                  |
-| Overlay             | Scoped ad hoc rules applied above the selected set. User and project overlays are portable configuration; conversation overlays are conversation-owned state. |
-| Guardrail           | Non-overridable restriction that can only preserve or reduce authority.                                                                                       |
-| Effective policy    | Immutable composition evaluated for one drafted call.                                                                                                         |
-| Tool descriptor     | Catalog-owned identity, groups, risks, argument selectors, and target extraction metadata.                                                                    |
-| Permission target   | Canonical structured resource affected by the call, such as a path, command segment, URL, agent, or whole tool.                                               |
+| Concept             | Target meaning                                                                                                  |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Permission rule     | Filters plus one `allow`, `prompt`, or `deny` decision.                                                         |
+| Permission rule set | Named, versioned, ordered collection of permission rules with source and compatibility metadata.                |
+| Built-in rule set   | Immutable application-owned Baseline, Read only, Supervised, Autonomous, or Planning policy.                    |
+| Overlay             | Ad hoc rules bound to one permission rule set and one user, project, or conversation ownership scope.           |
+| Guardrail           | Non-overridable restriction that can only preserve or reduce authority.                                         |
+| Effective policy    | Immutable composition evaluated for one drafted call.                                                           |
+| Tool descriptor     | Catalog-owned identity, groups, risks, argument selectors, and target extraction metadata.                      |
+| Permission target   | Canonical structured resource affected by the call, such as a path, command segment, URL, agent, or whole tool. |
 
 The tool manifest remains the source of truth for available names and metadata. This proposal intentionally does not duplicate the catalog.
 
@@ -74,16 +66,16 @@ Normalization is a security boundary. Rules never match untrusted raw argument t
 
 ### Composition order
 
-The target effective policy composes:
+The effective policy composes:
 
-1. non-overridable Baseline guardrails;
+1. Baseline foundation rules;
 2. one selected built-in or custom rule set;
-3. user overlay;
-4. project overlay;
-5. conversation overlay;
+3. the user overlay bound to that selected rule set;
+4. the project overlay bound to that selected rule set;
+5. the conversation overlay bound to that selected rule set;
 6. call-specific host constraints that can only reduce authority.
 
-Exact precedence is encoded in contracts, not inferred from storage order. Deny/guardrail behavior must remain monotonic: a lower-authority layer cannot override a non-overridable restriction.
+An overlay does not match merely because another rule set, such as Baseline, is also active. Planning and coding grants therefore remain isolated. Exact precedence is encoded in contracts, not inferred from storage order. User guardrails remain non-overridable within their bound rule set.
 
 ### Matching
 
@@ -102,21 +94,23 @@ Multi-target calls are allowed automatically only when the effective decision co
 
 ### Decision and evidence
 
-Every successful evaluation returns exactly one target decision:
+Every successful evaluation returns exactly one decision:
 
 ```ts
 type PermissionDecision = "allow" | "prompt" | "deny";
 ```
 
-The durable evidence should include the policy version/hash, normalized targets, applicable rule source versions, matched rule identifiers, reason, and any safe suggested overlay. Evidence is committed before execution starts so a later policy edit cannot change why an existing call proceeded or stopped.
+Durable evidence includes the selected and winning rule-set IDs, policy hash, normalized targets, matched rule, reason, and any safe suggested rule. The selected rule-set ID is copied into approval state so a durable grant is saved against evaluation-time policy identity even if conversation selection later changes. Evidence is committed before execution starts so a later policy edit cannot change why an existing call proceeded or stopped.
 
 Interaction tools that implement the human boundary must not recursively prompt for permission to display that boundary.
 
 ## Storage and portability
 
 - Built-in rule sets ship with the application and are immutable.
-- User and project rule sets/overlays use versioned portable configuration without absolute `NERVE_HOME` paths.
-- Conversation overlays are canonical conversation-owned data.
+- Each ownership scope keeps one atomic v2 overlay document with `overlays: [{ ruleSetId, rules }]`; separate per-rule-set files are not used.
+- User and project rule sets/overlays use portable configuration without absolute `NERVE_HOME` paths.
+- Conversation overlays are stored with managed conversation data.
+- Project trust covers the digest of the complete project overlay document.
 - Durable records store policy identity and evidence, not a mutable pointer whose meaning can change later.
 - Secrets never appear in rules or evidence.
 - Unknown tool names remain readable in historical evidence but cannot execute without an active catalog descriptor.
@@ -125,11 +119,11 @@ The final storage shape must follow the implemented [storage architecture](../ar
 
 ## Failure behavior
 
-The target evaluator denies when:
+The evaluator fails closed when:
 
 - arguments fail validation;
 - required targets cannot be derived or canonicalized;
-- a referenced rule set is missing, malformed, incompatible, or has an unknown version;
+- a referenced rule set is missing, malformed, incompatible, or has an unknown version; the host selects Baseline without overlays;
 - the selected policy exceeds an enclosing guardrail;
 - an unknown matcher could expand authority;
 - policy evidence cannot be committed before execution.
@@ -138,7 +132,7 @@ A policy failure is never converted into automatic approval.
 
 ## Implementation criteria
 
-The proposal is complete only when:
+The architecture remains complete only while:
 
 - shared contracts define rule sets, overlays, normalized requests, decisions, and evidence;
 - the tool manifest supplies all required metadata without a second inventory;

--- a/packages/contracts/src/domains/permissions/permission-rule-sets.ts
+++ b/packages/contracts/src/domains/permissions/permission-rule-sets.ts
@@ -357,12 +357,44 @@ export type PermissionRuleSet = z.infer<typeof permissionRuleSetSchema>;
 
 export const permissionOverlaySchema = z
   .object({
-    schemaVersion: z.literal(1),
+    ruleSetId: permissionRuleSetIdSchema,
     rules: z.array(permissionRuleSchema).max(256),
   })
   .strict()
   .superRefine((overlay, context) => validateRules(overlay.rules, context));
 export type PermissionOverlay = z.infer<typeof permissionOverlaySchema>;
+
+export const permissionOverlayDocumentSchema = z
+  .object({
+    schemaVersion: z.literal(2),
+    overlays: z.array(permissionOverlaySchema).max(256),
+  })
+  .strict()
+  .superRefine((document, context) => {
+    const ruleSetIds = new Set<string>();
+    let ruleCount = 0;
+    for (const [index, overlay] of document.overlays.entries()) {
+      if (ruleSetIds.has(overlay.ruleSetId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["overlays", index, "ruleSetId"],
+          message: "Overlay rule-set IDs must be unique within a document.",
+        });
+      }
+      ruleSetIds.add(overlay.ruleSetId);
+      ruleCount += overlay.rules.length;
+    }
+    if (ruleCount > 256) {
+      context.addIssue({
+        code: "custom",
+        path: ["overlays"],
+        message: "Permission overlay documents may contain at most 256 rules.",
+      });
+    }
+  });
+export type PermissionOverlayDocument = z.infer<
+  typeof permissionOverlayDocumentSchema
+>;
 
 export const permissionRuleOriginSchema = z.enum([
   "baseline",
@@ -402,9 +434,11 @@ export const permissionEvaluationResultSchema = z
     winningRuleId: identifierSchema,
     winningRule: permissionRuleSchema,
     winningRuleOrigin: permissionRuleOriginSchema,
+    winningRuleSetId: permissionRuleSetIdSchema,
     winningRuleEnforcement: ruleEnforcementSchema,
     winningRulePrecedence: rulePrecedenceSchema,
     activeRuleSetIds: z.array(identifierSchema).min(1).max(16),
+    selectedRuleSetId: permissionRuleSetIdSchema,
     ignoredOverlays: z.array(ignoredPermissionSourceSchema).max(16),
     policySnapshotHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
     suggestedRules: z.array(permissionRuleSchema).max(16),
@@ -461,9 +495,9 @@ export type ProjectPermissionTrust = z.infer<
 export const permissionPolicyConfigurationSchema = z
   .object({
     ruleSets: z.array(permissionRuleSetSummarySchema).max(256),
-    userOverlay: permissionOverlaySchema,
-    projectOverlay: permissionOverlaySchema,
-    conversationOverlay: permissionOverlaySchema.optional(),
+    userOverlays: permissionOverlayDocumentSchema,
+    projectOverlays: permissionOverlayDocumentSchema,
+    conversationOverlays: permissionOverlayDocumentSchema.optional(),
     projectTrust: projectPermissionTrustSchema,
     diagnostics: z.array(z.string().max(4_096)).max(256),
   })
@@ -472,34 +506,52 @@ export type PermissionPolicyConfiguration = z.infer<
   typeof permissionPolicyConfigurationSchema
 >;
 
+function validateOverlayOrigin(
+  origin: PermissionOverlayOrigin,
+  overlay: PermissionOverlay,
+  context: z.RefinementCtx,
+  pathPrefix: PropertyKey[] = [],
+): void {
+  if (origin === "user") return;
+  for (const [index, rule] of overlay.rules.entries()) {
+    if (rule.enforcement === "guardrail") {
+      context.addIssue({
+        code: "custom",
+        path: [...pathPrefix, "rules", index, "enforcement"],
+        message: `${origin} overlays may contain only overridable rules.`,
+      });
+    }
+    if (
+      origin === "project" &&
+      (rule.when.primaryTarget?.root === "nerve_home" ||
+        rule.when.primaryTarget?.root === "nerve_data" ||
+        rule.when.targets?.matcher.root === "nerve_home" ||
+        rule.when.targets?.matcher.root === "nerve_data") &&
+      rule.decision === "allow"
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: [...pathPrefix, "rules", index, "when"],
+        message: "Project overlays cannot grant broad Nerve-owned root access.",
+      });
+    }
+  }
+}
+
 export function permissionOverlayForOriginSchema(
   origin: PermissionOverlayOrigin,
 ) {
-  return permissionOverlaySchema.superRefine((overlay, context) => {
-    if (origin === "user") return;
-    for (const [index, rule] of overlay.rules.entries()) {
-      if (rule.enforcement === "guardrail") {
-        context.addIssue({
-          code: "custom",
-          path: ["rules", index, "enforcement"],
-          message: `${origin} overlays may contain only overridable rules.`,
-        });
-      }
-      if (
-        origin === "project" &&
-        (rule.when.primaryTarget?.root === "nerve_home" ||
-          rule.when.primaryTarget?.root === "nerve_data" ||
-          rule.when.targets?.matcher.root === "nerve_home" ||
-          rule.when.targets?.matcher.root === "nerve_data") &&
-        rule.decision === "allow"
-      ) {
-        context.addIssue({
-          code: "custom",
-          path: ["rules", index, "when"],
-          message:
-            "Project overlays cannot grant broad Nerve-owned root access.",
-        });
-      }
+  return permissionOverlaySchema.superRefine((overlay, context) =>
+    validateOverlayOrigin(origin, overlay, context),
+  );
+}
+
+export function permissionOverlayDocumentForOriginSchema(
+  origin: PermissionOverlayOrigin,
+) {
+  return permissionOverlayDocumentSchema.superRefine((document, context) => {
+    for (const [index, overlay] of document.overlays.entries()) {
+      validateOverlayOrigin(origin, overlay, context, ["overlays", index]);
     }
   });
 }

--- a/packages/contracts/src/domains/settings/home-configuration.ts
+++ b/packages/contracts/src/domains/settings/home-configuration.ts
@@ -6,7 +6,7 @@ import {
   thinkingLevelSchema,
 } from "../models/models.js";
 import {
-  permissionOverlaySchema,
+  permissionOverlayDocumentSchema,
   permissionRuleSetIdSchema,
 } from "../permissions/permission-rule-sets.js";
 import { permissionLevelSchema } from "../permissions/permissions.js";
@@ -300,11 +300,11 @@ export type LegacyPermissionsConfig = z.infer<
   typeof legacyPermissionsConfigSchema
 >;
 
-export const permissionsConfigSchema = permissionOverlaySchema;
+export const permissionsConfigSchema = permissionOverlayDocumentSchema;
 export type PermissionsConfig = z.infer<typeof permissionsConfigSchema>;
 export const defaultPermissionsConfig: PermissionsConfig = {
-  schemaVersion: 1,
-  rules: [],
+  schemaVersion: 2,
+  overlays: [],
 };
 
 export const headerConfigSchema = z.union([

--- a/packages/contracts/src/domains/tools/records.ts
+++ b/packages/contracts/src/domains/tools/records.ts
@@ -9,6 +9,7 @@ import {
 import {
   permissionEvaluationResultSchema,
   permissionRuleSchema,
+  permissionRuleSetIdSchema,
   permissionTargetKindSchema,
   staticToolRiskSchema,
   toolKindSchema,
@@ -196,6 +197,7 @@ export const approvalToolInteractionSchema = interactionBaseSchema.extend({
       .max(7),
     suggestedExceptions: z.array(permissionExceptionSchema).max(16).default([]),
     suggestedRules: z.array(permissionRuleSchema).max(16).default([]),
+    permissionRuleSetId: permissionRuleSetIdSchema.optional(),
   }),
   resolution: z
     .object({
@@ -467,6 +469,7 @@ export const approvalRecordSchema = z.object({
     .default(["single_call"]),
   suggestedExceptions: z.array(permissionExceptionSchema).max(16).default([]),
   suggestedRules: z.array(permissionRuleSchema).max(16).default([]),
+  permissionRuleSetId: permissionRuleSetIdSchema.optional(),
 });
 export type ApprovalRecord = z.infer<typeof approvalRecordSchema>;
 

--- a/packages/contracts/test/permission/permission-rule-set-validation.test.ts
+++ b/packages/contracts/test/permission/permission-rule-set-validation.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  permissionOverlayDocumentForOriginSchema,
+  permissionOverlayDocumentSchema,
   permissionOverlayForOriginSchema,
   permissionOverlaySchema,
   permissionRuleSchema,
@@ -28,14 +30,47 @@ test("permission rule schemas enforce priorities and guardrail decisions", () =>
   );
   assert.throws(() =>
     permissionOverlaySchema.parse({
-      schemaVersion: 1,
+      ruleSetId: "planning",
       rules: [rule, { ...rule, id: "other" }],
     }),
   );
   assert.throws(() =>
     permissionOverlaySchema.parse({
-      schemaVersion: 1,
+      ruleSetId: "planning",
       rules: [rule, { ...rule, priority: 11 }],
+    }),
+  );
+});
+
+test("overlay documents require one bounded group per rule set", () => {
+  assert.deepEqual(
+    permissionOverlayDocumentSchema
+      .parse({
+        schemaVersion: 2,
+        overlays: [
+          { ruleSetId: "planning", rules: [rule] },
+          {
+            ruleSetId: "supervised",
+            rules: [{ ...rule, id: "allow-read", priority: 10 }],
+          },
+        ],
+      })
+      .overlays.map((overlay) => overlay.ruleSetId),
+    ["planning", "supervised"],
+  );
+  assert.throws(() =>
+    permissionOverlayDocumentSchema.parse({
+      schemaVersion: 2,
+      overlays: [
+        { ruleSetId: "planning", rules: [] },
+        { ruleSetId: "planning", rules: [] },
+      ],
+    }),
+  );
+  assert.throws(() =>
+    permissionOverlayDocumentSchema.parse({
+      schemaVersion: 2,
+      overlays: [{ ruleSetId: "planning", rules: Array(257).fill(rule) }],
     }),
   );
 });
@@ -66,26 +101,31 @@ test("rule sets reject guardrails and unsafe IDs", () => {
 test("project and conversation sources reject forbidden authority", () => {
   assert.throws(() =>
     permissionOverlayForOriginSchema("conversation").parse({
-      schemaVersion: 1,
+      ruleSetId: "planning",
       rules: [{ ...rule, enforcement: "guardrail", decision: "deny" }],
     }),
   );
   assert.throws(() =>
-    permissionOverlayForOriginSchema("project").parse({
-      schemaVersion: 1,
-      rules: [
+    permissionOverlayDocumentForOriginSchema("project").parse({
+      schemaVersion: 2,
+      overlays: [
         {
-          ...rule,
-          when: {
-            targets: {
-              quantifier: "all",
-              matcher: {
-                kind: "path",
-                root: "nerve_data",
-                pattern: "**",
+          ruleSetId: "planning",
+          rules: [
+            {
+              ...rule,
+              when: {
+                targets: {
+                  quantifier: "all",
+                  matcher: {
+                    kind: "path",
+                    root: "nerve_data",
+                    pattern: "**",
+                  },
+                },
               },
             },
-          },
+          ],
         },
       ],
     }),

--- a/packages/tools/src/policy/permission-policy.ts
+++ b/packages/tools/src/policy/permission-policy.ts
@@ -51,12 +51,14 @@ export interface EffectivePermissionRule {
   rule: PermissionRule;
   origin: PermissionRuleOrigin;
   sourceId: string;
+  ruleSetId: string;
   precedence: RulePrecedence;
 }
 
 export interface EffectivePermissionPolicy {
   rules: readonly EffectivePermissionRule[];
   activeRuleSetIds: readonly string[];
+  selectedRuleSetId: string;
   ignoredOverlays: readonly IgnoredPermissionSource[];
   snapshotHash: string;
   subagent: boolean;
@@ -104,7 +106,7 @@ export function composeEffectivePermissionPolicy(
   if (!subagent) {
     const baseline = builtInPermissionRuleSet("baseline");
     activeRuleSetIds.push(baseline.id);
-    appendRules(entries, baseline.rules, "baseline", baseline.id);
+    appendRules(entries, baseline.rules, "baseline", baseline.id, baseline.id);
   }
   if (subagent || input.selectedRuleSet.id !== "baseline") {
     activeRuleSetIds.push(input.selectedRuleSet.id);
@@ -113,50 +115,77 @@ export function composeEffectivePermissionPolicy(
       input.selectedRuleSet.rules,
       "rule_set",
       input.selectedRuleSet.id,
+      input.selectedRuleSet.id,
     );
   }
+  const userOverlay = matchingOverlay(
+    input.userOverlay,
+    input.selectedRuleSet.id,
+  );
+  const projectOverlay = matchingOverlay(
+    input.projectOverlay,
+    input.selectedRuleSet.id,
+  );
+  const conversationOverlay = matchingOverlay(
+    input.conversationOverlay,
+    input.selectedRuleSet.id,
+  );
   if (!subagent) {
-    appendRules(entries, input.userOverlay?.rules ?? [], "user", "user");
-    appendRules(
-      entries,
-      input.projectOverlay?.rules ?? [],
-      "project",
-      "project",
-    );
-    appendRules(
-      entries,
-      input.conversationOverlay?.rules ?? [],
-      "conversation",
-      "conversation",
-    );
+    appendOverlay(entries, userOverlay, "user");
+    appendOverlay(entries, projectOverlay, "project");
+    appendOverlay(entries, conversationOverlay, "conversation");
   }
   const ignoredOverlays = [...(input.ignoredOverlays ?? [])];
   const snapshotHash = hashCanonical({
-    version: 1,
+    version: 2,
     subagent,
     activeRuleSetIds,
     sources: {
       baseline: subagent ? undefined : builtInPermissionRuleSet("baseline"),
       selectedRuleSet: input.selectedRuleSet,
-      userOverlay: subagent ? undefined : input.userOverlay,
-      projectOverlay: subagent ? undefined : input.projectOverlay,
-      conversationOverlay: subagent ? undefined : input.conversationOverlay,
+      userOverlay: subagent ? undefined : userOverlay,
+      projectOverlay: subagent ? undefined : projectOverlay,
+      conversationOverlay: subagent ? undefined : conversationOverlay,
     },
     ignoredOverlays,
-    rules: entries.map(({ rule, origin, sourceId, precedence }) => ({
+    rules: entries.map(({ rule, origin, sourceId, ruleSetId, precedence }) => ({
       rule,
       origin,
       sourceId,
+      ruleSetId,
       precedence,
     })),
   });
   return deepFreeze({
     rules: entries,
     activeRuleSetIds,
+    selectedRuleSetId: input.selectedRuleSet.id,
     ignoredOverlays,
     snapshotHash,
     subagent,
   });
+}
+
+function matchingOverlay(
+  overlay: PermissionOverlay | undefined,
+  selectedRuleSetId: string,
+): PermissionOverlay | undefined {
+  return overlay?.ruleSetId === selectedRuleSetId ? overlay : undefined;
+}
+
+function appendOverlay(
+  destination: EffectivePermissionRule[],
+  overlay: PermissionOverlay | undefined,
+  origin: "user" | "project" | "conversation",
+): void {
+  if (!overlay) return;
+  appendRules(
+    destination,
+    overlay.rules,
+    origin,
+    `${origin}:${overlay.ruleSetId}`,
+    overlay.ruleSetId,
+  );
 }
 
 function appendRules(
@@ -164,12 +193,14 @@ function appendRules(
   rules: readonly PermissionRule[],
   origin: PermissionRuleOrigin,
   sourceId: string,
+  ruleSetId: string,
 ): void {
   for (const rule of rules) {
     destination.push({
       rule,
       origin,
       sourceId,
+      ruleSetId,
       precedence: precedenceFor(rule, origin),
     });
   }
@@ -374,9 +405,11 @@ export function evaluatePermissionRequest(
     winningRuleId: winner.rule.id,
     winningRule: winner.rule,
     winningRuleOrigin: winner.origin,
+    winningRuleSetId: winner.ruleSetId,
     winningRuleEnforcement: winner.rule.enforcement,
     winningRulePrecedence: winner.precedence,
     activeRuleSetIds: [...input.policy.activeRuleSetIds],
+    selectedRuleSetId: input.policy.selectedRuleSetId,
     ignoredOverlays: [...input.policy.ignoredOverlays],
     policySnapshotHash: input.policy.snapshotHash,
     suggestedRules:

--- a/packages/tools/test/policy/permission-rule-sets.test.ts
+++ b/packages/tools/test/policy/permission-rule-sets.test.ts
@@ -74,8 +74,11 @@ function rule(
   };
 }
 
-function overlay(...rules: PermissionRule[]): PermissionOverlay {
-  return { schemaVersion: 1, rules };
+function overlay(
+  ruleSetId: string,
+  ...rules: PermissionRule[]
+): PermissionOverlay {
+  return { ruleSetId, rules };
 }
 
 test("catalog has complete static policy metadata", () => {
@@ -273,9 +276,51 @@ test("planning separates research, prompted analysis, and mutations", () => {
   }
 });
 
+test("overlays apply only to their selected permission rule set", () => {
+  const planningOverlay = overlay(
+    "planning",
+    rule("allow-write-in-planning", 10, "allow"),
+  );
+  assert.equal(
+    decision(
+      "planning",
+      "write",
+      { path: "/nerve/data/plans/a.md" },
+      { userOverlay: planningOverlay },
+    ).winningRuleId,
+    "allow-write-in-planning",
+  );
+  assert.equal(
+    decision(
+      "supervised",
+      "write",
+      { path: "src/a.ts" },
+      { userOverlay: planningOverlay },
+    ).decision,
+    "prompt",
+  );
+
+  const baselineOverlay = overlay(
+    "baseline",
+    rule("baseline-allow-write", 10, "allow"),
+  );
+  assert.notEqual(
+    decision(
+      "supervised",
+      "write",
+      { path: "src/a.ts" },
+      { userOverlay: baselineOverlay },
+    ).winningRuleId,
+    "baseline-allow-write",
+  );
+});
+
 test("guardrails and scope ranks precede numeric priority and decision kind", () => {
-  const userOverlay = overlay(rule("user-deny", 1000, "deny"));
-  const projectOverlay = overlay(rule("project-allow", -1000, "allow"));
+  const userOverlay = overlay("read_only", rule("user-deny", 1000, "deny"));
+  const projectOverlay = overlay(
+    "read_only",
+    rule("project-allow", -1000, "allow"),
+  );
   assert.equal(
     decision(
       "read_only",
@@ -286,8 +331,12 @@ test("guardrails and scope ranks precede numeric priority and decision kind", ()
     "allow",
   );
 
-  const guardrail = overlay(rule("never-write", -1000, "deny", "guardrail"));
+  const guardrail = overlay(
+    "autonomous",
+    rule("never-write", -1000, "deny", "guardrail"),
+  );
   const conversationOverlay = overlay(
+    "autonomous",
     rule("conversation-allow", 1000, "allow"),
   );
   const result = decision(
@@ -305,6 +354,7 @@ test("guardrails and scope ranks precede numeric priority and decision kind", ()
 
 test("greater priority wins only within the same enforcement and origin", () => {
   const projectOverlay = overlay(
+    "autonomous",
     rule("lower-deny", 10, "deny"),
     rule("higher-prompt", 20, "prompt"),
   );
@@ -332,7 +382,7 @@ test("all target matcher rejects empty target collections and covers compound ta
     },
     decision: "allow",
   };
-  const projectOverlay = overlay(allowPlans);
+  const projectOverlay = overlay("read_only", allowPlans);
   assert.equal(
     decision(
       "read_only",
@@ -409,10 +459,22 @@ test("policy hash is deterministic and changes with effective policy", () => {
     "write",
     { path: "a" },
     {
-      userOverlay: overlay(rule("allow-write", 1, "allow")),
+      userOverlay: overlay("supervised", rule("allow-write", 1, "allow")),
     },
   );
   assert.notEqual(first.policySnapshotHash, changed.policySnapshotHash);
+
+  const inactive = decision(
+    "supervised",
+    "write",
+    { path: "a" },
+    {
+      userOverlay: overlay("autonomous", rule("allow-write", 1, "allow")),
+    },
+  );
+  assert.equal(first.policySnapshotHash, inactive.policySnapshotHash);
+  assert.equal(changed.selectedRuleSetId, "supervised");
+  assert.equal(changed.winningRuleSetId, "supervised");
 });
 
 test("external and mixed grep paths remain distinct permission targets", () => {
@@ -447,7 +509,7 @@ test("external and mixed grep paths remain distinct permission targets", () => {
     },
   ]);
 
-  const projectOnly = overlay({
+  const projectOnly = overlay("supervised", {
     id: "allow-project-grep",
     enabled: true,
     priority: 1,
@@ -510,12 +572,12 @@ test("existing symlinks are canonicalized to external targets", async () => {
 test("source schemas reject forbidden guardrails and broad project grants", () => {
   assert.throws(() =>
     permissionOverlayForOriginSchema("conversation").parse(
-      overlay(rule("guard", 1, "deny", "guardrail")),
+      overlay("planning", rule("guard", 1, "deny", "guardrail")),
     ),
   );
   assert.throws(() =>
     permissionOverlayForOriginSchema("project").parse({
-      schemaVersion: 1,
+      ruleSetId: "planning",
       rules: [
         {
           id: "broad-home",

--- a/packages/website/src/content/docs/developers/tools-policy.md
+++ b/packages/website/src/content/docs/developers/tools-policy.md
@@ -15,17 +15,25 @@ Every dispatch produces persisted lifecycle records. File mutations serialize pe
 
 ## Policy decisions
 
-The server evaluates mode, permission, risk, tool availability, and request details:
+The server composes Baseline with one selected permission rule set:
 
-- Read only allows local inspection and interaction, but denies commands, network access, mutations, and child spawning;
-- Supervised automatically allows safe local reads and audited read-only integrations, then requests approval for other risks unless an exact-risk allow exception covers the complete request;
-- Autonomous permits allowed risks without normal approval, but explicit block exceptions still apply;
-- effective exceptions are the deduplicated union of user permissions under `~/.nerve/config/permissions.json` and project permissions under `<project>/.nerve/config/permissions.json`;
-- planning adds path-constrained writes, tool omissions, and shell guardrails before generic permission evaluation.
+- **Read only** allows interaction, local inspection, and Explore, then denies other capabilities;
+- **Supervised** allows interaction and local inspection, then prompts for other capabilities;
+- **Autonomous** allows valid requests unless a scoped overlay or guardrail replaces the decision;
+- **Planning** allows research, interaction, Explore, and plan-file writes, prompts for local analysis commands, and denies other mutations;
+- custom user rule sets can define another ordered policy for compatible agent modes.
 
-The permission engine combines manifest and argument-sensitive risk, normalized request targets, permission level, hard host constraints, and typed user exceptions to produce `allow`, `approval`, or `deny`. Block exceptions win across scopes. Allow exceptions cannot expand Read only or bypass planning restrictions. Compound Bash calls are parsed into segments, and every mutating segment must match an exact-risk command-prefix exception before the call can run without approval. Python execution remains opaque and never receives a durable allow suggestion.
+The permission engine combines manifest metadata, normalized arguments and targets, the selected rule set, and matching overlays to produce `allow`, `prompt`, or `deny`. A prompt becomes a durable Workbench approval interaction. Multi-target calls are automatically allowed only when the winning allow rule covers every relevant target.
 
-File path exceptions use project-relative POSIX globs such as `secrets/**`; web exceptions use exact or leading-wildcard hostnames. They apply to Nerve's corresponding tools and are not an operating-system sandbox.
+## Rule-set-scoped overlays
+
+User, project, and conversation overlays are each bound to exactly one permission rule set. A Planning grant does not affect Supervised or Autonomous, and a coding grant does not affect Planning. Ownership scopes still determine precedence within that rule set: conversation replaces project, project replaces ordinary user rules, and user guardrails cannot be overridden.
+
+User overlays are stored under `~/.nerve/config/permissions.json`; project overlays are stored under `<project>/.nerve/config/permissions.json`; conversation overlays are stored with managed conversation data. Each scope uses one atomic document containing groups shaped as `overlays: [{ ruleSetId, rules }]`, rather than one file per rule set. The complete project document digest must be trusted before any project group is active.
+
+Durable approval choices retain the permission rule set captured when the call was evaluated. Changing a conversation's selected rule set while an approval is pending cannot redirect the saved grant. If a selected custom set becomes missing, malformed, disabled, or incompatible, the host falls back to Baseline without applying overlays.
+
+Rules can match tool names/groups, risks, validated arguments, and canonical path or URL targets. Portable path matchers use rooted POSIX patterns such as `src/**`; external host-specific paths use exact argument matching. Rules apply to Nerve's corresponding tools and are not an operating-system sandbox.
 
 ## Distinctions
 

--- a/packages/workbench-app/src/lib/api.ts
+++ b/packages/workbench-app/src/lib/api.ts
@@ -158,6 +158,7 @@ export type {
 export type {
   PermissionException,
   PermissionOverlay,
+  PermissionOverlayDocument,
   PermissionOverlayOrigin,
   PermissionPolicyConfiguration,
   PermissionRule,

--- a/packages/workbench-app/src/lib/features/settings/views/pages/permissions/PermissionExceptionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/settings/views/pages/permissions/PermissionExceptionDialog.svelte
@@ -10,11 +10,18 @@ import { Textarea } from "@nervekit/ui-kit/components/ui/textarea";
 type Props = {
   open?: boolean;
   scope: "project" | "user";
+  ruleSetId: string;
   rule?: PermissionRule;
   onSave?: (rule: PermissionRule) => Promise<boolean>;
 };
 
-let { open = $bindable(false), scope, rule, onSave }: Props = $props();
+let {
+  open = $bindable(false),
+  scope,
+  ruleSetId,
+  rule,
+  onSave,
+}: Props = $props();
 let source = $state("");
 let saving = $state(false);
 let error = $state<string>();
@@ -36,13 +43,13 @@ async function save(): Promise<void> {
   }
 
   const parsed = permissionOverlayForOriginSchema(scope).safeParse({
-    schemaVersion: 1,
+    ruleSetId,
     rules: [value],
   });
   if (!parsed.success) {
     error = parsed.error.issues
       .map((issue) => {
-        const path = issue.path.slice(2).join(".");
+        const path = issue.path.slice(1).join(".");
         return path ? `${path}: ${issue.message}` : issue.message;
       })
       .join(" ");
@@ -79,7 +86,7 @@ function newRule(targetScope: "project" | "user"): PermissionRule {
   bind:open
   size="wide"
   title={`${rule ? "Edit" : "Add"} ${scope} permission rule`}
-  description="Edit the complete overlay rule. The rule is validated before the overlay is saved atomically."
+  description={`This rule applies only to the ${ruleSetId} permission rule set and is validated before the overlay is saved atomically.`}
 >
   <div class="grid gap-2">
     <Label for={`permission-rule-json-${scope}`}>Rule JSON</Label>

--- a/packages/workbench-app/src/lib/features/settings/views/pages/permissions/PermissionExceptionList.svelte
+++ b/packages/workbench-app/src/lib/features/settings/views/pages/permissions/PermissionExceptionList.svelte
@@ -75,7 +75,7 @@ function matcher(rule: PermissionRule): string {
             <Button
               size="icon-sm"
               variant="ghost"
-              disabled={pendingIds.includes(rule.id)}
+              disabled={!onEdit || pendingIds.includes(rule.id)}
               aria-label={`Edit ${rule.id} permission rule`}
               onclick={() => onEdit?.(rule)}
             >

--- a/packages/workbench-app/src/lib/features/settings/views/pages/permissions/PermissionsSettingsPage.svelte
+++ b/packages/workbench-app/src/lib/features/settings/views/pages/permissions/PermissionsSettingsPage.svelte
@@ -4,6 +4,7 @@ import RefreshCw from "@lucide/svelte/icons/refresh-cw";
 import ShieldCheck from "@lucide/svelte/icons/shield-check";
 import ShieldAlert from "@lucide/svelte/icons/shield-alert";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
+import SelectField from "@nervekit/ui-kit/components/composites/select-field";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import type { PermissionRule, ProjectRecord, Settings } from "$lib/api";
 import {
@@ -35,6 +36,12 @@ let editingProjectRule = $state<PermissionRule>();
 let editingUserRule = $state<PermissionRule>();
 
 $effect(() => controller.selectProject(activeProject));
+$effect(() =>
+  controller.selectRuleSet(
+    settingsDraft.defaultPermissionRuleSetId ??
+      settingsDraft.defaultPermissionLevel,
+  ),
+);
 
 const builtInPermissionItems: SettingsChoice[] = [
   {
@@ -81,6 +88,24 @@ const permissionItems = $derived<SettingsChoice[]>(
     : builtInPermissionItems,
 );
 
+const overlayRuleSetItems = $derived(
+  controller.configuration?.ruleSets.map((ruleSet) => ({
+    value: ruleSet.id,
+    label: ruleSet.name,
+    detail: ruleSet.available
+      ? ruleSet.description
+      : "Unavailable; stored rules are dormant",
+    disabled: !ruleSet.available && !hasRulesForRuleSet(ruleSet.id),
+  })) ?? [],
+);
+const managedRuleSet = $derived(
+  controller.configuration?.ruleSets.find(
+    (ruleSet) => ruleSet.id === controller.overlayRuleSetId,
+  ),
+);
+const canAddManagedRules = $derived(
+  Boolean(managedRuleSet?.available && managedRuleSet.enabled),
+);
 const projectRules = $derived(controller.rules("project"));
 const userRules = $derived(controller.rules("user"));
 const projectPendingIds = $derived(
@@ -125,6 +150,26 @@ async function saveUser(rule: PermissionRule): Promise<boolean> {
   return editingUserRule
     ? controller.update("user", editingUserRule.id, rule)
     : controller.add("user", rule);
+}
+
+function hasRulesForRuleSet(ruleSetId: string): boolean {
+  const configuration = controller.configuration;
+  if (!configuration) return false;
+  return [configuration.userOverlays, configuration.projectOverlays].some(
+    (document) =>
+      document.overlays.some(
+        (overlay) =>
+          overlay.ruleSetId === ruleSetId && overlay.rules.length > 0,
+      ),
+  );
+}
+
+function selectOverlayRuleSet(ruleSetId: string): void {
+  projectDialogOpen = false;
+  userDialogOpen = false;
+  editingProjectRule = undefined;
+  editingUserRule = undefined;
+  controller.selectRuleSet(ruleSetId);
 }
 
 function openProjectRule(rule?: PermissionRule): void {
@@ -221,6 +266,30 @@ function ruleSetRole(id: string, compatibleModes?: string[]): string {
   {/if}
 </SettingsSection>
 
+<SettingsSection
+  id="permission-overlay-target"
+  title="Manage permission overlays"
+  description="Choose the permission rule set whose user and project overlays you want to inspect or edit."
+>
+  <SettingsGroup>
+    <SettingsRow label="Permission rule set" layout="stacked">
+      <SelectField
+        items={overlayRuleSetItems}
+        value={controller.overlayRuleSetId}
+        placeholder="Select a permission rule set"
+        ariaLabel="Overlay permission rule set"
+        onValueChange={selectOverlayRuleSet}
+      />
+    </SettingsRow>
+  </SettingsGroup>
+  {#if managedRuleSet && !managedRuleSet.available}
+    <SettingsInlineMessage
+      tone="warning"
+      text="This rule set is unavailable. Its stored rules are dormant and may only be inspected or removed."
+    />
+  {/if}
+</SettingsSection>
+
 {#if controller.errorMessage}
   <SettingsInlineMessage tone="error" text={controller.errorMessage}>
     {#snippet actions()}
@@ -241,7 +310,7 @@ function ruleSetRole(id: string, compatibleModes?: string[]): string {
   id="project-permissions"
   title="Project permission overlay"
   description={activeProject
-    ? `Repository-controlled rules for ${activeProject.name}. The complete file digest must be trusted before these rules become active.`
+    ? `Repository-controlled ${managedRuleSet?.name ?? controller.overlayRuleSetId} rules for ${activeProject.name}. The complete file digest must be trusted before these rules become active.`
     : "Select a project to inspect and manage its permission overlay."}
 >
   {#if controller.loading}
@@ -288,14 +357,17 @@ function ruleSetRole(id: string, compatibleModes?: string[]): string {
 
   <div class="flex items-center justify-between gap-3">
     <p class="text-xs text-muted-foreground">
-      Project rules override ordinary user defaults but never user guardrails.
+      These rules apply only to the {managedRuleSet?.name ??
+        controller.overlayRuleSetId} permission rule set. Project rules override ordinary
+      user defaults but never user guardrails in that set.
     </p>
     <Button
       size="sm"
       variant="outline"
       disabled={!activeProject ||
         !controller.configuration ||
-        controller.loading}
+        controller.loading ||
+        !canAddManagedRules}
       onclick={() => openProjectRule()}
       ><Plus class="size-3.5" />Add rule</Button
     >
@@ -304,7 +376,7 @@ function ruleSetRole(id: string, compatibleModes?: string[]): string {
     rules={projectRules}
     pendingIds={projectPendingIds}
     emptyTitle={activeProject ? "No project rules" : "No project selected"}
-    onEdit={(rule) => openProjectRule(rule)}
+    onEdit={canAddManagedRules ? (rule) => openProjectRule(rule) : undefined}
     onRemove={(id) => void controller.remove("project", id)}
   />
 </SettingsSection>
@@ -312,19 +384,20 @@ function ruleSetRole(id: string, compatibleModes?: string[]): string {
 <SettingsSection
   id="user-permissions"
   title="User permission overlay"
-  description="Defaults and protected guardrails stored under your Nerve home and applied across primary-agent projects."
+  description={`Defaults and protected guardrails for ${managedRuleSet?.name ?? controller.overlayRuleSetId}, stored under your Nerve home and applied across primary-agent projects using that rule set.`}
 >
   <div class="flex items-center justify-between gap-3">
     <p class="text-xs text-muted-foreground">
       A guardrail may prompt or deny and cannot be replaced by project or
-      conversation rules.
+      conversation rules within this permission rule set.
     </p>
     <Button
       size="sm"
       variant="outline"
       disabled={!activeProject ||
         !controller.configuration ||
-        controller.loading}
+        controller.loading ||
+        !canAddManagedRules}
       onclick={() => openUserRule()}><Plus class="size-3.5" />Add rule</Button
     >
   </div>
@@ -332,7 +405,7 @@ function ruleSetRole(id: string, compatibleModes?: string[]): string {
     rules={userRules}
     pendingIds={userPendingIds}
     emptyTitle="No user rules"
-    onEdit={(rule) => openUserRule(rule)}
+    onEdit={canAddManagedRules ? (rule) => openUserRule(rule) : undefined}
     onRemove={(id) => void controller.remove("user", id)}
   />
 </SettingsSection>
@@ -340,12 +413,14 @@ function ruleSetRole(id: string, compatibleModes?: string[]): string {
 <PermissionExceptionDialog
   bind:open={projectDialogOpen}
   scope="project"
+  ruleSetId={controller.overlayRuleSetId}
   rule={editingProjectRule}
   onSave={saveProject}
 />
 <PermissionExceptionDialog
   bind:open={userDialogOpen}
   scope="user"
+  ruleSetId={controller.overlayRuleSetId}
   rule={editingUserRule}
   onSave={saveUser}
 />

--- a/packages/workbench-app/src/lib/features/settings/views/pages/permissions/permissions-page-state.svelte.ts
+++ b/packages/workbench-app/src/lib/features/settings/views/pages/permissions/permissions-page-state.svelte.ts
@@ -1,5 +1,6 @@
 import type {
   PermissionOverlay,
+  PermissionOverlayDocument,
   PermissionPolicyConfiguration,
   PermissionRule,
   ProjectRecord,
@@ -27,6 +28,7 @@ export class PermissionsPageState {
   loading = $state(false);
   errorMessage = $state<string>();
   pendingKeys = $state<string[]>([]);
+  overlayRuleSetId = $state("supervised");
   private generation = 0;
 
   constructor(private readonly dependencies: Dependencies) {}
@@ -49,22 +51,33 @@ export class PermissionsPageState {
     this.retry();
   }
 
+  selectRuleSet(ruleSetId: string): void {
+    this.overlayRuleSetId = ruleSetId;
+    this.errorMessage = undefined;
+  }
+
   rules(scope: PermissionScope): PermissionRule[] {
     if (!this.configuration) return [];
-    return scope === "project"
-      ? this.configuration.projectOverlay.rules
-      : this.configuration.userOverlay.rules;
+    const document =
+      scope === "project"
+        ? this.configuration.projectOverlays
+        : this.configuration.userOverlays;
+    return (
+      document.overlays.find(
+        (overlay) => overlay.ruleSetId === this.overlayRuleSetId,
+      )?.rules ?? []
+    );
   }
 
   isPending(scope: PermissionScope, id: string): boolean {
-    return this.pendingKeys.includes(`${scope}:${id}`);
+    return this.pendingKeys.includes(`${scope}:${this.overlayRuleSetId}:${id}`);
   }
 
   async remove(scope: PermissionScope, id: string): Promise<void> {
     await this.save(
       scope,
       this.rules(scope).filter((rule) => rule.id !== id),
-      `${scope}:${id}`,
+      `${scope}:${this.overlayRuleSetId}:${id}`,
     );
   }
 
@@ -87,7 +100,7 @@ export class PermissionsPageState {
     return this.save(
       scope,
       [...current, { ...input, priority }],
-      `${scope}:${input.id}`,
+      `${scope}:${this.overlayRuleSetId}:${input.id}`,
     );
   }
 
@@ -115,12 +128,16 @@ export class PermissionsPageState {
     }
     const rules = [...current];
     rules[index] = replacement;
-    return this.save(scope, rules, `${scope}:${originalId}`);
+    return this.save(
+      scope,
+      rules,
+      `${scope}:${this.overlayRuleSetId}:${originalId}`,
+    );
   }
 
   async setTrusted(trusted: boolean): Promise<void> {
     if (!this.project) return;
-    const key = "project:trust";
+    const key = `project:${this.overlayRuleSetId}:trust`;
     if (this.pendingKeys.includes(key)) return;
     this.pendingKeys = [...this.pendingKeys, key];
     this.errorMessage = undefined;
@@ -149,14 +166,24 @@ export class PermissionsPageState {
       const overlay = await this.dependencies.updateOverlay(
         this.project.id,
         scope,
-        { schemaVersion: 1, rules },
+        { ruleSetId: this.overlayRuleSetId, rules },
       );
       if (!this.configuration) return true;
       this.configuration = {
         ...this.configuration,
         ...(scope === "project"
-          ? { projectOverlay: overlay }
-          : { userOverlay: overlay }),
+          ? {
+              projectOverlays: replaceOverlay(
+                this.configuration.projectOverlays,
+                overlay,
+              ),
+            }
+          : {
+              userOverlays: replaceOverlay(
+                this.configuration.userOverlays,
+                overlay,
+              ),
+            }),
       };
       if (scope === "project")
         await this.load(this.project.id, ++this.generation);
@@ -192,6 +219,18 @@ export class PermissionsPageState {
       if (generation === this.generation) this.loading = false;
     }
   }
+}
+
+function replaceOverlay(
+  document: PermissionOverlayDocument,
+  overlay: PermissionOverlay,
+): PermissionOverlayDocument {
+  const overlays = document.overlays.filter(
+    (candidate) => candidate.ruleSetId !== overlay.ruleSetId,
+  );
+  if (overlay.rules.length > 0) overlays.push(overlay);
+  overlays.sort((left, right) => left.ruleSetId.localeCompare(right.ruleSetId));
+  return { schemaVersion: 2, overlays };
 }
 
 function errorMessage(error: unknown, fallback: string): string {

--- a/packages/workbench-app/src/lib/features/settings/views/pages/permissions/permissions-page-state.test.ts
+++ b/packages/workbench-app/src/lib/features/settings/views/pages/permissions/permissions-page-state.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type {
   PermissionOverlay,
+  PermissionOverlayDocument,
   PermissionPolicyConfiguration,
   ProjectRecord,
 } from "$lib/api";
@@ -20,11 +21,22 @@ const project: ProjectRecord = {
   updatedAt: "2026-01-01T00:00:00.000Z",
 };
 
-const emptyOverlay: PermissionOverlay = { schemaVersion: 1, rules: [] };
+const emptyOverlays: PermissionOverlayDocument = {
+  schemaVersion: 2,
+  overlays: [],
+};
 const configuration: PermissionPolicyConfiguration = {
-  ruleSets: [],
-  userOverlay: emptyOverlay,
-  projectOverlay: emptyOverlay,
+  ruleSets: [
+    {
+      id: "supervised",
+      name: "Supervised",
+      source: "builtin",
+      enabled: true,
+      available: true,
+    },
+  ],
+  userOverlays: emptyOverlays,
+  projectOverlays: emptyOverlays,
   projectTrust: { status: "missing" },
   diagnostics: [],
 };
@@ -57,7 +69,10 @@ describe("PermissionsPageState", () => {
   });
 
   it("adds and removes canonical rules through one overlay", async () => {
-    let saved: PermissionOverlay = emptyOverlay;
+    let saved: PermissionOverlay = {
+      ruleSetId: "supervised",
+      rules: [],
+    };
     const state = new PermissionsPageState({
       getConfiguration: async () => configuration,
       updateOverlay: async (_id, _scope, overlay) => {
@@ -78,6 +93,7 @@ describe("PermissionsPageState", () => {
       decision: "allow" as const,
     };
     assert.equal(await state.add("user", rule), true);
+    assert.equal(saved.ruleSetId, "supervised");
     assert.equal(saved.rules[0]?.id, "allow-write");
     const replacement = {
       ...saved.rules[0]!,
@@ -98,6 +114,41 @@ describe("PermissionsPageState", () => {
     assert.equal(saved.rules[0]?.decision, "prompt");
     await state.remove("user", "allow-write");
     assert.deepEqual(saved.rules, []);
+  });
+
+  it("edits only the selected rule-set overlay", async () => {
+    const planningRule = {
+      id: "planning-rule",
+      enabled: true,
+      priority: 0,
+      enforcement: "overridable" as const,
+      when: { toolNames: ["bash"] },
+      decision: "allow" as const,
+    };
+    let saved: PermissionOverlay | undefined;
+    const state = new PermissionsPageState({
+      getConfiguration: async () => ({
+        ...configuration,
+        userOverlays: {
+          schemaVersion: 2,
+          overlays: [{ ruleSetId: "planning", rules: [planningRule] }],
+        },
+      }),
+      updateOverlay: async (_id, _scope, overlay) => {
+        saved = overlay;
+        return overlay;
+      },
+      updateTrust: async () => undefined,
+    });
+    state.selectProject(project);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepEqual(state.rules("user"), []);
+    state.selectRuleSet("planning");
+    assert.deepEqual(state.rules("user"), [planningRule]);
+    await state.remove("user", planningRule.id);
+    assert.deepEqual(saved, { ruleSetId: "planning", rules: [] });
+    assert.deepEqual(state.configuration?.userOverlays.overlays, []);
   });
 
   it("refreshes project trust after a trust mutation", async () => {

--- a/packages/workbench-app/src/lib/features/tools/state/tool-interaction-projections.ts
+++ b/packages/workbench-app/src/lib/features/tools/state/tool-interaction-projections.ts
@@ -49,6 +49,7 @@ export function pendingApprovals(
               offeredScopes: approvalScopes(interaction.request.offeredScopes),
               suggestedExceptions: interaction.request.suggestedExceptions,
               suggestedRules: interaction.request.suggestedRules,
+              permissionRuleSetId: interaction.request.permissionRuleSetId,
               toolCall,
             },
           ]

--- a/packages/workbench-app/src/lib/presentation/tools/tool-call/ApprovalPrompt.svelte
+++ b/packages/workbench-app/src/lib/presentation/tools/tool-call/ApprovalPrompt.svelte
@@ -112,9 +112,21 @@ const hasPersistentChoice = $derived(
   canPersistConversation || canPersistProject || canPersistUser,
 );
 const reviewedTarget = $derived(reviewedRuleLabel());
+const permissionRuleSetLabel = $derived(
+  approval.permissionRuleSetId
+    ? approval.permissionRuleSetId
+        .replaceAll("_", " ")
+        .replace(/\b\w/g, (character) => character.toUpperCase())
+    : undefined,
+);
 </script>
 
 <div class="grid gap-2" aria-label="Tool approval">
+  {#if permissionRuleSetLabel && hasPersistentChoice}
+    <p class="text-xs text-muted-foreground">
+      Durable grants apply only to the {permissionRuleSetLabel} permission rule set.
+    </p>
+  {/if}
   <ToolFooter {meta} {detailsAction}>
     {#snippet actions()}
       {#if hasPersistentChoice}
@@ -141,7 +153,7 @@ const reviewedTarget = $derived(reviewedRuleLabel());
             {#if canPersistConversation}
               <DropdownMenu.Item
                 disabled={Boolean(decision)}
-                title={`Allow ${reviewedTarget} in this conversation`}
+                title={`Allow ${reviewedTarget} in this conversation${permissionRuleSetLabel ? ` for ${permissionRuleSetLabel}` : ""}`}
                 onSelect={() => void decide("always_conversation")}
               >
                 Allow in this conversation
@@ -150,7 +162,7 @@ const reviewedTarget = $derived(reviewedRuleLabel());
             {#if canPersistProject}
               <DropdownMenu.Item
                 disabled={Boolean(decision)}
-                title={`Always approve ${reviewedTarget} in this project`}
+                title={`Always approve ${reviewedTarget} in this project${permissionRuleSetLabel ? ` for ${permissionRuleSetLabel}` : ""}`}
                 onSelect={() => void decide("always_project")}
               >
                 Always approve in project
@@ -159,7 +171,7 @@ const reviewedTarget = $derived(reviewedRuleLabel());
             {#if canPersistUser}
               <DropdownMenu.Item
                 disabled={Boolean(decision)}
-                title={`Always approve ${reviewedTarget} for this user`}
+                title={`Always approve ${reviewedTarget} for this user${permissionRuleSetLabel ? ` in ${permissionRuleSetLabel}` : ""}`}
                 onSelect={() => void decide("always_user")}
               >
                 Always approve for user

--- a/packages/workbench-server/src/domains/permissions/permission-policy.service.ts
+++ b/packages/workbench-server/src/domains/permissions/permission-policy.service.ts
@@ -5,6 +5,7 @@ import type { AgentRecord } from "@nervekit/contracts/agents";
 import type {
   IgnoredPermissionSource,
   PermissionOverlay,
+  PermissionOverlayDocument,
   PermissionOverlayOrigin,
   PermissionPolicyConfiguration,
   PermissionRule,
@@ -14,7 +15,9 @@ import type {
 import type { ProjectRecord } from "@nervekit/contracts/projects";
 import { z } from "zod";
 import {
+  permissionOverlayDocumentForOriginSchema,
   permissionOverlayForOriginSchema,
+  permissionRuleSchema,
   permissionRuleSetSchema,
   projectPermissionTrustSchema,
 } from "@nervekit/contracts/permissions";
@@ -41,6 +44,16 @@ const trustRecordSchema = z
 type TrustRecord = z.infer<typeof trustRecordSchema>;
 const TRUST_NAMESPACE = "project-permission-trust";
 const TRUST_SCOPE = "global";
+const emptyOverlayDocument = (): PermissionOverlayDocument => ({
+  schemaVersion: 2,
+  overlays: [],
+});
+const legacyPermissionOverlaySchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    rules: z.array(permissionRuleSchema).max(256),
+  })
+  .strict();
 
 export interface ResolvedPermissionPolicy {
   policy: EffectivePermissionPolicy;
@@ -66,18 +79,12 @@ export class PermissionPolicyService {
       : agent.mode === "planning"
         ? "planning"
         : (agent.permissionRuleSetId ?? agent.permissionLevel);
-    const diagnostics: string[] = [];
+    const custom = await this.customRuleSets();
+    const diagnostics: string[] = [...custom.diagnostics];
     let selected: PermissionRuleSet | undefined =
       builtInPermissionRuleSets.find(
         (candidate) => candidate.id === selectedId,
-      );
-    if (!selected) {
-      const custom = await this.customRuleSets();
-      selected = custom.available.find(
-        (candidate) => candidate.id === selectedId,
-      );
-      diagnostics.push(...custom.diagnostics);
-    }
+      ) ?? custom.available.find((candidate) => candidate.id === selectedId);
     const compatibleMode = agent.mode === "planning" ? "planning" : "coding";
     const selectionValid =
       selected?.enabled === true &&
@@ -93,16 +100,23 @@ export class PermissionPolicyService {
     const effectiveSelected = selected ?? builtInPermissionRuleSet("baseline");
 
     const ignored: IgnoredPermissionSource[] = [];
-    const user = await this.loadOverlay(
+    const knownRuleSetIds = this.knownRuleSetIds(custom.available);
+    const userDocument = await this.loadOverlayDocument(
       "user",
       this.storage.paths.permissionsConfigPath,
       ignored,
+      knownRuleSetIds,
     );
     const projectPath = this.projectOverlayPath(project);
     const trust = await this.projectTrust(agent.projectId);
-    const projectOverlay =
+    const projectDocument =
       trust.status === "trusted"
-        ? await this.loadOverlay("project", projectPath, ignored)
+        ? await this.loadOverlayDocument(
+            "project",
+            projectPath,
+            ignored,
+            knownRuleSetIds,
+          )
         : undefined;
     if (trust.status === "invalid" || trust.status === "untrusted") {
       ignored.push({
@@ -112,22 +126,33 @@ export class PermissionPolicyService {
       });
     }
     const conversationPath = this.conversationOverlayPath(agent.conversationId);
-    const conversation = await this.loadOverlay(
+    const conversationDocument = await this.loadOverlayDocument(
       "conversation",
       conversationPath,
       ignored,
+      knownRuleSetIds,
     );
     diagnostics.push(...ignored.map((item) => `${item.path}: ${item.reason}`));
+    const overlaysEnabled = !subagent && !fallback;
     return {
       policy: composeEffectivePermissionPolicy({
         selectedRuleSet: effectiveSelected,
-        ...(subagent
-          ? {}
-          : {
-              userOverlay: user,
-              projectOverlay,
-              conversationOverlay: conversation,
-            }),
+        ...(overlaysEnabled
+          ? {
+              userOverlay: overlayForRuleSet(
+                userDocument,
+                effectiveSelected.id,
+              ),
+              projectOverlay: overlayForRuleSet(
+                projectDocument,
+                effectiveSelected.id,
+              ),
+              conversationOverlay: overlayForRuleSet(
+                conversationDocument,
+                effectiveSelected.id,
+              ),
+            }
+          : {}),
         ignoredOverlays: subagent ? [] : ignored,
         subagent,
       }),
@@ -148,28 +173,46 @@ export class PermissionPolicyService {
     conversationId?: string,
   ): Promise<PermissionPolicyConfiguration> {
     const custom = await this.customRuleSets();
+    const knownRuleSetIds = this.knownRuleSetIds(custom.available);
     const ignored: IgnoredPermissionSource[] = [];
-    const userOverlay = (await this.loadOverlay(
-      "user",
-      this.storage.paths.permissionsConfigPath,
-      ignored,
-    )) ?? { schemaVersion: 1 as const, rules: [] };
+    const userOverlays =
+      (await this.loadOverlayDocument(
+        "user",
+        this.storage.paths.permissionsConfigPath,
+        ignored,
+        knownRuleSetIds,
+      )) ?? emptyOverlayDocument();
     const project = this.getProject(projectId);
-    const projectOverlay = (await this.loadOverlay(
-      "project",
-      this.projectOverlayPath(project),
-      ignored,
-    )) ?? { schemaVersion: 1 as const, rules: [] };
-    const conversationOverlay = conversationId
-      ? ((await this.loadOverlay(
+    const projectOverlays =
+      (await this.loadOverlayDocument(
+        "project",
+        this.projectOverlayPath(project),
+        ignored,
+        knownRuleSetIds,
+      )) ?? emptyOverlayDocument();
+    const conversationOverlays = conversationId
+      ? ((await this.loadOverlayDocument(
           "conversation",
           this.conversationOverlayPath(conversationId),
           ignored,
-        )) ?? { schemaVersion: 1 as const, rules: [] })
+          knownRuleSetIds,
+        )) ?? emptyOverlayDocument())
       : undefined;
+    const availableRuleSets = [
+      ...builtInPermissionRuleSets,
+      ...custom.available,
+    ];
+    const referencedIds = new Set(
+      [userOverlays, projectOverlays, conversationOverlays]
+        .flatMap((document) => document?.overlays ?? [])
+        .map((overlay) => overlay.ruleSetId),
+    );
+    const unavailableIds = [...referencedIds]
+      .filter((id) => !availableRuleSets.some((ruleSet) => ruleSet.id === id))
+      .sort();
     return {
       ruleSets: [
-        ...builtInPermissionRuleSets.map((ruleSet) => ({
+        ...availableRuleSets.map((ruleSet) => ({
           id: ruleSet.id,
           name: ruleSet.name,
           description: ruleSet.description,
@@ -178,19 +221,18 @@ export class PermissionPolicyService {
           compatibleModes: ruleSet.compatibleModes,
           available: true,
         })),
-        ...custom.available.map((ruleSet) => ({
-          id: ruleSet.id,
-          name: ruleSet.name,
-          description: ruleSet.description,
-          source: ruleSet.source,
-          enabled: ruleSet.enabled,
-          compatibleModes: ruleSet.compatibleModes,
-          available: true,
+        ...unavailableIds.map((id) => ({
+          id,
+          name: id,
+          source: "user" as const,
+          enabled: false,
+          available: false,
+          diagnostic: "The referenced permission rule set is unavailable.",
         })),
       ],
-      userOverlay,
-      projectOverlay,
-      ...(conversationOverlay ? { conversationOverlay } : {}),
+      userOverlays,
+      projectOverlays,
+      ...(conversationOverlays ? { conversationOverlays } : {}),
       projectTrust: await this.projectTrust(projectId),
       diagnostics: [
         ...custom.diagnostics,
@@ -244,16 +286,11 @@ export class PermissionPolicyService {
 
   async readOverlay(
     origin: PermissionOverlayOrigin,
+    ruleSetId: string,
     ownerId?: string,
   ): Promise<PermissionOverlay> {
-    const path = this.overlayPath(origin, ownerId);
-    const ignored: IgnoredPermissionSource[] = [];
-    return (
-      (await this.loadOverlay(origin, path, ignored)) ?? {
-        schemaVersion: 1,
-        rules: [],
-      }
-    );
+    const document = await this.readOverlayDocument(origin, ownerId);
+    return overlayForRuleSet(document, ruleSetId) ?? { ruleSetId, rules: [] };
   }
 
   async replaceOverlay(
@@ -262,24 +299,29 @@ export class PermissionPolicyService {
     ownerId?: string,
   ): Promise<PermissionOverlay> {
     const parsed = permissionOverlayForOriginSchema(origin).parse(overlay);
-    const path = this.overlayPath(origin, ownerId);
     return this.exclusive(`${origin}:${ownerId ?? "global"}`, async () => {
-      await atomicWriteJson(path, parsed, 0o600);
-      if (origin === "project") {
-        if (!ownerId) throw new Error("Project ID is required.");
-        await this.trustProject(ownerId);
-      }
+      const current = await this.readOverlayDocument(origin, ownerId);
+      await this.writeOverlayDocument(
+        origin,
+        replaceOverlayGroup(current, parsed),
+        ownerId,
+      );
       return parsed;
     });
   }
 
   async saveRule(
     origin: PermissionOverlayOrigin,
+    ruleSetId: string,
     rule: PermissionRule,
     ownerId?: string,
   ): Promise<PermissionOverlay> {
     return this.exclusive(`${origin}:${ownerId ?? "global"}`, async () => {
-      const current = await this.readOverlay(origin, ownerId);
+      const currentDocument = await this.readOverlayDocument(origin, ownerId);
+      const current = overlayForRuleSet(currentDocument, ruleSetId) ?? {
+        ruleSetId,
+        rules: [],
+      };
       const canonical = canonicalMatcher(rule);
       const duplicate = current.rules.findIndex(
         (candidate) =>
@@ -314,14 +356,14 @@ export class PermissionPolicyService {
         enforcement: desiredEnforcement,
       };
       const parsed = permissionOverlayForOriginSchema(origin).parse({
-        schemaVersion: 1,
+        ruleSetId,
         rules: [...remaining, saved],
       });
-      await atomicWriteJson(this.overlayPath(origin, ownerId), parsed, 0o600);
-      if (origin === "project") {
-        if (!ownerId) throw new Error("Project ID is required.");
-        await this.trustProject(ownerId);
-      }
+      await this.writeOverlayDocument(
+        origin,
+        replaceOverlayGroup(currentDocument, parsed),
+        ownerId,
+      );
       return parsed;
     });
   }
@@ -340,7 +382,7 @@ export class PermissionPolicyService {
     }
     let digest: string;
     try {
-      permissionOverlayForOriginSchema("project").parse(JSON.parse(content));
+      parseOverlayDocument("project", content, []);
       digest = digestContent(content);
     } catch (error) {
       return {
@@ -370,7 +412,7 @@ export class PermissionPolicyService {
     const project = this.getProject(projectId);
     const path = this.projectOverlayPath(project);
     const content = await readFile(path, "utf8");
-    permissionOverlayForOriginSchema("project").parse(JSON.parse(content));
+    parseOverlayDocument("project", content, []);
     const digest = digestContent(content);
     await this.exclusive(`project-trust:${projectId}`, async () => {
       const current = await this.storage.canonicalStore.readDocument(
@@ -403,15 +445,54 @@ export class PermissionPolicyService {
     });
   }
 
-  private async loadOverlay(
+  private knownRuleSetIds(custom: readonly PermissionRuleSet[]): string[] {
+    return [...builtInPermissionRuleSets, ...custom]
+      .map((ruleSet) => ruleSet.id)
+      .filter((id, index, ids) => ids.indexOf(id) === index)
+      .sort();
+  }
+
+  private async readOverlayDocument(
+    origin: PermissionOverlayOrigin,
+    ownerId?: string,
+  ): Promise<PermissionOverlayDocument> {
+    const ignored: IgnoredPermissionSource[] = [];
+    const custom = await this.customRuleSets();
+    return (
+      (await this.loadOverlayDocument(
+        origin,
+        this.overlayPath(origin, ownerId),
+        ignored,
+        this.knownRuleSetIds(custom.available),
+      )) ?? emptyOverlayDocument()
+    );
+  }
+
+  private async writeOverlayDocument(
+    origin: PermissionOverlayOrigin,
+    document: PermissionOverlayDocument,
+    ownerId?: string,
+  ): Promise<void> {
+    const parsed =
+      permissionOverlayDocumentForOriginSchema(origin).parse(document);
+    await atomicWriteJson(this.overlayPath(origin, ownerId), parsed, 0o600);
+    if (origin === "project") {
+      if (!ownerId) throw new Error("Project ID is required.");
+      await this.trustProject(ownerId);
+    }
+  }
+
+  private async loadOverlayDocument(
     origin: PermissionOverlayOrigin,
     path: string,
     ignored: IgnoredPermissionSource[],
-  ): Promise<PermissionOverlay | undefined> {
+    knownRuleSetIds: readonly string[],
+  ): Promise<PermissionOverlayDocument | undefined> {
     try {
-      const content = await readFile(path, "utf8");
-      return permissionOverlayForOriginSchema(origin).parse(
-        JSON.parse(content),
+      return parseOverlayDocument(
+        origin,
+        await readFile(path, "utf8"),
+        knownRuleSetIds,
       );
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
@@ -467,6 +548,49 @@ export class PermissionPolicyService {
       if (this.queues.get(key) === tail) this.queues.delete(key);
     });
   }
+}
+
+function parseOverlayDocument(
+  origin: PermissionOverlayOrigin,
+  content: string,
+  knownRuleSetIds: readonly string[],
+): PermissionOverlayDocument {
+  const value: unknown = JSON.parse(content);
+  const current =
+    permissionOverlayDocumentForOriginSchema(origin).safeParse(value);
+  if (current.success) return current.data;
+
+  const legacy = legacyPermissionOverlaySchema.parse(value);
+  permissionOverlayForOriginSchema(origin).parse({
+    ruleSetId: "baseline",
+    rules: legacy.rules,
+  });
+  return permissionOverlayDocumentForOriginSchema(origin).parse({
+    schemaVersion: 2,
+    overlays: [...new Set(knownRuleSetIds)].sort().map((ruleSetId) => ({
+      ruleSetId,
+      rules: legacy.rules,
+    })),
+  });
+}
+
+function overlayForRuleSet(
+  document: PermissionOverlayDocument | undefined,
+  ruleSetId: string,
+): PermissionOverlay | undefined {
+  return document?.overlays.find((overlay) => overlay.ruleSetId === ruleSetId);
+}
+
+function replaceOverlayGroup(
+  document: PermissionOverlayDocument,
+  overlay: PermissionOverlay,
+): PermissionOverlayDocument {
+  const overlays = document.overlays.filter(
+    (candidate) => candidate.ruleSetId !== overlay.ruleSetId,
+  );
+  if (overlay.rules.length > 0) overlays.push(overlay);
+  overlays.sort((left, right) => left.ruleSetId.localeCompare(right.ruleSetId));
+  return { schemaVersion: 2, overlays };
 }
 
 function digestContent(content: string): string {

--- a/packages/workbench-server/src/domains/tools/execution/tool-service.ts
+++ b/packages/workbench-server/src/domains/tools/execution/tool-service.ts
@@ -462,6 +462,7 @@ export class ToolService {
       offeredScopes: durableApprovalScopes(interaction.request.offeredScopes),
       suggestedExceptions: interaction.request.suggestedExceptions,
       suggestedRules: interaction.request.suggestedRules,
+      permissionRuleSetId: interaction.request.permissionRuleSetId,
     };
   }
 
@@ -698,6 +699,8 @@ export class ToolService {
               suggestedExceptions: evaluation.suggestedExceptions ?? [],
               suggestedRules:
                 evaluation.permissionEvaluation?.suggestedRules ?? [],
+              permissionRuleSetId:
+                evaluation.permissionEvaluation?.selectedRuleSetId,
             },
           },
         ],

--- a/packages/workbench-server/src/domains/tools/orchestration/tool-interaction-resolution.service.ts
+++ b/packages/workbench-server/src/domains/tools/orchestration/tool-interaction-resolution.service.ts
@@ -82,8 +82,15 @@ export class ToolInteractionResolutionService {
             "This approval does not offer the requested durable grant scope.",
           );
         if (interaction.request.suggestedRules[0]) {
+          if (!interaction.request.permissionRuleSetId)
+            throw new ApplicationError(
+              400,
+              "APPROVAL_RULE_SET_MISSING",
+              "This historical approval cannot create a durable rule without its evaluated permission rule set.",
+            );
           await this.permissionPolicy.saveRule(
             durableScope,
+            interaction.request.permissionRuleSetId,
             interaction.request.suggestedRules[0],
             durableScope === "project"
               ? current.projectId

--- a/packages/workbench-server/test/domains/permissions/permission-policy-service.test.ts
+++ b/packages/workbench-server/test/domains/permissions/permission-policy-service.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -64,7 +64,12 @@ const allowWrite = {
 
 test("conversation rules persist independently and compose at highest scope", async () => {
   const { service, agent } = await setup();
-  await service.saveRule("conversation", allowWrite, agent.conversationId);
+  await service.saveRule(
+    "conversation",
+    "supervised",
+    allowWrite,
+    agent.conversationId,
+  );
   const resolved = await service.resolve(agent);
   const winner = resolved.policy.rules.find(
     (entry) =>
@@ -73,16 +78,131 @@ test("conversation rules persist independently and compose at highest scope", as
   assert.ok(winner);
   assert.equal(winner.precedence.scopeRank, 4);
   assert.deepEqual(
-    (await service.readOverlay("conversation", agent.conversationId)).rules,
+    (
+      await service.readOverlay(
+        "conversation",
+        "supervised",
+        agent.conversationId,
+      )
+    ).rules,
     [{ ...allowWrite, priority: 0 }],
   );
+});
+
+test("overlay rules apply only to their bound selected rule set", async () => {
+  const { service, agent } = await setup();
+  await service.saveRule("user", "planning", allowWrite);
+
+  const coding = await service.resolve(agent);
+  assert.equal(
+    coding.policy.rules.some(
+      (entry) => entry.origin === "user" && entry.rule.id === "allow-write",
+    ),
+    false,
+  );
+
+  agent.mode = "planning";
+  const planning = await service.resolve(agent);
+  assert.equal(planning.selectedRuleSetId, "planning");
+  assert.ok(
+    planning.policy.rules.some(
+      (entry) =>
+        entry.origin === "user" &&
+        entry.ruleSetId === "planning" &&
+        entry.rule.id === "allow-write",
+    ),
+  );
+});
+
+test("legacy flat overlays normalize to explicit groups and write forward", async () => {
+  const { service, storage } = await setup();
+  await writeFile(
+    storage.paths.permissionsConfigPath,
+    JSON.stringify({ schemaVersion: 1, rules: [allowWrite] }),
+  );
+
+  const configuration = await service.configuration("proj_test");
+  for (const id of ["planning", "supervised", "autonomous", "read_only"]) {
+    assert.ok(
+      configuration.userOverlays.overlays.some(
+        (overlay) =>
+          overlay.ruleSetId === id && overlay.rules[0]?.id === "allow-write",
+      ),
+    );
+  }
+
+  await service.replaceOverlay("user", {
+    ruleSetId: "supervised",
+    rules: [],
+  });
+  const written = JSON.parse(
+    await readFile(storage.paths.permissionsConfigPath, "utf8"),
+  );
+  assert.equal(written.schemaVersion, 2);
+  assert.equal(
+    written.overlays.some(
+      (overlay: { ruleSetId: string }) => overlay.ruleSetId === "supervised",
+    ),
+    false,
+  );
+  assert.ok(
+    written.overlays.some(
+      (overlay: { ruleSetId: string }) => overlay.ruleSetId === "planning",
+    ),
+  );
+});
+
+test("dormant overlays remain visible but never apply to another set", async () => {
+  const { service, storage, agent } = await setup();
+  await writeFile(
+    storage.paths.permissionsConfigPath,
+    JSON.stringify({
+      schemaVersion: 2,
+      overlays: [{ ruleSetId: "removed-set", rules: [allowWrite] }],
+    }),
+  );
+  const configuration = await service.configuration(agent.projectId);
+  const removed = configuration.ruleSets.find(
+    (ruleSet) => ruleSet.id === "removed-set",
+  );
+  assert.equal(removed?.available, false);
+  assert.equal(
+    (await service.resolve(agent)).policy.rules.some(
+      (entry) => entry.origin === "user",
+    ),
+    false,
+  );
+});
+
+test("trusted legacy project overlays retain trust until explicit v2 write-forward", async () => {
+  const { service, project } = await setup();
+  const path = join(project.dir, ".nerve", "config", "permissions.json");
+  await mkdir(join(project.dir, ".nerve", "config"), { recursive: true });
+  await writeFile(
+    path,
+    JSON.stringify({ schemaVersion: 1, rules: [allowWrite] }),
+  );
+  assert.equal((await service.trustProject(project.id)).status, "trusted");
+  assert.ok(
+    (await service.configuration(project.id)).projectOverlays.overlays.some(
+      (overlay) => overlay.ruleSetId === "planning",
+    ),
+  );
+
+  await service.replaceOverlay(
+    "project",
+    { ruleSetId: "planning", rules: [allowWrite] },
+    project.id,
+  );
+  assert.equal((await service.projectTrust(project.id)).status, "trusted");
+  assert.equal(JSON.parse(await readFile(path, "utf8")).schemaVersion, 2);
 });
 
 test("project overlays remain inactive until their complete content digest is trusted", async () => {
   const { service, project, agent } = await setup();
   await service.replaceOverlay(
     "project",
-    { schemaVersion: 1, rules: [allowWrite] },
+    { ruleSetId: "supervised", rules: [allowWrite] },
     project.id,
   );
   assert.equal((await service.projectTrust(project.id)).status, "trusted");
@@ -94,7 +214,7 @@ test("project overlays remain inactive until their complete content digest is tr
 
   const path = join(project.dir, ".nerve", "config", "permissions.json");
   const raw = JSON.parse(await readFile(path, "utf8"));
-  raw.rules[0].description = "Externally changed";
+  raw.overlays[0].rules[0].description = "Externally changed";
   await writeFile(path, JSON.stringify(raw));
   assert.equal((await service.projectTrust(project.id)).status, "untrusted");
   const resolved = await service.resolve(agent);
@@ -111,7 +231,7 @@ test("project trust persists across service reconstruction and revokes in isolat
   const { storage, service, project } = await setup();
   await service.replaceOverlay(
     "project",
-    { schemaVersion: 1, rules: [allowWrite] },
+    { ruleSetId: "supervised", rules: [allowWrite] },
     project.id,
   );
   const reconstructed = new PermissionPolicyService(storage, () => project);
@@ -127,7 +247,7 @@ test("invalid canonical project trust never activates an overlay", async () => {
   const { storage, service, project } = await setup();
   await service.replaceOverlay(
     "project",
-    { schemaVersion: 1, rules: [allowWrite] },
+    { ruleSetId: "supervised", rules: [allowWrite] },
     project.id,
   );
   const current = await storage.canonicalStore.readDocument(
@@ -149,9 +269,9 @@ test("invalid canonical project trust never activates an overlay", async () => {
   assert.equal((await service.projectTrust(project.id)).status, "untrusted");
 });
 
-test("invalid custom selection falls back to Baseline while retaining overlays", async () => {
+test("invalid custom selection falls back to Baseline without overlays", async () => {
   const { service, agent } = await setup();
-  await service.saveRule("user", {
+  await service.saveRule("user", "supervised", {
     ...allowWrite,
     id: "never-write",
     enforcement: "guardrail",
@@ -161,17 +281,16 @@ test("invalid custom selection falls back to Baseline while retaining overlays",
   const resolved = await service.resolve(agent);
   assert.equal(resolved.fallback, true);
   assert.deepEqual(resolved.policy.activeRuleSetIds, ["baseline"]);
-  assert.ok(
-    resolved.policy.rules.some(
-      (entry) => entry.origin === "user" && entry.rule.id === "never-write",
-    ),
+  assert.equal(
+    resolved.policy.rules.some((entry) => entry.origin === "user"),
+    false,
   );
   assert.match(resolved.diagnostics.join("\n"), /missing, disabled, malformed/);
 });
 
 test("Explore children receive only fixed Read only without overlays", async () => {
   const { service, agent } = await setup();
-  await service.saveRule("user", allowWrite);
+  await service.saveRule("user", "autonomous", allowWrite);
   agent.parentAgentId = "agent_parent";
   agent.permissionRuleSetId = "autonomous";
   const resolved = await service.resolve(agent);

--- a/packages/workbench-server/test/domains/tools/tool-interaction-resolution.test.ts
+++ b/packages/workbench-server/test/domains/tools/tool-interaction-resolution.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  PermissionOverlayOrigin,
+  PermissionRule,
+} from "@nervekit/contracts/permissions";
+import type { ToolCallRecord } from "@nervekit/contracts/tools";
+import { ToolInteractionResolutionService } from "../../../src/domains/tools/orchestration/tool-interaction-resolution.service.js";
+
+const suggestedRule: PermissionRule = {
+  id: "allow-command",
+  enabled: true,
+  priority: 0,
+  enforcement: "overridable",
+  when: { toolNames: ["bash"] },
+  decision: "allow",
+};
+
+function pendingToolCall(permissionRuleSetId?: string): ToolCallRecord {
+  return {
+    id: "tool_test",
+    revision: 1,
+    projectId: "proj_test",
+    conversationId: "conv_test",
+    interactions: [
+      {
+        ordinal: 0,
+        kind: "approval",
+        status: "pending",
+        request: {
+          risk: "command",
+          reason: "Approval required.",
+          offeredScopes: ["single_call", "always_project"],
+          suggestedExceptions: [],
+          suggestedRules: [suggestedRule],
+          permissionRuleSetId,
+        },
+      },
+    ],
+  } as unknown as ToolCallRecord;
+}
+
+function service(input: {
+  toolCall: ToolCallRecord;
+  saveRule(...args: unknown[]): Promise<unknown>;
+}) {
+  return new ToolInteractionResolutionService(
+    { getToolCall: () => input.toolCall } as never,
+    {} as never,
+    { resolveApproval: async () => input.toolCall } as never,
+    { saveRule: input.saveRule } as never,
+    {} as never,
+  );
+}
+
+const durableProjectRequest = {
+  toolCallId: "tool_test",
+  interactionOrdinal: 0,
+  expectedRevision: 1,
+  resolutionRequestId: "resolution_test",
+  resolution: {
+    kind: "approval" as const,
+    action: "allow" as const,
+    scope: "always_project" as const,
+  },
+};
+
+test("durable approvals persist to the evaluation-time permission rule set", async () => {
+  const calls: Array<{
+    origin: PermissionOverlayOrigin;
+    ruleSetId: string;
+    rule: PermissionRule;
+    ownerId?: string;
+  }> = [];
+  const resolver = service({
+    toolCall: pendingToolCall("planning"),
+    saveRule: async (origin, ruleSetId, rule, ownerId) => {
+      calls.push({
+        origin: origin as PermissionOverlayOrigin,
+        ruleSetId: ruleSetId as string,
+        rule: rule as PermissionRule,
+        ownerId: ownerId as string | undefined,
+      });
+      return undefined;
+    },
+  });
+
+  await resolver.resolve(durableProjectRequest);
+  assert.deepEqual(calls, [
+    {
+      origin: "project",
+      ruleSetId: "planning",
+      rule: suggestedRule,
+      ownerId: "proj_test",
+    },
+  ]);
+});
+
+test("historical approvals without rule-set evidence cannot create durable rules", async () => {
+  let saved = false;
+  const resolver = service({
+    toolCall: pendingToolCall(),
+    saveRule: async () => {
+      saved = true;
+    },
+  });
+
+  await assert.rejects(
+    resolver.resolve(durableProjectRequest),
+    /historical approval cannot create a durable rule/,
+  );
+  assert.equal(saved, false);
+});

--- a/packages/workbench-server/test/infrastructure/persistence/legacy-v2-home-migration.test.ts
+++ b/packages/workbench-server/test/infrastructure/persistence/legacy-v2-home-migration.test.ts
@@ -261,7 +261,7 @@ test("migrates legacy v2 configuration, conversations, credentials, payloads, an
   );
   // Permission exceptions were never externally shipped and are not imported
   // into the versioned rule-set/overlay format.
-  assert.deepEqual(storage.configuration.permissions.rules, []);
+  assert.deepEqual(storage.configuration.permissions.overlays, []);
   const migratedAgent = await storage.canonicalStore.readDocument<
     Record<string, unknown>
   >("agent", "global", "agent_migration_test");


### PR DESCRIPTION
## Summary
- store user, project, and conversation overlays as rule-set-bound groups in one atomic v2 document per scope
- compose only overlays for the selected rule set and bind durable approvals to evaluation-time rule-set identity
- add legacy overlay migration, project trust handling, settings/approval UI updates, tests, and documentation

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`
