### PR TITLE
Refine workbench shell status bar styling

### DIFF
--- a/packages/workbench-app/src/lib/app/shell/LayoutControl.svelte
+++ b/packages/workbench-app/src/lib/app/shell/LayoutControl.svelte
@@ -21,6 +21,7 @@ import {
 } from "$lib/application/commands/command-registry";
 import {
   DOCK_LABELS,
+  STATUS_BAR_CHIP_BUTTON,
   type DockId,
   type DockToggle,
 } from "$lib/presentation/shell";
@@ -73,13 +74,16 @@ function changeZoomLevel(delta: number) {
 
 <Popover
   size="md"
-  triggerClass="h-5.5 rounded-sm px-1.5 text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+  triggerClass={STATUS_BAR_CHIP_BUTTON}
   ariaLabel="Open layout controls"
   side="top"
   align="end"
 >
   {#snippet trigger()}
-    <span class="layout-trigger" title={`Layout · Zoom ${zoomPercent}%`}>
+    <span
+      class="inline-flex items-center gap-1.5 tabular-nums"
+      title={`Layout · Zoom ${zoomPercent}%`}
+    >
       <PanelsTopLeft size={12} strokeWidth={2.1} aria-hidden="true" />
       <span>{zoomPercent}%</span>
     </span>
@@ -155,12 +159,3 @@ function changeZoomLevel(delta: number) {
     </PopoverSection>
   </PopoverBody>
 </Popover>
-
-<style>
-.layout-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  font-variant-numeric: tabular-nums;
-}
-</style>

--- a/packages/workbench-app/src/lib/app/shell/MaintenanceStatus.svelte
+++ b/packages/workbench-app/src/lib/app/shell/MaintenanceStatus.svelte
@@ -5,6 +5,7 @@ import * as Popover from "@nervekit/ui-kit/components/ui/popover";
 import { Spinner } from "@nervekit/ui-kit/components/ui/spinner";
 import MaintenanceProgressView from "$lib/presentation/maintenance/MaintenanceProgressView.svelte";
 import { maintenance } from "$lib/application/maintenance/maintenance-state.svelte";
+import { STATUS_BAR_CHIP_BUTTON } from "$lib/presentation/shell";
 let { operation }: { operation: MaintenanceOperation } = $props();
 const label = $derived(
   operation.totalItems === undefined
@@ -19,7 +20,7 @@ const label = $derived(
         {...props}
         variant="ghost"
         size="xs"
-        class="h-5 min-w-0 gap-1 px-1.5 text-xs"
+        class={`${STATUS_BAR_CHIP_BUTTON} min-w-0`}
         ariaLabel={`${label}. Show progress`}
         title={label}
       >

--- a/packages/workbench-app/src/lib/app/shell/StatusBar.svelte
+++ b/packages/workbench-app/src/lib/app/shell/StatusBar.svelte
@@ -6,7 +6,13 @@ import GitBranch from "@lucide/svelte/icons/git-branch";
 import Terminal from "@lucide/svelte/icons/terminal";
 import TriangleAlert from "@lucide/svelte/icons/triangle-alert";
 import { Button } from "@nervekit/ui-kit/components/ui/button";
-import { ShellStatusBar, type DockToggle } from "$lib/presentation/shell";
+import { cn } from "@nervekit/ui-kit/utils";
+import {
+  ShellStatusBar,
+  STATUS_BAR_CHIP,
+  STATUS_BAR_CHIP_BUTTON,
+  type DockToggle,
+} from "$lib/presentation/shell";
 import type {
   MaintenanceOperation,
   TaskRecord,
@@ -77,15 +83,11 @@ const activeTasks = $derived(
 const projectPath = $derived(
   activeProject ? tildePath(activeProject.dir, homeDir) : "No project",
 );
-
-const hasUsage = $derived(
-  subscriptionUsages.some((entry) =>
-    Boolean(entry.usage?.session ?? entry.usage?.weekly),
-  ),
+// Phones have no room for a path, and truncating one from the left hides the
+// part that identifies the project, so show the project name instead.
+const projectLabel = $derived(
+  phone ? (activeProject?.name ?? "No project") : projectPath,
 );
-// Phone: usage outranks the project path for the one available slot, but the
-// path still fills it when there is no subscription usage to show.
-const showUsageInLeft = $derived(phone && hasUsage);
 
 function changeCountLabel(count: number): string {
   return `${count} ${count === 1 ? "change" : "changes"}`;
@@ -111,21 +113,23 @@ function gitStatusTitle(status: GitStatus): string {
 
 <ShellStatusBar toggles={dockToggles}>
   {#snippet left()}
-    {#if showUsageInLeft}
-      <SubscriptionUsageChip usages={subscriptionUsages} compact />
-    {:else}
-      <span class="footer-project-path" title={activeProject?.dir}
-        >{projectPath}</span
-      >
-    {/if}
+    <span
+      class={cn(STATUS_BAR_CHIP, "min-w-0 shrink")}
+      title={activeProject?.dir}
+    >
+      <span class="truncate">{projectLabel}</span>
+    </span>
 
     {#if !phone && gitStatus}
-      <span class="footer-item footer-git" title={gitStatusTitle(gitStatus)}>
+      <span
+        class={cn(STATUS_BAR_CHIP, "min-w-0 shrink gap-2")}
+        title={gitStatusTitle(gitStatus)}
+      >
         <GitBranch size={12} strokeWidth={2.1} aria-hidden="true" />
-        <span class="footer-git-branch">{gitStatus.branch}</span>
+        <span class="max-w-40 min-w-0 truncate">{gitStatus.branch}</span>
         {#if gitStatus.changeCount > 0}
           <span
-            class="footer-git-detail"
+            class="inline-flex items-center gap-0.5"
             aria-label={changeCountLabel(gitStatus.changeCount)}
           >
             <Diff
@@ -135,11 +139,11 @@ function gitStatusTitle(status: GitStatus): string {
             />{gitStatus.changeCount}
           </span>
         {:else if gitStatus.dirty}
-          <span class="footer-git-dot" aria-label="Uncommitted changes">•</span>
+          <span aria-label="Uncommitted changes">•</span>
         {/if}
         {#if (gitStatus.ahead ?? 0) > 0}
           <span
-            class="footer-git-detail"
+            class="inline-flex items-center gap-0.5"
             aria-label={`${gitStatus.ahead} ahead`}
           >
             <ArrowUp
@@ -151,7 +155,7 @@ function gitStatusTitle(status: GitStatus): string {
         {/if}
         {#if (gitStatus.behind ?? 0) > 0}
           <span
-            class="footer-git-detail"
+            class="inline-flex items-center gap-0.5"
             aria-label={`${gitStatus.behind} behind`}
           >
             <ArrowDown
@@ -163,38 +167,49 @@ function gitStatusTitle(status: GitStatus): string {
         {/if}
       </span>
     {/if}
+
+    <!-- Attention chips sit next to the work they describe, and stay visible on
+         phones where the informational chips give up their space first. -->
+    {#if activeTasks > 0}
+      <span
+        class={STATUS_BAR_CHIP}
+        title={`${activeTasks} running ${activeTasks === 1 ? "task" : "tasks"}`}
+      >
+        <Terminal size={12} strokeWidth={2.1} aria-hidden="true" />
+        <span>{activeTasks}</span>
+      </span>
+    {/if}
+
+    {#if pendingApprovals > 0}
+      <Button
+        variant="ghost"
+        size="xs"
+        class={cn(
+          STATUS_BAR_CHIP_BUTTON,
+          "text-warning hover:text-warning focus-visible:text-warning",
+        )}
+        ariaLabel={`Open ${pendingApprovals === 1 ? "pending approval" : "pending approvals"}`}
+        title={`${pendingApprovals} ${pendingApprovals === 1 ? "pending approval" : "pending approvals"} · Open conversation`}
+        onclick={() => onOpenPendingApproval?.()}
+      >
+        <TriangleAlert size={12} strokeWidth={2.1} aria-hidden="true" />
+        <span>{pendingApprovals}</span>
+      </Button>
+    {/if}
   {/snippet}
 
   {#snippet right()}
-    <span class="inline-flex items-center gap-1" data-tour-id="status-controls">
+    <span
+      class="inline-flex items-center gap-0.5"
+      data-tour-id="status-controls"
+    >
       {#if maintenanceOperation}
         <MaintenanceStatus operation={maintenanceOperation} />
       {/if}
 
+      <SubscriptionUsageChip usages={subscriptionUsages} compact={phone} />
+
       {#if !phone}
-        {#if activeTasks > 0}
-          <span class="footer-item" title="Running tasks">
-            <Terminal size={12} strokeWidth={2.1} aria-hidden="true" />
-            <span>{activeTasks}</span>
-          </span>
-        {/if}
-
-        {#if pendingApprovals > 0}
-          <Button
-            variant="ghost"
-            size="xs"
-            class="footer-item warn text-xs"
-            ariaLabel={`Open ${pendingApprovals === 1 ? "pending approval" : "pending approvals"}`}
-            title={`${pendingApprovals} ${pendingApprovals === 1 ? "pending approval" : "pending approvals"} · Open conversation`}
-            onclick={() => onOpenPendingApproval?.()}
-          >
-            <TriangleAlert size={12} strokeWidth={2.1} aria-hidden="true" />
-            <span>{pendingApprovals}</span>
-          </Button>
-        {/if}
-
-        <SubscriptionUsageChip usages={subscriptionUsages} />
-
         <LayoutControl {zoomLevel} {dockToggles} {onZoomLevelChange} />
       {/if}
 
@@ -202,64 +217,3 @@ function gitStatusTitle(status: GitStatus): string {
     </span>
   {/snippet}
 </ShellStatusBar>
-
-<style>
-/* Shared shape for the status chips in this bar. */
-.footer-item {
-  display: inline-flex;
-  align-items: center;
-  flex: none;
-  gap: 0.3rem;
-  height: 1.375rem;
-  border-radius: var(--radius-sm);
-  padding: 0 0.375rem;
-  color: var(--muted-foreground);
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
-
-/* The chip icons are Lucide components (escape-hatch reason 5). */
-.footer-item :global(svg) {
-  flex: none;
-  color: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
-}
-
-.footer-item.warn,
-.footer-item.warn :global(svg) {
-  color: var(--warning);
-}
-
-.footer-project-path {
-  flex: 0 1 auto;
-  overflow: hidden;
-  min-width: 0;
-  margin-left: 0.25rem;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-}
-
-.footer-git {
-  min-width: 0;
-  gap: 0.4rem;
-}
-
-.footer-git-branch {
-  overflow: hidden;
-  min-width: 0;
-  max-width: min(16rem, 30vw);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-}
-
-.footer-git-detail {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.15rem;
-}
-
-.footer-git-dot {
-  color: color-mix(in oklab, var(--muted-foreground) 80%, transparent);
-}
-</style>

--- a/packages/workbench-app/src/lib/app/shell/StatusPopover.svelte
+++ b/packages/workbench-app/src/lib/app/shell/StatusPopover.svelte
@@ -10,6 +10,7 @@ import Popover, {
 } from "@nervekit/ui-kit/components/composites/popover-panel";
 import { StatusDot } from "@nervekit/ui-kit/components/composites/status-dot";
 import { type StatusTone } from "@nervekit/ui-kit/display/status";
+import { STATUS_BAR_CHIP_BUTTON } from "$lib/presentation/shell";
 
 type Props = {
   connection?: string;
@@ -49,13 +50,16 @@ const uptime = $derived.by(() => {
 
 <Popover
   size="sm"
-  triggerClass="h-5.5 rounded-sm px-1.5 text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+  triggerClass={STATUS_BAR_CHIP_BUTTON}
   ariaLabel="Open daemon status"
   {side}
   align="end"
 >
   {#snippet trigger()}
-    <span class="status-trigger" title={`Nerve daemon · ${summary}`}>
+    <span
+      class="inline-flex items-center gap-1.5"
+      title={`Nerve daemon · ${summary}`}
+    >
       <StatusDot tone={connectionTone} pulse={live} />
       {#if !compact}<span>{summary}</span>{/if}
     </span>
@@ -100,11 +104,3 @@ const uptime = $derived.by(() => {
     </PopoverProperties>
   </PopoverBody>
 </Popover>
-
-<style>
-.status-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-</style>

--- a/packages/workbench-app/src/lib/features/usage/views/SubscriptionUsageChip.svelte
+++ b/packages/workbench-app/src/lib/features/usage/views/SubscriptionUsageChip.svelte
@@ -14,6 +14,7 @@ import Popover, {
   PopoverHeader,
   PopoverSection,
 } from "@nervekit/ui-kit/components/composites/popover-panel";
+import { STATUS_BAR_CHIP_BUTTON } from "$lib/presentation/shell";
 
 type Props = {
   usages?: SubscriptionUsageEntry[];
@@ -186,30 +187,32 @@ const title = $derived.by(() => {
 {#if hasData}
   <Popover
     size="md"
-    triggerClass="h-5.5 rounded-sm px-1.5 text-muted-foreground hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+    triggerClass={STATUS_BAR_CHIP_BUTTON}
     ariaLabel="Open subscription usage details"
     side="top"
     align="end"
   >
     {#snippet trigger()}
-      <span class="usage-trigger" {title}>
+      <span class="inline-flex items-center gap-1.5 whitespace-nowrap" {title}>
         {#each triggerWindows as item (item.slot)}
           {@const percent = item.window.usedPercent}
-          <span class="usage-meter">
-            <span class="usage-meter-label">{item.abbreviation}</span>
-            <span class="usage-meter-track">
+          <span class="inline-flex items-center gap-1">
+            <span>{item.abbreviation}</span>
+            <span
+              class="h-1 w-6 overflow-hidden rounded-full bg-muted-foreground/30"
+            >
               <span
-                class={cn("usage-meter-fill", toneBarClass(percent))}
+                class={cn("block h-full rounded-full", toneBarClass(percent))}
                 style="width: {clampPercent(percent)}%"
               ></span>
             </span>
-            <span class={cn("usage-meter-value", toneTextClass(percent))}
+            <span class={cn("tabular-nums", toneTextClass(percent))}
               >{percentLabel(percent)}</span
             >
           </span>
         {/each}
         {#if triggerReset}
-          <span class="usage-reset">{triggerReset}</span>
+          <span class="tabular-nums">{triggerReset}</span>
         {/if}
       </span>
     {/snippet}
@@ -253,46 +256,3 @@ const title = $derived.by(() => {
     </PopoverBody>
   </Popover>
 {/if}
-
-<style>
-.usage-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  white-space: nowrap;
-}
-
-.usage-meter {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-}
-
-.usage-meter-label {
-  color: var(--muted-foreground);
-}
-
-.usage-meter-track {
-  position: relative;
-  overflow: hidden;
-  width: 1.5rem;
-  height: 0.25rem;
-  border-radius: 999px;
-  background: color-mix(in oklab, var(--muted-foreground) 28%, transparent);
-}
-
-.usage-meter-fill {
-  display: block;
-  height: 100%;
-  border-radius: 999px;
-}
-
-.usage-meter-value,
-.usage-reset {
-  font-variant-numeric: tabular-nums;
-}
-
-.usage-reset {
-  color: var(--muted-foreground);
-}
-</style>

--- a/packages/workbench-app/src/lib/presentation/shell/DockTabStrip.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/DockTabStrip.svelte
@@ -230,7 +230,7 @@ const tourIdByView: Record<string, string> = {
 </script>
 
 <div
-  class="dock-tab-strip"
+  class="dock-tab-strip chrome-tab-track"
   class:drag-active={dragActive}
   data-tour-id={dock === "left" ? "panel-layout" : undefined}
   bind:this={strip}
@@ -251,14 +251,14 @@ const tourIdByView: Record<string, string> = {
       )}
       {#if view.id !== shellDrag.viewId && dropIndex === remainingIndex}
         <span
-          class="inline-block h-8 w-8 flex-none rounded-t-md border border-b-0 border-primary/55 bg-primary/10 shadow-inner"
+          class="inline-block h-8 w-8 flex-none border-t-2 border-t-primary/55 bg-primary/10"
           aria-hidden="true"
         ></span>
       {/if}
       <ContextMenu items={menuItems(view, index)} triggerClass="contents">
         <button
           type="button"
-          class={`dock-tab ${index > 0 ? "-ml-px" : ""}`}
+          class="dock-tab"
           class:active={view.id === activeViewId}
           class:dragging={collapsedDragViewId === view.id}
           data-view-id={view.id}
@@ -301,7 +301,7 @@ const tourIdByView: Record<string, string> = {
     {/each}
     {#if dragActive && dropIndex !== undefined && dropIndex >= remainingViews.length}
       <span
-        class="inline-block h-8 w-8 flex-none rounded-t-md border border-b-0 border-primary/55 bg-primary/10 shadow-inner"
+        class="inline-block h-8 w-8 flex-none border-t-2 border-t-primary/55 bg-primary/10"
         aria-hidden="true"
       ></span>
     {/if}
@@ -316,7 +316,9 @@ const tourIdByView: Record<string, string> = {
   align-items: stretch;
   min-width: 0;
   height: 2rem;
-  background: var(--card);
+  /* Surface comes from the shared `.chrome-tab-track` shade: a short step under
+   * the dock `card`, so the active tab reads as that panel surface filling the
+   * track. */
 }
 
 /* Keep the rail divider behind the active tab so that tab joins the panel. */
@@ -328,7 +330,7 @@ const tourIdByView: Record<string, string> = {
   left: 0;
   z-index: 1;
   height: 1px;
-  background: color-mix(in oklab, var(--primary) 60%, transparent);
+  background: var(--border);
   pointer-events: none;
 }
 
@@ -354,21 +356,21 @@ const tourIdByView: Record<string, string> = {
   flex: none;
   width: 2rem;
   height: 2rem;
-  border: 1px solid color-mix(in oklab, var(--border) 62%, transparent);
-  border-bottom: 0;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  border-top: 2px solid transparent;
   color: var(--muted-foreground);
   cursor: pointer;
 }
 
-.dock-tab:hover {
-  background: color-mix(in oklab, var(--accent) 60%, transparent);
+.dock-tab:hover:not(.active) {
+  background: color-mix(in oklab, var(--accent) 45%, transparent);
   color: var(--foreground);
 }
 
+/* The active tab is the panel surface filling the track, marked by the same
+ * `primary` top rule the editor tabs use. */
 .dock-tab.active {
   z-index: 2;
-  border-color: color-mix(in oklab, var(--primary) 60%, transparent);
+  border-top-color: var(--primary);
   background: var(--card);
   color: var(--foreground);
 }

--- a/packages/workbench-app/src/lib/presentation/shell/EditorTabStrip.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/EditorTabStrip.svelte
@@ -328,7 +328,7 @@ function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
 />
 
 <nav
-  class="relative flex min-h-8 min-w-0 bg-card after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-primary/60 after:content-['']"
+  class="chrome-tab-track relative flex min-h-8 min-w-0 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border after:content-['']"
   aria-label="Open editor tabs"
 >
   {#if canScrollLeft || canScrollRight}
@@ -354,10 +354,10 @@ function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
       {@const ToggleIcon = tab.toggle?.icon}
       <ContextMenu
         items={menuItems(tab, index)}
-        triggerClass={`h-8 min-w-0 flex-none ${index > 0 ? "-ml-px" : ""} ${tab.active ? "relative z-2" : ""} ${tab.wide ? "w-54 basis-54" : "w-50 basis-50"}`}
+        triggerClass={`h-8 min-w-0 flex-none ${tab.active ? "relative z-2" : ""} ${tab.wide ? "w-54 basis-54" : "w-50 basis-50"}`}
       >
         <div
-          class="editor-tab group relative inline-grid h-8 w-full touch-pan-y grid-cols-[auto_minmax(0,1fr)_auto] rounded-t-md border border-b-0 border-border/62 bg-card text-muted-foreground data-[active]:border-primary/60 data-[active]:bg-background data-[active]:text-foreground data-[placeholder]:border data-[placeholder]:border-primary/55 data-[placeholder]:bg-primary/10 data-[placeholder]:text-transparent data-[placeholder]:shadow-inner data-[placeholder]:[&>*]:invisible not-data-[active]:not-data-[placeholder]:hover:bg-accent/60 not-data-[active]:not-data-[placeholder]:hover:text-foreground"
+          class="editor-tab group relative inline-grid h-8 w-full touch-pan-y grid-cols-[auto_minmax(0,1fr)_auto] border-t-2 border-r border-t-transparent border-r-border/45 text-muted-foreground data-[active]:border-t-primary data-[active]:bg-background data-[active]:text-foreground data-[placeholder]:bg-primary/10 data-[placeholder]:text-transparent data-[placeholder]:[&>*]:invisible not-data-[active]:not-data-[placeholder]:hover:bg-accent/45 not-data-[active]:not-data-[placeholder]:hover:text-foreground"
           data-active={tab.active ? "" : undefined}
           data-running={tab.running ? "" : undefined}
           data-errored={tab.error ? "" : undefined}
@@ -477,7 +477,7 @@ function menuItems(tab: WorkbenchTabModel, index: number): ContextMenuItem[] {
   {@const PreviewIcon = draggedTab.icon}
   {@const PreviewSelectIcon = draggedTab.selectIcon}
   <div
-    class="pointer-events-none fixed z-50 inline-grid h-8 grid-cols-[auto_minmax(0,1fr)_auto] border border-border bg-background text-foreground opacity-90 shadow-lg"
+    class="pointer-events-none fixed z-50 inline-grid h-8 grid-cols-[auto_minmax(0,1fr)_auto] border-t-2 border-t-primary bg-background text-foreground opacity-90 shadow-lg"
     style:top={`${pointerDrag.top}px`}
     style:left={`${previewLeft}px`}
     style:width={`${pointerDrag.width}px`}

--- a/packages/workbench-app/src/lib/presentation/shell/ShellStatusBar.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/ShellStatusBar.svelte
@@ -52,19 +52,19 @@ const trailingToggles = $derived(
     : icons[toggle.dock].closed}
   <Button
     variant="ghost"
-    size="icon-sm"
-    class="size-5.5 rounded-sm max-sm:size-9"
+    size="icon-xs"
+    class="rounded-sm text-muted-foreground max-sm:size-9"
     ariaLabel={`Toggle ${toggle.label}`}
     title={toggle.open ? `Hide ${toggle.label}` : `Show ${toggle.label}`}
     pressed={toggle.open}
     onclick={toggle.onToggle}
   >
-    <Icon size={13} strokeWidth={2.1} aria-hidden="true" />
+    <Icon size={12} strokeWidth={2.1} aria-hidden="true" />
   </Button>
 {/snippet}
 
 <footer
-  class="flex h-full min-w-0 items-center justify-between gap-3 border-t border-border bg-card px-1.5 text-xs text-muted-foreground select-none max-sm:pb-[env(safe-area-inset-bottom)]"
+  class="flex h-full min-w-0 items-center justify-between gap-2 border-t border-border bg-panel px-1.5 text-xs text-muted-foreground select-none max-sm:pb-[env(safe-area-inset-bottom)]"
 >
   <div class="flex min-w-0 flex-auto items-center gap-0.5 overflow-hidden">
     {#each leadingToggles as toggle (toggle.dock)}

--- a/packages/workbench-app/src/lib/presentation/shell/ShellTitlebar.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/ShellTitlebar.svelte
@@ -17,7 +17,7 @@ let {
 <!-- `-webkit-app-region: drag` makes the desktop titlebar the window drag
      handle (escape-hatch reason 7). -->
 <header
-  class={`flex h-full min-w-0 items-center justify-between gap-4 bg-card px-3 pt-[env(safe-area-inset-top)] select-none ${
+  class={`flex h-full min-w-0 items-center justify-between gap-4 border-b border-border bg-panel px-3 pt-[env(safe-area-inset-top)] select-none ${
     desktop ? "[-webkit-app-region:drag]" : ""
   }`}
 >

--- a/packages/workbench-app/src/lib/presentation/shell/WorkbenchShell.svelte
+++ b/packages/workbench-app/src/lib/presentation/shell/WorkbenchShell.svelte
@@ -61,8 +61,10 @@ let {
 const leftViews = $derived(dockDescriptors(layout, "left", descriptors));
 const rightViews = $derived(dockDescriptors(layout, "right", descriptors));
 const bottomViews = $derived(dockDescriptors(layout, "bottom", descriptors));
-const sideResizerClass =
-  "bg-card hover:bg-card data-[active=keyboard]:bg-card data-[active=pointer]:bg-card after:pointer-events-none after:absolute after:top-8 after:bottom-0 after:left-0 after:w-px after:bg-border after:content-[''] before:pointer-events-none before:absolute before:top-8 before:left-0 before:h-px before:w-px before:-translate-y-px before:bg-primary/60 before:content-['']";
+/* The 1px handle is the only separator between a side dock and the editor, so
+ * it carries the stronger `input` hairline and runs the full column height,
+ * tab row included. */
+const sideResizerClass = "bg-input";
 
 const leftVisible = $derived(!compact && isDockVisible(layout, "left"));
 const rightVisible = $derived(!compact && isDockVisible(layout, "right"));

--- a/packages/workbench-app/src/lib/presentation/shell/index.ts
+++ b/packages/workbench-app/src/lib/presentation/shell/index.ts
@@ -5,6 +5,7 @@ export { default as EditorArea } from "./EditorArea.svelte";
 export { default as EditorTabStrip } from "./EditorTabStrip.svelte";
 export * from "./shell-drag.svelte.js";
 export * from "./shell-layout.js";
+export * from "./status-bar-chip.js";
 export type {
   DockId,
   DockState,

--- a/packages/workbench-app/src/lib/presentation/shell/status-bar-chip.ts
+++ b/packages/workbench-app/src/lib/presentation/shell/status-bar-chip.ts
@@ -1,0 +1,13 @@
+/**
+ * Every status-bar item — the project/git info on the left, the alert chips,
+ * and the popover triggers on the right — shares one chip shape so the footer
+ * reads as a single row instead of two differently shaped clusters.
+ *
+ * The chip sits on the shared control scale: `h-6` (xs) on desktop, stepping up
+ * to `h-9` (lg) below `sm` so the footer stays touch friendly on phones.
+ */
+export const STATUS_BAR_CHIP =
+  "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-sm px-1.5 text-xs text-muted-foreground tabular-nums max-sm:h-9 max-sm:px-2.5";
+
+/** Interactive variant: same shape, with the shared ghost hover/open feedback. */
+export const STATUS_BAR_CHIP_BUTTON = `${STATUS_BAR_CHIP} cursor-pointer transition-colors hover:bg-muted hover:text-foreground data-[state=open]:bg-muted data-[state=open]:text-foreground`;

--- a/packages/workbench-app/src/styles/components/shell.css
+++ b/packages/workbench-app/src/styles/components/shell.css
@@ -1,3 +1,17 @@
+/* Shell chrome is flat and hairline-separated, never shaded: the titlebar and
+ * status bar bracket the window in `panel` behind a 1px border, and every tab
+ * row shares one `--chrome-track` shade a short step under the content it opens
+ * onto. Tabs carry no outline of their own — an active tab is the content
+ * surface filling the track, marked by a `primary` top rule. */
+:root {
+  --chrome-track: color-mix(in oklab, var(--muted) 45%, var(--card));
+}
+
+/* Tab track shared by EditorTabStrip and DockTabStrip. */
+.chrome-tab-track {
+  background-color: var(--chrome-track);
+}
+
 /* Dock layout contract shared by WorkbenchShell and DockPanel: WorkbenchShell
  * renders a `.dock-panel` of its own inside the compact sheet, and reuses
  * DockPanel elsewhere, so these classes cannot belong to either component. */


### PR DESCRIPTION
## Summary
- unify status-bar chips and responsive control sizing
- refine shell tabs, titlebar, and status-bar surfaces
- share shell presentation styling across legacy and current components

## Validation
- `pnpm fix`
- `pnpm check`
- `pnpm run test:affected`