### PR TITLE
Clarify plan mode guidance

### DIFF
--- a/packages/workbench-server/src/domains/agents/prompting/nerve-system-prompt.ts
+++ b/packages/workbench-server/src/domains/agents/prompting/nerve-system-prompt.ts
@@ -73,7 +73,7 @@ function defaultPrompt(options: {
   for (const guideline of options.promptGuidelines) addToolRule(guideline);
   if (options.mode !== "planning" && activeTools.has("plan_mode_enter")) {
     addToolRule(
-      "Enter plan mode before requested plans or design-heavy edits.",
+      "Use Plan Mode only for explicit plan requests or implementation with unresolved design decisions—not codebase questions, exploration, debugging, or routine edits.",
     );
   }
 


### PR DESCRIPTION
## Summary
- restrict Plan Mode to explicit planning requests or unresolved implementation design decisions
- clarify that codebase questions, exploration, debugging, and routine edits should not trigger Plan Mode

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`