### PR TITLE
Fix stale approval recovery blocking startup

### DIFF
--- a/packages/workbench-server/src/domains/human-input/approval-batch-resolution.ts
+++ b/packages/workbench-server/src/domains/human-input/approval-batch-resolution.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { ApprovalRecord, ToolCallRecord } from "@nervekit/contracts/tools";
 import type { ConversationEntry } from "@nervekit/contracts/conversations";
 import { ApplicationError } from "../../core/application-error.js";
+import type { ApplicationLogger } from "../../infrastructure/diagnostics/logging.js";
 import type {
   ApprovalInteractionBatch,
   WorkbenchRunService,
@@ -12,6 +13,7 @@ import { toToolCallTranscriptRecord } from "../tools/artifacts/tool-call-transcr
 interface ApprovalBatchResolutionDeps {
   tools: ToolService;
   runs: WorkbenchRunService;
+  logger?: ApplicationLogger;
   appendToolResult(
     toolCall: ToolCallRecord,
     isError: boolean,
@@ -162,7 +164,7 @@ export class ApprovalBatchResolutionService {
           ) &&
           (await this.batchReady(current))
         ) {
-          await this.drain(current, interaction.toolCallId);
+          await this.recoverValidatedBatch(current, interaction.toolCallId);
         }
       });
     }
@@ -227,6 +229,46 @@ export class ApprovalBatchResolutionService {
     // Validate the branch before any approved side effect starts. Continuation
     // validation is intentionally not sufficient because it runs after tools.
     await this.deps.runs.assertApprovalBatchContextUnchanged(batch);
+    return this.drainValidated(batch, targetToolCallId);
+  }
+
+  private async recoverValidatedBatch(
+    batch: ApprovalInteractionBatch,
+    targetToolCallId: string,
+  ): Promise<ToolCallRecord> {
+    try {
+      await this.deps.runs.assertApprovalBatchContextUnchanged(batch);
+    } catch (error) {
+      if (!isStaleApprovalContextError(error)) throw error;
+      const result = await this.deps.runs.cancelStaleApprovalBatch(
+        batch,
+        `saved approval context became stale (${error.code})`,
+      );
+      if (result.outcome === "cancelled") {
+        await this.deps.logger?.warn(
+          "Saved approval recovery was cancelled because its context changed; no tools were executed by this recovery attempt. Review the conversation before starting a new turn",
+          {
+            conversationId: result.run.conversationId,
+            agentId: result.run.agentId,
+            runId: batch.runId,
+            context: {
+              errorCode: error.code,
+              checkpointId: batch.checkpointId,
+              toolCallIds: batch.batchToolCallIds,
+              outcome: result.outcome,
+            },
+          },
+        );
+      }
+      return this.deps.tools.getToolCallDetails(targetToolCallId);
+    }
+    return this.drainValidated(batch, targetToolCallId);
+  }
+
+  private async drainValidated(
+    batch: ApprovalInteractionBatch,
+    targetToolCallId: string,
+  ): Promise<ToolCallRecord> {
     const toolCalls: ToolCallRecord[] = [];
     const approvalsByToolCallId = new Map<string, ApprovalRecord>();
     for (const toolCallId of batch.batchToolCallIds) {
@@ -296,6 +338,16 @@ export class ApprovalBatchResolutionService {
       if (this.locks.get(key) === tail) this.locks.delete(key);
     });
   }
+}
+
+function isStaleApprovalContextError(
+  error: unknown,
+): error is ApplicationError {
+  return (
+    error instanceof ApplicationError &&
+    (error.code === "RUN_CHECKPOINT_STALE" ||
+      error.code === "RUN_TOOL_REVISION_STALE")
+  );
 }
 
 function resolutionRequestId(

--- a/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
+++ b/packages/workbench-server/src/domains/human-input/human-input-resolution.service.ts
@@ -86,6 +86,7 @@ export class HumanInputResolutionService {
     this.approvalBatches = new ApprovalBatchResolutionService({
       tools: deps.tools,
       runs: deps.runs,
+      logger: deps.logger,
       appendToolResult: (toolCall, isError) =>
         this.appendToolResultForToolCall(toolCall, isError),
       existingToolResultEntry: async (toolCall) =>

--- a/packages/workbench-server/src/domains/runs/application/workbench-run.service.ts
+++ b/packages/workbench-server/src/domains/runs/application/workbench-run.service.ts
@@ -339,6 +339,27 @@ export class WorkbenchRunService {
     };
   }
 
+  async cancelStaleApprovalBatch(
+    batch: ApprovalInteractionBatch,
+    reason: string,
+  ) {
+    const result = await this.coordinator.cancelWaitingCheckpoint({
+      runId: batch.runId,
+      checkpointId: batch.checkpointId,
+      interactionIds: batch.interactions.map((interaction) => interaction.id),
+      reason,
+    });
+    if (result.run.status === "cancellation_failed") {
+      throw new ApplicationError(
+        500,
+        "CANCELLATION_UNCONFIRMED",
+        result.run.failure?.message ??
+          "Stale approval recovery could not confirm run cancellation.",
+      );
+    }
+    return result;
+  }
+
   async assertApprovalBatchContextUnchanged(
     batch: ApprovalInteractionBatch,
   ): Promise<void> {

--- a/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
+++ b/packages/workbench-server/src/domains/runs/runtime/run-coordinator.ts
@@ -116,6 +116,10 @@ async function withCancellationDeadline<T>(
   }
 }
 
+export type GuardedRunCancellationResult =
+  | { outcome: "cancelled"; run: RunRecord }
+  | { outcome: "not_applicable"; run: RunRecord };
+
 export class RunCoordinator {
   private readonly locks = new KeyedSerialLock();
   private readonly live = new LiveExecutionRegistry();
@@ -393,24 +397,81 @@ export class RunCoordinator {
     );
   }
   async cancel(runId: string, reason?: string): Promise<RunRecord> {
-    const targets = CANCELLATION_TARGETS;
-    const requested = await this.exclusive(`run:${runId}`, async () => {
+    const requested = await this.requestRunCancellation(runId);
+    if (TERMINAL_STATUSES.has(requested.status)) return requested;
+    return this.finishRunCancellation(requested, reason);
+  }
+
+  async cancelWaitingCheckpoint(input: {
+    runId: string;
+    checkpointId: string;
+    interactionIds: readonly string[];
+    reason?: string;
+  }): Promise<GuardedRunCancellationResult> {
+    const requested = await this.exclusive(`run:${input.runId}`, async () => {
+      const state = await this.require(input.runId);
+      if (TERMINAL_STATUSES.has(state.run.status)) {
+        return { outcome: "not_applicable" as const, run: state.run };
+      }
+      const expectedInteractionsRemainPending = input.interactionIds.every(
+        (interactionId) =>
+          state.interactions.some(
+            (interaction) =>
+              interaction.id === interactionId &&
+              interaction.kind === "approval" &&
+              interaction.status === "pending" &&
+              interaction.checkpointId === input.checkpointId,
+          ),
+      );
+      if (
+        state.run.status !== "waiting" ||
+        state.run.lastCheckpointId !== input.checkpointId ||
+        !expectedInteractionsRemainPending
+      ) {
+        return { outcome: "not_applicable" as const, run: state.run };
+      }
+      return {
+        outcome: "requested" as const,
+        run: await this.commitCancellationRequest(state),
+      };
+    });
+    if (requested.outcome === "not_applicable") return requested;
+    return {
+      outcome: "cancelled",
+      run: await this.finishRunCancellation(requested.run, input.reason),
+    };
+  }
+
+  private async requestRunCancellation(runId: string): Promise<RunRecord> {
+    return this.exclusive(`run:${runId}`, async () => {
       const state = await this.require(runId);
       if (TERMINAL_STATUSES.has(state.run.status)) return state.run;
-      const request = requestCancellation(state, this.now());
-      await this.commit(state, request.run, "cancellation_requested", {
-        ...request.changes,
-        events: request.changes.prompts?.map((prompt) =>
-          this.events.cancelledPrompt(request.run, prompt),
-        ),
-      });
-      return request.run;
+      return this.commitCancellationRequest(state);
     });
-    if (TERMINAL_STATUSES.has(requested.status)) return requested;
+  }
+
+  private async commitCancellationRequest(
+    state: RunHydratedState,
+  ): Promise<RunRecord> {
+    const request = requestCancellation(state, this.now());
+    await this.commit(state, request.run, "cancellation_requested", {
+      ...request.changes,
+      events: request.changes.prompts?.map((prompt) =>
+        this.events.cancelledPrompt(request.run, prompt),
+      ),
+    });
+    return request.run;
+  }
+
+  private async finishRunCancellation(
+    requested: RunRecord,
+    reason?: string,
+  ): Promise<RunRecord> {
+    const runId = requested.runId;
     this.live.get(runId)?.abort.abort(reason);
     const execution = this.live.get(runId)?.execution;
     const evidence = await Promise.all(
-      targets.map(async (target) => {
+      CANCELLATION_TARGETS.map(async (target) => {
         try {
           const status = await withCancellationDeadline(
             cancelRunTarget(

--- a/packages/workbench-server/test/domains/agents/approval-batch-resolution.test.ts
+++ b/packages/workbench-server/test/domains/agents/approval-batch-resolution.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ApprovalRecord, ToolCallRecord } from "@nervekit/contracts/tools";
 import type { ConversationEntry } from "@nervekit/contracts/conversations";
+import { ApplicationError } from "../../../src/core/application-error.js";
 import { ApprovalBatchResolutionService } from "../../../src/domains/human-input/approval-batch-resolution.js";
 import type {
   ApprovalInteractionBatch,
@@ -93,4 +94,135 @@ test("startup recovery loads evicted terminal approval tool calls asynchronously
   assert.equal(finalizations, 0, "terminal tools must not execute again");
   assert.ok(canonicalLoads.includes(decided.id));
   assert.ok(canonicalLoads.includes(policyTerminal.id));
+});
+
+for (const code of [
+  "RUN_CHECKPOINT_STALE",
+  "RUN_TOOL_REVISION_STALE",
+] as const) {
+  test(`startup recovery cancels a stale approval batch for ${code} without executing tools`, async () => {
+    const decided = {
+      ...terminalToolCall("tool_decided"),
+      status: "approved",
+      settledAt: undefined,
+    } as unknown as ToolCallRecord;
+    const approval = {
+      id: "approval_decided_0",
+      toolCallId: decided.id,
+      status: "granted",
+    } as unknown as ApprovalRecord;
+    const batch = {
+      runId: "run_test",
+      checkpointId: "checkpoint_test",
+      batchToolCallIds: [decided.id],
+      interactions: [
+        {
+          id: "interaction_test",
+          toolCallId: decided.id,
+          status: "pending",
+        },
+      ],
+    } as unknown as ApprovalInteractionBatch;
+    let finalizations = 0;
+    let appended = 0;
+    let resolutions = 0;
+    let cancellations = 0;
+    const warnings: Array<{ message: string; context: unknown }> = [];
+    const tools = {
+      listApprovals: (status?: ApprovalRecord["status"]) =>
+        status === "pending" ? [] : [approval],
+      getToolCallDetails: async () => decided,
+      getApprovalForToolCallDetails: async () => approval,
+      finalizeDecidedApproval: async () => {
+        finalizations += 1;
+        return terminalToolCall(decided.id);
+      },
+    } as unknown as ToolService;
+    const runs = {
+      listPendingApprovalInteractions: async () => batch.interactions,
+      approvalBatchForToolCall: async () => batch,
+      assertApprovalBatchContextUnchanged: async () => {
+        throw new ApplicationError(409, code, "stale");
+      },
+      cancelStaleApprovalBatch: async () => {
+        cancellations += 1;
+        return {
+          outcome: "cancelled",
+          run: {
+            runId: batch.runId,
+            conversationId: "conv_test",
+            agentId: "agent_test",
+            status: "cancelled",
+          },
+        };
+      },
+      resolveInteractionBatchForToolCalls: async () => {
+        resolutions += 1;
+      },
+    } as unknown as WorkbenchRunService;
+    const service = new ApprovalBatchResolutionService({
+      tools,
+      runs,
+      logger: {
+        warn: async (message: string, context: unknown) => {
+          warnings.push({ message, context });
+        },
+      } as never,
+      appendToolResult: async () => {
+        appended += 1;
+        return {} as ConversationEntry;
+      },
+      existingToolResultEntry: () => undefined,
+    });
+
+    await service.recoverReadyBatches();
+
+    assert.equal(cancellations, 1);
+    assert.equal(finalizations, 0);
+    assert.equal(appended, 0);
+    assert.equal(resolutions, 0);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!.message, /no tools were executed/);
+    assert.deepEqual(
+      (warnings[0]!.context as { context: { errorCode: string } }).context
+        .errorCode,
+      code,
+    );
+  });
+}
+
+test("startup recovery propagates unexpected context validation failures", async () => {
+  const decided = terminalToolCall("tool_decided");
+  const approval = {
+    id: "approval_decided_0",
+    toolCallId: decided.id,
+    status: "denied",
+  } as unknown as ApprovalRecord;
+  const batch = {
+    runId: "run_test",
+    checkpointId: "checkpoint_test",
+    batchToolCallIds: [decided.id],
+    interactions: [
+      { id: "interaction_test", toolCallId: decided.id, status: "pending" },
+    ],
+  } as unknown as ApprovalInteractionBatch;
+  const service = new ApprovalBatchResolutionService({
+    tools: {
+      listApprovals: (status?: ApprovalRecord["status"]) =>
+        status === "pending" ? [] : [approval],
+      getToolCallDetails: async () => decided,
+      getApprovalForToolCallDetails: async () => approval,
+    } as unknown as ToolService,
+    runs: {
+      listPendingApprovalInteractions: async () => batch.interactions,
+      approvalBatchForToolCall: async () => batch,
+      assertApprovalBatchContextUnchanged: async () => {
+        throw new Error("storage unavailable");
+      },
+    } as unknown as WorkbenchRunService,
+    appendToolResult: async () => ({}) as ConversationEntry,
+    existingToolResultEntry: () => undefined,
+  });
+
+  await assert.rejects(service.recoverReadyBatches(), /storage unavailable/);
 });

--- a/packages/workbench-server/test/domains/agents/stale-approval-recovery.test.ts
+++ b/packages/workbench-server/test/domains/agents/stale-approval-recovery.test.ts
@@ -1,0 +1,159 @@
+import { registerAgentScriptedProvider } from "@nervekit/harness/models";
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { shutdownServerRuntime } from "../../../src/app/runtime/server-runtime.js";
+import { WorkbenchRunUnitOfWork } from "../../../src/domains/runs/persistence/run-transition.repository.js";
+import { initializeStorage } from "../../../src/infrastructure/storage-bootstrap/index.js";
+import { createRuntimeFixture } from "../../support/runtime-fixture.js";
+
+test("a stale decided approval is cancelled durably across restarts without tool execution", async () => {
+  const provider = "nerve-scripted-stale-approval";
+  const root = await mkdtemp(join(tmpdir(), "nerve-stale-approval-"));
+  const home = join(root, "home");
+  const workspace = join(root, "workspace");
+  const marker = join(workspace, "stale-tool-executed");
+  await mkdir(workspace);
+  const registration = registerAgentScriptedProvider({
+    provider,
+    steps: [
+      {
+        type: "toolCall",
+        id: "stale_write_call",
+        name: "write",
+        args: { path: marker, content: "executed" },
+      },
+    ],
+  });
+  let runtime = createRuntimeFixture(
+    await initializeStorage(home),
+    "127.0.0.1",
+    0,
+  );
+  try {
+    await runtime.lifecycle.hydrate();
+    const project = await runtime.services.projectLifecycle.createProject({
+      dir: workspace,
+    });
+    const conversation =
+      await runtime.services.conversationLifecycle.createConversation({
+        projectId: project.id,
+      });
+    const agent = await runtime.services.agentLifecycle.createAgent({
+      projectId: project.id,
+      conversationId: conversation.id,
+      model: { provider, modelId: "scripted-fast" },
+      permissionLevel: "supervised",
+      permissionRuleSetId: "supervised",
+    });
+
+    await runtime.services.workbenchRun.promptAgent(agent.id, {
+      text: "Request the scripted tool.",
+    });
+    const approval = await waitForValue(
+      () =>
+        runtime.services.tools
+          .listApprovals("pending")
+          .find((candidate) => candidate.conversationId === conversation.id),
+      () =>
+        JSON.stringify({
+          agent: runtime.services.agentLifecycle.getAgent(agent.id),
+          tools: runtime.services.tools.listToolCalls(),
+          approvals: runtime.services.tools.listApprovals(),
+          entries:
+            runtime.services.conversationLifecycle.getConversationEntries(
+              conversation.id,
+            ),
+        }),
+    );
+    const toolCallId = approval.toolCallId;
+
+    await runtime.services.conversationLifecycle.appendEntry({
+      conversationId: conversation.id,
+      agentId: agent.id,
+      role: "user",
+      text: "Move the active branch after the approval checkpoint.",
+    });
+    await assert.rejects(
+      runtime.services.humanInput.resolveApproval(approval.id, "allow"),
+      (error: unknown) =>
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "RUN_CHECKPOINT_STALE",
+    );
+    await assertNoFile(marker);
+    await shutdownServerRuntime(runtime.runtime);
+
+    runtime = createRuntimeFixture(
+      await initializeStorage(home),
+      "127.0.0.1",
+      0,
+    );
+    await runtime.lifecycle.hydrate();
+    const unitOfWork = new WorkbenchRunUnitOfWork(home, 0);
+    const recovered = (await unitOfWork.list()).find(
+      (state) => state.run.conversationId === conversation.id,
+    );
+    assert.equal(recovered?.run.status, "cancelled");
+    assert.ok(
+      recovered?.interactions.every(
+        (interaction) => interaction.status === "cancelled",
+      ),
+    );
+    assert.equal(
+      (await runtime.services.tools.getToolCallDetails(toolCallId)).status,
+      "failed",
+    );
+    await assertNoFile(marker);
+    const entriesAfterRecovery =
+      await runtime.services.conversationLifecycle.getConversationEntries(
+        conversation.id,
+      );
+    assert.equal(
+      entriesAfterRecovery.at(-1)?.text,
+      "Move the active branch after the approval checkpoint.",
+    );
+    await shutdownServerRuntime(runtime.runtime);
+
+    runtime = createRuntimeFixture(
+      await initializeStorage(home),
+      "127.0.0.1",
+      0,
+    );
+    await runtime.lifecycle.hydrate();
+    const repeated = (await new WorkbenchRunUnitOfWork(home, 0).list()).find(
+      (state) => state.run.conversationId === conversation.id,
+    );
+    assert.equal(repeated?.run.status, "cancelled");
+    assert.equal(
+      repeated?.transitions.filter(
+        (transition) => transition.kind === "cancellation_requested",
+      ).length,
+      1,
+    );
+    await assertNoFile(marker);
+  } finally {
+    registration.unregister();
+    await shutdownServerRuntime(runtime.runtime).catch(() => undefined);
+    await rm(root, { recursive: true, force: true, maxRetries: 5 });
+  }
+});
+
+async function waitForValue<T>(
+  read: () => T | undefined,
+  diagnostics: () => string,
+): Promise<T> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const value = read();
+    if (value !== undefined) return value;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for value: ${diagnostics()}`);
+}
+
+async function assertNoFile(path: string): Promise<void> {
+  await assert.rejects(access(path));
+}

--- a/packages/workbench-server/test/domains/runs/run-coordinator.contract.test.ts
+++ b/packages/workbench-server/test/domains/runs/run-coordinator.contract.test.ts
@@ -1425,6 +1425,74 @@ test("cancellation terminalizes every pending approval batch member", async () =
   );
 });
 
+test("checkpoint-scoped cancellation only settles the expected pending approval batch", async () => {
+  const harness = fixture();
+  const run = await start(harness.coordinator);
+  await harness.coordinator.waitMany(run.runId, [
+    {
+      kind: "approval",
+      toolCallId: "tool_first",
+      interactionOrdinal: 0,
+      toolCallRevision: 1,
+      batchToolCallIds: ["tool_first", "tool_second"],
+      prompt: "Approve first",
+      risk: ["write"],
+      normalizedArgs: {},
+      offeredScopes: ["single_call"],
+      checkpoint: suspensionCheckpoint(),
+    },
+    {
+      kind: "approval",
+      toolCallId: "tool_second",
+      interactionOrdinal: 0,
+      toolCallRevision: 1,
+      batchToolCallIds: ["tool_first", "tool_second"],
+      prompt: "Approve second",
+      risk: ["write"],
+      normalizedArgs: {},
+      offeredScopes: ["single_call"],
+      checkpoint: suspensionCheckpoint(),
+    },
+  ]);
+  const waiting = await harness.coordinator.get(run.runId);
+  const interactionIds = waiting!.interactions.map((item) => item.id);
+  const checkpointId = waiting!.run.lastCheckpointId!;
+
+  const superseded = await harness.coordinator.cancelWaitingCheckpoint({
+    runId: run.runId,
+    checkpointId: "checkpoint_superseded",
+    interactionIds,
+  });
+  assert.equal(superseded.outcome, "not_applicable");
+  assert.equal(
+    (await harness.coordinator.get(run.runId))?.run.status,
+    "waiting",
+  );
+
+  const cancelled = await harness.coordinator.cancelWaitingCheckpoint({
+    runId: run.runId,
+    checkpointId,
+    interactionIds,
+    reason: "stale saved approval",
+  });
+  assert.equal(cancelled.outcome, "cancelled");
+  assert.equal(cancelled.run.status, "cancelled");
+  assert.deepEqual(
+    (await harness.coordinator.get(run.runId))?.interactions.map(
+      (interaction) => interaction.status,
+    ),
+    ["cancelled", "cancelled"],
+  );
+
+  const repeated = await harness.coordinator.cancelWaitingCheckpoint({
+    runId: run.runId,
+    checkpointId,
+    interactionIds,
+  });
+  assert.equal(repeated.outcome, "not_applicable");
+  assert.equal(repeated.run.status, "cancelled");
+});
+
 test("atomically resolves and completes an interaction without waking execution", async () => {
   const harness = fixture();
   const run = await start(harness.coordinator);


### PR DESCRIPTION
## Summary
- cancel stale approval batches through a checkpoint-scoped, race-safe run cancellation path
- prevent stale saved approvals from executing tools while allowing daemon recovery to continue
- add structured recovery diagnostics and persisted restart regression coverage

## Validation
- `pnpm --filter @nervekit/workbench-server check`
- `pnpm --filter @nervekit/workbench-server test`
- `pnpm fix && pnpm check && pnpm run test:affected`

Fixes #298