### PR TITLE
Improve task definition editing and duplication

### DIFF
--- a/packages/workbench-app/src/lib/features/tasks/views/TaskDefinitionDialog.svelte
+++ b/packages/workbench-app/src/lib/features/tasks/views/TaskDefinitionDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { untrack } from "svelte";
 import type {
   CreateTaskDefinitionRequest,
   UpdateTaskDefinitionRequest,
@@ -14,7 +15,13 @@ import type { TaskPanelDefinition } from "./task-panel-types";
 type Props = {
   open?: boolean;
   definition?: TaskPanelDefinition;
-  initial?: { label?: string; command: string; cwd?: string; port?: number };
+  initial?: {
+    label?: string;
+    command: string;
+    cwd?: string;
+    port?: number;
+    runPolicy?: "single" | "concurrent";
+  };
   projectCwd?: string;
   saving?: boolean;
   title?: string;
@@ -39,11 +46,12 @@ let {
   onOpenChange,
 }: Props = $props();
 
-let label = $state("");
-let commandText = $state("");
-let cwd = $state("");
-let port = $state<number | undefined>(undefined);
-let runPolicy = $state<"single" | "concurrent">("single");
+const source = untrack(() => definition ?? initial);
+let label = $state(source?.label ?? "");
+let commandText = $state(source?.command ?? "");
+let cwd = $state(source?.cwd ?? "");
+let port = $state<number | undefined>(source?.port);
+let runPolicy = $state<"single" | "concurrent">(source?.runPolicy ?? "single");
 
 const dialogTitle = $derived(
   title ?? (definition ? "Edit task" : "Create task"),
@@ -61,16 +69,6 @@ const portValid = $derived(
   port === undefined || (Number.isInteger(port) && port >= 1 && port <= 65_535),
 );
 const canSave = $derived(!saving && commandText.trim().length > 0 && portValid);
-
-$effect(() => {
-  if (!open) return;
-  const source = definition ?? initial;
-  label = source?.label ?? "";
-  commandText = source?.command ?? "";
-  cwd = source?.cwd ?? "";
-  port = source?.port;
-  runPolicy = definition?.runPolicy ?? "single";
-});
 
 function submit() {
   if (!canSave) return;
@@ -90,13 +88,14 @@ function submit() {
   bind:open
   title={dialogTitle}
   description={dialogDescription}
-  class="max-w-xl"
+  size="sm"
   {onOpenChange}
 >
-  <div class="grid gap-4">
+  <div class="grid gap-3">
     <div class="grid gap-1.5">
       <Label for="task-definition-label">Label</Label>
       <Input
+        size="xs"
         id="task-definition-label"
         bind:value={label}
         placeholder="web-dev"
@@ -109,9 +108,9 @@ function submit() {
       <Textarea
         id="task-definition-command"
         bind:value={commandText}
-        rows={4}
+        rows={3}
         placeholder="pnpm dev"
-        class="font-mono text-xs"
+        class="min-h-20 py-1.5 font-mono text-xs md:text-xs"
         disabled={saving}
       />
       <p class="text-xs text-muted-foreground">
@@ -122,6 +121,7 @@ function submit() {
     <div class="grid gap-1.5">
       <Label for="task-definition-port">Port</Label>
       <Input
+        size="xs"
         id="task-definition-port"
         bind:value={port}
         type="number"
@@ -146,6 +146,7 @@ function submit() {
           { value: "concurrent", label: "Concurrent runs" },
         ]}
         disabled={saving}
+        triggerClass="h-7 px-2 text-xs"
       />
       <p class="text-xs text-muted-foreground">
         Single run focuses an existing process. Concurrent runs may start
@@ -156,6 +157,7 @@ function submit() {
     <div class="grid gap-1.5">
       <Label for="task-definition-cwd">Working directory</Label>
       <Input
+        size="xs"
         id="task-definition-cwd"
         bind:value={cwd}
         placeholder={projectCwd
@@ -165,7 +167,8 @@ function submit() {
         disabled={saving}
       />
       <p class="text-xs text-muted-foreground">
-        Leave blank to use the default working directory.
+        Leave blank to use the project directory. Relative paths resolve from
+        it.
       </p>
     </div>
   </div>

--- a/packages/workbench-app/src/lib/features/tasks/views/TaskDefinitionRow.svelte
+++ b/packages/workbench-app/src/lib/features/tasks/views/TaskDefinitionRow.svelte
@@ -33,6 +33,7 @@ let {
   onForceKill,
   onRestart,
   onEdit,
+  onDuplicate,
   onDelete,
   onCleanupRuns,
   onCopy,
@@ -46,6 +47,7 @@ let {
   onForceKill?: (taskId: string) => void;
   onRestart?: (taskId: string) => void;
   onEdit?: () => void;
+  onDuplicate?: () => void;
   onDelete?: () => void;
   onCleanupRuns?: (taskIds: readonly string[]) => void;
   onCopy?: (text: string) => void;
@@ -133,6 +135,12 @@ const menuItems = $derived.by<ContextMenuItem[]>(() => {
     icon: Pencil,
     disabled: !capabilities.manageDefinitions,
     onSelect: () => onEdit?.(),
+  });
+  items.push({
+    label: "Duplicate task",
+    icon: Copy,
+    disabled: !capabilities.manageDefinitions,
+    onSelect: () => onDuplicate?.(),
   });
   items.push({
     label: "Delete task",

--- a/packages/workbench-app/src/lib/features/tasks/views/TasksPanel.svelte
+++ b/packages/workbench-app/src/lib/features/tasks/views/TasksPanel.svelte
@@ -63,14 +63,18 @@ const selectedSiblingRuns = $derived.by(() => {
     )
     .sort((left, right) => right.startedAt.localeCompare(left.startedAt));
 });
-let addOpen = $state(false);
+type TaskDialogSession =
+  | { kind: "create" }
+  | { kind: "edit"; definition: TaskPanelDefinition }
+  | { kind: "duplicate"; definition: TaskPanelDefinition }
+  | { kind: "save-run"; task: TaskRecord };
+
+let taskDialog = $state<TaskDialogSession | undefined>();
 let saving = $state(false);
 let confirmPruneOpen = $state(false);
 let forceKillTask = $state<TaskRecord | undefined>();
-let editDefinition = $state<TaskPanelDefinition | undefined>();
 let deleteDefinition = $state<TaskPanelDefinition | undefined>();
 let cleanupRunIds = $state<readonly string[]>([]);
-let saveSourceTask = $state<TaskRecord | undefined>();
 let panelWidth = $state(0);
 let runsRegion = $state<HTMLDivElement | null>(null);
 let runsFooter = $state<HTMLDivElement | null>(null);
@@ -111,30 +115,42 @@ const capabilities = $derived<TaskEntryCapabilities>({
   manageDefinitions: model.capabilities.manageDefinitions.enabled,
 });
 
-async function createDefinition(
-  input: CreateTaskDefinitionRequest,
+async function saveDefinition(
+  input: CreateTaskDefinitionRequest | UpdateTaskDefinitionRequest,
 ): Promise<void> {
+  const session = taskDialog;
+  if (!session) return;
   saving = true;
   try {
-    await panelActions.createDefinition(input);
-    addOpen = false;
-    saveSourceTask = undefined;
+    if (session.kind === "edit") {
+      await panelActions.updateDefinition(session.definition, input);
+    } else {
+      await panelActions.createDefinition({
+        ...input,
+        ...(session.kind === "save-run"
+          ? { sourceTaskId: session.task.id }
+          : {}),
+      });
+    }
+    taskDialog = undefined;
   } finally {
     saving = false;
   }
 }
 
-async function updateDefinition(
-  input: UpdateTaskDefinitionRequest,
-): Promise<void> {
-  if (!editDefinition) return;
-  saving = true;
-  try {
-    await panelActions.updateDefinition(editDefinition, input);
-    editDefinition = undefined;
-  } finally {
-    saving = false;
+function dialogInitial(session: TaskDialogSession) {
+  if (session.kind === "duplicate") {
+    const { label, command, cwd, port, runPolicy } = session.definition;
+    return { label, command, cwd, port, runPolicy };
   }
+  if (session.kind === "save-run") {
+    return {
+      label: session.task.displayName ?? session.task.name,
+      command: session.task.command,
+      cwd: session.task.cwd === model.defaultCwd ? undefined : session.task.cwd,
+    };
+  }
+  return undefined;
 }
 
 async function cleanupRuns(): Promise<void> {
@@ -200,7 +216,7 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
               size="xs"
               variant="outline"
               disabled={!model.capabilities.manageDefinitions.enabled}
-              onclick={() => (addOpen = true)}
+              onclick={() => (taskDialog = { kind: "create" })}
             >
               <Plus />
               New task
@@ -219,7 +235,16 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
               onCancel={(id) => void panelActions.cancelTask(id)}
               onForceKill={requestForceKill}
               onRestart={(id) => void panelActions.restartTask(id)}
-              onEdit={() => (editDefinition = entry.definition)}
+              onEdit={() =>
+                (taskDialog = {
+                  kind: "edit",
+                  definition: entry.definition,
+                })}
+              onDuplicate={() =>
+                (taskDialog = {
+                  kind: "duplicate",
+                  definition: entry.definition,
+                })}
               onDelete={() => (deleteDefinition = entry.definition)}
               onCleanupRuns={(ids) => (cleanupRunIds = ids)}
               onCopy={(text) => void panelActions.copyText(text)}
@@ -257,7 +282,8 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
               onRestart={(id) => void panelActions.restartTask(id)}
               onRemove={(id) => void panelActions.removeTask(id)}
               onCopy={(text) => void panelActions.copyText(text)}
-              onSaveAsDefinition={(task) => (saveSourceTask = task)}
+              onSaveAsDefinition={(task) =>
+                (taskDialog = { kind: "save-run", task })}
             />
           {/each}
         </PanelList>
@@ -291,7 +317,7 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
               icon={Plus}
               label="Create task"
               disabled={!model.capabilities.manageDefinitions.enabled}
-              onclick={() => (addOpen = true)}
+              onclick={() => (taskDialog = { kind: "create" })}
             />
           {/if}
         {/snippet}
@@ -346,48 +372,39 @@ function rerunDefinition(entry: { definition?: TaskPanelDefinition }): void {
   onRerunDefinition={rerunDefinition}
   onRemove={(id) => void panelActions.removeTask(id)}
   onCopy={(text) => void panelActions.copyText(text)}
-  onSaveAsDefinition={(task) => (saveSourceTask = task)}
+  onSaveAsDefinition={(task) => (taskDialog = { kind: "save-run", task })}
 />
-<TaskDefinitionDialog
-  bind:open={addOpen}
-  projectCwd={model.defaultCwd}
-  {saving}
-  onSave={(input) => void createDefinition(input)}
-/>
-<TaskDefinitionDialog
-  open={Boolean(editDefinition)}
-  definition={editDefinition}
-  projectCwd={model.defaultCwd}
-  {saving}
-  onSave={(input) => void updateDefinition(input)}
-  onOpenChange={(open) => {
-    if (!open) editDefinition = undefined;
-  }}
-/>
-<TaskDefinitionDialog
-  open={Boolean(saveSourceTask)}
-  projectCwd={model.defaultCwd}
-  initial={saveSourceTask
-    ? {
-        label: saveSourceTask.displayName ?? saveSourceTask.name,
-        command: saveSourceTask.command,
-        cwd:
-          saveSourceTask.cwd === model.defaultCwd
-            ? undefined
-            : saveSourceTask.cwd,
-      }
-    : undefined}
-  title="Save as task definition"
-  description="Create a reusable definition from this run. The run stays linked to it."
-  submitLabel="Save task"
-  {saving}
-  onSave={(input) =>
-    saveSourceTask &&
-    void createDefinition({ ...input, sourceTaskId: saveSourceTask.id })}
-  onOpenChange={(open) => {
-    if (!open) saveSourceTask = undefined;
-  }}
-/>
+{#if taskDialog}
+  {@const session = taskDialog}
+  {#key session}
+    <TaskDefinitionDialog
+      open
+      definition={session.kind === "edit" ? session.definition : undefined}
+      initial={dialogInitial(session)}
+      projectCwd={model.defaultCwd}
+      title={session.kind === "duplicate"
+        ? "Duplicate task"
+        : session.kind === "save-run"
+          ? "Save as task definition"
+          : undefined}
+      description={session.kind === "duplicate"
+        ? "Create a new task definition from this saved task."
+        : session.kind === "save-run"
+          ? "Create a reusable definition from this run. The run stays linked to it."
+          : undefined}
+      submitLabel={session.kind === "duplicate"
+        ? "Create duplicate"
+        : session.kind === "save-run"
+          ? "Save task"
+          : undefined}
+      {saving}
+      onSave={(input) => void saveDefinition(input)}
+      onOpenChange={(open) => {
+        if (!open) taskDialog = undefined;
+      }}
+    />
+  {/key}
+{/if}
 <ConfirmDialog
   open={Boolean(model.portConflict)}
   destructive

--- a/packages/workbench-server/src/domains/task-definitions/task-definition-operations.ts
+++ b/packages/workbench-server/src/domains/task-definitions/task-definition-operations.ts
@@ -2,6 +2,7 @@ import type { ProjectRecord } from "@nervekit/contracts/projects";
 import type { CreateTaskDefinitionRequest } from "@nervekit/contracts/task-definitions";
 import type { TaskPortConflictListener } from "@nervekit/contracts/tasks";
 import type { WorkbenchTaskService } from "../tasks/adapters/workbench-task-service.js";
+import { resolveTaskWorkingDirectory } from "../tasks/model/task-working-directory.js";
 import type { TaskDefinitionService } from "./task-definition.service.js";
 
 export class TaskDefinitionOperations {
@@ -45,7 +46,10 @@ export class TaskDefinitionOperations {
         definitionPort: definition.port,
         terminateListeners,
         projectId: project.id,
-        cwd: definition.cwd ?? project.dir,
+        cwd: resolveTaskWorkingDirectory(
+          definition.cwd ?? project.dir,
+          project.dir,
+        ),
         command: definition.command,
         displayName: definition.label ?? definition.command,
         origin: { kind: "utility_panel" },

--- a/packages/workbench-server/src/domains/tasks/application/task-service.ts
+++ b/packages/workbench-server/src/domains/tasks/application/task-service.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type {
   StartTaskRequest,
   TaskPortConflictListener,
@@ -19,6 +18,7 @@ import {
 } from "../model/task-definition-launch.js";
 import { TaskProcessSupervisor } from "./task-process-supervisor.js";
 import { isTerminalTaskStatus } from "../model/task-status.js";
+import { resolveTaskWorkingDirectory } from "../model/task-working-directory.js";
 
 export { isTerminalTaskStatus } from "../model/task-status.js";
 
@@ -780,15 +780,4 @@ function boundedErrorMessage(error: unknown): string {
     0,
     4_096,
   );
-}
-
-export function resolveTaskWorkingDirectory(input: string): string {
-  const flavor =
-    /^[A-Za-z]:[\\/]/.test(input) || input.startsWith("\\")
-      ? path.win32
-      : path.posix;
-  if (!flavor.isAbsolute(input)) {
-    throw new Error("Task working directory must be an absolute path");
-  }
-  return flavor.resolve(input);
 }

--- a/packages/workbench-server/src/domains/tasks/model/task-working-directory.ts
+++ b/packages/workbench-server/src/domains/tasks/model/task-working-directory.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+
+export function resolveTaskWorkingDirectory(
+  input: string,
+  baseDirectory?: string,
+): string {
+  const inputFlavor = pathFlavor(input);
+  if (inputFlavor.isAbsolute(input)) return inputFlavor.resolve(input);
+  if (!baseDirectory) {
+    throw new Error("Task working directory must be an absolute path");
+  }
+
+  const baseFlavor = pathFlavor(baseDirectory);
+  if (!baseFlavor.isAbsolute(baseDirectory)) {
+    throw new Error("Task working directory base must be an absolute path");
+  }
+  return baseFlavor.resolve(baseDirectory, input);
+}
+
+function pathFlavor(input: string): typeof path.posix | typeof path.win32 {
+  return /^[A-Za-z]:[\\/]/.test(input) || input.startsWith("\\")
+    ? path.win32
+    : path.posix;
+}

--- a/packages/workbench-server/test/domains/tasks/task-definition-operations.test.ts
+++ b/packages/workbench-server/test/domains/tasks/task-definition-operations.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ProjectRecord } from "@nervekit/contracts/projects";
+import type { TaskDefinition } from "@nervekit/contracts/task-definitions";
+import { TaskDefinitionOperations } from "../../../src/domains/task-definitions/task-definition-operations.js";
+import type { TaskDefinitionService } from "../../../src/domains/task-definitions/task-definition.service.js";
+import type { WorkbenchTaskService } from "../../../src/domains/tasks/adapters/workbench-task-service.js";
+
+const now = "2026-09-06T00:00:00.000Z";
+const project: ProjectRecord = {
+  id: "proj_task_definition_cwd",
+  name: "Task definition cwd",
+  dir: "/workspace/project",
+  createdAt: now,
+  updatedAt: now,
+};
+
+function definition(cwd?: string): TaskDefinition {
+  return {
+    id: "taskdef_cwd",
+    scope: { kind: "project", projectId: project.id },
+    command: "pnpm dev",
+    cwd,
+    runPolicy: "single",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe("task definition launch working directories", () => {
+  it("resolves relative cwd values from the owning project", async () => {
+    const launched: Array<{ cwd: string }> = [];
+    let current = definition("apps/web");
+    const definitions = {
+      list: async () => [current],
+    } as unknown as TaskDefinitionService;
+    const tasks = {
+      launchDefinition: async (request: { cwd: string }) => {
+        launched.push(request);
+        return undefined;
+      },
+    } as unknown as WorkbenchTaskService;
+    const operations = new TaskDefinitionOperations(definitions, tasks, () => [
+      project,
+    ]);
+
+    await operations.launch(current.id);
+    current = definition("/opt/web");
+    await operations.launch(current.id);
+    current = definition();
+    await operations.launch(current.id);
+
+    assert.deepEqual(
+      launched.map((request) => request.cwd),
+      ["/workspace/project/apps/web", "/opt/web", "/workspace/project"],
+    );
+  });
+
+  it("uses Windows path semantics for Windows projects", async () => {
+    const windowsProject = { ...project, dir: "C:\\workspace\\project" };
+    const current = {
+      ...definition("apps\\web"),
+      scope: { kind: "project" as const, projectId: windowsProject.id },
+    };
+    let launchedCwd = "";
+    const definitions = {
+      list: async () => [current],
+    } as unknown as TaskDefinitionService;
+    const tasks = {
+      launchDefinition: async (request: { cwd: string }) => {
+        launchedCwd = request.cwd;
+        return undefined;
+      },
+    } as unknown as WorkbenchTaskService;
+
+    await new TaskDefinitionOperations(definitions, tasks, () => [
+      windowsProject,
+    ]).launch(current.id);
+
+    assert.equal(launchedCwd, "C:\\workspace\\project\\apps\\web");
+  });
+});

--- a/packages/workbench-server/test/domains/tasks/task-service.contract.test.ts
+++ b/packages/workbench-server/test/domains/tasks/task-service.contract.test.ts
@@ -351,13 +351,25 @@ test("terminal callbacks are idempotent across repeated exit and cancellation ra
   );
 });
 
-test("task working directories normalize POSIX and Windows absolute paths", async () => {
+test("task working directories normalize absolute and project-relative paths", async () => {
   const { resolveTaskWorkingDirectory } =
-    await import("../../../src/domains/tasks/application/task-service.js");
+    await import("../../../src/domains/tasks/model/task-working-directory.js");
   assert.equal(resolveTaskWorkingDirectory("/workspace/a/.."), "/workspace");
+  assert.equal(
+    resolveTaskWorkingDirectory("apps/web/..", "/workspace/project"),
+    "/workspace/project/apps",
+  );
+  assert.equal(
+    resolveTaskWorkingDirectory("../shared", "/workspace/project"),
+    "/workspace/shared",
+  );
   assert.equal(
     resolveTaskWorkingDirectory("C:\\workspace\\project\\.."),
     "C:\\workspace",
+  );
+  assert.equal(
+    resolveTaskWorkingDirectory("apps\\web\\..", "C:\\workspace\\project"),
+    "C:\\workspace\\project\\apps",
   );
   assert.equal(
     resolveTaskWorkingDirectory("\\\\server\\share\\project"),
@@ -366,6 +378,10 @@ test("task working directories normalize POSIX and Windows absolute paths", asyn
   assert.throws(
     () => resolveTaskWorkingDirectory("workspace/project"),
     /absolute path/,
+  );
+  assert.throws(
+    () => resolveTaskWorkingDirectory("workspace/project", "relative/base"),
+    /base must be an absolute path/,
   );
 });
 


### PR DESCRIPTION
## Summary
- stabilize task definition dialog state and use compact settings-style fields
- add task definition duplication with prefilled editable values
- support project-relative working directories with cross-platform resolution

## Validation
- `pnpm fix && pnpm check && pnpm run test:affected`