### PR TITLE
fix: normalize legacy tool permission evidence

### DIFF
--- a/packages/contracts/src/domains/tools/records.ts
+++ b/packages/contracts/src/domains/tools/records.ts
@@ -396,6 +396,36 @@ export const toolCallRecordSchema = toolCallRecordBaseSchema.superRefine(
 );
 export type ToolCallRecord = z.infer<typeof toolCallRecordSchema>;
 
+/**
+ * Upgrades permission evidence stored before v0.27 without changing schemas or
+ * checksum inputs for immutable conversation journal commits.
+ */
+export function normalizeLegacyToolCallRecord(
+  record: ToolCallRecord,
+): ToolCallRecord {
+  const evaluation = record.permissionEvaluation;
+  if (
+    !evaluation ||
+    Object.hasOwn(evaluation, "winningRuleSetId") ||
+    Object.hasOwn(evaluation, "selectedRuleSetId")
+  ) {
+    return record;
+  }
+  const selectedRuleSetId = evaluation.activeRuleSetIds.at(-1);
+  if (!selectedRuleSetId) return record;
+  return {
+    ...record,
+    permissionEvaluation: {
+      ...evaluation,
+      winningRuleSetId:
+        evaluation.winningRuleOrigin === "baseline"
+          ? "baseline"
+          : selectedRuleSetId,
+      selectedRuleSetId,
+    },
+  };
+}
+
 export const toolCallPreviewOverflowSchema = z.object({
   hidden: z.number().int().nonnegative(),
   noun: z.string().min(1),

--- a/packages/contracts/test/tool/tool-result-payload-validation.test.ts
+++ b/packages/contracts/test/tool/tool-result-payload-validation.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  normalizeLegacyToolCallRecord,
   toolCallRecordSchema,
   toolResultPayloadReferenceSchema,
 } from "../../src/domains/tools/index.js";
@@ -17,6 +18,61 @@ const reference = {
   encoding: "utf-8" as const,
   completeness: "complete" as const,
 };
+
+describe("stored tool-call compatibility", () => {
+  it("infers rule-set evidence omitted before v0.27", () => {
+    const now = "2026-08-25T00:00:00.000Z";
+    const legacy = {
+      id: "tool_legacy",
+      agentId: "agent_test",
+      conversationId: "conv_test",
+      projectId: "proj_test",
+      toolName: "read",
+      risk: "read",
+      args: { path: "README.md" },
+      cwd: "/tmp/project",
+      status: "running",
+      revision: 1,
+      attempt: 1,
+      interactions: [],
+      permissionEvaluation: {
+        decision: "allow",
+        reason: "Legacy permission decision.",
+        baseRisk: "read",
+        normalizedTargets: [{ kind: "whole_tool" }],
+        winningRuleId: "allow-read",
+        winningRule: {
+          id: "allow-read",
+          enabled: true,
+          priority: 10,
+          enforcement: "overridable",
+          when: { baseRisks: ["read"] },
+          decision: "allow",
+        },
+        winningRuleOrigin: "rule_set",
+        winningRuleEnforcement: "overridable",
+        winningRulePrecedence: {
+          enforcementRank: 0,
+          scopeRank: 1,
+          priority: 10,
+        },
+        activeRuleSetIds: ["baseline", "autonomous"],
+        ignoredOverlays: [],
+        policySnapshotHash: `sha256:${"0".repeat(64)}`,
+        suggestedRules: [],
+      },
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    assert.equal(toolCallRecordSchema.safeParse(legacy).success, false);
+    const parsed = toolCallRecordSchema.parse(
+      normalizeLegacyToolCallRecord(legacy as never),
+    );
+    assert.equal(parsed.permissionEvaluation?.selectedRuleSetId, "autonomous");
+    assert.equal(parsed.permissionEvaluation?.winningRuleSetId, "autonomous");
+  });
+});
 
 describe("tool-result payload reference", () => {
   it("accepts a transport-safe owner and digest descriptor", () => {

--- a/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
+++ b/packages/workbench-server/src/domains/conversations/conversation-journal.repository.ts
@@ -39,7 +39,10 @@ import {
   type RunRecord,
   type RunTransitionRecord,
 } from "@nervekit/contracts/runs";
-import { type ToolCallRecord } from "@nervekit/contracts/tools";
+import {
+  normalizeLegacyToolCallRecord,
+  type ToolCallRecord,
+} from "@nervekit/contracts/tools";
 
 export interface ConversationJournalState {
   conversationId: string;
@@ -426,11 +429,18 @@ export class ConversationJournalRepository {
     await this.ready;
     const stored = await this.canonical.readConversationJournal(conversationId);
     const state = stored.snapshot
-      ? deserializeState(decode(stored.snapshot) as SerializedConversationState)
+      ? deserializeState(
+          normalizeLegacyToolCalls(
+            decode(stored.snapshot),
+          ) as SerializedConversationState,
+        )
       : emptyState(conversationId);
     for (const value of stored.commits) {
-      const commit = conversationJournalCommitSchema.parse(decode(value));
-      verifyCommit(state, commit);
+      const decoded = decode(value) as Record<string, unknown>;
+      const commit = conversationJournalCommitSchema.parse(
+        normalizeLegacyToolCalls(decoded),
+      );
+      verifyCommit(state, commit, decoded);
       applyCommit(state, commit);
     }
     if (
@@ -542,9 +552,28 @@ export function journalChecksum(value: unknown): string {
   return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
 }
 
+function normalizeLegacyToolCalls(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeLegacyToolCalls);
+  if (typeof value !== "object" || value === null) return value;
+  const record = value as Record<string, unknown>;
+  const normalized = Object.hasOwn(record, "permissionEvaluation")
+    ? (normalizeLegacyToolCallRecord(record as ToolCallRecord) as Record<
+        string,
+        unknown
+      >)
+    : record;
+  return Object.fromEntries(
+    Object.entries(normalized).map(([key, child]) => [
+      key,
+      normalizeLegacyToolCalls(child),
+    ]),
+  );
+}
+
 function verifyCommit(
   state: ConversationJournalState,
   commit: ConversationJournalCommit,
+  checksumSource: Record<string, unknown> = commit,
 ): void {
   if (
     commit.epoch !== CONVERSATION_JOURNAL_EPOCH ||
@@ -558,7 +587,7 @@ function verifyCommit(
     );
   }
   const base = Object.fromEntries(
-    Object.entries(commit).filter(([key]) => key !== "checksum"),
+    Object.entries(checksumSource).filter(([key]) => key !== "checksum"),
   );
   if (journalChecksum(base) !== commit.checksum) {
     throw new Error(

--- a/packages/workbench-server/src/domains/tools/artifacts/tool-call.repository.ts
+++ b/packages/workbench-server/src/domains/tools/artifacts/tool-call.repository.ts
@@ -1,4 +1,5 @@
 import {
+  normalizeLegacyToolCallRecord,
   toolCallRecordSchema,
   type ToolCallDetails,
   type ToolCallRecord,
@@ -104,7 +105,8 @@ export class ToolCallRepository {
       this.journal.countToolCallProjections(),
       this.journal.listToolCallStartupRecords(),
     ]);
-    for (const record of startupRecords) {
+    for (const storedRecord of startupRecords) {
+      const record = normalizeLegacyToolCallRecord(storedRecord);
       if (record.interactions.length > 0) {
         this.interactionRecords.set(record.id, record);
       }
@@ -190,8 +192,9 @@ export class ToolCallRepository {
     if (cached) return cached.record;
     const stored = await this.journal.readToolCall(toolCallId);
     if (!stored) throw new Error("Tool call not found.");
-    this.cacheTerminal(stored, Buffer.byteLength(JSON.stringify(stored)));
-    return stored;
+    const record = normalizeLegacyToolCallRecord(stored);
+    this.cacheTerminal(record, Buffer.byteLength(JSON.stringify(record)));
+    return record;
   }
 
   async getDetails(toolCallId: string): Promise<ToolCallDetails> {
@@ -349,10 +352,12 @@ export class ToolCallRepository {
       }
       const candidate = mutate(current);
       assertImmutableIdentity(current, candidate);
-      const next = toolCallRecordSchema.parse({
-        ...candidate,
-        revision: current.revision + 1,
-      });
+      const next = toolCallRecordSchema.parse(
+        normalizeLegacyToolCallRecord({
+          ...candidate,
+          revision: current.revision + 1,
+        }),
+      );
       const journalState = await this.journal.load(next.conversationId);
       const events: ConversationJournalEvent[] = [
         {


### PR DESCRIPTION
## Summary
- normalize pre-v0.27 tool-call permission evidence when loading stored records and journal data
- preserve journal checksum inputs while applying compatibility normalization
- add contract coverage for legacy permission records